### PR TITLE
fix: unlock Snakemake before each pipeline run to handle interrupted restarts

### DIFF
--- a/scripts/run_cloud_gpu.sh
+++ b/scripts/run_cloud_gpu.sh
@@ -316,6 +316,7 @@ tmux kill-session -t pipeline 2>/dev/null || true
 tmux new-session -d -s pipeline "
     source \"\$HOME/miniforge3/etc/profile.d/conda.sh\" 2>/dev/null || true
     conda activate snakemake
+    snakemake --unlock --configfile ${CONFIG_FILE} 2>/dev/null || true
     snakemake \\
         --cores \$(nproc) \\
         --use-conda \\
@@ -477,6 +478,7 @@ find ${RESULTS_DIR} -name report.html -delete
 source "\$HOME/miniforge3/etc/profile.d/conda.sh"
 conda activate snakemake
 
+snakemake --unlock --configfile ${CONFIG_FILE} config/tcrdock_gpu.yaml 2>/dev/null || true
 snakemake \\
     --cores "\$(nproc)" \\
     --use-conda \\


### PR DESCRIPTION
## Summary

- Add `snakemake --unlock` before both the CPU and GPU pipeline invocations in `run_cloud_gpu.sh`
- Cancelled or interrupted runs leave `.snakemake/locks/` behind, blocking the next run with a lock error
- The `|| true` means it succeeds silently whether or not a lock existed

## Test plan
- [x] Manually verified lock error is resolved by `snakemake --unlock`
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)