### PR TITLE
Filter 9-mers to only those spanning the splice junction breakpoint

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,9 +7,9 @@ Update this file only when something is **not derivable from the code or git his
 Modernised reimplementation of a 2015 cancer neoepitope prediction pipeline (Jin-Ho Lee, Seoul National University). Identifies tumor-specific splice junctions from RNA-Seq data and predicts MHC-binding neoepitopes.
 
 ## Infrastructure
-- Running on a GCP Compute Engine VM (`splice-pipeline`, `us-central1-a`)
-- See `docs/google_cloud_guide.md` for full setup instructions
-- Pipeline is run with `snakemake --cores $(nproc) --use-conda` inside a `tmux` session
+- Running on GCP Compute Engine VMs — see `docs/google_cloud_guide.md` for full setup
+- Current production VM: `splice-prod-test`, `europe-west1-b` (zone varies by quota availability; us-central1 has been exhausted in the past)
+- Pipeline is run with `snakemake --cores $(nproc) --use-conda --rerun-triggers mtime` inside a `tmux` session
 
 ## Pipeline Design Decisions
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,8 @@ RNA-Seq data (local FASTQ files or GDC API)
   16-mer peptides (3 reading frames, truncated at stop codons)
         │
         ▼ Step 5: Predict
-  MHCflurry 2.x → IC50 binding affinities (HLA-A*02:01, 9-mers)
+  Junction-spanning 9-mer filter → MHCflurry 2.x → IC50 binding affinities (HLA-A*02:01)
+  (filter currently applied here; will move to Step 4 in issue #20)
         │
         ▼ Step 6: Report
   Junction origin summary + top binders HTML report
@@ -603,6 +604,7 @@ pipeline to this modernised implementation.  See
 | Data source | TCGA HTTP directory (retired) | **GDC Data Portal REST API** | TCGA HTTP retired in 2016 |
 | RNA-Seq aligner | TopHat2 | **HISAT2** (default) / **STAR** (optional) | HISAT2 for low-memory runs; STAR planned for production (issue #17) |
 | Epitope predictor | NetMHCPan **2.8** | **MHCflurry 2.x** | Open source; no registration; SOTA accuracy |
+| Junction-spanning filter | None (all 9-mers included) | **Complete-codon rule** — only 9-mers with ≥1 full codon from each exon retained (issue #18); will move to contig assembly step (issue #20) | Eliminates purely exonic false positives (e.g. `YLADLYHFV` = SH3BP1) |
 | Biopython API | `Bio.Alphabet` | **`Bio.Seq` only** | `Bio.Alphabet` removed in Biopython ≥1.78 |
 | Workflow management | Manual shell scripts | **Snakemake** | Reproducibility, parallelism, DAG tracking |
 | Environment management | None | **Conda** (per rule) | Reproducible software environments |

--- a/README.md
+++ b/README.md
@@ -28,26 +28,21 @@ RNA-Seq.
 11. [Modernisation Changelog](#modernisation-changelog)
 12. [Project Structure](#project-structure)
 13. [Citation](#citation)
+14. [Further Reading](#further-reading)
 
 ---
 
 ## Scientific Background
 
-Cancer cells frequently harbour somatic mutations and aberrant splicing events.
-Novel splice junctions — those not present in the reference transcriptome —
-can produce peptide sequences that are absent from normal tissues and therefore
-recognisable as foreign by the immune system.  These **neoepitopes** are
-candidate targets for cancer immunotherapy.
+Tumors frequently exhibit splice junctions absent from matched normal tissue.
+These tumor-specific junctions can produce novel peptide sequences — **neoepitopes** —
+that are recognisable as foreign by the immune system and are candidate targets for
+cancer immunotherapy.
 
-This pipeline:
-1. Generates splice junction quantification from RNA-Seq data (local alignment or GDC download).
-2. Classifies junctions by origin: removes annotated (GENCODE) junctions, then separates tumor-specific from patient-specific junctions using the matched normal sample.
-3. Constructs short nucleotide contigs spanning each tumor-specific junction.
-4. Translates the contigs into peptides in all three reading frames.
-5. Predicts MHC-I binding affinity using MHCflurry 2.x.
+This pipeline identifies those junctions from RNA-seq data, filters them against the
+matched normal sample, and predicts which resulting peptides bind MHC class I molecules.
 
-Cancer types analysed: **BRCA** (breast adenocarcinoma), **LUAD** (lung
-adenocarcinoma), **LAML** (acute myeloid leukemia).
+> For full biological background and study design, see [`docs/INTRODUCTION.md`](docs/INTRODUCTION.md).
 
 ---
 
@@ -199,7 +194,7 @@ This pipeline supports two data source modes:
 
 | Mode | Institutional Access | Description |
 |------|---------------------|-------------|
-| **Local Alignment** | ❌ Not required | Align your own FASTQ files using STAR |
+| **Local Alignment** | ❌ Not required | Align your own FASTQ files using HISAT2 or STAR |
 | **GDC Download** | ✅ Required | Download pre-computed files from GDC |
 
 ---
@@ -606,7 +601,7 @@ pipeline to this modernised implementation.  See
 | Reference genome | hg19 | **GRCh38/hg38** | Current standard assembly |
 | Reference annotation | UCSC RefSeq hg19 | **GENCODE v47 GRCh38** | Comprehensive, programmatically reproducible |
 | Data source | TCGA HTTP directory (retired) | **GDC Data Portal REST API** | TCGA HTTP retired in 2016 |
-| RNA-Seq aligner | TopHat2 | **STAR** (GDC harmonised) | GDC re-aligned all TCGA data with STAR |
+| RNA-Seq aligner | TopHat2 | **HISAT2** (default) / **STAR** (optional) | HISAT2 for low-memory runs; STAR planned for production (issue #17) |
 | Epitope predictor | NetMHCPan **2.8** | **MHCflurry 2.x** | Open source; no registration; SOTA accuracy |
 | Biopython API | `Bio.Alphabet` | **`Bio.Seq` only** | `Bio.Alphabet` removed in Biopython ≥1.78 |
 | Workflow management | Manual shell scripts | **Snakemake** | Reproducibility, parallelism, DAG tracking |
@@ -655,8 +650,11 @@ splice-neoepitope-pipeline/
 │       ├── run_mhcflurry.py          # MHCflurry 2.x wrapper + parser
 │       └── generate_report.py        # HTML report generation
 ├── docs/
-│   ├── modernization_notes.md        # Detailed change log
-│   └── google_cloud_guide.md         # GCP setup and cost guide
+│   ├── INTRODUCTION.md               # Biological background and study design
+│   ├── METHODS.md                    # Technical pipeline description
+│   ├── DISCUSSIONS.md                # Design tradeoffs and future directions
+│   ├── google_cloud_guide.md         # GCP setup and cost guide
+│   └── modernization_notes.md        # Detailed change log from 2015 pipeline
 └── resources/
     └── README.md                     # Instructions for reference data
 ```
@@ -685,3 +683,16 @@ And the key tools used:
 - **GENCODE**: Frankish et al. (2023). GENCODE: reference annotation for the
   human and mouse genomes in 2023. *Nucleic Acids Research*, 51(D1),
   D942–D949.
+
+---
+
+## Further Reading
+
+Detailed documentation for the pipeline is available in the `docs/` directory:
+
+| Document | Contents |
+|----------|----------|
+| [`docs/INTRODUCTION.md`](docs/INTRODUCTION.md) | Biological background, motivation, and study design |
+| [`docs/METHODS.md`](docs/METHODS.md) | Technical pipeline description with diagrams and formulas |
+| [`docs/DISCUSSIONS.md`](docs/DISCUSSIONS.md) | Design tradeoffs, known limitations, and future directions |
+| [`docs/google_cloud_guide.md`](docs/google_cloud_guide.md) | Step-by-step GCP setup and run guide |

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -7,8 +7,8 @@
 # -----------------------------------------------------------------
 # "gdc"   — Download pre-computed splice junction files from GDC (requires
 #           institutional dbGaP access and a GDC authentication token)
-# "local" — Align your own RNA-Seq FASTQ files using STAR (no institutional
-#           access required; uses publicly available or your own data)
+# "local" — Align your own RNA-Seq FASTQ files using HISAT2 or STAR (no
+#           institutional access required; uses publicly available or your own data)
 data_source: "local"
 
 # -----------------------------------------------------------------

--- a/docs/DISCUSSIONS.md
+++ b/docs/DISCUSSIONS.md
@@ -1,0 +1,86 @@
+# Discussions
+
+Deeper reasoning behind design decisions, known tradeoffs, and open questions.
+Intended as a living document to inform a future Discussion section in a publication.
+
+---
+
+## Junction-spanning filter: chimeric codons and the complete-codon rule
+
+The junction-spanning filter (see `METHODS.md` §5.2) requires each retained 9-mer to
+contain at least one **complete codon** from each side of the splice junction. This is
+a conservative approximation that warrants discussion.
+
+### Why chimeric codons are not checked individually
+
+A chimeric codon — one whose three nucleotides span the junction (e.g. 2 upstream nt +
+1 downstream nt) — could in principle encode a novel amino acid not present in the
+normal protein. A more precise implementation would translate each chimeric codon and
+compare it against the reference proteome, keeping the 9-mer only when the amino acid
+genuinely differs.
+
+In practice this check is omitted for two reasons:
+
+1. **Codon degeneracy makes chimeric codons unreliable.** The downstream exon may
+   contribute a nucleotide that, combined with the upstream nucleotides, still encodes
+   the same amino acid. This was observed directly in the first gastric cancer
+   production run: the chimeric last codon of `YLADLYHFV` still encoded valine (V),
+   making the entire 9-mer identical to SH3BP1 residues 209–217. There is no guarantee
+   that a chimeric codon is novel without explicitly checking.
+
+2. **Peripheral amino acid changes have limited biological impact.** MHC class I
+   binding affinity is governed primarily by **anchor positions** — typically positions
+   2 and 9 for HLA-A\*02:01 (P2 and PΩ anchor motif). A single amino acid change at
+   a peripheral position (1 or 8) arising from a chimeric codon is unlikely to
+   meaningfully alter binding affinity or T-cell receptor (TCR) recognition. Such
+   peptides are therefore weak neoepitope candidates even if the amino acid does differ.
+
+### Conservative bias and its justification
+
+The complete-codon rule discards some true positives near the junction boundary.
+Peptides retained by the rule contain multiple novel downstream amino acids and are more
+likely to be genuinely foreign to the immune system. This conservative bias is
+preferable in a discovery context: the cost of a missed weak candidate is lower than the
+cost of pursuing a false positive through expensive downstream validation.
+
+### Future refinement
+
+A hybrid approach could be considered: apply the complete-codon rule as the primary
+filter, then optionally recover chimeric-codon 9-mers where the altered amino acid falls
+at an anchor position (P2 or P9). These would represent a small, high-confidence set of
+junction-boundary candidates worth investigating further.
+
+---
+
+## Normal sample filtering: junction level vs. peptide level
+
+Tumor-specific junctions are currently defined by absence in the matched normal sample
+at the **junction level** (see `METHODS.md` §3). An alternative approach would be to
+run MHC binding prediction on both tumor and normal samples and subtract normal
+predictions from tumor predictions at the **peptide level**.
+
+The junction-level approach was chosen because:
+
+- It is computationally cheaper (normal predictions never need to be run).
+- A junction present in normal tissue is not tumor-specific by definition, regardless
+  of the peptide it produces.
+
+The peptide-level approach would additionally catch cases where a tumor-specific junction
+produces a peptide that happens to match a normal protein at a completely different
+genomic locus. The junction-spanning filter addresses the most common version of this
+(same-locus exonic sequence), but a cross-proteome BLAST check would be more thorough.
+This remains an open improvement.
+
+---
+
+## HISAT2 vs. STAR for novel junction detection
+
+HISAT2 is used for local development and testing (macOS M1, 8 GB RAM). Benchmarks
+consistently show STAR to be more sensitive for novel/unannotated junction detection,
+which is the critical step for this pipeline. STAR requires ~32 GB RAM for the full
+GRCh38 index and is therefore unsuitable for local runs but appropriate for cloud
+production runs.
+
+A planned comparison (issue #17) will run both aligners on the same gastric cancer
+samples and compare the number and quality of tumor-specific junctions detected. The
+HISAT2 production run provides a baseline.

--- a/docs/INTRODUCTION.md
+++ b/docs/INTRODUCTION.md
@@ -1,0 +1,72 @@
+# Introduction
+
+Draft introduction for the splice neoepitope prediction pipeline.
+Intended as a living document to be refined into a publication introduction section.
+
+---
+
+## Cancer Neoepitopes
+
+The immune system can recognize and eliminate tumor cells through cytotoxic T lymphocytes
+(CTLs) that detect tumor-specific peptides presented on MHC class I molecules at the cell
+surface. These peptides — neoepitopes — arise from somatic alterations in tumor cells that
+produce protein sequences absent from normal tissue and therefore not subject to central
+immune tolerance.
+
+Neoepitope-based immunotherapy has emerged as a promising approach in cancer treatment,
+underpinning the development of personalized cancer vaccines and adoptive T-cell therapies.
+Most neoepitope discovery pipelines focus on single-nucleotide variants (SNVs) and small
+insertions/deletions (indels) as the source of altered peptide sequences. However, a
+broader class of tumor-specific alterations — aberrant splicing — has received comparatively
+less attention despite its potential to generate highly immunogenic neoepitopes.
+
+---
+
+## Aberrant Splicing in Cancer
+
+Alternative splicing is a fundamental mechanism of gene regulation, and its dysregulation
+is a hallmark of cancer. Tumors frequently exhibit splice junctions that are absent from
+matched normal tissue, arising from mutations in splicing factor genes, alterations at
+splice donor/acceptor sites, or broader transcriptional dysregulation. These tumor-specific
+junctions can produce novel open reading frames encoding peptide sequences that are
+entirely absent from the normal proteome.
+
+Because splice-junction-derived neoepitopes arise from intronic or exon-boundary sequences
+that are never translated in normal tissue, they represent a class of truly tumor-specific
+antigens with strong potential for immune recognition.
+
+---
+
+## The Original 2015 Pipeline
+
+This project is a modernised reimplementation of a neoepitope prediction pipeline first
+developed in 2015 at Seoul National University (Jin-Ho Lee). The original pipeline
+identified tumor-specific splice junctions from RNA-seq data and predicted MHC-binding
+neoepitopes from the resulting novel peptide sequences. The core biological logic —
+filtering junctions against matched normal tissue and retaining only those absent from
+the normal transcriptome — remains unchanged.
+
+The reimplementation updates the toolchain to current standards:
+
+| Component | Original (2015) | Current |
+|---|---|---|
+| Aligner | TopHat | HISAT2 / STAR |
+| Junction extraction | TopHat output | regtools |
+| MHC binding prediction | NetMHCPan | MHCflurry 2.x |
+| Workflow management | custom scripts | Snakemake |
+| Reference genome | GRCh37/hg19 | GRCh38/hg38 |
+| Gene annotation | Ensembl | GENCODE v47 |
+
+---
+
+## Study Design
+
+This pipeline is applied to matched tumor/normal RNA-seq pairs. The matched normal sample
+serves as a patient-specific baseline: any splice junction present in the normal is
+considered a germline or tissue-specific splicing event and is excluded from neoepitope
+prediction. Only junctions that are (i) absent from the GENCODE annotation and (ii) absent
+from the matched normal sample are carried forward as tumor-specific candidates.
+
+The current study uses a matched gastric cancer tumor/normal pair (SRR9143066 / SRR9143065,
+gastric cancer surgical section and adjacent stomach tissue respectively; Illumina HiSeq
+3000, single-end). Data were obtained from the European Nucleotide Archive (ENA).

--- a/docs/METHODS.md
+++ b/docs/METHODS.md
@@ -1,0 +1,176 @@
+# Pipeline Methods
+
+Draft methods section for the splice neoepitope prediction pipeline.
+Intended as a living document to be refined into a publication methods section.
+
+---
+
+## Overview
+
+The pipeline identifies tumor-specific splice junctions from RNA-seq data and predicts
+peptides derived from those junctions that may bind MHC class I molecules (neoepitopes).
+The workflow is implemented in Snakemake and consists of five major stages: alignment,
+junction extraction, junction classification, contig assembly and translation, and
+MHC binding prediction.
+
+---
+
+## 1. RNA-seq Alignment
+
+Reads are aligned to the GRCh38 (hg38) reference genome using HISAT2 (v2.x), a
+splice-aware aligner. Alignments are output as coordinate-sorted BAM files using
+samtools. For single-end data, HISAT2 is run with the `-U` flag.
+
+---
+
+## 2. Splice Junction Extraction
+
+Splice junctions are extracted from the aligned BAM files using regtools
+(`junctions extract`), with the following parameters:
+
+- Minimum anchor length: 8 nt (`-a 8`)
+- Minimum intron length: 50 nt (`-m 50`)
+- Maximum intron length: 500,000 nt (`-M 500000`)
+- Strand specificity inferred from the XS tag (`-s XS`)
+
+Output is a BED file of junction coordinates with read support counts.
+
+---
+
+## 3. Junction Classification
+
+Junctions are classified into three categories:
+
+```
+all junctions
+  └─ annotated          (present in GENCODE annotation)   → discard
+  └─ unannotated        (absent from GENCODE annotation)
+       ├─ patient_specific   (also found in matched normal) → discard
+       └─ tumor_specific     (absent in matched normal)     → neoepitope prediction
+```
+
+**Annotated junctions** are filtered against the GENCODE v47 GTF reference junction set.
+
+**Patient-specific junctions** are filtered by comparing tumor junctions against the
+matched normal sample. A junction present in the normal at ≥ 2 reads is considered
+patient-specific (germline or tissue-specific splicing) and discarded. These are
+retained in the output TSV for reference but excluded from prediction.
+
+**Tumor-specific junctions** — unannotated and absent from the matched normal — are
+carried forward to neoepitope prediction.
+
+When no matched normal sample is available, all unannotated junctions are labeled
+`tumor_specific` with a warning.
+
+---
+
+## 4. Contig Assembly and Translation
+
+For each tumor-specific junction, a 50 nt nucleotide contig is assembled by joining:
+
+- 26 nt immediately upstream of the junction (last 26 nt of the upstream exon)
+- 24 nt immediately downstream of the junction (first 24 nt of the downstream exon)
+
+Contigs containing soft-clipped (lower-case) bases are excluded.
+
+Each contig is translated in all three reading frames (offsets 0, 1, 2), yielding
+up to three 16-mer peptide sequences per junction.
+
+---
+
+## 5. MHC Binding Prediction and Junction-Spanning Filter
+
+### 5.1 The junction-spanning filter
+
+A 16-mer peptide is sliced into 9-mers using a sliding window (8 windows per 16-mer).
+**Not all 9-mers are novel sequences**: those that fall entirely within one exon are
+identical to sequences present in the normal proteome and are therefore not valid
+neoepitope candidates.
+
+The diagram below illustrates the issue for reading frame 1 (offset 0):
+
+```
+50 nt contig
+|<---------- 26 nt upstream ---------->|<------- 24 nt downstream ------->|
+ nt: 0                                 26                                  49
+     ─────────────────────────────────┬──────────────────────────────────
+                                      ^
+                               junction breakpoint
+
+Codons (frame offset = 0, each codon spans 3 nt):
+  AA:  0     1     2     3  ...  7     8    ...
+  nt: 0-2   3-5   6-8  9-11 ... 21-23 24-26 ...
+                                        ^^^
+                                 codon spans junction (nt 24, 25 upstream; nt 26 downstream)
+
+9-mer sliding window positions (start_nt = i × 3 for frame offset 0):
+
+  i=0  start_nt= 0  covers nt  0–26  → last codon spans junction by 1 nt
+                                         but first 8 amino acids are purely upstream
+                                         ✗ FALSE POSITIVE (matches normal protein)
+
+  i=1  start_nt= 3  covers nt  3–29  → contains complete codons from both sides ✓
+  i=2  start_nt= 6  covers nt  6–32  ✓
+  ...
+  i=7  start_nt=21  covers nt 21–47  → contains complete codons from both sides ✓
+```
+
+### 5.2 Spanning condition
+
+Only 9-mers that contain **at least one complete codon from each side** of the junction
+are kept. For a 9-mer at 0-indexed position `i` with reading frame offset `f`:
+
+```
+start_nt = f + i × 3
+
+Keep if:   upstream_nt - (window_size - 1) × 3   ≤   start_nt   ≤   upstream_nt - 3
+           ───────────────────────────────────        ───────────────────────────────
+           ensures ≥ 1 downstream codon             ensures ≥ 1 upstream codon
+
+With defaults (upstream_nt = 26, window_size = 9):
+           2   ≤   start_nt   ≤   23
+```
+
+This filter was present in the original 2015 pipeline and is critical for avoiding
+false positives. Without it, the top-ranked strong binder in the gastric cancer
+production run (`YLADLYHFV`, IC50 = 9.4 nM) was found by BLAST to be residues 209–217
+of the normal SH3BP1 protein — a peptide the immune system is already tolerant to.
+
+### 5.3 MHCflurry prediction
+
+Junction-spanning 9-mers are scored for MHC class I binding affinity using MHCflurry
+2.x (`Class1AffinityPredictor`). Peptides are classified as:
+
+- **Strong binder:** IC50 < 50 nM
+- **Weak binder:** IC50 < 500 nM
+- **Non-binder:** IC50 ≥ 500 nM
+
+The default HLA allele is HLA-A\*02:01 (the most common allele in populations of
+European descent). Future work will incorporate patient-specific HLA typing.
+
+---
+
+## 6. Output
+
+The pipeline produces:
+
+| File | Contents |
+|------|----------|
+| `results/junctions/<cancer_type>/novel_junctions.tsv` | All unannotated junctions with origin labels |
+| `results/predictions/<cancer_type>/predictions.tsv` | All 9-mer predictions with IC50 and binder class |
+| `results/reports/<cancer_type>/report.html` | Summary HTML report |
+
+---
+
+## Known Limitations and Future Work
+
+- **Single HLA allele:** currently only HLA-A\*02:01 is scored. Patient-specific HLA
+  typing (e.g. via OptiType or HLA-HD) would improve clinical relevance.
+- **No proteome filter:** peptides are not cross-referenced against the full human
+  proteome beyond the junction-spanning filter. A BLAST or exact-match check against
+  the reference proteome would catch any remaining false positives.
+- **HISAT2 vs STAR:** STAR has been shown to detect more novel splice junctions in
+  benchmarks. Future production runs will compare results between the two aligners
+  (see issue #17).
+- **Pre-built genome index:** the HISAT2 index is currently built from scratch on each
+  new VM run (~60–90 min). Using a pre-built index (issue #16) would reduce startup time.

--- a/docs/METHODS.md
+++ b/docs/METHODS.md
@@ -105,15 +105,29 @@ Codons (frame offset = 0, each codon spans 3 nt):
 
 9-mer sliding window positions (start_nt = i × 3 for frame offset 0):
 
-  i=0  start_nt= 0  covers nt  0–26  → last codon spans junction by 1 nt
-                                         but first 8 amino acids are purely upstream
-                                         ✗ FALSE POSITIVE (matches normal protein)
+  i=0  start_nt= 0  covers nt  0–26
+       AA 0–7: nt  0–23  entirely upstream (8 normal amino acids)
+       AA 8:   nt 24–26  chimeric codon: 2 nt upstream + 1 nt downstream
+                                         ✗ FALSE POSITIVE — see note below
 
-  i=1  start_nt= 3  covers nt  3–29  → contains complete codons from both sides ✓
+  i=1  start_nt= 3  covers nt  3–29
+       AA 0:   nt  3– 5  entirely upstream (complete upstream codon) ✓
+       ...
+       AA 8:   nt 27–29  entirely downstream (complete downstream codon) ✓
+
   i=2  start_nt= 6  covers nt  6–32  ✓
   ...
-  i=7  start_nt=21  covers nt 21–47  → contains complete codons from both sides ✓
+  i=7  start_nt=21  covers nt 21–47  ✓
 ```
+
+**Why a chimeric codon is not enough (i=0 subtlety).**
+At i=0, the 9th amino acid's codon straddles the junction (2 upstream nt + 1 downstream
+nt).  In principle this codon could encode a novel amino acid not seen in the normal
+protein.  In practice it frequently does not — the downstream exon may contribute a
+nucleotide that still encodes the same amino acid by chance (codon degeneracy).  This is
+exactly what happened with `YLADLYHFV`: the last codon still encoded valine (V), so all
+9 amino acids matched the normal SH3BP1 sequence.  A chimeric codon gives no reliable
+guarantee of novelty; only a **complete downstream codon** does.
 
 ### 5.2 Spanning condition
 
@@ -125,7 +139,8 @@ start_nt = f + i × 3
 
 Keep if:   upstream_nt - (window_size - 1) × 3   ≤   start_nt   ≤   upstream_nt - 3
            ───────────────────────────────────        ───────────────────────────────
-           ensures ≥ 1 downstream codon             ensures ≥ 1 upstream codon
+           ensures last AA is fully downstream       ensures first AA is fully upstream
+           (complete downstream codon)               (complete upstream codon)
 
 With defaults (upstream_nt = 26, window_size = 9):
            2   ≤   start_nt   ≤   23

--- a/docs/google_cloud_guide.md
+++ b/docs/google_cloud_guide.md
@@ -113,6 +113,11 @@ would on any local machine.
 
 **Using gcloud CLI:**
 
+> **Zone availability:** `us-central1-a` is used as the example zone below, but
+> capacity for specific machine types varies. If you get a quota or availability
+> error, try another zone (e.g. `us-central1-c`, `europe-west1-b`, `us-east1-b`).
+> Run `gcloud compute zones list` to see all available zones.
+
 ```bash
 # For HISAT2 (8 GB RAM sufficient, using 16 GB for comfort)
 gcloud compute instances create splice-pipeline \
@@ -286,7 +291,7 @@ tmux new -s pipeline
 snakemake --cores 4 --use-conda -n
 
 # Inside tmux: full run — pipeline logs to pipeline.log, VM shuts down when done
-snakemake --cores $(nproc) --use-conda 2>&1 | tee pipeline.log ; bash auto_stop.sh
+snakemake --cores $(nproc) --use-conda --rerun-triggers mtime 2>&1 | tee pipeline.log ; bash auto_stop.sh
 ```
 
 > **Always include `; bash auto_stop.sh`** at the end of your run command.

--- a/workflow/rules/analysis.smk
+++ b/workflow/rules/analysis.smk
@@ -10,6 +10,7 @@ rule generate_report:
     input:
         novel_junctions=rules.filter_junctions.output.novel_junctions,
         predictions_tsv=rules.run_mhcflurry.output.predictions_tsv,
+        contigs_fasta=rules.assemble_contigs.output.contigs_fasta,
     output:
         report_html=os.path.join(
             OUT["reports"], "{cancer_type}", "report.html"

--- a/workflow/scripts/generate_report.py
+++ b/workflow/scripts/generate_report.py
@@ -18,6 +18,7 @@ Usage (Snakemake):
 """
 
 import argparse
+import html
 import logging
 from pathlib import Path
 
@@ -215,9 +216,9 @@ def _build_strong_table_html(
 
         rows.append(
             f"<tr>"
-            f"<td>{row['source_header']}</td>"
-            f"<td>{row['peptide_9mer']}</td>"
-            f"<td>{row['allele']}</td>"
+            f"<td>{html.escape(str(row['source_header']))}</td>"
+            f"<td>{html.escape(str(row['peptide_9mer']))}</td>"
+            f"<td>{html.escape(str(row['allele']))}</td>"
             f"<td>{row['ic50_nM']:.1f}</td>"
             f"<td>{row['percentile_rank']:.3f}</td>"
             f"<td>{contig_html}</td>"

--- a/workflow/scripts/generate_report.py
+++ b/workflow/scripts/generate_report.py
@@ -215,6 +215,7 @@ def _build_strong_table_html(
 
         rows.append(
             f"<tr>"
+            f"<td>{row['source_header']}</td>"
             f"<td>{row['peptide_9mer']}</td>"
             f"<td>{row['allele']}</td>"
             f"<td>{row['ic50_nM']:.1f}</td>"
@@ -228,9 +229,14 @@ def _build_strong_table_html(
         "<span class='nt-pep-up'>peptide (upstream)</span> "
         "<span class='nt-pep-down'>peptide (downstream)</span>"
     )
+    percentile_header = (
+        "<th title='Percentage of random peptides that bind worse than this one. "
+        "Lower is better — &lt;2% is the standard binder threshold.'>Percentile rank ▾</th>"
+    )
     table = (
         f"<table><thead><tr>"
-        f"<th>9-mer</th><th>Allele</th><th>IC50 (nM)</th><th>Percentile rank</th>"
+        f"<th>Source</th><th>9-mer</th><th>Allele</th><th>IC50 (nM)</th>"
+        f"{percentile_header}"
         f"<th>Contig ({legend})</th>"
         f"</tr></thead><tbody>{''.join(rows)}</tbody></table>"
     )

--- a/workflow/scripts/generate_report.py
+++ b/workflow/scripts/generate_report.py
@@ -22,6 +22,7 @@ import logging
 from pathlib import Path
 
 import pandas as pd
+from Bio import SeqIO
 
 logging.basicConfig(
     level=logging.INFO,
@@ -114,6 +115,14 @@ _HTML_TEMPLATE = """\
     .split-right {{ flex: 1; background: #eafaf1; padding: 10px 12px; text-align: center; }}
     .discard {{ color: #c0392b; }}
     .keep    {{ color: #27ae60; }}
+
+    /* Contig visualisation */
+    .contig  {{ font-family: monospace; font-size: 0.85em; white-space: nowrap; }}
+    .nt-up   {{ color: #555; }}
+    .nt-down {{ color: #555; }}
+    .nt-pep-up   {{ background: #d6eaf8; color: #1a5276; font-weight: bold; }}
+    .nt-pep-down {{ background: #d5f5e3; color: #1e8449; font-weight: bold; }}
+    .junction-mark {{ color: #e74c3c; font-weight: bold; }}
   </style>
 </head>
 <body>
@@ -149,6 +158,87 @@ _HTML_TEMPLATE = """\
 """
 
 
+def _load_contigs(contigs_fasta: str | Path) -> dict[str, str]:
+    """Parse contigs FASTA into {contig_key: sequence} dict.
+
+    The contig key matches source_header in predictions minus the '|frame{N}' suffix.
+    """
+    contigs: dict[str, str] = {}
+    for record in SeqIO.parse(contigs_fasta, "fasta"):
+        contigs[record.description] = str(record.seq).upper()
+    return contigs
+
+
+def _render_contig(seq: str, start_nt: int, end_nt_incl: int,
+                   upstream_nt: int = 26) -> str:
+    """Render a 50 nt contig as HTML with junction marker and peptide highlighted."""
+    html_parts = []
+    for i, nt in enumerate(seq):
+        if i == upstream_nt:
+            html_parts.append('<span class="junction-mark">|</span>')
+        in_pep = start_nt <= i <= end_nt_incl
+        if in_pep and i < upstream_nt:
+            html_parts.append(f'<span class="nt-pep-up">{nt}</span>')
+        elif in_pep:
+            html_parts.append(f'<span class="nt-pep-down">{nt}</span>')
+        elif i < upstream_nt:
+            html_parts.append(f'<span class="nt-up">{nt}</span>')
+        else:
+            html_parts.append(f'<span class="nt-down">{nt}</span>')
+    return f'<span class="contig">{"".join(html_parts)}</span>'
+
+
+def _build_strong_table_html(
+    pred_df: pd.DataFrame,
+    contigs: dict[str, str],
+    upstream_nt: int = 26,
+    max_rows: int = 50,
+) -> str:
+    """Build the top strong binders table with a contig visualisation column."""
+    strong_df = pred_df[pred_df["binder_class"] == "strong"].sort_values("ic50_nM")
+    if strong_df.empty:
+        return "<p><em>No strong binders found.</em></p>"
+
+    rows = []
+    for _, row in strong_df.head(max_rows).iterrows():
+        header = row["source_header"]
+        contig_key = header.rsplit("|", 1)[0]  # strip |frame{N}
+        frame_part = header.rsplit("|", 1)[-1]
+        frame_offset = (int(frame_part[5:]) - 1) if frame_part.startswith("frame") and frame_part[5:].isdigit() else 0
+
+        position_0 = int(row["position"]) - 1  # convert to 0-indexed
+        start_nt = frame_offset + position_0 * 3
+        end_nt_incl = start_nt + 26  # 9 aa × 3 nt − 1
+
+        seq = contigs.get(contig_key, "")
+        contig_html = _render_contig(seq, start_nt, end_nt_incl, upstream_nt) if seq else "<em>n/a</em>"
+
+        rows.append(
+            f"<tr>"
+            f"<td>{row['peptide_9mer']}</td>"
+            f"<td>{row['allele']}</td>"
+            f"<td>{row['ic50_nM']:.1f}</td>"
+            f"<td>{row['percentile_rank']:.3f}</td>"
+            f"<td>{contig_html}</td>"
+            f"</tr>"
+        )
+
+    legend = (
+        "upstream <span class='junction-mark'>|</span> downstream — "
+        "<span class='nt-pep-up'>peptide (upstream)</span> "
+        "<span class='nt-pep-down'>peptide (downstream)</span>"
+    )
+    table = (
+        f"<table><thead><tr>"
+        f"<th>9-mer</th><th>Allele</th><th>IC50 (nM)</th><th>Percentile rank</th>"
+        f"<th>Contig ({legend})</th>"
+        f"</tr></thead><tbody>{''.join(rows)}</tbody></table>"
+    )
+    if len(strong_df) > max_rows:
+        table += f"<p><em>Showing {max_rows} of {len(strong_df)} rows.</em></p>"
+    return table
+
+
 def _df_to_html(df: pd.DataFrame, max_rows: int = 100) -> str:
     if df.empty:
         return "<p><em>No data.</em></p>"
@@ -166,6 +256,7 @@ def generate_report(
     novel_junctions_tsv: str | Path,
     predictions_tsv: str | Path,
     output_html: str | Path,
+    contigs_fasta: str | Path | None = None,
     ic50_strong: float = 50.0,
 ) -> None:
     """Generate the summary HTML report.
@@ -174,6 +265,7 @@ def generate_report(
         novel_junctions_tsv: Classified junctions TSV (with junction_origin column).
         predictions_tsv:     MHCflurry predictions TSV.
         output_html:         Destination HTML file.
+        contigs_fasta:       Contig FASTA for junction visualisation (optional).
         ic50_strong:         Strong-binder IC50 threshold (nM).
     """
     output_html = Path(output_html)
@@ -181,6 +273,7 @@ def generate_report(
 
     junc_df = pd.read_csv(novel_junctions_tsv, sep="\t")
     pred_df = pd.read_csv(predictions_tsv, sep="\t")
+    contigs = _load_contigs(contigs_fasta) if contigs_fasta else {}
 
     # --- Junction origin summary ---
     if junc_df.empty or "junction_origin" not in junc_df.columns:
@@ -211,14 +304,11 @@ def generate_report(
         binder_counts.columns = ["binder_class", "count"]
         binder_html = _df_to_html(binder_counts)
 
-    # --- Top strong binders ---
+    # --- Top strong binders with contig visualisation ---
     if pred_df.empty:
         strong_html = "<p><em>No predictions available.</em></p>"
     else:
-        strong_df = pred_df[pred_df["binder_class"] == "strong"].sort_values("ic50_nM")
-        strong_cols = [c for c in ["source_header", "peptide_9mer", "allele", "ic50_nM", "rank"]
-                       if c in strong_df.columns]
-        strong_html = _df_to_html(strong_df[strong_cols], max_rows=50)
+        strong_html = _build_strong_table_html(pred_df, contigs)
 
     html = _HTML_TEMPLATE.format(
         pipeline_diagram=_PIPELINE_DIAGRAM,
@@ -243,6 +333,7 @@ def _snakemake_main() -> None:
         novel_junctions_tsv=snakemake.input.novel_junctions,  # type: ignore[name-defined]  # noqa: F821
         predictions_tsv=snakemake.input.predictions_tsv,  # type: ignore[name-defined]  # noqa: F821
         output_html=snakemake.output.report_html,  # type: ignore[name-defined]  # noqa: F821
+        contigs_fasta=snakemake.input.contigs_fasta,  # type: ignore[name-defined]  # noqa: F821
         ic50_strong=float(snakemake.params.ic50_strong),  # type: ignore[name-defined]  # noqa: F821
     )
 
@@ -254,6 +345,7 @@ def _cli_main() -> None:
     parser.add_argument("--novel-junctions", required=True, help="Classified junctions TSV")
     parser.add_argument("--predictions", required=True, help="MHCflurry predictions TSV")
     parser.add_argument("--output", required=True, help="Output HTML report")
+    parser.add_argument("--contigs-fasta", default=None, help="Contigs FASTA for junction visualisation")
     parser.add_argument("--ic50-strong", type=float, default=50.0)
     args = parser.parse_args()
 
@@ -261,6 +353,7 @@ def _cli_main() -> None:
         novel_junctions_tsv=args.novel_junctions,
         predictions_tsv=args.predictions,
         output_html=args.output,
+        contigs_fasta=args.contigs_fasta,
         ic50_strong=args.ic50_strong,
     )
 

--- a/workflow/scripts/run_mhcflurry.py
+++ b/workflow/scripts/run_mhcflurry.py
@@ -66,17 +66,22 @@ def _read_peptides_fasta(fasta_path: str | Path) -> Iterator[tuple[str, str]]:
         yield record.description, str(record.seq)
 
 
+# Convention mirrors the frame tokens written by translate_peptides.py
+_FRAME_OFFSETS = {"frame1": 0, "frame2": 1, "frame3": 2}
+
+
 def _parse_frame_offset(header: str) -> int | None:
     """Extract the 0-based reading frame offset from a peptide FASTA header.
 
     Headers from translate_peptides.py end with ``|frame1``, ``|frame2``, or
     ``|frame3``, corresponding to 0-based offsets 0, 1, 2.
 
-    Returns None if the frame token is absent (no junction filter applied).
+    Returns None if the frame token is absent or unrecognised (no junction
+    filter applied).
     """
     for part in header.split("|"):
-        if part.startswith("frame") and part[5:].isdigit():
-            return int(part[5:]) - 1  # frame1 → 0, frame2 → 1, frame3 → 2
+        if part in _FRAME_OFFSETS:
+            return _FRAME_OFFSETS[part]
     return None
 
 

--- a/workflow/scripts/run_mhcflurry.py
+++ b/workflow/scripts/run_mhcflurry.py
@@ -66,25 +66,62 @@ def _read_peptides_fasta(fasta_path: str | Path) -> Iterator[tuple[str, str]]:
         yield record.description, str(record.seq)
 
 
+def _parse_frame_offset(header: str) -> int | None:
+    """Extract the 0-based reading frame offset from a peptide FASTA header.
+
+    Headers from translate_peptides.py end with ``|frame1``, ``|frame2``, or
+    ``|frame3``, corresponding to 0-based offsets 0, 1, 2.
+
+    Returns None if the frame token is absent (no junction filter applied).
+    """
+    for part in header.split("|"):
+        if part.startswith("frame") and part[5:].isdigit():
+            return int(part[5:]) - 1  # frame1 → 0, frame2 → 1, frame3 → 2
+    return None
+
+
 def _generate_9mers(
     peptide_16mer: str,
     window_size: int = 9,
+    frame_offset: int | None = None,
+    upstream_nt: int = 26,
 ) -> list[tuple[int, str]]:
-    """Generate all 9-mer sub-peptides from a 16-mer using a sliding window.
+    """Generate 9-mer sub-peptides from a 16-mer that span the splice junction.
+
+    Only 9-mers containing at least one complete amino acid from each side of
+    the junction are returned.  A 9-mer at 0-indexed position i with frame
+    offset f starts at nucleotide f + i*3 in the 50 nt contig.  The junction
+    falls between nucleotides upstream_nt-1 and upstream_nt (default 25/26).
+
+    Spanning condition: 2 <= f + i*3 <= 23  (with defaults upstream_nt=26,
+    window_size=9).
 
     Args:
         peptide_16mer: The 16-mer amino acid sequence.
         window_size:   Length of each sub-peptide (default 9).
+        frame_offset:  0-based reading frame offset used to translate the contig.
+                       If None, all 9-mers are returned (no junction filter).
+        upstream_nt:   Number of upstream nucleotides in the contig (default 26).
 
     Returns:
         List of (position, 9-mer) tuples where position is 1-indexed.
     """
+    min_start = upstream_nt - (window_size - 1) * 3      # = 2 for defaults
+    max_start = upstream_nt - 3                           # = 23 for defaults
+
     nmers = []
     for i in range(len(peptide_16mer) - window_size + 1):
         nmer = peptide_16mer[i : i + window_size]
         # Skip peptides containing stop codons or invalid characters
         if "*" in nmer or "X" in nmer:
             continue
+        # Keep only 9-mers that span the junction: must include at least one
+        # complete codon from the upstream exon and one from the downstream exon.
+        # Without this, purely exonic 9-mers match normal proteins (false positives).
+        if frame_offset is not None:
+            start_nt = frame_offset + i * 3
+            if not (min_start <= start_nt <= max_start):
+                continue
         nmers.append((i + 1, nmer))  # 1-indexed position
     return nmers
 
@@ -199,7 +236,8 @@ def run_prediction(
     peptide_to_source: dict[str, list[dict]] = {}
 
     for header, seq_16mer in _read_peptides_fasta(peptides_fasta):
-        for pos, nmer in _generate_9mers(seq_16mer, peptide_length):
+        frame_offset = _parse_frame_offset(header)
+        for pos, nmer in _generate_9mers(seq_16mer, peptide_length, frame_offset):
             record = {
                 "source_header": header,
                 "peptide_16mer": seq_16mer,

--- a/workflow/tests/test_run_mhcflurry.py
+++ b/workflow/tests/test_run_mhcflurry.py
@@ -20,6 +20,11 @@ class TestParseFrameOffset:
         header = "some_header_without_frame"
         assert _parse_frame_offset(header) is None
 
+    def test_invalid_frame_token_returns_none(self):
+        for bad in ("frame0", "frame4", "frame10"):
+            header = f"chr22:100:200:+|{bad}"
+            assert _parse_frame_offset(header) is None, f"expected None for {bad}"
+
 
 class TestGenerate9mers:
     # A 16-mer with no stop codons or invalid characters

--- a/workflow/tests/test_run_mhcflurry.py
+++ b/workflow/tests/test_run_mhcflurry.py
@@ -1,0 +1,76 @@
+"""Tests for run_mhcflurry.py — 9-mer generation and junction-spanning filter."""
+
+from run_mhcflurry import _generate_9mers, _parse_frame_offset
+
+
+class TestParseFrameOffset:
+    def test_frame1(self):
+        header = "chr22:100:200:+|chr22:100-200:+|Primary Tumor|frame1"
+        assert _parse_frame_offset(header) == 0
+
+    def test_frame2(self):
+        header = "chr22:100:200:+|chr22:100-200:+|Primary Tumor|frame2"
+        assert _parse_frame_offset(header) == 1
+
+    def test_frame3(self):
+        header = "chr22:100:200:+|chr22:100-200:+|Primary Tumor|frame3"
+        assert _parse_frame_offset(header) == 2
+
+    def test_no_frame_token(self):
+        header = "some_header_without_frame"
+        assert _parse_frame_offset(header) is None
+
+
+class TestGenerate9mers:
+    # A 16-mer with no stop codons or invalid characters
+    SEQ = "ACDEFGHIKLMNPQRS"  # 16 standard amino acids
+
+    def test_no_filter_returns_all_8_positions(self):
+        # Without frame_offset, all 8 windows (16 - 9 + 1) are returned
+        result = _generate_9mers(self.SEQ, window_size=9, frame_offset=None)
+        assert len(result) == 8
+
+    def test_positions_are_1_indexed(self):
+        result = _generate_9mers(self.SEQ, window_size=9, frame_offset=None)
+        positions = [pos for pos, _ in result]
+        assert positions == [1, 2, 3, 4, 5, 6, 7, 8]
+
+    def test_junction_filter_frame0_drops_position1_and_last(self):
+        # frame_offset=0, upstream_nt=26: valid start_nt range is [2, 23]
+        # position i (0-indexed): start_nt = 0 + i*3
+        # i=0 → start_nt=0  (< 2) → excluded
+        # i=1 → start_nt=3  ✓
+        # i=7 → start_nt=21 ✓
+        # i=8 would be start_nt=24 (> 23) → excluded, but 16-mer only has 8 windows
+        result = _generate_9mers(self.SEQ, window_size=9, frame_offset=0, upstream_nt=26)
+        positions = [pos for pos, _ in result]
+        assert 1 not in positions  # start_nt=0, purely upstream
+        assert 2 in positions      # start_nt=3, spans junction
+
+    def test_junction_filter_frame1_drops_position1(self):
+        # frame_offset=1: start_nt = 1 + i*3
+        # i=0 → start_nt=1 (< 2) → excluded
+        # i=1 → start_nt=4 ✓
+        result = _generate_9mers(self.SEQ, window_size=9, frame_offset=1, upstream_nt=26)
+        positions = [pos for pos, _ in result]
+        assert 1 not in positions
+        assert 2 in positions
+
+    def test_junction_filter_frame2_includes_position1(self):
+        # frame_offset=2: start_nt = 2 + i*3
+        # i=0 → start_nt=2, which equals min_start=2 → included
+        result = _generate_9mers(self.SEQ, window_size=9, frame_offset=2, upstream_nt=26)
+        positions = [pos for pos, _ in result]
+        assert 1 in positions
+
+    def test_stop_codon_excluded(self):
+        seq = "ACDEFGHIK*MNPQRS"
+        result = _generate_9mers(seq, window_size=9, frame_offset=None)
+        nmers = [nmer for _, nmer in result]
+        assert all("*" not in nmer for nmer in nmers)
+
+    def test_x_excluded(self):
+        seq = "ACDEFGHIKXMNPQRS"
+        result = _generate_9mers(seq, window_size=9, frame_offset=None)
+        nmers = [nmer for _, nmer in result]
+        assert all("X" not in nmer for nmer in nmers)


### PR DESCRIPTION
## Problem
9-mers that fall entirely within one exon were being included as neoepitope candidates, producing false positives that match normal proteins. Verified with BLAST: `YLADLYHFV` (top strong binder from the gastric cancer production run) is a perfect match to SH3BP1 residues 209–217.

## Fix
In `_generate_9mers`, only keep 9-mers where the nucleotide start position satisfies `upstream_nt - (window_size-1)*3 <= start_nt <= upstream_nt - 3` (i.e. `2 <= start_nt <= 23` with defaults). This ensures at least one complete codon from the upstream exon and one from the downstream exon contribute to every predicted peptide.

Adds `_parse_frame_offset()` to extract the frame offset from the FASTA header (`frame1`/`frame2`/`frame3` → offsets 0/1/2).

## Tests
11 new unit tests covering `_parse_frame_offset` and the junction-spanning filter for all three frames.

Closes #18