### PR TITLE
infra: upgrade CPU VM to n1-standard-8 and make threads config-driven (issue #40)

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -26,6 +26,7 @@ alignment:
   aligner: "hisat2"                           # "star" (32 GB RAM) or "hisat2" (8 GB RAM)
   hisat2_index_dir: "resources/hisat2_index"  # where the prebuilt HISAT2 index lives
   star_index_dir: "resources/star_index"      # where the prebuilt STAR index lives
+  threads: 8          # threads for index build + alignment
 
 # -----------------------------------------------------------------
 # Reference genome
@@ -84,6 +85,8 @@ mhcflurry:
 hla:
   enabled: true
   min_reads_per_locus: 30   # minimum OptiType Reads count to trust a call
+  threads: 4                # threads per OptiType sample — keep at half of alignment.threads
+                            # so two samples run in parallel rather than serialised
 
 # -----------------------------------------------------------------
 # TCRdock structural validation (Step 6 — optional, GPU required)

--- a/config/test_config.yaml
+++ b/config/test_config.yaml
@@ -23,6 +23,7 @@ samples_tsv: "config/test_samples.tsv"
 alignment:
   hisat2_index_dir: "resources/test/hisat2_index"   # separate from production index
   star_index_dir: "resources/test/star_index"        # separate from production index
+  threads: 4      # M1 MacBook Air (8 GB RAM) — leave headroom for other processes
 
 reference:
   genome: "GRCh38_chr22"

--- a/scripts/run_cloud_gpu.sh
+++ b/scripts/run_cloud_gpu.sh
@@ -48,7 +48,8 @@ set -euo pipefail
 CPU_VM="neoepitope-predict-cpu"
 GPU_VM="mhc-p-tcr-structure-spot-gpu"
 ZONE="europe-west1-b"
-MACHINE_TYPE="n1-standard-4"
+CPU_MACHINE_TYPE="n1-standard-8"
+GPU_MACHINE_TYPE="n1-standard-4"
 ACCELERATOR="type=nvidia-tesla-t4,count=1"
 DISK_SIZE="100GB"
 IMAGE_FAMILY="common-cu128-ubuntu-2204-nvidia-570"  # CUDA 12.8 pre-installed
@@ -278,7 +279,7 @@ elif [[ "${CPU_STATUS}" == "NOT_FOUND" ]]; then
     log "CPU VM ${CPU_VM} not found — creating it..."
     gcloud compute instances create "${CPU_VM}" \
         --zone="${ZONE}" \
-        --machine-type="${MACHINE_TYPE}" \
+        --machine-type="${CPU_MACHINE_TYPE}" \
         --image-family="ubuntu-2204-lts" \
         --image-project="ubuntu-os-cloud" \
         --boot-disk-size="50GB" \
@@ -386,7 +387,7 @@ if [[ "${GPU_STATUS}" == "NOT_FOUND" ]]; then
     log "Creating GPU Spot VM ${GPU_VM}..."
     gcloud compute instances create "${GPU_VM}" \
         --zone="${ZONE}" \
-        --machine-type="${MACHINE_TYPE}" \
+        --machine-type="${GPU_MACHINE_TYPE}" \
         --accelerator="${ACCELERATOR}" \
         --maintenance-policy=TERMINATE \
         --provisioning-model=SPOT \

--- a/workflow/rules/alignment.smk
+++ b/workflow/rules/alignment.smk
@@ -136,7 +136,7 @@ if config.get("alignment", {}).get("aligner") == "hisat2":
             done=touch(os.path.join(_HISAT2_INDEX_DIR, "index.done")),
         log:
             os.path.join(OUT["logs"], "hisat2", "hisat2_index.log"),
-        threads: 8
+        threads: config.get("alignment", {}).get("threads", 8)
         resources:
             mem_mb=8000,
         conda:
@@ -177,7 +177,7 @@ if config.get("alignment", {}).get("aligner") == "hisat2":
             output_prefix=lambda wildcards: os.path.join(
                 OUT["raw_data"], wildcards.patient_id, "files", wildcards.sample
             ),
-        threads: 8
+        threads: config.get("alignment", {}).get("threads", 8)
         resources:
             mem_mb=8000,
         conda:
@@ -241,7 +241,7 @@ elif config.get("alignment", {}).get("aligner") == "star":
             done=touch(os.path.join(_STAR_INDEX_DIR, "index.done")),
         log:
             os.path.join(OUT["logs"], "star", "star_index.log"),
-        threads: 8
+        threads: config.get("alignment", {}).get("threads", 8)
         resources:
             mem_mb=32000,
         conda:
@@ -289,7 +289,7 @@ elif config.get("alignment", {}).get("aligner") == "star":
             output_prefix=lambda wildcards: os.path.join(
                 OUT["raw_data"], wildcards.patient_id, "files", f"{wildcards.sample}_"
             ),
-        threads: 8
+        threads: config.get("alignment", {}).get("threads", 8)
         resources:
             mem_mb=32000,
         conda:

--- a/workflow/rules/hla_typing.smk
+++ b/workflow/rules/hla_typing.smk
@@ -75,7 +75,7 @@ if config.get("hla", {}).get("enabled", False):
             os.path.join(OUT["logs"], "hla_typing", "{patient_id}_{sample}.log"),
         params:
             outdir=lambda w: os.path.join(_HLA_TYPING_DIR, w.patient_id, w.sample),
-        threads: 4
+        threads: config.get("hla", {}).get("threads", 4)
         conda:
             "../envs/optitype.yaml"
         shell:


### PR DESCRIPTION
## Summary

- `run_cloud_gpu.sh`: split `MACHINE_TYPE` into `CPU_MACHINE_TYPE=n1-standard-8` and `GPU_MACHINE_TYPE=n1-standard-4` — GPU VM unchanged since TCRdock is GPU-bound and 4 vCPUs is sufficient
- `config.yaml`: add `alignment.threads: 8` and `hla.threads: 4`
- `test_config.yaml`: override `alignment.threads: 4` for local M1 MacBook Air dev
- `alignment.smk`: all four rules read threads from `config.alignment.threads`
- `hla_typing.smk`: `run_optitype` reads threads from `config.hla.threads` — kept at half of `alignment.threads` so two samples run in parallel (4+4) rather than serialised at 8 each

## Manual step after merge

Resize the existing VM (no reinstallation needed):
```bash
gcloud compute instances stop neoepitope-predict-cpu --zone europe-west1-b
gcloud compute instances set-machine-type neoepitope-predict-cpu \
  --zone europe-west1-b --machine-type n1-standard-8
gcloud compute instances start neoepitope-predict-cpu --zone europe-west1-b
```

## Test plan

- [x] `snakemake --dry-run --configfile config/test_config.yaml` — DAG resolves, rules pick up `threads: 4` from test config
- [x] CI passes

Closes #40.

🤖 Generated with [Claude Code](https://claude.com/claude-code)