### PR TITLE
Derive PATIENT_IDS from samples_tsv; rename sample IDs to SRR accessions

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -36,14 +36,28 @@
 
 configfile: "config/config.yaml"
 
+import csv
+
 # ── convenience aliases ──────────────────────────────────────────────────────
-PATIENT_ID  = config["patient_id"]
-OUT         = config["output"]
+OUT = config["output"]
+
+# Derive patient IDs from the samples TSV — the TSV is the single source of
+# truth for what to run. All rows sharing the same patient_id are treated as
+# a matched set (e.g. tumor + normal for one patient).
+def _read_patient_ids(samples_tsv):
+    with open(samples_tsv) as f:
+        return list({
+            row["patient_id"]
+            for row in csv.DictReader(f, delimiter="\t")
+            if not row["patient_id"].startswith("#")
+        })
+
+PATIENT_IDS = _read_patient_ids(config["samples_tsv"])
 
 
 # ── include rule modules ─────────────────────────────────────────────────────
 include: "workflow/rules/download.smk"
-include: "workflow/rules/local_alignment.smk"
+include: "workflow/rules/star_alignment.smk"
 include: "workflow/rules/hisat2_alignment.smk"
 include: "workflow/rules/filter.smk"
 include: "workflow/rules/assemble.smk"
@@ -56,9 +70,16 @@ include: "workflow/rules/tcrdock.smk"
 if config.get("tcrdock", {}).get("enabled", False):
     ruleorder: generate_report_with_structure > generate_report
 
+# In fastq mode the aligner manifest rules take precedence over the GDC download rule.
+if config.get("data_source") == "fastq":
+    if config.get("alignment", {}).get("aligner") == "hisat2":
+        ruleorder: create_hisat2_manifest > download_gdc_manifest
+    else:
+        ruleorder: create_star_manifest > download_gdc_manifest
+
 
 # ── final target ─────────────────────────────────────────────────────────────
 rule all:
     input:
-        f"{OUT['reports']}/{PATIENT_ID}/report.html",
+        expand("{reports}/{patient_id}/report.html", reports=OUT["reports"], patient_id=PATIENT_IDS),
 

--- a/Snakefile
+++ b/Snakefile
@@ -45,12 +45,14 @@ OUT = config["output"]
 # truth for what to run. All rows sharing the same patient_id are treated as
 # a matched set (e.g. tumor + normal for one patient).
 def _read_patient_ids(samples_tsv):
+    patient_ids = set()
     with open(samples_tsv) as f:
-        return list({
-            row["patient_id"]
-            for row in csv.DictReader(f, delimiter="\t")
-            if not row["patient_id"].startswith("#")
-        })
+        for row in csv.DictReader(f, delimiter="\t"):
+            pid = (row.get("patient_id") or "").strip()
+            if not pid or pid.startswith("#"):
+                continue
+            patient_ids.add(pid)
+    return sorted(patient_ids)
 
 PATIENT_IDS = _read_patient_ids(config["samples_tsv"])
 

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -12,22 +12,6 @@
 data_source: "fastq"
 
 # -----------------------------------------------------------------
-# Patient identifier
-# -----------------------------------------------------------------
-# Unique label for this patient/experiment. Used as an output path
-# segment so results for different patients stay separated
-# (e.g. results/predictions/<patient_id>/). The pipeline is
-# patient-centric: one run = one patient, and ALL samples listed
-# in `samples_tsv` below are assumed to belong to
-# this patient (typically a matched tumor/normal pair).
-#
-# Default "patient_001" matches the example gastric cancer pair
-# in config/samples.tsv (SRR9143066 tumor / SRR9143065 normal).
-# Replace with your own identifier before running on real data.
-patient_id: "patient_001"
-
-
-# -----------------------------------------------------------------
 # Sample manifest (used when data_source is "fastq")
 # -----------------------------------------------------------------
 # Path to a TSV listing the RNA-Seq FASTQs for this patient. Columns:

--- a/config/samples.tsv
+++ b/config/samples.tsv
@@ -1,9 +1,13 @@
-sample_id	sample_type	fastq1	fastq2
+patient_id	sample_id	sample_type	fastq1	fastq2
 # ---------------------------------------------------------------------------
 # Sample manifest — replace with your own samples.
 #
 # Column descriptions:
-#   sample_id    Unique sample identifier (used as file names in results)
+#   patient_id   Unique patient/experiment identifier. All rows with the same
+#                patient_id are treated as a matched set (e.g. tumor + normal).
+#                Used as an output path segment: results/predictions/<patient_id>/
+#   sample_id    Unique sample identifier (used as file names in results).
+#                Use the original accession (e.g. SRR9143066) where possible.
 #   sample_type  "Primary Tumor" or "Solid Tissue Normal"
 #                  Primary Tumor        — junctions used for neoepitope prediction
 #                  Solid Tissue Normal  — used to filter out patient-specific junctions
@@ -14,5 +18,5 @@ sample_id	sample_type	fastq1	fastq2
 # Source: https://www.ebi.ac.uk/ena/browser/view/SRR9143066
 # Download with: bash scripts/prepare_production_data.sh
 # ---------------------------------------------------------------------------
-gastric_tumor	Primary Tumor	data/gastric_tumor.fastq.gz
-gastric_normal	Solid Tissue Normal	data/gastric_normal.fastq.gz
+patient_001	SRR9143066	Primary Tumor	data/SRR9143066.fastq.gz
+patient_001	SRR9143065	Solid Tissue Normal	data/SRR9143065.fastq.gz

--- a/config/test_samples.tsv
+++ b/config/test_samples.tsv
@@ -1,3 +1,3 @@
-sample_id	sample_type	fastq1	fastq2
-test_tumor	Primary Tumor	data/test/test_tumor.fastq.gz
-test_normal	Solid Tissue Normal	data/test/test_normal.fastq.gz
+patient_id	sample_id	sample_type	fastq1	fastq2
+patient_001	SRR9143066_test	Primary Tumor	data/test/SRR9143066_test.fastq.gz
+patient_001	SRR9143065_test	Solid Tissue Normal	data/test/SRR9143065_test.fastq.gz

--- a/scripts/prepare_production_data.sh
+++ b/scripts/prepare_production_data.sh
@@ -25,33 +25,40 @@ mkdir -p "$DATA"
 TUMOR_URL="https://ftp.sra.ebi.ac.uk/vol1/fastq/SRR914/006/SRR9143066/SRR9143066.fastq.gz"
 NORMAL_URL="https://ftp.sra.ebi.ac.uk/vol1/fastq/SRR914/005/SRR9143065/SRR9143065.fastq.gz"
 
+TUMOR_DEST="$DATA/SRR9143066.fastq.gz"
+NORMAL_DEST="$DATA/SRR9143065.fastq.gz"
+
 echo "=== Downloading production FASTQs ==="
 echo "    Tumor:  SRR9143066 (~several GB — may take 30–60 min)"
 echo "    Normal: SRR9143065 (~several GB — may take 30–60 min)"
 echo ""
 
-if [[ -f "$DATA/gastric_tumor.fastq.gz" ]]; then
+# Migrate old filenames if present
+[[ -f "$DATA/gastric_tumor.fastq.gz"  && ! -f "$TUMOR_DEST"  ]] && mv "$DATA/gastric_tumor.fastq.gz"  "$TUMOR_DEST"
+[[ -f "$DATA/gastric_normal.fastq.gz" && ! -f "$NORMAL_DEST" ]] && mv "$DATA/gastric_normal.fastq.gz" "$NORMAL_DEST"
+
+if [[ -f "$TUMOR_DEST" ]]; then
     echo "    Tumor FASTQ already exists — skipping."
 else
     echo "    Downloading tumor (SRR9143066)..."
-    curl --fail -L --progress-bar "$TUMOR_URL" -o "$DATA/gastric_tumor.fastq.gz"
-    if ! gzip -t "$DATA/gastric_tumor.fastq.gz" 2>/dev/null; then
+    curl --fail -L --progress-bar "$TUMOR_URL" -o "$TUMOR_DEST"
+    if ! gzip -t "$TUMOR_DEST" 2>/dev/null; then
         echo "ERROR: Tumor FASTQ download appears corrupt." >&2; exit 1
     fi
-    echo "    Saved: $DATA/gastric_tumor.fastq.gz"
+    echo "    Saved: $TUMOR_DEST"
 fi
 
 echo ""
 
-if [[ -f "$DATA/gastric_normal.fastq.gz" ]]; then
+if [[ -f "$NORMAL_DEST" ]]; then
     echo "    Normal FASTQ already exists — skipping."
 else
     echo "    Downloading normal (SRR9143065)..."
-    curl --fail -L --progress-bar "$NORMAL_URL" -o "$DATA/gastric_normal.fastq.gz"
-    if ! gzip -t "$DATA/gastric_normal.fastq.gz" 2>/dev/null; then
+    curl --fail -L --progress-bar "$NORMAL_URL" -o "$NORMAL_DEST"
+    if ! gzip -t "$NORMAL_DEST" 2>/dev/null; then
         echo "ERROR: Normal FASTQ download appears corrupt." >&2; exit 1
     fi
-    echo "    Saved: $DATA/gastric_normal.fastq.gz"
+    echo "    Saved: $NORMAL_DEST"
 fi
 
 echo ""

--- a/scripts/prepare_test_data.sh
+++ b/scripts/prepare_test_data.sh
@@ -73,32 +73,40 @@ echo "    Streaming via ENA HTTPS — no sra-tools required."
 TUMOR_URL="https://ftp.sra.ebi.ac.uk/vol1/fastq/SRR914/006/SRR9143066/SRR9143066.fastq.gz"
 NORMAL_URL="https://ftp.sra.ebi.ac.uk/vol1/fastq/SRR914/005/SRR9143065/SRR9143065.fastq.gz"
 
-if [[ -f "$DATA/test_tumor.fastq.gz" ]]; then
+# Destination paths — must match fastq1/fastq2 in config/test_samples.tsv
+TUMOR_DEST="$DATA/SRR9143066_test.fastq.gz"
+NORMAL_DEST="$DATA/SRR9143065_test.fastq.gz"
+
+# Migrate old filenames if present
+[[ -f "$DATA/test_tumor.fastq.gz"  && ! -f "$TUMOR_DEST"  ]] && mv "$DATA/test_tumor.fastq.gz"  "$TUMOR_DEST"
+[[ -f "$DATA/test_normal.fastq.gz" && ! -f "$NORMAL_DEST" ]] && mv "$DATA/test_normal.fastq.gz" "$NORMAL_DEST"
+
+if [[ -f "$TUMOR_DEST" ]]; then
     echo "    Tumor FASTQ already exists — skipping."
 else
     echo "    Downloading tumor (SRR9143066)..."
     set +o pipefail
-    curl -L --progress-bar "$TUMOR_URL" | zcat | head -n 2000000 | gzip > "$DATA/test_tumor.fastq.gz"
+    curl -L --progress-bar "$TUMOR_URL" | zcat | head -n 2000000 | gzip > "$TUMOR_DEST"
     set -o pipefail
-    if [[ ! -s "$DATA/test_tumor.fastq.gz" ]]; then
-        echo "ERROR: $DATA/test_tumor.fastq.gz is missing or empty after download." >&2
+    if [[ ! -s "$TUMOR_DEST" ]]; then
+        echo "ERROR: $TUMOR_DEST is missing or empty after download." >&2
         exit 1
     fi
-    echo "    Saved: $DATA/test_tumor.fastq.gz"
+    echo "    Saved: $TUMOR_DEST"
 fi
 
-if [[ -f "$DATA/test_normal.fastq.gz" ]]; then
+if [[ -f "$NORMAL_DEST" ]]; then
     echo "    Normal FASTQ already exists — skipping."
 else
     echo "    Downloading normal (SRR9143065)..."
     set +o pipefail
-    curl -L --progress-bar "$NORMAL_URL" | zcat | head -n 2000000 | gzip > "$DATA/test_normal.fastq.gz"
+    curl -L --progress-bar "$NORMAL_URL" | zcat | head -n 2000000 | gzip > "$NORMAL_DEST"
     set -o pipefail
-    if [[ ! -s "$DATA/test_normal.fastq.gz" ]]; then
-        echo "ERROR: $DATA/test_normal.fastq.gz is missing or empty after download." >&2
+    if [[ ! -s "$NORMAL_DEST" ]]; then
+        echo "ERROR: $NORMAL_DEST is missing or empty after download." >&2
         exit 1
     fi
-    echo "    Saved: $DATA/test_normal.fastq.gz"
+    echo "    Saved: $NORMAL_DEST"
 fi
 
 # ---------------------------------------------------------------------------

--- a/workflow/rules/hisat2_alignment.smk
+++ b/workflow/rules/hisat2_alignment.smk
@@ -69,9 +69,14 @@ if config.get("data_source") == "fastq" and config.get("alignment", {}).get("ali
         samples_file = Path(config["samples_tsv"])
         if not samples_file.exists():
             return []
+        rows = []
         with samples_file.open() as f:
-            rows = [r for r in csv.DictReader(f, delimiter="\t")
-                    if not r["patient_id"].startswith("#")]
+            for r in csv.DictReader(f, delimiter="\t"):
+                pid = (r.get("patient_id") or "").strip()
+                if not pid or pid.startswith("#"):
+                    continue
+                r["patient_id"] = pid
+                rows.append(r)
         if patient_id is not None:
             rows = [r for r in rows if r["patient_id"] == patient_id]
         return rows

--- a/workflow/rules/hisat2_alignment.smk
+++ b/workflow/rules/hisat2_alignment.smk
@@ -63,28 +63,31 @@ if config.get("data_source") == "fastq" and config.get("alignment", {}).get("ali
             """
 
 
-    def get_local_samples_hisat2():
-        """Read samples from the local samples TSV file."""
+    def get_local_samples_hisat2(patient_id=None):
+        """Read samples from the local samples TSV, optionally filtered by patient_id."""
         import csv
         samples_file = Path(config["samples_tsv"])
         if not samples_file.exists():
             return []
         with samples_file.open() as f:
-            reader = csv.DictReader(f, delimiter="\t")
-            return list(reader)
+            rows = [r for r in csv.DictReader(f, delimiter="\t")
+                    if not r["patient_id"].startswith("#")]
+        if patient_id is not None:
+            rows = [r for r in rows if r["patient_id"] == patient_id]
+        return rows
 
 
     def get_fastq1_hisat2(wildcards):
         """Get path to read 1 FASTQ for a sample."""
-        for sample in get_local_samples_hisat2():
+        for sample in get_local_samples_hisat2(wildcards.patient_id):
             if sample["sample_id"] == wildcards.sample:
                 return sample["fastq1"]
-        raise ValueError(f"Sample not found: {wildcards.sample}")
+        raise ValueError(f"Sample not found: {wildcards.sample} (patient: {wildcards.patient_id})")
 
 
     def get_fastq2_hisat2(wildcards):
         """Get path to read 2 FASTQ for a sample (or empty list if single-end)."""
-        for sample in get_local_samples_hisat2():
+        for sample in get_local_samples_hisat2(wildcards.patient_id):
             if sample["sample_id"] == wildcards.sample:
                 fastq2 = sample.get("fastq2", "")
                 return [fastq2] if fastq2 else []
@@ -105,13 +108,13 @@ if config.get("data_source") == "fastq" and config.get("alignment", {}).get("ali
             fastq1=get_fastq1_hisat2,
             fastq2=get_fastq2_hisat2,
         output:
-            junctions=os.path.join(OUT["raw_data"], PATIENT_ID, "files", "{sample}.tsv"),
-            done=touch(os.path.join(OUT["raw_data"], PATIENT_ID, "files", "{sample}.done")),
+            junctions=os.path.join(OUT["raw_data"], "{patient_id}", "files", "{sample}.tsv"),
+            done=touch(os.path.join(OUT["raw_data"], "{patient_id}", "files", "{sample}.done")),
         log:
-            os.path.join(OUT["logs"], "hisat2", "{sample}_align.log"),
+            os.path.join(OUT["logs"], "hisat2", "{patient_id}_{sample}_align.log"),
         params:
             index_prefix=os.path.join(_HISAT2_INDEX_DIR, "genome"),
-            output_prefix=lambda w: os.path.join(OUT["raw_data"], PATIENT_ID, "files", f"{w.sample}"),
+            output_prefix=lambda wildcards: os.path.join(OUT["raw_data"], wildcards.patient_id, "files", wildcards.sample),
         threads: 8
         resources:
             mem_mb=8000,  # HISAT2 alignment needs only ~8 GB
@@ -164,19 +167,18 @@ if config.get("data_source") == "fastq" and config.get("alignment", {}).get("ali
             """
 
 
-    rule create_local_manifest_hisat2:
+    rule create_hisat2_manifest:
         """Create a manifest TSV from the local samples configuration.
 
         This mirrors the GDC manifest format so downstream rules can use the
         same filtering logic regardless of data source.
         """
         output:
-            manifest=os.path.join(OUT["raw_data"], PATIENT_ID, "manifest.tsv"),
+            manifest=os.path.join(OUT["raw_data"], "{patient_id}", "manifest.tsv"),
         log:
-            os.path.join(OUT["logs"], "hisat2", "manifest.log"),
+            os.path.join(OUT["logs"], "hisat2", "{patient_id}_manifest.log"),
         params:
             samples_tsv=config["samples_tsv"],
-            patient_id=PATIENT_ID,
         conda:
             "../envs/python.yaml"
         run:
@@ -191,25 +193,27 @@ if config.get("data_source") == "fastq" and config.get("alignment", {}).get("ali
                 reader = csv.DictReader(fin, delimiter="\t")
                 fout.write("file_id\tfile_name\tsample_type\tproject_id\n")
                 for row in reader:
+                    if row["patient_id"] != wildcards.patient_id:
+                        continue
                     sample_id = row["sample_id"]
                     sample_type = row.get("sample_type", "Unknown")
-                    fout.write(f"{sample_id}\t{sample_id}.tsv\t{sample_type}\t{params.patient_id}\n")
+                    fout.write(f"{sample_id}\t{sample_id}.tsv\t{sample_type}\t{wildcards.patient_id}\n")
 
 
     # Checkpoint to collect all aligned samples
-    checkpoint local_alignment_complete_hisat2:
+    checkpoint hisat2_alignment_complete:
         """Checkpoint that triggers after all local samples are aligned.
 
         This replaces the GDC download checkpoint for local mode.
         """
         input:
-            manifest=os.path.join(OUT["raw_data"], PATIENT_ID, "manifest.tsv"),
-            samples=lambda w: expand(
-                os.path.join(OUT["raw_data"], PATIENT_ID, "files", "{sample}.tsv"),
-                sample=[s["sample_id"] for s in get_local_samples_hisat2()]
+            manifest=os.path.join(OUT["raw_data"], "{patient_id}", "manifest.tsv"),
+            samples=lambda wildcards: expand(
+                os.path.join(OUT["raw_data"], wildcards.patient_id, "files", "{sample}.tsv"),
+                sample=[s["sample_id"] for s in get_local_samples_hisat2(wildcards.patient_id)]
             ),
         output:
-            done=os.path.join(OUT["raw_data"], PATIENT_ID, "download.done"),
-            data_dir=directory(os.path.join(OUT["raw_data"], PATIENT_ID, "files")),
+            done=os.path.join(OUT["raw_data"], "{patient_id}", "download.done"),
+            data_dir=directory(os.path.join(OUT["raw_data"], "{patient_id}", "files")),
         shell:
             "touch {output.done}"

--- a/workflow/rules/star_alignment.smk
+++ b/workflow/rules/star_alignment.smk
@@ -71,28 +71,31 @@ if config.get("data_source") == "fastq" and config.get("alignment", {}).get("ali
             """
 
 
-    def get_local_samples():
-        """Read samples from the local samples TSV file."""
+    def get_local_samples(patient_id=None):
+        """Read samples from the local samples TSV, optionally filtered by patient_id."""
         import csv
         samples_file = Path(config["samples_tsv"])
         if not samples_file.exists():
             return []
         with samples_file.open() as f:
-            reader = csv.DictReader(f, delimiter="\t")
-            return list(reader)
+            rows = [r for r in csv.DictReader(f, delimiter="\t")
+                    if not r["patient_id"].startswith("#")]
+        if patient_id is not None:
+            rows = [r for r in rows if r["patient_id"] == patient_id]
+        return rows
 
 
     def get_fastq1(wildcards):
         """Get path to read 1 FASTQ for a sample."""
-        for sample in get_local_samples():
+        for sample in get_local_samples(wildcards.patient_id):
             if sample["sample_id"] == wildcards.sample:
                 return sample["fastq1"]
-        raise ValueError(f"Sample not found: {wildcards.sample}")
+        raise ValueError(f"Sample not found: {wildcards.sample} (patient: {wildcards.patient_id})")
 
 
     def get_fastq2(wildcards):
         """Get path to read 2 FASTQ for a sample (or empty list if single-end)."""
-        for sample in get_local_samples():
+        for sample in get_local_samples(wildcards.patient_id):
             if sample["sample_id"] == wildcards.sample:
                 fastq2 = sample.get("fastq2", "")
                 return [fastq2] if fastq2 else []
@@ -111,12 +114,12 @@ if config.get("data_source") == "fastq" and config.get("alignment", {}).get("ali
             fastq1=get_fastq1,
             fastq2=get_fastq2,
         output:
-            junctions=os.path.join(OUT["raw_data"], PATIENT_ID, "files", "{sample}.tsv"),
-            done=touch(os.path.join(OUT["raw_data"], PATIENT_ID, "files", "{sample}.done")),
+            junctions=os.path.join(OUT["raw_data"], "{patient_id}", "files", "{sample}.tsv"),
+            done=touch(os.path.join(OUT["raw_data"], "{patient_id}", "files", "{sample}.done")),
         log:
-            os.path.join(OUT["logs"], "star", "{sample}_align.log"),
+            os.path.join(OUT["logs"], "star", "{patient_id}_{sample}_align.log"),
         params:
-            output_prefix=lambda w: os.path.join(OUT["raw_data"], PATIENT_ID, "files", f"{w.sample}_"),
+            output_prefix=lambda wildcards: os.path.join(OUT["raw_data"], wildcards.patient_id, "files", f"{wildcards.sample}_"),
         threads: 8
         resources:
             mem_mb=32000,
@@ -164,19 +167,18 @@ if config.get("data_source") == "fastq" and config.get("alignment", {}).get("ali
             """
 
 
-    rule create_local_manifest:
+    rule create_star_manifest:
         """Create a manifest TSV from the local samples configuration.
 
         This mirrors the GDC manifest format so downstream rules can use the
         same filtering logic regardless of data source.
         """
         output:
-            manifest=os.path.join(OUT["raw_data"], PATIENT_ID, "manifest.tsv"),
+            manifest=os.path.join(OUT["raw_data"], "{patient_id}", "manifest.tsv"),
         log:
-            os.path.join(OUT["logs"], "star", "manifest.log"),
+            os.path.join(OUT["logs"], "star", "{patient_id}_manifest.log"),
         params:
             samples_tsv=config["samples_tsv"],
-            patient_id=PATIENT_ID,
         conda:
             "../envs/python.yaml"
         run:
@@ -191,25 +193,27 @@ if config.get("data_source") == "fastq" and config.get("alignment", {}).get("ali
                 reader = csv.DictReader(fin, delimiter="\t")
                 fout.write("file_id\tfile_name\tsample_type\tproject_id\n")
                 for row in reader:
+                    if row["patient_id"] != wildcards.patient_id:
+                        continue
                     sample_id = row["sample_id"]
                     sample_type = row.get("sample_type", "Unknown")
-                    fout.write(f"{sample_id}\t{sample_id}.tsv\t{sample_type}\t{params.patient_id}\n")
+                    fout.write(f"{sample_id}\t{sample_id}.tsv\t{sample_type}\t{wildcards.patient_id}\n")
 
 
     # Checkpoint to collect all aligned samples
-    checkpoint local_alignment_complete:
+    checkpoint star_alignment_complete:
         """Checkpoint that triggers after all local samples are aligned.
 
         This replaces the GDC download checkpoint for local mode.
         """
         input:
-            manifest=os.path.join(OUT["raw_data"], PATIENT_ID, "manifest.tsv"),
-            samples=lambda w: expand(
-                os.path.join(OUT["raw_data"], PATIENT_ID, "files", "{sample}.tsv"),
-                sample=[s["sample_id"] for s in get_local_samples()]
+            manifest=os.path.join(OUT["raw_data"], "{patient_id}", "manifest.tsv"),
+            samples=lambda wildcards: expand(
+                os.path.join(OUT["raw_data"], wildcards.patient_id, "files", "{sample}.tsv"),
+                sample=[s["sample_id"] for s in get_local_samples(wildcards.patient_id)]
             ),
         output:
-            done=os.path.join(OUT["raw_data"], PATIENT_ID, "download.done"),
-            data_dir=directory(os.path.join(OUT["raw_data"], PATIENT_ID, "files")),
+            done=os.path.join(OUT["raw_data"], "{patient_id}", "download.done"),
+            data_dir=directory(os.path.join(OUT["raw_data"], "{patient_id}", "files")),
         shell:
             "touch {output.done}"

--- a/workflow/tests/test_regression.py
+++ b/workflow/tests/test_regression.py
@@ -65,8 +65,10 @@ def _first_patient_id() -> str:
     tsv = REPO_ROOT / "config" / "test_samples.tsv"
     with tsv.open() as f:
         for row in csv.DictReader(f, delimiter="\t"):
-            if not row["patient_id"].startswith("#"):
-                return row["patient_id"]
+            pid = (row.get("patient_id") or "").strip()
+            if not pid or pid.startswith("#"):
+                continue
+            return pid
     raise RuntimeError(f"No patient_id found in {tsv}")
 
 PATIENT_ID = _first_patient_id()

--- a/workflow/tests/test_regression.py
+++ b/workflow/tests/test_regression.py
@@ -59,17 +59,17 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 RESULTS = REPO_ROOT / "results" / "test"
 GOLDEN_DIR = Path(__file__).parent / "golden"
 
-# Read patient_id from config/config.yaml so this stays in sync automatically.
-# test_config.yaml inherits this value via Snakemake's recursive config merge.
-def _read_patient_id() -> str:
-    config_path = REPO_ROOT / "config" / "config.yaml"
-    for line in config_path.read_text().splitlines():
-        stripped = line.strip()
-        if stripped.startswith("patient_id:"):
-            return stripped.split(":", 1)[1].strip().strip("'\"")
-    raise RuntimeError(f"patient_id not found in {config_path}")
+# Read the first patient_id from test_samples.tsv — the same source of truth
+# the pipeline uses, so this stays in sync automatically.
+def _first_patient_id() -> str:
+    tsv = REPO_ROOT / "config" / "test_samples.tsv"
+    with tsv.open() as f:
+        for row in csv.DictReader(f, delimiter="\t"):
+            if not row["patient_id"].startswith("#"):
+                return row["patient_id"]
+    raise RuntimeError(f"No patient_id found in {tsv}")
 
-PATIENT_ID = _read_patient_id()
+PATIENT_ID = _first_patient_id()
 GOLDEN_FILE = GOLDEN_DIR / "test_metrics.json"
 
 


### PR DESCRIPTION
Closes #32

## Summary
- `PATIENT_IDS` is now derived from `samples_tsv` at parse time — `patient_id` has been removed from `config.yaml` entirely
- Sample IDs renamed to SRR accession numbers (`SRR9143066_test` / `SRR9143065_test`) for data provenance
- `local_alignment.smk` renamed to `star_alignment.smk`; checkpoint/manifest rules renamed (`create_star_manifest`, `star_alignment_complete`) to match
- `test_regression.py` now reads the first patient_id from `test_samples.tsv` instead of `config.yaml`
- `ruleorder` for manifest disambiguation uses `config.get("data_source")` directly (no more `DATA_SOURCE` module-level variable)

## Test plan
- [x] `snakemake --dry-run --configfile config/test_config.yaml` — DAG resolves with `patient_001` in all paths
- [x] `pytest workflow/tests/` — 75 passed
- [x] `grep -rn '"local"' workflow/rules/ workflow/tests/` — no stale path segments

🤖 Generated with [Claude Code](https://claude.com/claude-code)