### PR TITLE
fix(report): show '✓ concordant' for HLA loci with no normal/tumor discrepancy

### DIFF
--- a/workflow/scripts/generate_report.py
+++ b/workflow/scripts/generate_report.py
@@ -275,12 +275,13 @@ def _build_hla_section(hla_qc_tsv: str) -> str:
             f'<span style="color:{colour};font-weight:bold">'
             f'{html_mod.escape(source)}</span>'
         )
-        discrepancy = str(row.get("discrepancy", "") or "").strip()
+        _disc_raw = row.get("discrepancy", "")
+        discrepancy = "" if pd.isna(_disc_raw) else str(_disc_raw).strip()
         if discrepancy:
             has_discrepancy = True
         disc_cell = (
             f'<td style="background:#fef3cd">{html_mod.escape(discrepancy)}</td>'
-            if discrepancy else "<td>—</td>"
+            if discrepancy else '<td style="color:#27ae60">&#10003; concordant</td>'
         )
         rows.append(
             f"<tr>"


### PR DESCRIPTION
## Summary

- `pd.read_csv` converts empty discrepancy cells to `NaN` (float). `str(NaN)` → `"nan"` which is truthy, so it was rendered as a yellow discrepancy cell with the text "nan" instead of a clean no-discrepancy indicator.
- Fixed with `pd.isna()` check before stringifying.
- Replaced the bare `—` fallback with a green `✓ concordant` label for readability.

## Test plan

- [ ] On production data (patient_001), HLA loci where normal and tumor agree show `✓ concordant` in green instead of `nan` or `—`
- [ ] Loci with real discrepancies still render correctly with yellow background

🤖 Generated with [Claude Code](https://claude.com/claude-code)