### PR TITLE
Add prepare_production_data.sh and update samples.tsv for production run

### DIFF
--- a/config/samples.tsv
+++ b/config/samples.tsv
@@ -1,21 +1,18 @@
 sample_id	sample_type	fastq1	fastq2
-
-# Example entries — replace with your actual sample data
-# Delete these comment lines and add your samples below
+# ---------------------------------------------------------------------------
+# Sample manifest — replace with your own samples.
 #
-# For tumor vs normal comparison (Fisher's exact test):
-#   - Use "Primary Tumor" for tumor samples
-#   - Use "Solid Tissue Normal" for normal samples
+# Column descriptions:
+#   sample_id    Unique sample identifier (used as file names in results)
+#   sample_type  "Primary Tumor" or "Solid Tissue Normal"
+#                  Primary Tumor        — junctions used for neoepitope prediction
+#                  Solid Tissue Normal  — used to filter out patient-specific junctions
+#   fastq1       Path to FASTQ file (or read 1 for paired-end)
+#   fastq2       Path to read 2 FASTQ for paired-end data (leave empty for single-end)
 #
-# For single-end RNA-Seq, leave the fastq2 column empty
-#
-# Example paired-end samples:
-# tumor_sample_01	Primary Tumor	data/tumor_01_R1.fastq.gz	data/tumor_01_R2.fastq.gz
-# tumor_sample_02	Primary Tumor	data/tumor_02_R1.fastq.gz	data/tumor_02_R2.fastq.gz
-# normal_sample_01	Solid Tissue Normal	data/normal_01_R1.fastq.gz	data/normal_01_R2.fastq.gz
-#
-# Example single-end samples:
-# tumor_sample_03	Primary Tumor	data/tumor_03.fastq.gz	
-# normal_sample_02	Solid Tissue Normal	data/normal_02.fastq.gz	
-
-SRR37781424	Primary Tumor	data/SRR37781424_1.fastq	data/SRR37781424_2.fastq
+# Example below: matched gastric cancer tumor/normal pair (SRR9143066 / SRR9143065)
+# Source: https://www.ebi.ac.uk/ena/browser/view/SRR9143066
+# Download with: bash scripts/prepare_production_data.sh
+# ---------------------------------------------------------------------------
+gastric_tumor	Primary Tumor	data/gastric_tumor.fastq.gz
+gastric_normal	Solid Tissue Normal	data/gastric_normal.fastq.gz

--- a/scripts/prepare_production_data.sh
+++ b/scripts/prepare_production_data.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# scripts/prepare_production_data.sh
+#
+# Download full FASTQs for the matched gastric cancer tumor/normal pair.
+#
+# Samples:
+#   SRR9143066 — Primary Tumor (gastric cancer surgical section, HiSeq 3000, single-end)
+#   SRR9143065 — Solid Tissue Normal (adjacent stomach tissue, HiSeq 3000, single-end)
+#
+# Files are downloaded via ENA HTTPS — no sra-tools or controlled access required.
+# The reference genome (GRCh38 FASTA + GENCODE GTF) is downloaded by setup_cloud.sh.
+#
+# Usage:
+#   bash scripts/prepare_production_data.sh
+#
+# After this script finishes, run the pipeline with:
+#   conda activate snakemake
+#   snakemake --cores $(nproc) --use-conda 2>&1 | tee pipeline.log ; bash auto_stop.sh
+#
+set -euo pipefail
+
+DATA="data"
+mkdir -p "$DATA"
+
+TUMOR_URL="https://ftp.sra.ebi.ac.uk/vol1/fastq/SRR914/006/SRR9143066/SRR9143066.fastq.gz"
+NORMAL_URL="https://ftp.sra.ebi.ac.uk/vol1/fastq/SRR914/005/SRR9143065/SRR9143065.fastq.gz"
+
+echo "=== Downloading production FASTQs ==="
+echo "    Tumor:  SRR9143066 (~several GB — may take 30–60 min)"
+echo "    Normal: SRR9143065 (~several GB — may take 30–60 min)"
+echo ""
+
+if [[ -f "$DATA/gastric_tumor.fastq.gz" ]]; then
+    echo "    Tumor FASTQ already exists — skipping."
+else
+    echo "    Downloading tumor (SRR9143066)..."
+    curl --fail -L --progress-bar "$TUMOR_URL" -o "$DATA/gastric_tumor.fastq.gz"
+    if ! gzip -t "$DATA/gastric_tumor.fastq.gz" 2>/dev/null; then
+        echo "ERROR: Tumor FASTQ download appears corrupt." >&2; exit 1
+    fi
+    echo "    Saved: $DATA/gastric_tumor.fastq.gz"
+fi
+
+echo ""
+
+if [[ -f "$DATA/gastric_normal.fastq.gz" ]]; then
+    echo "    Normal FASTQ already exists — skipping."
+else
+    echo "    Downloading normal (SRR9143065)..."
+    curl --fail -L --progress-bar "$NORMAL_URL" -o "$DATA/gastric_normal.fastq.gz"
+    if ! gzip -t "$DATA/gastric_normal.fastq.gz" 2>/dev/null; then
+        echo "ERROR: Normal FASTQ download appears corrupt." >&2; exit 1
+    fi
+    echo "    Saved: $DATA/gastric_normal.fastq.gz"
+fi
+
+echo ""
+echo "=== Downloads complete! ==="
+echo ""
+echo "Run the pipeline with:"
+echo "    conda activate snakemake"
+echo "    snakemake --cores \$(nproc) --use-conda 2>&1 | tee pipeline.log ; bash auto_stop.sh"


### PR DESCRIPTION
## Summary

- Adds `scripts/prepare_production_data.sh` — downloads the full FASTQs for the matched gastric cancer tumor/normal pair (SRR9143066 / SRR9143065) from ENA HTTPS, with `--fail` and `gzip -t` validation
- Updates `config/samples.tsv` with the production samples, usage comments, column descriptions, and ENA source link

## Test plan

- [x] CI passes

## Next step

Spin up a VM, run `setup_cloud.sh` + `prepare_production_data.sh`, then run the full pipeline.

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)