### PR TITLE
Add unit tests for core pipeline scripts

### DIFF
--- a/workflow/envs/python.yaml
+++ b/workflow/envs/python.yaml
@@ -13,6 +13,7 @@ dependencies:
   - seaborn >=0.13
   - requests >=2.31
   - jinja2 >=3.1
+  - pytest >=8.0
   - tensorflow >=2.10  # Required by MHCflurry
   - pip
   - pip:

--- a/workflow/tests/conftest.py
+++ b/workflow/tests/conftest.py
@@ -1,0 +1,5 @@
+import sys
+from pathlib import Path
+
+# Make workflow/scripts importable without installation
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))

--- a/workflow/tests/test_assemble_contigs.py
+++ b/workflow/tests/test_assemble_contigs.py
@@ -1,0 +1,101 @@
+"""Tests for assemble_contigs.py — contig assembly helpers."""
+
+import pandas as pd
+
+from assemble_contigs import (
+    _build_downstream_bed,
+    _build_upstream_bed,
+    _has_soft_clip,
+    _parse_fasta,
+)
+
+
+class TestHasSoftClip:
+    def test_all_uppercase_returns_false(self):
+        assert _has_soft_clip("ATCGATCGATCG") is False
+
+    def test_lowercase_bases_return_true(self):
+        assert _has_soft_clip("ATCGatcg") is True
+
+    def test_all_lowercase_returns_true(self):
+        assert _has_soft_clip("atcgatcg") is True
+
+    def test_empty_string_returns_false(self):
+        assert _has_soft_clip("") is False
+
+
+class TestBuildUpstreamBed:
+    def _make_junctions(self):
+        return pd.DataFrame({
+            "chrom": ["chr22"],
+            "start": [200],   # 0-based junction start
+            "end":   [300],
+            "strand": ["+"],
+            "junction_id": ["chr22:201:300:+"],
+        })
+
+    def test_upstream_end_equals_junction_start(self):
+        df = self._make_junctions()
+        bed = _build_upstream_bed(df, upstream_nt=26)
+        assert bed.iloc[0]["end"] == 200
+
+    def test_upstream_start_is_junction_start_minus_nt(self):
+        df = self._make_junctions()
+        bed = _build_upstream_bed(df, upstream_nt=26)
+        assert bed.iloc[0]["start"] == 174
+
+    def test_upstream_start_clipped_at_zero(self):
+        df = pd.DataFrame({
+            "chrom": ["chr22"], "start": [10], "end": [200],
+            "strand": ["+"], "junction_id": ["chr22:11:200:+"],
+        })
+        bed = _build_upstream_bed(df, upstream_nt=26)
+        assert bed.iloc[0]["start"] == 0
+
+
+class TestBuildDownstreamBed:
+    def _make_junctions(self):
+        return pd.DataFrame({
+            "chrom": ["chr22"],
+            "start": [200],
+            "end":   [300],   # 0-based junction end
+            "strand": ["+"],
+            "junction_id": ["chr22:201:300:+"],
+        })
+
+    def test_downstream_start_equals_junction_end(self):
+        df = self._make_junctions()
+        bed = _build_downstream_bed(df, downstream_nt=24)
+        assert bed.iloc[0]["start"] == 300
+
+    def test_downstream_end_is_junction_end_plus_nt(self):
+        df = self._make_junctions()
+        bed = _build_downstream_bed(df, downstream_nt=24)
+        assert bed.iloc[0]["end"] == 324
+
+
+class TestParseFasta:
+    def test_parses_single_record(self, tmp_path):
+        fa = tmp_path / "test.fa"
+        fa.write_text(">header1\nATCGATCG\n")
+        result = _parse_fasta(fa)
+        assert result == {"header1": "ATCGATCG"}
+
+    def test_parses_multiple_records(self, tmp_path):
+        fa = tmp_path / "test.fa"
+        fa.write_text(">seq1\nAAAA\n>seq2\nCCCC\n")
+        result = _parse_fasta(fa)
+        assert result["seq1"] == "AAAA"
+        assert result["seq2"] == "CCCC"
+
+    def test_strips_bedtools_coordinate_suffix(self, tmp_path):
+        # bedtools getfasta -name appends ::chrom:start-end to the header
+        fa = tmp_path / "test.fa"
+        fa.write_text(">chr22:201:300:+::chr22:174-200\nATCG\n")
+        result = _parse_fasta(fa)
+        assert "chr22:201:300:+" in result
+
+    def test_empty_file_returns_empty_dict(self, tmp_path):
+        fa = tmp_path / "empty.fa"
+        fa.write_text("")
+        assert _parse_fasta(fa) == {}

--- a/workflow/tests/test_filter_junctions.py
+++ b/workflow/tests/test_filter_junctions.py
@@ -1,0 +1,262 @@
+"""Tests for filter_junctions.py — junction origin classification logic."""
+
+import pandas as pd
+import pytest
+
+from filter_junctions import (
+    _build_normal_junction_set,
+    _load_reference_junctions,
+    _parse_junction_id,
+    classify_junctions,
+)
+
+
+# ---------------------------------------------------------------------------
+# _parse_junction_id
+# ---------------------------------------------------------------------------
+
+class TestParseJunctionId:
+    def test_colon_separator(self):
+        # Standard format: chr:start:end:strand (1-based start → 0-based)
+        assert _parse_junction_id("chr22:101:200:+") == ("chr22", 100, 200, "+")
+
+    def test_minus_strand(self):
+        assert _parse_junction_id("chr1:51:150:-") == ("chr1", 50, 150, "-")
+
+    def test_dash_separator_fallback(self):
+        # Some tools emit chr-start-end-strand
+        assert _parse_junction_id("chr22-101-200-+") == ("chr22", 100, 200, "+")
+
+    def test_invalid_strand_becomes_dot(self):
+        result = _parse_junction_id("chr22:101:200:?")
+        assert result is not None
+        assert result[3] == "."
+
+    def test_too_few_parts_returns_none(self):
+        assert _parse_junction_id("chr22:100") is None
+
+    def test_non_numeric_coords_returns_none(self):
+        assert _parse_junction_id("chr22:abc:200:+") is None
+
+    def test_start_converts_to_zero_based(self):
+        # 1-based start 1 → 0-based start 0
+        chrom, start, end, strand = _parse_junction_id("chr22:1:100:+")
+        assert start == 0
+        assert end == 100
+
+
+# ---------------------------------------------------------------------------
+# _load_reference_junctions
+# ---------------------------------------------------------------------------
+
+class TestLoadReferenceJunctions:
+    def test_loads_bed_correctly(self, tmp_path):
+        bed = tmp_path / "ref.bed"
+        # BED6: chrom, start, end, name, score, strand
+        bed.write_text(
+            "chr22\t100\t200\tjunc1\t0\t+\n"
+            "chr22\t300\t400\tjunc2\t0\t-\n"
+        )
+        ref = _load_reference_junctions(bed)
+        assert ("chr22", 100, 200, "+") in ref
+        assert ("chr22", 300, 400, "-") in ref
+        assert len(ref) == 2
+
+    def test_skips_comment_lines(self, tmp_path):
+        bed = tmp_path / "ref.bed"
+        bed.write_text(
+            "# comment\n"
+            "chr22\t100\t200\tjunc1\t0\t+\n"
+        )
+        ref = _load_reference_junctions(bed)
+        assert len(ref) == 1
+
+    def test_skips_short_lines(self, tmp_path):
+        bed = tmp_path / "ref.bed"
+        bed.write_text("chr22\t100\t200\n")  # only 3 columns
+        ref = _load_reference_junctions(bed)
+        assert len(ref) == 0
+
+
+# ---------------------------------------------------------------------------
+# _build_normal_junction_set
+# ---------------------------------------------------------------------------
+
+class TestBuildNormalJunctionSet:
+    def _write_junction_file(self, path, rows):
+        """Write a junction TSV: junction_id<TAB>reads."""
+        path.write_text("".join(f"{jid}\t{reads}\n" for jid, reads in rows))
+
+    def test_includes_junctions_above_min_reads(self, tmp_path):
+        f = tmp_path / "normal.tsv"
+        self._write_junction_file(f, [("chr22:101:200:+", 5)])
+        ref = frozenset()
+        result = _build_normal_junction_set([(f, "normal")], ref, min_reads=2)
+        assert ("chr22", 100, 200, "+") in result
+
+    def test_excludes_junctions_below_min_reads(self, tmp_path):
+        f = tmp_path / "normal.tsv"
+        self._write_junction_file(f, [("chr22:101:200:+", 1)])
+        ref = frozenset()
+        result = _build_normal_junction_set([(f, "normal")], ref, min_reads=2)
+        assert ("chr22", 100, 200, "+") not in result
+
+    def test_excludes_reference_junctions(self, tmp_path):
+        f = tmp_path / "normal.tsv"
+        self._write_junction_file(f, [("chr22:101:200:+", 5)])
+        ref = frozenset({("chr22", 100, 200, "+")})
+        result = _build_normal_junction_set([(f, "normal")], ref, min_reads=2)
+        assert len(result) == 0
+
+    def test_empty_normal_files_returns_empty_set(self):
+        result = _build_normal_junction_set([], frozenset(), min_reads=2)
+        assert len(result) == 0
+
+
+# ---------------------------------------------------------------------------
+# classify_junctions (integration)
+# ---------------------------------------------------------------------------
+
+class TestClassifyJunctions:
+    def _write_junction_file(self, path, rows):
+        path.write_text("".join(f"{jid}\t{reads}\n" for jid, reads in rows))
+
+    def _write_manifest(self, path, entries):
+        """entries: list of (file_id, sample_type)"""
+        lines = ["file_id\tfile_name\tsample_type\tproject_id\n"]
+        for file_id, sample_type in entries:
+            lines.append(f"{file_id}\t{file_id}.tsv\t{sample_type}\tlocal\n")
+        path.write_text("".join(lines))
+
+    def _write_reference_bed(self, path, junctions):
+        """junctions: list of (chrom, start, end, strand)"""
+        lines = [f"{c}\t{s}\t{e}\tjunc\t0\t{st}\n" for c, s, e, st in junctions]
+        path.write_text("".join(lines))
+
+    def test_tumor_specific_labeled_correctly(self, tmp_path):
+        files_dir = tmp_path / "files"
+        files_dir.mkdir()
+
+        # Junction only in tumor → tumor_specific.
+        # Add a low-read noise junction so the high-read one clears the mean filter
+        # (classify_junctions keeps junctions with reads > mean).
+        tumor_f = files_dir / "tumor.tsv"
+        normal_f = files_dir / "normal.tsv"
+        self._write_junction_file(tumor_f, [
+            ("chr22:201:300:+", 100),  # unannotated, absent in normal
+            ("chr22:401:500:+", 1),    # noise — below mean, filtered out
+        ])
+        self._write_junction_file(normal_f, [])
+
+        manifest = tmp_path / "manifest.tsv"
+        self._write_manifest(manifest, [
+            ("tumor", "Primary Tumor"),
+            ("normal", "Solid Tissue Normal"),
+        ])
+
+        ref_bed = tmp_path / "ref.bed"
+        self._write_reference_bed(ref_bed, [("chr22", 100, 200, "+")])
+
+        output = tmp_path / "novel.tsv"
+        classify_junctions(
+            junction_files=[tumor_f, normal_f],
+            manifest_path=manifest,
+            reference_bed=ref_bed,
+            output_path=output,
+        )
+
+        df = pd.read_csv(output, sep="\t")
+        assert len(df) == 1
+        assert df.iloc[0]["junction_origin"] == "tumor_specific"
+
+    def test_patient_specific_labeled_correctly(self, tmp_path):
+        files_dir = tmp_path / "files"
+        files_dir.mkdir()
+
+        # Same junction in both tumor and normal → patient_specific
+        tumor_f = files_dir / "tumor.tsv"
+        normal_f = files_dir / "normal.tsv"
+        self._write_junction_file(tumor_f, [
+            ("chr22:201:300:+", 100),
+            ("chr22:401:500:+", 1),  # noise — below mean, filtered out
+        ])
+        self._write_junction_file(normal_f, [("chr22:201:300:+", 5)])
+
+        manifest = tmp_path / "manifest.tsv"
+        self._write_manifest(manifest, [
+            ("tumor", "Primary Tumor"),
+            ("normal", "Solid Tissue Normal"),
+        ])
+
+        ref_bed = tmp_path / "ref.bed"
+        self._write_reference_bed(ref_bed, [])
+
+        output = tmp_path / "novel.tsv"
+        classify_junctions(
+            junction_files=[tumor_f, normal_f],
+            manifest_path=manifest,
+            reference_bed=ref_bed,
+            output_path=output,
+        )
+
+        df = pd.read_csv(output, sep="\t")
+        assert len(df) == 1
+        assert df.iloc[0]["junction_origin"] == "patient_specific"
+
+    def test_annotated_junctions_discarded(self, tmp_path):
+        files_dir = tmp_path / "files"
+        files_dir.mkdir()
+
+        tumor_f = files_dir / "tumor.tsv"
+        normal_f = files_dir / "normal.tsv"
+        self._write_junction_file(tumor_f, [("chr22:101:200:+", 100)])
+        self._write_junction_file(normal_f, [])
+
+        manifest = tmp_path / "manifest.tsv"
+        self._write_manifest(manifest, [
+            ("tumor", "Primary Tumor"),
+            ("normal", "Solid Tissue Normal"),
+        ])
+
+        ref_bed = tmp_path / "ref.bed"
+        # Junction chr22:100:200:+ is annotated (0-based = 100, 1-based start = 101)
+        self._write_reference_bed(ref_bed, [("chr22", 100, 200, "+")])
+
+        output = tmp_path / "novel.tsv"
+        classify_junctions(
+            junction_files=[tumor_f, normal_f],
+            manifest_path=manifest,
+            reference_bed=ref_bed,
+            output_path=output,
+        )
+
+        df = pd.read_csv(output, sep="\t")
+        assert len(df) == 0
+
+    def test_no_normal_sample_all_labeled_tumor_specific(self, tmp_path):
+        files_dir = tmp_path / "files"
+        files_dir.mkdir()
+
+        tumor_f = files_dir / "tumor.tsv"
+        self._write_junction_file(tumor_f, [
+            ("chr22:201:300:+", 100),
+            ("chr22:401:500:+", 1),  # noise — below mean, filtered out
+        ])
+
+        manifest = tmp_path / "manifest.tsv"
+        self._write_manifest(manifest, [("tumor", "Primary Tumor")])
+
+        ref_bed = tmp_path / "ref.bed"
+        self._write_reference_bed(ref_bed, [])
+
+        output = tmp_path / "novel.tsv"
+        classify_junctions(
+            junction_files=[tumor_f],
+            manifest_path=manifest,
+            reference_bed=ref_bed,
+            output_path=output,
+        )
+
+        df = pd.read_csv(output, sep="\t")
+        assert len(df) == 1
+        assert df.iloc[0]["junction_origin"] == "tumor_specific"

--- a/workflow/tests/test_generate_report.py
+++ b/workflow/tests/test_generate_report.py
@@ -1,0 +1,28 @@
+"""Tests for generate_report.py — HTML generation helpers."""
+
+import pandas as pd
+
+from generate_report import _df_to_html
+
+
+class TestDfToHtml:
+    def test_empty_dataframe_returns_no_data_message(self):
+        df = pd.DataFrame(columns=["a", "b"])
+        assert _df_to_html(df) == "<p><em>No data.</em></p>"
+
+    def test_small_dataframe_returns_html_table(self):
+        df = pd.DataFrame({"sample": ["s1"], "count": [5]})
+        html = _df_to_html(df)
+        assert "<table" in html
+        assert "s1" in html
+
+    def test_large_dataframe_shows_truncation_message(self):
+        df = pd.DataFrame({"x": range(200)})
+        html = _df_to_html(df, max_rows=10)
+        assert "Showing 10 of 200 rows" in html
+
+    def test_large_dataframe_respects_max_rows(self):
+        df = pd.DataFrame({"x": range(50)})
+        html = _df_to_html(df, max_rows=10)
+        # Only 10 data rows should be in the table (row 0–9, not 10–49)
+        assert "49" not in html

--- a/workflow/tests/test_translate_peptides.py
+++ b/workflow/tests/test_translate_peptides.py
@@ -1,0 +1,56 @@
+"""Tests for translate_peptides.py — in-silico translation logic."""
+
+from translate_peptides import translate_contig
+
+
+class TestTranslateContig:
+    def test_frame0_basic(self):
+        # ATG = Met, GGG = Gly, ... simple 50 nt contig, no stop codon
+        # Use a known sequence: 48 nt → 16 aa in frame 0
+        seq = "ATG" * 16  # 48 nt, all Met
+        results = translate_contig(seq, reading_frames=[0], peptide_length=16)
+        assert len(results) == 1
+        frame, peptide = results[0]
+        assert frame == 0
+        assert peptide == "M" * 16
+
+    def test_all_three_frames(self):
+        # GCC (Ala) repeated: no stop codons in any reading frame
+        # Frame 0: GCC GCC... = Ala; Frame 1: CCG CCG... = Pro; Frame 2: CGC CGC... = Arg
+        seq = "GCC" * 17  # 51 nt
+        results = translate_contig(seq, reading_frames=[0, 1, 2], peptide_length=16)
+        frames_returned = {r[0] for r in results}
+        assert frames_returned == {0, 1, 2}
+
+    def test_stop_codon_truncates_peptide(self):
+        # TAA is a stop codon; peptide should be truncated before it
+        # Frame 0: ATG ATG TAA ... → "MM" (2 aa) — too short, filtered out
+        # Use a longer prefix: 8× ATG then TAA
+        seq = "ATG" * 8 + "TAA" + "ATG" * 5
+        results = translate_contig(seq, reading_frames=[0], peptide_length=16)
+        assert len(results) == 1
+        frame, peptide = results[0]
+        assert "*" not in peptide
+        assert len(peptide) == 8
+
+    def test_immediate_stop_codon_excluded(self):
+        # TAA at position 0 in frame 0 → no peptide for that frame
+        seq = "TAA" + "ATG" * 20
+        results = translate_contig(seq, reading_frames=[0], peptide_length=16)
+        assert len(results) == 0
+
+    def test_short_peptide_filtered_out(self):
+        # Only 6 aa before stop → below _MIN_PEPTIDE_LENGTH (8), excluded
+        seq = "ATG" * 6 + "TAA" + "ATG" * 10
+        results = translate_contig(seq, reading_frames=[0], peptide_length=16)
+        assert len(results) == 0
+
+    def test_peptide_trimmed_to_target_length(self):
+        seq = "ATG" * 20  # 60 nt → 20 aa in frame 0, trimmed to 16
+        results = translate_contig(seq, reading_frames=[0], peptide_length=16)
+        assert len(results) == 1
+        assert len(results[0][1]) == 16
+
+    def test_empty_sequence_returns_nothing(self):
+        results = translate_contig("", reading_frames=[0, 1, 2], peptide_length=16)
+        assert results == []


### PR DESCRIPTION
## Summary

- Adds `workflow/tests/` with 42 pytest tests covering the pure logic functions in the four core scripts
- `test_filter_junctions.py` — junction ID parsing (coordinate conversion, malformed input), reference BED loading, normal junction set building (min_reads threshold), and full `classify_junctions` end-to-end with mock files (tumor_specific, patient_specific, annotated discard, tumor-only mode)
- `test_translate_peptides.py` — frame offsets, stop codon truncation, minimum peptide length filter
- `test_assemble_contigs.py` — soft-clip detection, upstream/downstream BED coordinate arithmetic, FASTA parsing
- `test_generate_report.py` — empty DataFrame handling, row truncation
- Adds `pytest >=8.0` to `workflow/envs/python.yaml`
- Branch rebased onto `5-junction-provenance-classification` (depends on that PR)

## Test plan

- [x] 42/42 tests pass locally (`python -m pytest workflow/tests/ -v`)

## Notes

Tests cover only pure Python functions — rules that shell out to HISAT2, bedtools, or MHCflurry are validated by the end-to-end pipeline run instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)