### PR TITLE
perf(mhcflurry): parallel allele predictions with ProcessPoolExecutor (issue #50)

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -59,7 +59,7 @@ include: "workflow/rules/hla_typing.smk"
 include: "workflow/rules/filter.smk"
 include: "workflow/rules/assemble.smk"
 include: "workflow/rules/translate.smk"
-include: "workflow/rules/predict.smk"
+include: "workflow/rules/mhcflurry.smk"
 include: "workflow/rules/analysis.smk"
 include: "workflow/rules/tcrdock.smk"
 

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -70,6 +70,7 @@ mhcflurry:
     C: "HLA-C*07:02"
   ic50_strong:  50            # nM threshold for strong binders
   ic50_weak:   500            # nM threshold for weak binders
+  threads: 8                  # parallel allele predictions (n1-standard-8)
   # MHCflurry supports multiple prediction modes:
   #   "affinity"        - binding affinity only (IC50)
   #   "presentation"    - presentation score (recommended)

--- a/config/test_config.yaml
+++ b/config/test_config.yaml
@@ -25,6 +25,9 @@ alignment:
   star_index_dir: "resources/test/star_index"        # separate from production index
   threads: 4      # M1 MacBook Air (8 GB RAM) — leave headroom for other processes
 
+mhcflurry:
+  threads: 4      # M1 MacBook Air (8 GB RAM)
+
 reference:
   genome: "GRCh38_chr22"
   genome_fasta: "resources/test/chr22.fa"

--- a/workflow/rules/analysis.smk
+++ b/workflow/rules/analysis.smk
@@ -11,7 +11,7 @@ def _generate_report_input(wildcards):
             OUT["junctions"], wildcards.patient_id, "novel_junctions.tsv"
         ),
         "predictions_tsv": os.path.join(
-            OUT["predictions"], wildcards.patient_id, "predictions.tsv"
+            OUT["predictions"], wildcards.patient_id, "mhc_affinity.tsv"
         ),
         "contigs_fasta": os.path.join(
             OUT["contigs"], wildcards.patient_id, "contigs.fa"

--- a/workflow/rules/mhcflurry.smk
+++ b/workflow/rules/mhcflurry.smk
@@ -55,6 +55,8 @@ rule run_mhcflurry:
         fallback_alleles=list(config["mhcflurry"]["fallback_alleles"].values()),
         ic50_strong=config["mhcflurry"]["ic50_strong"],
         ic50_weak=config["mhcflurry"]["ic50_weak"],
+        threads=config["mhcflurry"]["threads"],
+    threads: config["mhcflurry"]["threads"]
     conda:
         "../envs/python.yaml"
     script:

--- a/workflow/rules/mhcflurry.smk
+++ b/workflow/rules/mhcflurry.smk
@@ -45,8 +45,8 @@ rule run_mhcflurry:
     input:
         unpack(_run_mhcflurry_input),
     output:
-        predictions_tsv=os.path.join(
-            OUT["predictions"], "{patient_id}", "predictions.tsv"
+        mhc_affinity_tsv=os.path.join(
+            OUT["predictions"], "{patient_id}", "mhc_affinity.tsv"
         ),
     log:
         os.path.join(OUT["logs"], "predict", "{patient_id}_predict.log"),

--- a/workflow/rules/tcrdock.smk
+++ b/workflow/rules/tcrdock.smk
@@ -33,7 +33,7 @@ if _TCRDOCK_ENABLED:
         PDB structure and docking geometry scores.
         """
         input:
-            predictions_tsv=rules.run_mhcflurry.output.predictions_tsv,
+            predictions_tsv=rules.run_mhcflurry.output.mhc_affinity_tsv,
         output:
             pdb=os.path.join(
                 OUT["predictions"], "{patient_id}", "tcrdock", "top_candidate.pdb"

--- a/workflow/scripts/generate_report.py
+++ b/workflow/scripts/generate_report.py
@@ -10,7 +10,7 @@ Produces a self-contained HTML page showing:
 Usage (standalone):
   python generate_report.py \\
       --novel-junctions results/junctions/local/novel_junctions.tsv \\
-      --predictions results/predictions/local/predictions.tsv \\
+      --predictions results/predictions/local/mhc_affinity.tsv \\
       --output results/reports/local/report.html
 
 Usage (Snakemake):

--- a/workflow/scripts/run_mhcflurry.py
+++ b/workflow/scripts/run_mhcflurry.py
@@ -46,7 +46,7 @@ Usage (Snakemake):
 import argparse
 import csv
 import logging
-from concurrent.futures import ThreadPoolExecutor, as_completed
+from concurrent.futures import ProcessPoolExecutor, as_completed
 from pathlib import Path
 
 import pandas as pd
@@ -189,6 +189,34 @@ def classify(ic50: float, ic50_strong: float = 50.0, ic50_weak: float = 500.0) -
 
 
 # ---------------------------------------------------------------------------
+# Per-process worker (module-level so ProcessPoolExecutor can pickle it)
+# ---------------------------------------------------------------------------
+
+def _predict_allele_worker(
+    allele: str,
+    unique_peptides: list[str],
+    peptides_df: "pd.DataFrame",
+    ic50_strong: float,
+    ic50_weak: float,
+) -> "pd.DataFrame":
+    """Load predictor fresh in this worker process and predict for one allele."""
+    predictor = _load_mhcflurry_predictor()
+    pred_df = _run_mhcflurry_predictions(unique_peptides, allele, predictor=predictor)
+    pred_df = pred_df.rename(columns={
+        "prediction": "ic50_nM",
+        "prediction_percentile": "percentile_rank",
+    })[["peptide", "ic50_nM", "percentile_rank"]]
+    merged = peptides_df.merge(pred_df, on="peptide", how="left")
+    merged["allele"] = allele
+    merged["ic50_nM"] = merged["ic50_nM"].fillna(float("inf"))
+    merged["percentile_rank"] = merged["percentile_rank"].fillna(float("nan"))
+    merged["binder_class"] = merged["ic50_nM"].apply(
+        lambda v: classify(v, ic50_strong, ic50_weak)
+    )
+    return merged
+
+
+# ---------------------------------------------------------------------------
 # Main orchestrator
 # ---------------------------------------------------------------------------
 
@@ -258,31 +286,24 @@ def run_prediction(
         len(peptides_df), len(unique_peptides), peptides_tsv,
     )
 
-    # Step 2: Load the predictor once, then run for each allele in parallel.
-    # MHCflurry releases the GIL during TensorFlow inference, so threads give
-    # real parallelism. The predictor object is read-only after load, making
-    # concurrent predict_to_dataframe() calls safe.
-    predictor = _load_mhcflurry_predictor()
-
-    def _predict_allele(allele: str) -> pd.DataFrame:
-        pred_df = _run_mhcflurry_predictions(unique_peptides, allele, predictor=predictor)
-        pred_df = pred_df.rename(columns={
-            "prediction": "ic50_nM",
-            "prediction_percentile": "percentile_rank",
-        })[["peptide", "ic50_nM", "percentile_rank"]]
-        merged = peptides_df.merge(pred_df, on="peptide", how="left")
-        merged["allele"] = allele
-        merged["ic50_nM"] = merged["ic50_nM"].fillna(float("inf"))
-        merged["percentile_rank"] = merged["percentile_rank"].fillna(float("nan"))
-        merged["binder_class"] = merged["ic50_nM"].apply(
-            lambda v: classify(v, ic50_strong, ic50_weak)
-        )
-        return merged
-
+    # Step 2: Run predictions for each allele in parallel.
+    # predict_to_dataframe() is not thread-safe (shared TensorFlow state), so we
+    # use ProcessPoolExecutor — each worker process loads its own predictor copy.
+    # Total wall-clock time ≈ model_load + max(per-allele prediction time) rather
+    # than model_load + sum(per-allele prediction time).
     max_workers = min(len(resolved_alleles), threads)
-    log.info("Running predictions for %d allele(s) with %d thread(s)", len(resolved_alleles), max_workers)
-    with ThreadPoolExecutor(max_workers=max_workers) as executor:
-        futures = {executor.submit(_predict_allele, allele): allele for allele in resolved_alleles}
+    log.info(
+        "Running predictions for %d allele(s) with %d worker(s)",
+        len(resolved_alleles), max_workers,
+    )
+    with ProcessPoolExecutor(max_workers=max_workers) as executor:
+        futures = {
+            executor.submit(
+                _predict_allele_worker,
+                allele, unique_peptides, peptides_df, ic50_strong, ic50_weak,
+            ): allele
+            for allele in resolved_alleles
+        }
         allele_dfs = [future.result() for future in as_completed(futures)]
 
     # Step 3: Write combined output

--- a/workflow/scripts/run_mhcflurry.py
+++ b/workflow/scripts/run_mhcflurry.py
@@ -46,6 +46,7 @@ Usage (Snakemake):
 import argparse
 import csv
 import logging
+import os
 from concurrent.futures import ProcessPoolExecutor, as_completed
 from pathlib import Path
 
@@ -192,28 +193,50 @@ def classify(ic50: float, ic50_strong: float = 50.0, ic50_weak: float = 500.0) -
 # Per-process worker (module-level so ProcessPoolExecutor can pickle it)
 # ---------------------------------------------------------------------------
 
+# Predictor cache: populated once per worker process by _worker_init().
+_worker_predictor = None
+
+
+def _worker_init() -> None:
+    """One-time initialiser for each worker process.
+
+    Sets TF/BLAS thread-count env vars *before* MHCflurry (and TensorFlow) are
+    imported so that each worker uses only one intra-op/inter-op thread.
+    Without this, every subprocess spawns its own full thread pool, which
+    oversubscribes CPU cores when several workers run in parallel.
+    """
+    os.environ.setdefault("OMP_NUM_THREADS", "1")
+    os.environ.setdefault("OPENBLAS_NUM_THREADS", "1")
+    os.environ.setdefault("TF_NUM_INTRAOP_THREADS", "1")
+    os.environ.setdefault("TF_NUM_INTEROP_THREADS", "1")
+    global _worker_predictor
+    _worker_predictor = _load_mhcflurry_predictor()
+
+
 def _predict_allele_worker(
     allele: str,
     unique_peptides: list[str],
-    peptides_df: "pd.DataFrame",
     ic50_strong: float,
     ic50_weak: float,
 ) -> "pd.DataFrame":
-    """Load predictor fresh in this worker process and predict for one allele."""
-    predictor = _load_mhcflurry_predictor()
-    pred_df = _run_mhcflurry_predictions(unique_peptides, allele, predictor=predictor)
+    """Predict binding for one allele; returns a lean per-allele DataFrame.
+
+    Columns: peptide, allele, ic50_nM, percentile_rank, binder_class.
+    peptides_df (with contig_key/start_nt) is kept in the parent process to
+    avoid pickling it into every worker.
+    """
+    pred_df = _run_mhcflurry_predictions(unique_peptides, allele, predictor=_worker_predictor)
     pred_df = pred_df.rename(columns={
         "prediction": "ic50_nM",
         "prediction_percentile": "percentile_rank",
     })[["peptide", "ic50_nM", "percentile_rank"]]
-    merged = peptides_df.merge(pred_df, on="peptide", how="left")
-    merged["allele"] = allele
-    merged["ic50_nM"] = merged["ic50_nM"].fillna(float("inf"))
-    merged["percentile_rank"] = merged["percentile_rank"].fillna(float("nan"))
-    merged["binder_class"] = merged["ic50_nM"].apply(
+    pred_df["allele"] = allele
+    pred_df["ic50_nM"] = pred_df["ic50_nM"].fillna(float("inf"))
+    pred_df["percentile_rank"] = pred_df["percentile_rank"].fillna(float("nan"))
+    pred_df["binder_class"] = pred_df["ic50_nM"].apply(
         lambda v: classify(v, ic50_strong, ic50_weak)
     )
-    return merged
+    return pred_df
 
 
 # ---------------------------------------------------------------------------
@@ -265,6 +288,9 @@ def run_prediction(
     else:
         raise ValueError("Either alleles or alleles_tsv must be provided.")
 
+    if threads < 1:
+        raise ValueError(f"Invalid threads value {threads!r}: threads must be >= 1.")
+
     output_tsv = Path(output_tsv)
     output_tsv.parent.mkdir(parents=True, exist_ok=True)
 
@@ -291,26 +317,26 @@ def run_prediction(
     # use ProcessPoolExecutor — each worker process loads its own predictor copy.
     # Total wall-clock time ≈ model_load + max(per-allele prediction time) rather
     # than model_load + sum(per-allele prediction time).
-    if threads < 1:
-        raise ValueError(
-            f"Invalid threads value {threads!r}: threads must be >= 1."
-        )
     max_workers = min(len(resolved_alleles), threads)
     log.info(
         "Running predictions for %d allele(s) with %d worker(s)",
         len(resolved_alleles), max_workers,
     )
-    with ProcessPoolExecutor(max_workers=max_workers) as executor:
+    with ProcessPoolExecutor(max_workers=max_workers, initializer=_worker_init) as executor:
         futures = {
             executor.submit(
                 _predict_allele_worker,
-                allele, unique_peptides, peptides_df, ic50_strong, ic50_weak,
+                allele, unique_peptides, ic50_strong, ic50_weak,
             ): allele
             for allele in resolved_alleles
         }
-        allele_dfs = [future.result() for future in as_completed(futures)]
+        pred_dfs = [future.result() for future in as_completed(futures)]
 
-    # Step 3: Write combined output
+    # Step 3: Merge per-allele predictions with peptides_df (held in parent to
+    # avoid pickling the full table into every worker), then concatenate.
+    allele_dfs = [peptides_df.merge(pred_df, on="peptide", how="left") for pred_df in pred_dfs]
+
+    # Step 4: Write combined output
     df = pd.concat(allele_dfs, ignore_index=True)[
         ["contig_key", "start_nt", "peptide", "allele",
          "ic50_nM", "percentile_rank", "binder_class"]

--- a/workflow/scripts/run_mhcflurry.py
+++ b/workflow/scripts/run_mhcflurry.py
@@ -243,7 +243,7 @@ def run_prediction(
                         alleles are loaded from the file (takes precedence over alleles).
         ic50_strong:    Strong-binder IC50 threshold (nM).
         ic50_weak:      Weak-binder IC50 threshold (nM).
-        threads:        Number of alleles to predict in parallel (ThreadPoolExecutor).
+        threads:        Number of alleles to predict in parallel (ProcessPoolExecutor worker processes).
 
     Raises:
         ValueError: If neither alleles nor alleles_tsv is provided.

--- a/workflow/scripts/run_mhcflurry.py
+++ b/workflow/scripts/run_mhcflurry.py
@@ -291,6 +291,10 @@ def run_prediction(
     # use ProcessPoolExecutor — each worker process loads its own predictor copy.
     # Total wall-clock time ≈ model_load + max(per-allele prediction time) rather
     # than model_load + sum(per-allele prediction time).
+    if threads < 1:
+        raise ValueError(
+            f"Invalid threads value {threads!r}: threads must be >= 1."
+        )
     max_workers = min(len(resolved_alleles), threads)
     log.info(
         "Running predictions for %d allele(s) with %d worker(s)",

--- a/workflow/scripts/run_mhcflurry.py
+++ b/workflow/scripts/run_mhcflurry.py
@@ -46,6 +46,7 @@ Usage (Snakemake):
 import argparse
 import csv
 import logging
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 
 import pandas as pd
@@ -198,6 +199,7 @@ def run_prediction(
     alleles_tsv: str | None = None,
     ic50_strong: float = 50.0,
     ic50_weak: float = 500.0,
+    threads: int = 1,
 ) -> None:
     """Run MHCflurry on junction-spanning 9-mers and write results to TSV.
 
@@ -213,6 +215,7 @@ def run_prediction(
                         alleles are loaded from the file (takes precedence over alleles).
         ic50_strong:    Strong-binder IC50 threshold (nM).
         ic50_weak:      Weak-binder IC50 threshold (nM).
+        threads:        Number of alleles to predict in parallel (ThreadPoolExecutor).
 
     Raises:
         ValueError: If neither alleles nor alleles_tsv is provided.
@@ -255,19 +258,18 @@ def run_prediction(
         len(peptides_df), len(unique_peptides), peptides_tsv,
     )
 
-    # Step 2: Load the predictor once, then run for each allele
+    # Step 2: Load the predictor once, then run for each allele in parallel.
+    # MHCflurry releases the GIL during TensorFlow inference, so threads give
+    # real parallelism. The predictor object is read-only after load, making
+    # concurrent predict_to_dataframe() calls safe.
     predictor = _load_mhcflurry_predictor()
 
-    allele_dfs = []
-    for allele in resolved_alleles:
+    def _predict_allele(allele: str) -> pd.DataFrame:
         pred_df = _run_mhcflurry_predictions(unique_peptides, allele, predictor=predictor)
-
-        # Rename mhcflurry output columns and merge with the full peptides table
         pred_df = pred_df.rename(columns={
             "prediction": "ic50_nM",
             "prediction_percentile": "percentile_rank",
         })[["peptide", "ic50_nM", "percentile_rank"]]
-
         merged = peptides_df.merge(pred_df, on="peptide", how="left")
         merged["allele"] = allele
         merged["ic50_nM"] = merged["ic50_nM"].fillna(float("inf"))
@@ -275,7 +277,13 @@ def run_prediction(
         merged["binder_class"] = merged["ic50_nM"].apply(
             lambda v: classify(v, ic50_strong, ic50_weak)
         )
-        allele_dfs.append(merged)
+        return merged
+
+    max_workers = min(len(resolved_alleles), threads)
+    log.info("Running predictions for %d allele(s) with %d thread(s)", len(resolved_alleles), max_workers)
+    with ThreadPoolExecutor(max_workers=max_workers) as executor:
+        futures = {executor.submit(_predict_allele, allele): allele for allele in resolved_alleles}
+        allele_dfs = [future.result() for future in as_completed(futures)]
 
     # Step 3: Write combined output
     df = pd.concat(allele_dfs, ignore_index=True)[
@@ -302,7 +310,7 @@ def _snakemake_main() -> None:
     logging.getLogger().addHandler(logging.FileHandler(log_file))
 
     # Use patient-specific alleles when HLA typing is enabled (alleles_tsv input
-    # is only wired in predict.smk when config.hla.enabled is true).
+    # is only wired in mhcflurry.smk when config.hla.enabled is true).
     alleles_tsv = getattr(snakemake.input, "alleles_tsv", None)  # type: ignore[name-defined]  # noqa: F821
     run_prediction(
         peptides_tsv=snakemake.input.peptides_tsv,  # type: ignore[name-defined]  # noqa: F821
@@ -311,6 +319,7 @@ def _snakemake_main() -> None:
         alleles_tsv=alleles_tsv,
         ic50_strong=float(snakemake.params.ic50_strong),  # type: ignore[name-defined]  # noqa: F821
         ic50_weak=float(snakemake.params.ic50_weak),  # type: ignore[name-defined]  # noqa: F821
+        threads=int(snakemake.params.threads),  # type: ignore[name-defined]  # noqa: F821
     )
 
 
@@ -330,6 +339,8 @@ def _cli_main() -> None:
     )
     parser.add_argument("--ic50-strong", type=float, default=50.0)
     parser.add_argument("--ic50-weak", type=float, default=500.0)
+    parser.add_argument("--threads", type=int, default=1,
+                        help="Parallel allele prediction threads (default: 1 = serial).")
     args = parser.parse_args()
 
     if not args.alleles and not args.alleles_tsv:
@@ -342,6 +353,7 @@ def _cli_main() -> None:
         alleles_tsv=args.alleles_tsv,
         ic50_strong=args.ic50_strong,
         ic50_weak=args.ic50_weak,
+        threads=args.threads,
     )
 
 

--- a/workflow/scripts/run_mhcflurry.py
+++ b/workflow/scripts/run_mhcflurry.py
@@ -28,7 +28,7 @@ Output TSV columns:
 Usage (standalone, explicit alleles):
   python run_mhcflurry.py \\
       --peptides-tsv results/peptides/patient_001/peptides.tsv \\
-      --output results/predictions/patient_001/predictions.tsv \\
+      --output results/predictions/patient_001/mhc_affinity.tsv \\
       --alleles HLA-A*02:01 HLA-B*07:02 HLA-C*07:02 \\
       --ic50-strong 50 \\
       --ic50-weak 500
@@ -36,7 +36,7 @@ Usage (standalone, explicit alleles):
 Usage (standalone, alleles from HLA typing):
   python run_mhcflurry.py \\
       --peptides-tsv results/peptides/patient_001/peptides.tsv \\
-      --output results/predictions/patient_001/predictions.tsv \\
+      --output results/predictions/patient_001/mhc_affinity.tsv \\
       --alleles-tsv results/hla_typing/patient_001/alleles.tsv
 
 Usage (Snakemake):
@@ -335,7 +335,7 @@ def _snakemake_main() -> None:
     alleles_tsv = getattr(snakemake.input, "alleles_tsv", None)  # type: ignore[name-defined]  # noqa: F821
     run_prediction(
         peptides_tsv=snakemake.input.peptides_tsv,  # type: ignore[name-defined]  # noqa: F821
-        output_tsv=snakemake.output.predictions_tsv,  # type: ignore[name-defined]  # noqa: F821
+        output_tsv=snakemake.output.mhc_affinity_tsv,  # type: ignore[name-defined]  # noqa: F821
         alleles=None if alleles_tsv else list(snakemake.params.fallback_alleles),  # type: ignore[name-defined]  # noqa: F821
         alleles_tsv=alleles_tsv,
         ic50_strong=float(snakemake.params.ic50_strong),  # type: ignore[name-defined]  # noqa: F821

--- a/workflow/scripts/run_tcrdock.py
+++ b/workflow/scripts/run_tcrdock.py
@@ -38,7 +38,7 @@ Outputs
 
 Usage (standalone, Linux + GPU only):
   python run_tcrdock.py \\
-      --predictions-tsv results/predictions/local/predictions.tsv \\
+      --predictions-tsv results/predictions/local/mhc_affinity.tsv \\
       --output-pdb results/predictions/local/tcrdock/top_candidate.pdb \\
       --output-scores results/predictions/local/tcrdock/docking_scores.tsv
 

--- a/workflow/tests/test_regression.py
+++ b/workflow/tests/test_regression.py
@@ -157,7 +157,7 @@ def collect_metrics() -> dict:
     n_unique_peptides = len(set(r["peptide"] for r in pep_rows))
 
     # Predictions -------------------------------------------------------------
-    pred_rows = _read_tsv(RESULTS / "predictions" / PATIENT_ID / "predictions.tsv")
+    pred_rows = _read_tsv(RESULTS / "predictions" / PATIENT_ID / "mhc_affinity.tsv")
     binder_counts: dict[str, int] = {}
     for r in pred_rows:
         bc = r["binder_class"]

--- a/workflow/tests/test_run_mhcflurry.py
+++ b/workflow/tests/test_run_mhcflurry.py
@@ -151,6 +151,91 @@ class TestRunPredictionEmpty:
 
 
 # ---------------------------------------------------------------------------
+# _worker_init and _predict_allele_worker — isolated unit tests
+# ---------------------------------------------------------------------------
+
+class TestWorker:
+    """Unit tests for the per-process worker functions.
+
+    Tests run entirely in-process: _worker_predictor is set manually and
+    _run_mhcflurry_predictions is monkeypatched, so no MHCflurry models or
+    subprocess spawning are needed.
+    """
+
+    PEPTIDES = ["ACDEFGHIK", "LMNPQRSTV", "YKLMFSTAV"]
+
+    @pytest.fixture(autouse=True)
+    def _patch_mhcflurry(self, monkeypatch):
+        import run_mhcflurry
+
+        def fake_predict(peptides, allele, predictor=None):
+            ic50 = {"HLA-A*02:01": 30.0, "HLA-B*07:02": 300.0}.get(allele, 9999.0)
+            return pd.DataFrame({
+                "peptide": peptides,
+                "prediction": [ic50] * len(peptides),
+                "prediction_percentile": [5.0] * len(peptides),
+            })
+
+        monkeypatch.setattr(run_mhcflurry, "_load_mhcflurry_predictor", lambda: object())
+        monkeypatch.setattr(run_mhcflurry, "_run_mhcflurry_predictions", fake_predict)
+        monkeypatch.setattr(run_mhcflurry, "_worker_predictor", object())
+
+    def test_worker_returns_correct_columns(self):
+        from run_mhcflurry import _predict_allele_worker
+        df = _predict_allele_worker("HLA-A*02:01", self.PEPTIDES, 50.0, 500.0)
+        assert list(df.columns) == ["peptide", "ic50_nM", "percentile_rank", "allele", "binder_class"]
+
+    def test_worker_allele_assigned(self):
+        from run_mhcflurry import _predict_allele_worker
+        df = _predict_allele_worker("HLA-B*07:02", self.PEPTIDES, 50.0, 500.0)
+        assert (df["allele"] == "HLA-B*07:02").all()
+
+    def test_worker_binder_class_strong(self):
+        """IC50=30 nM → strong binder (threshold 50 nM)."""
+        from run_mhcflurry import _predict_allele_worker
+        df = _predict_allele_worker("HLA-A*02:01", self.PEPTIDES, 50.0, 500.0)
+        assert (df["binder_class"] == "strong").all()
+
+    def test_worker_binder_class_weak(self):
+        """IC50=300 nM → weak binder (threshold 500 nM)."""
+        from run_mhcflurry import _predict_allele_worker
+        df = _predict_allele_worker("HLA-B*07:02", self.PEPTIDES, 50.0, 500.0)
+        assert (df["binder_class"] == "weak").all()
+
+    def test_worker_binder_class_non(self):
+        """Unknown allele gets IC50=9999 nM → non-binder."""
+        from run_mhcflurry import _predict_allele_worker
+        df = _predict_allele_worker("HLA-C*07:02", self.PEPTIDES, 50.0, 500.0)
+        assert (df["binder_class"] == "non").all()
+
+    def test_worker_init_sets_env_vars(self, monkeypatch):
+        """_worker_init must set TF/BLAS thread-count env vars before model load."""
+        import os
+        import run_mhcflurry
+        for var in ("OMP_NUM_THREADS", "OPENBLAS_NUM_THREADS",
+                    "TF_NUM_INTRAOP_THREADS", "TF_NUM_INTEROP_THREADS"):
+            monkeypatch.delenv(var, raising=False)
+
+        run_mhcflurry._worker_init()
+
+        assert os.environ["OMP_NUM_THREADS"] == "1"
+        assert os.environ["TF_NUM_INTRAOP_THREADS"] == "1"
+        assert os.environ["TF_NUM_INTEROP_THREADS"] == "1"
+
+    def test_invalid_threads_raises(self, tmp_path):
+        """threads=0 must raise ValueError before any workers are spawned."""
+        peptides_tsv = tmp_path / "peptides.tsv"
+        peptides_tsv.write_text("contig_key\tstart_nt\tpeptide\n")
+        with pytest.raises(ValueError, match="threads"):
+            run_prediction(
+                peptides_tsv=peptides_tsv,
+                output_tsv=tmp_path / "out.tsv",
+                alleles=["HLA-A*02:01"],
+                threads=0,
+            )
+
+
+# ---------------------------------------------------------------------------
 # Binder classification
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Renamed `predict.smk` → `mhcflurry.smk` (rule file only contains MHCflurry rules)
- Added `threads` param to `run_mhcflurry.py` and `mhcflurry.smk`; default 1 (serial), configurable via `config.mhcflurry.threads`
- Replaced serial for-loop with `ProcessPoolExecutor` — wall-clock time ≈ model_load + max(per-allele time) vs model_load + sum(per-allele time)
- Used `ProcessPoolExecutor` (not `ThreadPoolExecutor`): `predict_to_dataframe()` is not thread-safe due to shared TensorFlow state — threads produced identical IC50 values across alleles for the same peptide; processes each load an isolated predictor copy

## Config defaults

- `config.yaml`: `mhcflurry.threads: 8` (n1-standard-8 cloud VM)
- `test_config.yaml`: `mhcflurry.threads: 4` (M1 MacBook Air override)

## Test plan

- [x] Serial baseline vs ProcessPoolExecutor: 8226 rows, 54 strong, 317 weak, max IC50 diff = 0.00e+00 (identical results)
- [x] ThreadPoolExecutor failure confirmed: same IC50 (267.12 nM) across all alleles for identical peptides — shared TF state corruption
- [ ] Cloud run: MHCflurry step on CPU VM with `threads: 8`

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)