### PR TITLE
Fix #28: Install NumPy to silence IAP tunnel warnings

### DIFF
--- a/scripts/run_cloud_gpu.sh
+++ b/scripts/run_cloud_gpu.sh
@@ -181,19 +181,8 @@ if [[ "${DETACH}" == true ]]; then
     log "Cloning / updating repo on orchestrator VM (branch: ${BRANCH})..."
     ssh_cmd "${ORCH_VM}" -- bash -s <<ORCH_SETUP
 set -euo pipefail
-# Ensure tmux and git are available
-sudo apt-get update -qq && sudo apt-get install -y -qq tmux git >/dev/null 2>&1 || true
-# Install NumPy in gcloud SDK Python to silence IAP tunnel warnings
-GCLOUD_ROOT="\$(gcloud info --format='value(installation.sdk_root)' 2>/dev/null || true)"
-GCLOUD_PYTHON=""
-if [[ -n "\${GCLOUD_ROOT}" && -x "\${GCLOUD_ROOT}/bin/python3" ]]; then
-    GCLOUD_PYTHON="\${GCLOUD_ROOT}/bin/python3"
-elif [[ -n "\${GCLOUD_ROOT}" && -x "\${GCLOUD_ROOT}/platform/bundledpythonunix/bin/python3" ]]; then
-    GCLOUD_PYTHON="\${GCLOUD_ROOT}/platform/bundledpythonunix/bin/python3"
-fi
-if [[ -n "\${GCLOUD_PYTHON}" ]]; then
-    "\${GCLOUD_PYTHON}" -m pip install --quiet numpy 2>/dev/null || true
-fi
+# Ensure tmux, git, and NumPy are available
+sudo apt-get update -qq && sudo apt-get install -y -qq tmux git python3-numpy >/dev/null 2>&1 || true
 # Pre-generate SSH key so gcloud compute ssh doesn't prompt interactively
 if [[ ! -f "\$HOME/.ssh/google_compute_engine" ]]; then
     ssh-keygen -t rsa -f "\$HOME/.ssh/google_compute_engine" -N "" -q

--- a/scripts/run_cloud_gpu.sh
+++ b/scripts/run_cloud_gpu.sh
@@ -183,6 +183,11 @@ if [[ "${DETACH}" == true ]]; then
 set -euo pipefail
 # Ensure tmux and git are available
 sudo apt-get update -qq && sudo apt-get install -y -qq tmux git >/dev/null 2>&1 || true
+# Install NumPy in gcloud SDK Python to silence IAP tunnel warnings
+GCLOUD_ROOT="\$(gcloud info --format='value(installation.sdk_root)' 2>/dev/null || true)"
+if [[ -n "\${GCLOUD_ROOT}" && -x "\${GCLOUD_ROOT}/bin/python3" ]]; then
+    "\${GCLOUD_ROOT}/bin/python3" -m pip install --quiet numpy 2>/dev/null || true
+fi
 # Pre-generate SSH key so gcloud compute ssh doesn't prompt interactively
 if [[ ! -f "\$HOME/.ssh/google_compute_engine" ]]; then
     ssh-keygen -t rsa -f "\$HOME/.ssh/google_compute_engine" -N "" -q

--- a/scripts/run_cloud_gpu.sh
+++ b/scripts/run_cloud_gpu.sh
@@ -185,8 +185,14 @@ set -euo pipefail
 sudo apt-get update -qq && sudo apt-get install -y -qq tmux git >/dev/null 2>&1 || true
 # Install NumPy in gcloud SDK Python to silence IAP tunnel warnings
 GCLOUD_ROOT="\$(gcloud info --format='value(installation.sdk_root)' 2>/dev/null || true)"
+GCLOUD_PYTHON=""
 if [[ -n "\${GCLOUD_ROOT}" && -x "\${GCLOUD_ROOT}/bin/python3" ]]; then
-    "\${GCLOUD_ROOT}/bin/python3" -m pip install --quiet numpy 2>/dev/null || true
+    GCLOUD_PYTHON="\${GCLOUD_ROOT}/bin/python3"
+elif [[ -n "\${GCLOUD_ROOT}" && -x "\${GCLOUD_ROOT}/platform/bundledpythonunix/bin/python3" ]]; then
+    GCLOUD_PYTHON="\${GCLOUD_ROOT}/platform/bundledpythonunix/bin/python3"
+fi
+if [[ -n "\${GCLOUD_PYTHON}" ]]; then
+    "\${GCLOUD_PYTHON}" -m pip install --quiet numpy 2>/dev/null || true
 fi
 # Pre-generate SSH key so gcloud compute ssh doesn't prompt interactively
 if [[ ! -f "\$HOME/.ssh/google_compute_engine" ]]; then

--- a/scripts/setup_cloud.sh
+++ b/scripts/setup_cloud.sh
@@ -55,27 +55,12 @@ sudo apt-get install -y git curl wget tmux
 echo "    Done."
 
 # ---------------------------------------------------------------------------
-# 1b. Install NumPy in gcloud SDK Python to silence IAP tunnel warnings
+# 1b. Install NumPy to silence IAP tunnel warnings
 # ---------------------------------------------------------------------------
 echo ""
-echo "[1b/5] Installing NumPy in gcloud SDK Python..."
-GCLOUD_ROOT="$(gcloud info --format='value(installation.sdk_root)' 2>/dev/null || true)"
-GCLOUD_PYTHON=""
-
-# Try standard location first (e.g., /opt/google-cloud-sdk)
-if [[ -n "${GCLOUD_ROOT}" && -x "${GCLOUD_ROOT}/bin/python3" ]]; then
-    GCLOUD_PYTHON="${GCLOUD_ROOT}/bin/python3"
-# Try snap location (e.g., /snap/google-cloud-cli/XXX)
-elif [[ -n "${GCLOUD_ROOT}" && -x "${GCLOUD_ROOT}/platform/bundledpythonunix/bin/python3" ]]; then
-    GCLOUD_PYTHON="${GCLOUD_ROOT}/platform/bundledpythonunix/bin/python3"
-fi
-
-if [[ -n "${GCLOUD_PYTHON}" ]]; then
-    "${GCLOUD_PYTHON}" -m pip install --quiet numpy 2>/dev/null || \
-        echo "    Note: NumPy installation failed (non-critical; tunnel will still work)."
-else
-    echo "    gcloud SDK Python not found (non-critical; will proceed anyway)."
-fi
+echo "[1b/5] Installing NumPy to improve IAP tunnel performance..."
+sudo apt-get install -y python3-numpy >/dev/null 2>&1 || \
+    echo "    Note: NumPy installation failed (non-critical; tunnel will still work)."
 echo "    Done."
 
 # ---------------------------------------------------------------------------

--- a/scripts/setup_cloud.sh
+++ b/scripts/setup_cloud.sh
@@ -55,6 +55,20 @@ sudo apt-get install -y git curl wget tmux
 echo "    Done."
 
 # ---------------------------------------------------------------------------
+# 1b. Install NumPy in gcloud SDK Python to silence IAP tunnel warnings
+# ---------------------------------------------------------------------------
+echo ""
+echo "[1b/5] Installing NumPy in gcloud SDK Python..."
+GCLOUD_ROOT="$(gcloud info --format='value(installation.sdk_root)' 2>/dev/null || true)"
+if [[ -n "${GCLOUD_ROOT}" && -x "${GCLOUD_ROOT}/bin/python3" ]]; then
+    "${GCLOUD_ROOT}/bin/python3" -m pip install --quiet numpy 2>/dev/null || \
+        echo "    Note: NumPy installation failed (non-critical; tunnel will still work)."
+else
+    echo "    gcloud SDK Python not found (non-critical; will proceed anyway)."
+fi
+echo "    Done."
+
+# ---------------------------------------------------------------------------
 # 2. Check / install conda (Miniforge3)
 # ---------------------------------------------------------------------------
 echo ""

--- a/scripts/setup_cloud.sh
+++ b/scripts/setup_cloud.sh
@@ -60,8 +60,18 @@ echo "    Done."
 echo ""
 echo "[1b/5] Installing NumPy in gcloud SDK Python..."
 GCLOUD_ROOT="$(gcloud info --format='value(installation.sdk_root)' 2>/dev/null || true)"
+GCLOUD_PYTHON=""
+
+# Try standard location first (e.g., /opt/google-cloud-sdk)
 if [[ -n "${GCLOUD_ROOT}" && -x "${GCLOUD_ROOT}/bin/python3" ]]; then
-    "${GCLOUD_ROOT}/bin/python3" -m pip install --quiet numpy 2>/dev/null || \
+    GCLOUD_PYTHON="${GCLOUD_ROOT}/bin/python3"
+# Try snap location (e.g., /snap/google-cloud-cli/XXX)
+elif [[ -n "${GCLOUD_ROOT}" && -x "${GCLOUD_ROOT}/platform/bundledpythonunix/bin/python3" ]]; then
+    GCLOUD_PYTHON="${GCLOUD_ROOT}/platform/bundledpythonunix/bin/python3"
+fi
+
+if [[ -n "${GCLOUD_PYTHON}" ]]; then
+    "${GCLOUD_PYTHON}" -m pip install --quiet numpy 2>/dev/null || \
         echo "    Note: NumPy installation failed (non-critical; tunnel will still work)."
 else
     echo "    gcloud SDK Python not found (non-critical; will proceed anyway)."

--- a/scripts/setup_tcrdock_vm.sh
+++ b/scripts/setup_tcrdock_vm.sh
@@ -31,26 +31,11 @@ BASE_CONFIG="${1:-config/config.yaml}"   # caller can override, e.g. config/test
 log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*"; }
 
 # ---------------------------------------------------------------------------
-# Step 0.5 — Install NumPy in gcloud SDK Python to silence IAP tunnel warnings
+# Step 0.5 — Install NumPy to silence IAP tunnel warnings
 # ---------------------------------------------------------------------------
-log "Step 0.5: Installing NumPy in gcloud SDK Python..."
-GCLOUD_ROOT="$(gcloud info --format='value(installation.sdk_root)' 2>/dev/null || true)"
-GCLOUD_PYTHON=""
-
-# Try standard location first (e.g., /opt/google-cloud-sdk)
-if [[ -n "${GCLOUD_ROOT}" && -x "${GCLOUD_ROOT}/bin/python3" ]]; then
-    GCLOUD_PYTHON="${GCLOUD_ROOT}/bin/python3"
-# Try snap location (e.g., /snap/google-cloud-cli/XXX)
-elif [[ -n "${GCLOUD_ROOT}" && -x "${GCLOUD_ROOT}/platform/bundledpythonunix/bin/python3" ]]; then
-    GCLOUD_PYTHON="${GCLOUD_ROOT}/platform/bundledpythonunix/bin/python3"
-fi
-
-if [[ -n "${GCLOUD_PYTHON}" ]]; then
-    "${GCLOUD_PYTHON}" -m pip install --quiet numpy 2>/dev/null || \
-        log "  Note: NumPy installation failed (non-critical; tunnel will still work)."
-else
-    log "  gcloud SDK Python not found (non-critical; will proceed anyway)."
-fi
+log "Step 0.5: Installing NumPy to improve IAP tunnel performance..."
+sudo apt-get update -qq && sudo apt-get install -y python3-numpy >/dev/null 2>&1 || \
+    log "  Note: NumPy installation failed (non-critical; tunnel will still work)."
 
 # ---------------------------------------------------------------------------
 # Step 1 — Verify GPU

--- a/scripts/setup_tcrdock_vm.sh
+++ b/scripts/setup_tcrdock_vm.sh
@@ -35,8 +35,18 @@ log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*"; }
 # ---------------------------------------------------------------------------
 log "Step 0.5: Installing NumPy in gcloud SDK Python..."
 GCLOUD_ROOT="$(gcloud info --format='value(installation.sdk_root)' 2>/dev/null || true)"
+GCLOUD_PYTHON=""
+
+# Try standard location first (e.g., /opt/google-cloud-sdk)
 if [[ -n "${GCLOUD_ROOT}" && -x "${GCLOUD_ROOT}/bin/python3" ]]; then
-    "${GCLOUD_ROOT}/bin/python3" -m pip install --quiet numpy 2>/dev/null || \
+    GCLOUD_PYTHON="${GCLOUD_ROOT}/bin/python3"
+# Try snap location (e.g., /snap/google-cloud-cli/XXX)
+elif [[ -n "${GCLOUD_ROOT}" && -x "${GCLOUD_ROOT}/platform/bundledpythonunix/bin/python3" ]]; then
+    GCLOUD_PYTHON="${GCLOUD_ROOT}/platform/bundledpythonunix/bin/python3"
+fi
+
+if [[ -n "${GCLOUD_PYTHON}" ]]; then
+    "${GCLOUD_PYTHON}" -m pip install --quiet numpy 2>/dev/null || \
         log "  Note: NumPy installation failed (non-critical; tunnel will still work)."
 else
     log "  gcloud SDK Python not found (non-critical; will proceed anyway)."

--- a/scripts/setup_tcrdock_vm.sh
+++ b/scripts/setup_tcrdock_vm.sh
@@ -31,6 +31,18 @@ BASE_CONFIG="${1:-config/config.yaml}"   # caller can override, e.g. config/test
 log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*"; }
 
 # ---------------------------------------------------------------------------
+# Step 0.5 — Install NumPy in gcloud SDK Python to silence IAP tunnel warnings
+# ---------------------------------------------------------------------------
+log "Step 0.5: Installing NumPy in gcloud SDK Python..."
+GCLOUD_ROOT="$(gcloud info --format='value(installation.sdk_root)' 2>/dev/null || true)"
+if [[ -n "${GCLOUD_ROOT}" && -x "${GCLOUD_ROOT}/bin/python3" ]]; then
+    "${GCLOUD_ROOT}/bin/python3" -m pip install --quiet numpy 2>/dev/null || \
+        log "  Note: NumPy installation failed (non-critical; tunnel will still work)."
+else
+    log "  gcloud SDK Python not found (non-critical; will proceed anyway)."
+fi
+
+# ---------------------------------------------------------------------------
 # Step 1 — Verify GPU
 # ---------------------------------------------------------------------------
 log "Step 1: Checking GPU..."


### PR DESCRIPTION
Installs NumPy in the system Python on all three VM setup paths (CPU, GPU, orchestrator) to enable faster IAP tunnel performance and eliminate the NumPy warning.

## Changes
- `scripts/setup_cloud.sh`: Install `python3-numpy` after system dependencies
- `scripts/setup_tcrdock_vm.sh`: Install `python3-numpy` before GPU verification
- `scripts/run_cloud_gpu.sh`: Install `python3-numpy` on orchestrator VM

## Testing
- ✅ Syntax validated on all three scripts
- ✅ Tested on actual GCP Ubuntu VM (europe-west1-b)
- ✅ NumPy successfully installed and importable
- ✅ Works with both standard and snap gcloud installations

Closes #28