### PR TITLE
infra: suppress Next steps blocks when scripts are called from run_cloud_gpu.sh

### DIFF
--- a/scripts/prepare_production_data.sh
+++ b/scripts/prepare_production_data.sh
@@ -19,6 +19,14 @@
 #
 set -euo pipefail
 
+STANDALONE=true
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --no-next-steps) STANDALONE=false; shift ;;
+        *) echo "Unknown argument: $1" >&2; exit 1 ;;
+    esac
+done
+
 DATA="data"
 mkdir -p "$DATA"
 
@@ -63,7 +71,10 @@ fi
 
 echo ""
 echo "=== Downloads complete! ==="
-echo ""
-echo "Run the pipeline with:"
-echo "    conda activate snakemake"
-echo "    snakemake --cores \$(nproc) --use-conda 2>&1 | tee pipeline.log"
+
+if [[ "${STANDALONE}" == true ]]; then
+    echo ""
+    echo "Run the pipeline with:"
+    echo "    conda activate snakemake"
+    echo "    snakemake --cores \$(nproc) --use-conda 2>&1 | tee pipeline.log"
+fi

--- a/scripts/run_cloud_gpu.sh
+++ b/scripts/run_cloud_gpu.sh
@@ -291,16 +291,14 @@ fi
 wait_for_ssh "${CPU_VM}"
 
 log "Running setup_cloud.sh on ${CPU_VM}..."
-ssh_cmd "${CPU_VM}" -- bash -s -- --repo-branch "${BRANCH}" < scripts/setup_cloud.sh
-log "  Setup complete."
+ssh_cmd "${CPU_VM}" -- bash -s -- --repo-branch "${BRANCH}" --no-next-steps < scripts/setup_cloud.sh
 
 log "Preparing data on ${CPU_VM} (${PREPARE_DATA_SCRIPT})..."
 ssh_cmd "${CPU_VM}" -- bash -s <<REMOTE
 set -euo pipefail
 cd "\$HOME/splice-neoepitope-pipeline"
-bash ${PREPARE_DATA_SCRIPT}
+bash ${PREPARE_DATA_SCRIPT} --no-next-steps
 REMOTE
-log "  Data ready."
 
 log "Pulling branch '${BRANCH}' and starting pipeline on ${CPU_VM}..."
 ssh_cmd "${CPU_VM}" -- bash -s <<EOF

--- a/scripts/setup_cloud.sh
+++ b/scripts/setup_cloud.sh
@@ -29,8 +29,9 @@ set -euo pipefail
 REPO_URL="https://github.com/Jin-HoMLee/splice-neoepitope-pipeline.git"
 REPO_DIR="$HOME/splice-neoepitope-pipeline"
 REPO_BRANCH="main"
+STANDALONE=true
 
-# Parse optional --repo-branch argument
+# Parse optional arguments
 while [[ $# -gt 0 ]]; do
     case $1 in
         --repo-branch)
@@ -39,6 +40,7 @@ while [[ $# -gt 0 ]]; do
                 exit 1
             fi
             REPO_BRANCH="$2"; shift 2 ;;
+        --no-next-steps) STANDALONE=false; shift ;;
         *) echo "Unknown argument: $1" >&2; exit 1 ;;
     esac
 done
@@ -178,16 +180,19 @@ fi
 # ---------------------------------------------------------------------------
 echo ""
 echo "=== Setup complete! ==="
-echo ""
-echo "Next steps:"
-echo "  0. Open a new shell (or run: source ~/.bashrc) so that 'conda' is on your PATH"
-echo "  1. Edit config/samples.tsv with your sample FASTQ paths and sample types"
-echo "  2. Activate the Snakemake environment:"
-echo "       conda activate snakemake"
-echo "  3. From inside a tmux session, run the pipeline:"
-echo "       cd $REPO_DIR"
-echo "       snakemake --cores \$(nproc) --use-conda 2>&1 | tee pipeline.log"
-echo ""
-echo "     The VM will NOT shut down automatically — stop it manually when done"
-echo "     to avoid charges. (The automated run_cloud_gpu.sh handles shutdown.)"
-echo "     To detach from tmux without stopping the run: Ctrl+B, then D."
+
+if [[ "${STANDALONE}" == true ]]; then
+    echo ""
+    echo "Next steps:"
+    echo "  0. Open a new shell (or run: source ~/.bashrc) so that 'conda' is on your PATH"
+    echo "  1. Edit config/samples.tsv with your sample FASTQ paths and sample types"
+    echo "  2. Activate the Snakemake environment:"
+    echo "       conda activate snakemake"
+    echo "  3. From inside a tmux session, run the pipeline:"
+    echo "       cd $REPO_DIR"
+    echo "       snakemake --cores \$(nproc) --use-conda 2>&1 | tee pipeline.log"
+    echo ""
+    echo "     The VM will NOT shut down automatically — stop it manually when done"
+    echo "     to avoid charges. (The automated run_cloud_gpu.sh handles shutdown.)"
+    echo "     To detach from tmux without stopping the run: Ctrl+B, then D."
+fi


### PR DESCRIPTION
## Summary

- `setup_cloud.sh` and `prepare_production_data.sh` both print a "Next steps" guidance block intended for standalone use. When called from `run_cloud_gpu.sh` these blocks are noise in the orchestrator log.
- Both scripts: add `--no-next-steps` flag; suppress the guidance block when set.
- `run_cloud_gpu.sh`: pass `--no-next-steps` to both scripts; remove redundant `"Setup complete."` and `"Data ready."` log lines — the scripts own those messages.

## Test plan

- [x] `bash scripts/setup_cloud.sh --no-next-steps` — prints setup progress, no "Next steps" block at end
- [x] `bash scripts/setup_cloud.sh` (standalone) — still prints full "Next steps" guidance
- [x] `bash scripts/prepare_production_data.sh --no-next-steps` — same suppression
- [x] Verify `run_cloud_gpu.sh` passes `--no-next-steps` to both scripts

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)