### PR TITLE
docs: lab notebook entries Apr 13–17

### DIFF
--- a/docs/lab_notebook.md
+++ b/docs/lab_notebook.md
@@ -2,6 +2,93 @@
 
 ---
 
+## 2026-04-17
+
+### Patient_001 (gastric cancer) — first full production run with HLA typing + TCRdock
+
+**Patient:** SRR9143065 (Solid Tissue Normal) / SRR9143066 (Primary Tumor) — gastric cancer surgical section, single-end Illumina HiSeq 3000.
+
+**Junction filtering results:**
+- Unannotated junctions: 30,029
+- Normal-shared (filtered out): 2,682 (8.9%)
+- Tumor-exclusive candidates: 27,347
+
+**HLA typing (OptiType):** HLA-A\*26:01, HLA-A\*31:01, HLA-B\*15:05, HLA-B\*18:20, HLA-C\*03:21, HLA-C\*07:01 — no ground-truth alleles available for this patient, so typing cannot be validated.
+
+**MHCflurry predictions:** 8,226 peptide × allele pairs (1,371 9-mers across 6 alleles), 54 strong binders (IC50 ≤ 50 nM), 317 weak binders (IC50 ≤ 500 nM).
+
+**Top neoepitope candidate:** EVAEYNASF / HLA-A\*26:01, IC50 16.5 nM (strong binder). TCRdock structure predicted on P100 GPU VM; Mol\* viewer renders ternary complex with correct chain labels (A=MHC, B=peptide, C=TCR-α, D=TCR-β). Results archived to `gs://splice-neoepitope-project-tcrdock-handoff/results/`.
+
+**Infrastructure issues resolved during this run:**
+- P100 GPU VM required proprietary nvidia kernel modules (`linux-modules-nvidia-570-server-6.8.0-1053-gcp`); open-source modules (`linux-modules-nvidia-570-server-open-*`) do not support Pascal (P100) GPUs.
+- GCS download of pipeline outputs onto the GPU VM fresh-stamped all files, causing Snakemake's `--rerun-triggers mtime` to re-run MHCflurry unnecessarily. Fixed by switching the GPU phase to `--rerun-triggers code params`.
+- Mol\* viewer silently broken by unpinned CDN URL (`unpkg.com/molstar` → v5.8.0, breaking API). Pinned to `molstar@4.9.0`.
+
+---
+
+### Issue #50 — parallel MHCflurry allele predictions (ProcessPoolExecutor)
+
+**Problem:** Serial per-allele loop was the bottleneck for patients with 6+ HLA alleles.
+
+**First attempt (ThreadPoolExecutor) — failed:** `predict_to_dataframe()` is not thread-safe due to shared TensorFlow state. Testing revealed identical IC50 values (267.12 nM) across different alleles for the same peptide — confirmed state corruption. Threads release the GIL during I/O but TensorFlow's internal state is mutated during inference.
+
+**Fix:** Switched to `ProcessPoolExecutor` with `initializer=_worker_init`. Each worker process loads its own predictor copy, sets `TF_NUM_INTRAOP_THREADS=1` / `OMP_NUM_THREADS=1` before TensorFlow imports (prevents CPU oversubscription when running multiple workers), and returns a lean per-allele DataFrame (no `peptides_df` pickling across process boundaries).
+
+**Test result:** 8,226 rows, 54 strong, 317 weak — max IC50 diff vs. serial baseline = 0.00e+00. Local run: 6 alleles, 4 workers, ~12 s total.
+
+**Also renamed:** `predict.smk` → `mhcflurry.smk`, `predictions.tsv` → `mhc_affinity.tsv` (tool-agnostic naming).
+
+---
+
+### Patient_002 planning — osteosarcoma IPISRC044
+
+**Dataset:** Publicly available osteosarcoma dataset (https://osteosarc.com/data/). Patient IPISRC044, multi-institutional (UCLA / UCSF / Boston Gene / Tempus). GCS bucket: `gs://osteosarc-genomics`.
+
+**Plan:** Start with T0 tumor (Boston Gene, Nov 2022) as the baseline timepoint.
+- FASTQs: `rna-seq/fastq/bostongene_2022/202211_bostongene_tumor_rna_BG003082_R1.fastq.gz` + `_R2.fastq.gz` (paired-end, ~10 GB)
+- Run OptiType for HLA typing — ground-truth Class I alleles are known from Red Cross serology (A\*01:01/01:11N, B\*08:01/27:05, C\*01:02/07:01), giving us a validation opportunity we didn't have for patient_001.
+
+**No matched RNA-seq normal available.** Blood WGS DNA cannot be used as a substitute — `regtools junctions extract` requires spliced RNA-seq reads (`N` CIGAR operations); DNA-seq reads map continuously without splicing and produce no junctions. Pipeline runs in warning mode, labelling all unannotated junctions `tumor_exclusive`. Based on patient_001 statistics, approximately 9% of unannotated junctions may be normal-shared and would be misclassified. The downstream MHCflurry + TCRdock funnel is expected to absorb most of this noise.
+
+---
+
+## 2026-04-16
+
+**Goal:** Implement HLA typing with OptiType and stabilise the cloud pipeline for a production run.
+
+**Done:**
+- Implemented HLA typing step (issue #42): OptiType runs on each sample's FASTQ, typing results aggregated per patient into `alleles.tsv`, passed to MHCflurry in place of fallback alleles when `hla.enabled: true`.
+- Added configurable CBC ILP solver for OptiType (issue #49) — reduces OptiType runtime significantly on VMs with multiple cores.
+- Fixed `PYTHONUNBUFFERED=1` for OptiType log flushing (issue #52): without it, log output was buffered and appeared to stall.
+- Fixed HLA concordance display in report (issue #53): loci with no normal/tumor discrepancy now show ✓ concordant instead of blank.
+- Upgraded CPU VM to n1-standard-8 and made thread counts config-driven (issue #40).
+- Fixed Snakemake unlock on interrupted restarts (issue #47).
+- Suppressed interactive "Next steps" prompts when `run_cloud_gpu.sh` calls sub-scripts (issue #48).
+- Dropped all GDC/TCGA code (issue #44) — pipeline is now fully open-access, no registration-gated data sources.
+- Renamed junction origin labels to `tumor_exclusive` / `normal_shared` (issue #38).
+
+---
+
+## 2026-04-14
+
+**Goal:** Refactor pipeline to be patient-centric and unify alignment rules.
+
+**Done:**
+- Replaced `{cancer_type}` wildcard with `{patient_id}` throughout (issue #26). Config key `cancer_types: [local]` → `patient_id` string. Routing in `filter.smk` now switches on `config["data_source"]` rather than hardcoded `"local"` path segments.
+- Unified STAR and HISAT2 alignment into a single `alignment.smk` module (issue #35). Both aligners produce junction TSVs in the same format; downstream rules are aligner-agnostic.
+- `PATIENT_IDS` now derived from `samples_tsv` at DAG construction time; sample IDs renamed to SRR accessions throughout.
+
+---
+
+## 2026-04-13
+
+**Goal:** Merge TCRdock structural validation and get a clean production baseline.
+
+**Done:**
+- Merged PR #27 (issue #25): TCRdock step, Mol\* 3D viewer, `run_cloud_gpu.sh` three-phase lifecycle (CPU → GCS → GPU Spot VM). Full end-to-end test passed.
+
+---
+
 ## 2026-04-10
 
 **Goal:** Get TCRdock structural validation running end-to-end via Docker on the GCP GPU Spot VM.


### PR DESCRIPTION
## Summary

- Patient_001 gastric cancer production run results: junction stats (30,029 unannotated → 27,347 tumor-exclusive), HLA typing, top candidate EVAEYNASF / HLA-A*26:01 IC50 16.5 nM, TCRdock structure
- Issue #50: documents ThreadPoolExecutor corruption finding and ProcessPoolExecutor fix
- Patient_002 osteosarcoma IPISRC044 planning notes: dataset overview, no RNA-seq normal rationale (~9% expected misclassification), HLA typing validation opportunity
- Catch-up entries for Apr 13–16: TCRdock merge, patient_id refactor, HLA typing implementation day

Note: `docs/lab-notebook` is a persistent branch — future notebook updates will accumulate here and PR to main periodically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)