### PR TITLE
feat(hla): serology columns in samples TSV + tumor-first allele priority (issue #59)

### DIFF
--- a/config/samples/patient_001.tsv
+++ b/config/samples/patient_001.tsv
@@ -1,5 +1,6 @@
-patient_id	sample_id	sample_type	fastq1	fastq2
+patient_id	sample_id	sample_type	fastq1	fastq2	serology_A1	serology_A2	serology_B1	serology_B2	serology_C1	serology_C2
 # Matched gastric cancer tumor/normal pair (SRR9143066 / SRR9143065)
 # Source: https://www.ebi.ac.uk/ena/browser/view/SRR9143066
+# No clinical HLA serotyping available for this patient.
 patient_001	SRR9143066	Primary Tumor	https://ftp.sra.ebi.ac.uk/vol1/fastq/SRR914/006/SRR9143066/SRR9143066.fastq.gz
 patient_001	SRR9143065	Solid Tissue Normal	https://ftp.sra.ebi.ac.uk/vol1/fastq/SRR914/005/SRR9143065/SRR9143065.fastq.gz

--- a/config/samples/patient_001_test.tsv
+++ b/config/samples/patient_001_test.tsv
@@ -1,3 +1,3 @@
-patient_id	sample_id	sample_type	fastq1	fastq2
+patient_id	sample_id	sample_type	fastq1	fastq2	serology_A1	serology_A2	serology_B1	serology_B2	serology_C1	serology_C2
 patient_001_test	SRR9143066_test	Primary Tumor	data/test/SRR9143066_test.fastq.gz
 patient_001_test	SRR9143065_test	Solid Tissue Normal	data/test/SRR9143065_test.fastq.gz

--- a/config/samples/patient_002.tsv
+++ b/config/samples/patient_002.tsv
@@ -1,8 +1,10 @@
-patient_id	sample_id	sample_type	fastq1	fastq2
+patient_id	sample_id	sample_type	fastq1	fastq2	serology_A1	serology_A2	serology_B1	serology_B2	serology_C1	serology_C2
 # Boston Gene osteosarcoma BG003082, paired-end RNA-seq (Nov 2022).
 # No matched RNA-seq normal — all unannotated junctions labeled tumor_exclusive.
 # WES blood normal included for HLA typing only (OptiType --rna tolerates WES).
 # FASTQs are publicly downloadable from the Backblaze B2 bucket via HTTPS.
 # Dataset migrated from gs://osteosarc-genomics to B2 in Apr 2025.
+# Serology (Red Cross): A*01:01/A*01:11N, B*08:01/B*27:05, C*01:02/C*07:01.
+# A*01:11N is a null allele (not expressed); excluded from prediction, shown in QC.
 patient_002	BG003082_T0	Primary Tumor	https://b2.osteosarc.com/rna-seq/fastq/bostongene_2022/202211_bostongene_tumor_rna_BG003082_R1.fastq.gz	https://b2.osteosarc.com/rna-seq/fastq/bostongene_2022/202211_bostongene_tumor_rna_BG003082_R2.fastq.gz
-patient_002	BG003082_N0_WES	Blood Derived Normal	https://b2.osteosarc.com/genomics/genomics-bulk/2022.12.16/DNA/2022.12.16.dna.bostongene.WES/fastqs/normal-blood/BG003082_WES-normal_1.fastq.gz	https://b2.osteosarc.com/genomics/genomics-bulk/2022.12.16/DNA/2022.12.16.dna.bostongene.WES/fastqs/normal-blood/BG003082_WES-normal_2.fastq.gz
+patient_002	BG003082_N0_WES	Blood Derived Normal	https://b2.osteosarc.com/genomics/genomics-bulk/2022.12.16/DNA/2022.12.16.dna.bostongene.WES/fastqs/normal-blood/BG003082_WES-normal_1.fastq.gz	https://b2.osteosarc.com/genomics/genomics-bulk/2022.12.16/DNA/2022.12.16.dna.bostongene.WES/fastqs/normal-blood/BG003082_WES-normal_2.fastq.gz	HLA-A*01:01	HLA-A*01:11N	HLA-B*08:01	HLA-B*27:05	HLA-C*01:02	HLA-C*07:01

--- a/workflow/scripts/aggregate_hla_alleles.py
+++ b/workflow/scripts/aggregate_hla_alleles.py
@@ -2,24 +2,33 @@
 """aggregate_hla_alleles.py — Aggregate per-sample OptiType HLA calls into a
 per-patient alleles TSV.
 
-Normal-first policy
--------------------
-HLA alleles are germline, so normal tissue gives a cleaner signal than tumor
-(which may carry CNV or LOH events at the HLA locus). For each locus (A, B, C)
-the aggregator:
+Priority order
+--------------
+HLA alleles are germline, so reliable sources are preferred over noisier ones.
+For each locus (A, B, C) the aggregator applies this cascade:
 
-  1. Collects calls from Solid Tissue Normal / Blood Derived Normal samples
-     that pass the min_reads threshold.
-  2. Falls back to the Primary Tumor sample if no normal call is available.
-  3. Falls back to config-defined fallback alleles if no sample call is
-     available or confident.
+  1. OptiType from Primary Tumor — reflects what the tumor cell actually
+     presents, including any HLA loss-of-heterozygosity (LOH) events.
+  2. Clinical serology (Red Cross / WGS) — germline ground truth, more
+     accurate than RNA-seq-based typing. Read from serology_X1/X2 columns
+     in the samples TSV (germline/normal row only; tumor row should be empty).
+  3. OptiType from Solid Tissue Normal / Blood Derived Normal — used when no
+     serology is available.
+  4. Config-defined fallback alleles when no sample call is available or
+     confident (reads < min_reads_per_locus).
+
+Null alleles (alleles ending in 'N', e.g. A*01:11N) are not expressed at the
+cell surface and are excluded from the prediction allele list, but are stored
+in the QC output for transparency.
 
 QC output
 ---------
 A side TSV records per-locus:
-  - source      (normal / tumor / fallback)
-  - reads       (total HLA reads from OptiType for the chosen sample)
-  - discrepancy (if normal and tumor calls differ)
+  - source              (tumor / serology / normal / fallback)
+  - reads               (total HLA reads from OptiType for the chosen sample)
+  - discrepancy         (if normal and tumor OptiType calls differ)
+  - serology_allele1/2  (known alleles from serology, if provided)
+  - serology_validation (match / match (null allele excluded) / mismatch: ...)
 
 Input (via Snakemake)
 ---------------------
@@ -62,6 +71,34 @@ def read_samples(tsv_path: str) -> dict[str, str]:
     return result
 
 
+def load_serology(tsv_path: str) -> dict[str, tuple[str, str]]:
+    """Read clinical serology alleles from the samples TSV.
+
+    Returns {locus: (allele1, allele2)} using the first non-empty serology
+    values found across all rows. Serology is per-patient; only the germline
+    (normal/blood) row is expected to carry values.
+
+    Null alleles (e.g. A*01:11N) are preserved as-is for QC display; callers
+    filter them before using alleles for prediction.
+    """
+    result: dict[str, tuple[str, str]] = {}
+    with open(tsv_path) as f:
+        for row in csv.DictReader(f, delimiter="\t"):
+            sid = (row.get("sample_id") or "").strip()
+            if not sid or sid.startswith("#"):
+                continue
+            for locus in _LOCI:
+                if locus in result:
+                    continue
+                allele1 = normalise_allele(row.get(f"serology_{locus}1", "") or "")
+                allele2 = normalise_allele(row.get(f"serology_{locus}2", "") or "")
+                if allele1:
+                    result[locus] = (allele1, allele2 if allele2 else allele1)
+    if result:
+        log.info("Loaded serology for loci: %s", sorted(result))
+    return result
+
+
 def load_optitype_result(tsv_path: str) -> dict[str, tuple[list[str], int]]:
     """Load an OptiType *_result.tsv file.
 
@@ -86,10 +123,10 @@ def load_optitype_result(tsv_path: str) -> dict[str, tuple[list[str], int]]:
                 reads = int(float(row.get("Reads", 0) or 0))
                 result: dict[str, tuple[list[str], int]] = {}
                 for locus in _LOCI:
-                    a1 = normalise_allele(row.get(f"{locus}1", ""))
-                    a2 = normalise_allele(row.get(f"{locus}2", ""))
-                    if a1:
-                        result[locus] = ([a1, a2] if a2 else [a1], reads)
+                    allele1 = normalise_allele(row.get(f"{locus}1", ""))
+                    allele2 = normalise_allele(row.get(f"{locus}2", ""))
+                    if allele1:
+                        result[locus] = ([allele1, allele2] if allele2 else [allele1], reads)
                 return result
     except Exception as exc:
         log.warning("Could not parse OptiType TSV %s: %s", tsv_path, exc)
@@ -100,7 +137,8 @@ def normalise_allele(raw: str) -> str:
     """Return allele in HLA-X*YY:ZZ format (4-digit resolution).
 
     OptiType returns alleles like ``A*02:01``; MHCflurry expects ``HLA-A*02:01``.
-    Truncates to the first two colon-separated fields.
+    Truncates to the first two colon-separated fields (preserves trailing N for
+    null alleles, e.g. ``HLA-A*01:11N``).
     """
     raw = raw.strip()
     if not raw:
@@ -109,6 +147,31 @@ def normalise_allele(raw: str) -> str:
         raw = f"HLA-{raw}"
     parts = raw.split(":")
     return ":".join(parts[:2])
+
+
+def _validate_vs_serology(
+    optitype_alleles: list[str] | None,
+    serology: tuple[str, str],
+) -> str:
+    """Compare an OptiType call against known serology alleles.
+
+    Null alleles (ending in 'N') are not expressed and will not appear in
+    OptiType calls; they are excluded from the serology set before comparison.
+
+    Returns one of: 'match', 'match (null allele excluded)', 'mismatch: ...', ''.
+    """
+    if not optitype_alleles:
+        return ""
+    ser_allele1, ser_allele2 = serology
+    ser_set = {ser_allele1, ser_allele2}
+    ser_non_null = {allele for allele in ser_set if not allele.endswith("N")}
+    optitype_set = set(optitype_alleles)
+
+    if optitype_set == ser_set:
+        return "match"
+    if ser_non_null and optitype_set == ser_non_null:
+        return "match (null allele excluded)"
+    return f"mismatch: optitype={sorted(optitype_set)} serology={sorted(ser_set)}"
 
 
 # ---------------------------------------------------------------------------
@@ -125,6 +188,7 @@ def aggregate(
 ) -> None:
     """Aggregate OptiType results into per-patient alleles.tsv and hla_qc.tsv."""
     sample_types = read_samples(samples_tsv)
+    serology = load_serology(samples_tsv)
     log.info("Loaded %d samples from %s", len(sample_types), samples_tsv)
 
     # Map sample_id → result TSV path
@@ -165,20 +229,28 @@ def aggregate(
                     )
             return calls
 
-        normal_calls = _get_calls(normal_samples)
         tumor_calls  = _get_calls(tumor_samples)
+        normal_calls = _get_calls(normal_samples)
 
-        # Normal-first policy
-        if normal_calls:
+        # Priority: tumor OptiType > serology > normal OptiType > fallback
+        if tumor_calls:
+            best = max(tumor_calls, key=lambda s: tumor_calls[s][1])
+            chosen_alleles, reads = tumor_calls[best]
+            source = "tumor"
+            log.info("Locus %s: using tumor sample %s (%d reads)", locus, best, reads)
+        elif serology and locus in serology:
+            ser_allele1, ser_allele2 = serology[locus]
+            # Exclude null alleles from prediction (not expressed at cell surface)
+            expressed = [a for a in [ser_allele1, ser_allele2] if a and not a.endswith("N")]
+            chosen_alleles = expressed if expressed else [ser_allele1]
+            reads = 0
+            source = "serology"
+            log.info("Locus %s: using serology (%s / %s)", locus, ser_allele1, ser_allele2)
+        elif normal_calls:
             best = max(normal_calls, key=lambda s: normal_calls[s][1])
             chosen_alleles, reads = normal_calls[best]
             source = "normal"
             log.info("Locus %s: using normal sample %s (%d reads)", locus, best, reads)
-        elif tumor_calls:
-            best = max(tumor_calls, key=lambda s: tumor_calls[s][1])
-            chosen_alleles, reads = tumor_calls[best]
-            source = "tumor"
-            log.warning("Locus %s: no normal call, using tumor sample %s", locus, best)
         else:
             fb = fallback.get(locus, "")
             chosen_alleles = [fb] if fb else []
@@ -191,7 +263,7 @@ def aggregate(
 
         allele_rows.append({"locus": locus, "allele1": allele1, "allele2": allele2})
 
-        # QC: normal/tumor concordance check
+        # QC: normal/tumor OptiType concordance check
         discrepancy = ""
         if normal_calls and tumor_calls:
             n_best = max(normal_calls, key=lambda s: normal_calls[s][1])
@@ -202,9 +274,26 @@ def aggregate(
                 discrepancy = f"normal={sorted(n_set)} tumor={sorted(t_set)}"
                 log.warning("Locus %s: normal/tumor discrepancy — %s", locus, discrepancy)
 
+        # QC: OptiType vs serology validation
+        ser_allele1 = ser_allele2 = ""
+        serology_validation = ""
+        if serology and locus in serology:
+            ser_allele1, ser_allele2 = serology[locus]
+            # Compare the best available OptiType call against serology
+            best_optitype: list[str] | None = None
+            if tumor_calls:
+                best_optitype = tumor_calls[max(tumor_calls, key=lambda s: tumor_calls[s][1])][0]
+            elif normal_calls:
+                best_optitype = normal_calls[max(normal_calls, key=lambda s: normal_calls[s][1])][0]
+            serology_validation = _validate_vs_serology(best_optitype, (ser_allele1, ser_allele2))
+            if serology_validation:
+                log.info("Locus %s serology validation: %s", locus, serology_validation)
+
         qc_rows.append({
             "locus": locus, "allele1": allele1, "allele2": allele2,
             "source": source, "reads": reads, "discrepancy": discrepancy,
+            "serology_allele1": ser_allele1, "serology_allele2": ser_allele2,
+            "serology_validation": serology_validation,
         })
 
     Path(out_alleles).parent.mkdir(parents=True, exist_ok=True)
@@ -219,7 +308,10 @@ def aggregate(
     with open(out_qc, "w", newline="") as f:
         writer = csv.DictWriter(
             f,
-            fieldnames=["locus", "allele1", "allele2", "source", "reads", "discrepancy"],
+            fieldnames=[
+                "locus", "allele1", "allele2", "source", "reads", "discrepancy",
+                "serology_allele1", "serology_allele2", "serology_validation",
+            ],
             delimiter="\t",
         )
         writer.writeheader()

--- a/workflow/scripts/generate_report.py
+++ b/workflow/scripts/generate_report.py
@@ -250,8 +250,10 @@ _HTML_TEMPLATE = """\
 def _build_hla_section(hla_qc_tsv: str) -> str:
     """Build the HLA typing results section from hla_qc.tsv.
 
-    Shows per-locus alleles, the source of each call (normal / tumor / fallback),
-    the number of HLA reads OptiType used, and any normal/tumor discrepancies.
+    Shows per-locus alleles, the source of each call (tumor / serology /
+    normal / fallback), HLA read counts, normal/tumor discrepancy, and —
+    when serology columns are present — a validation column comparing
+    OptiType against the known clinical alleles.
     """
     try:
         df = pd.read_csv(hla_qc_tsv, sep="\t")
@@ -263,10 +265,19 @@ def _build_hla_section(hla_qc_tsv: str) -> str:
         return ""
 
     source_colours = {
-        "normal":   "#27ae60",
         "tumor":    "#e67e22",
+        "serology": "#8e44ad",
+        "normal":   "#27ae60",
         "fallback": "#c0392b",
     }
+
+    # Show serology column only when at least one locus has known alleles
+    has_serology = (
+        "serology_allele1" in df.columns
+        and df["serology_allele1"].notna().any()
+        and (df["serology_allele1"].astype(str).str.strip() != "").any()
+    )
+
     rows = []
     has_discrepancy = False
     for _, row in df.iterrows():
@@ -284,6 +295,33 @@ def _build_hla_section(hla_qc_tsv: str) -> str:
             f'<td style="background:#fef3cd">{html_mod.escape(discrepancy)}</td>'
             if discrepancy else '<td style="color:#27ae60">&#10003; concordant</td>'
         )
+
+        serology_cell = ""
+        if has_serology:
+            _ser1 = row.get("serology_allele1", "")
+            _ser2 = row.get("serology_allele2", "")
+            ser_allele1 = "" if pd.isna(_ser1) else str(_ser1).strip()
+            ser_allele2 = "" if pd.isna(_ser2) else str(_ser2).strip()
+            _val_raw = row.get("serology_validation", "")
+            validation = "" if pd.isna(_val_raw) else str(_val_raw).strip()
+
+            if ser_allele1:
+                alleles_str = (
+                    f"<code>{html_mod.escape(ser_allele1)}</code> / "
+                    f"<code>{html_mod.escape(ser_allele2)}</code>"
+                    if ser_allele2 and ser_allele2 != ser_allele1
+                    else f"<code>{html_mod.escape(ser_allele1)}</code>"
+                )
+                if validation.startswith("match"):
+                    val_badge = f' <span style="color:#27ae60">&#10003; {html_mod.escape(validation)}</span>'
+                elif validation.startswith("mismatch"):
+                    val_badge = f' <span style="color:#c0392b">&#10007; {html_mod.escape(validation)}</span>'
+                else:
+                    val_badge = ""
+                serology_cell = f"<td>{alleles_str}{val_badge}</td>"
+            else:
+                serology_cell = "<td></td>"
+
         rows.append(
             f"<tr>"
             f"<td><strong>{html_mod.escape(str(row['locus']))}</strong></td>"
@@ -292,13 +330,16 @@ def _build_hla_section(hla_qc_tsv: str) -> str:
             f"<td>{source_badge}</td>"
             f"<td>{html_mod.escape(str(row.get('reads', '')))}</td>"
             f"{disc_cell}"
+            f"{serology_cell}"
             f"</tr>"
         )
 
+    serology_header = "<th>Known alleles / validation</th>" if has_serology else ""
     table = (
         "<table><thead><tr>"
         "<th>Locus</th><th>Allele 1</th><th>Allele 2</th>"
         "<th>Source</th><th>HLA reads</th><th>Normal/tumor discrepancy</th>"
+        f"{serology_header}"
         "</tr></thead><tbody>"
         + "".join(rows)
         + "</tbody></table>"
@@ -308,7 +349,7 @@ def _build_hla_section(hla_qc_tsv: str) -> str:
     if has_discrepancy:
         note = (
             "<p><em><strong>Note:</strong> Normal/tumor discrepancy detected in one or "
-            "more loci. Normal sample calls are used for prediction (normal-first policy). "
+            "more loci. Tumor sample calls are used for prediction (tumor-first policy). "
             "Discrepancies may indicate loss of heterozygosity at the HLA locus in the "
             "tumor, or low read depth in the test subset.</em></p>"
         )
@@ -316,8 +357,9 @@ def _build_hla_section(hla_qc_tsv: str) -> str:
     return (
         "<h2>HLA typing (OptiType)</h2>"
         "<p>Patient HLA-A/B/C alleles typed by OptiType from RNA-seq reads. "
-        "<strong>Normal-first policy:</strong> calls from Solid Tissue Normal are "
-        "preferred over tumor (which may carry LOH at the HLA locus). "
+        "Priority order: <strong>tumor OptiType → serology → normal OptiType → fallback</strong>. "
+        "Tumor calls are preferred as they reflect what the tumor cell actually presents, "
+        "including any HLA loss-of-heterozygosity. "
         "These alleles were used for patient-specific neoepitope prediction.</p>"
         + note + table
     )

--- a/workflow/tests/test_aggregate_hla_alleles.py
+++ b/workflow/tests/test_aggregate_hla_alleles.py
@@ -8,7 +8,9 @@ import pytest
 from aggregate_hla_alleles import (
     aggregate,
     load_optitype_result,
+    load_serology,
     normalise_allele,
+    _validate_vs_serology,
 )
 
 
@@ -28,11 +30,21 @@ def _write_optitype_tsv(path: Path, a1="A*02:01", a2="A*02:01",
     return path
 
 
+_SEROLOGY_FIELDS = [
+    "serology_A1", "serology_A2",
+    "serology_B1", "serology_B2",
+    "serology_C1", "serology_C2",
+]
+
+
 def _write_samples_tsv(path: Path, rows: list[dict]) -> Path:
     with path.open("w", newline="") as f:
         writer = csv.DictWriter(
-            f, fieldnames=["patient_id", "sample_id", "sample_type", "fastq1", "fastq2"],
+            f,
+            fieldnames=["patient_id", "sample_id", "sample_type", "fastq1", "fastq2"]
+                       + _SEROLOGY_FIELDS,
             delimiter="\t",
+            extrasaction="ignore",
         )
         writer.writeheader()
         writer.writerows(rows)
@@ -95,19 +107,19 @@ class TestLoadOptitypeResult:
 
 
 # ---------------------------------------------------------------------------
-# aggregate — normal-first policy
+# aggregate — priority order and serology
 # ---------------------------------------------------------------------------
 
 class TestAggregate:
-    def test_normal_first_policy(self, tmp_path):
-        """Normal sample call is used even when tumor has more reads."""
+    def test_tumor_first_policy(self, tmp_path):
+        """Tumor sample call is preferred over normal."""
         normal_tsv = _write_optitype_tsv(
             tmp_path / "normal_result.tsv",
-            a1="A*02:01", a2="A*02:01", reads=100,
+            a1="A*02:01", a2="A*02:01", reads=9999,
         )
         tumor_tsv = _write_optitype_tsv(
             tmp_path / "tumor_result.tsv",
-            a1="A*03:01", a2="A*03:01", reads=9999,
+            a1="A*03:01", a2="A*03:01", reads=100,
         )
         samples_tsv = _write_samples_tsv(tmp_path / "samples.tsv", [
             {"patient_id": "p1", "sample_id": "normal", "sample_type": "Solid Tissue Normal", "fastq1": "x", "fastq2": ""},
@@ -127,11 +139,103 @@ class TestAggregate:
 
         rows = list(csv.DictReader(out_alleles.open(), delimiter="\t"))
         a_row = next(r for r in rows if r["locus"] == "A")
-        assert a_row["allele1"] == "HLA-A*02:01"
+        assert a_row["allele1"] == "HLA-A*03:01"
 
         qc_rows = list(csv.DictReader(out_qc.open(), delimiter="\t"))
         a_qc = next(r for r in qc_rows if r["locus"] == "A")
-        assert a_qc["source"] == "normal"
+        assert a_qc["source"] == "tumor"
+
+    def test_serology_over_normal(self, tmp_path):
+        """Serology is preferred over normal OptiType when tumor has no confident call."""
+        normal_tsv = _write_optitype_tsv(
+            tmp_path / "normal_result.tsv",
+            a1="A*02:01", a2="A*02:01", reads=200,
+        )
+        samples_tsv = _write_samples_tsv(tmp_path / "samples.tsv", [
+            {"patient_id": "p1", "sample_id": "normal", "sample_type": "Solid Tissue Normal",
+             "fastq1": "x", "fastq2": "", "serology_A1": "HLA-A*01:01", "serology_A2": "HLA-A*01:01"},
+        ])
+        out_alleles = tmp_path / "alleles.tsv"
+        out_qc      = tmp_path / "hla_qc.tsv"
+
+        aggregate(
+            result_tsvs=[str(normal_tsv)],
+            samples_tsv=str(samples_tsv),
+            min_reads=30,
+            fallback=FALLBACK,
+            out_alleles=str(out_alleles),
+            out_qc=str(out_qc),
+        )
+
+        rows = list(csv.DictReader(out_alleles.open(), delimiter="\t"))
+        a_row = next(r for r in rows if r["locus"] == "A")
+        assert a_row["allele1"] == "HLA-A*01:01"
+
+        qc_rows = list(csv.DictReader(out_qc.open(), delimiter="\t"))
+        a_qc = next(r for r in qc_rows if r["locus"] == "A")
+        assert a_qc["source"] == "serology"
+
+    def test_serology_not_used_when_tumor_available(self, tmp_path):
+        """Tumor OptiType wins over serology even when serology is provided."""
+        tumor_tsv = _write_optitype_tsv(
+            tmp_path / "tumor_result.tsv",
+            a1="A*03:01", a2="A*03:01", reads=200,
+        )
+        samples_tsv = _write_samples_tsv(tmp_path / "samples.tsv", [
+            {"patient_id": "p1", "sample_id": "tumor", "sample_type": "Primary Tumor",
+             "fastq1": "x", "fastq2": "", "serology_A1": "HLA-A*01:01", "serology_A2": "HLA-A*01:01"},
+        ])
+        out_alleles = tmp_path / "alleles.tsv"
+        out_qc      = tmp_path / "hla_qc.tsv"
+
+        aggregate(
+            result_tsvs=[str(tumor_tsv)],
+            samples_tsv=str(samples_tsv),
+            min_reads=30,
+            fallback=FALLBACK,
+            out_alleles=str(out_alleles),
+            out_qc=str(out_qc),
+        )
+
+        qc_rows = list(csv.DictReader(out_qc.open(), delimiter="\t"))
+        a_qc = next(r for r in qc_rows if r["locus"] == "A")
+        assert a_qc["source"] == "tumor"
+        assert a_qc["allele1"] == "HLA-A*03:01"
+
+    def test_null_allele_excluded_from_prediction(self, tmp_path):
+        """Null alleles in serology are not written to alleles.tsv."""
+        samples_tsv = _write_samples_tsv(tmp_path / "samples.tsv", [
+            {"patient_id": "p1", "sample_id": "normal", "sample_type": "Blood Derived Normal",
+             "fastq1": "x", "fastq2": "",
+             "serology_A1": "HLA-A*01:01", "serology_A2": "HLA-A*01:11N"},
+        ])
+        # Empty OptiType result so serology is used
+        empty_tsv = tmp_path / "normal_result.tsv"
+        empty_tsv.write_text("\tA1\tA2\tB1\tB2\tC1\tC2\tReads\tObjective\n")
+
+        out_alleles = tmp_path / "alleles.tsv"
+        out_qc      = tmp_path / "hla_qc.tsv"
+
+        aggregate(
+            result_tsvs=[str(empty_tsv)],
+            samples_tsv=str(samples_tsv),
+            min_reads=30,
+            fallback=FALLBACK,
+            out_alleles=str(out_alleles),
+            out_qc=str(out_qc),
+        )
+
+        rows = list(csv.DictReader(out_alleles.open(), delimiter="\t"))
+        a_row = next(r for r in rows if r["locus"] == "A")
+        # Null allele excluded; both prediction slots use the expressed allele
+        assert a_row["allele1"] == "HLA-A*01:01"
+        assert a_row["allele2"] == "HLA-A*01:01"
+
+        qc_rows = list(csv.DictReader(out_qc.open(), delimiter="\t"))
+        a_qc = next(r for r in qc_rows if r["locus"] == "A")
+        assert a_qc["source"] == "serology"
+        # Null allele still visible in QC
+        assert a_qc["serology_allele2"] == "HLA-A*01:11N"
 
     def test_fallback_when_no_reads(self, tmp_path):
         """Fallback alleles used when all samples have empty result TSVs."""
@@ -189,8 +293,8 @@ class TestAggregate:
         assert a_qc["source"] == "fallback"
         assert a_qc["allele1"] == "HLA-A*02:01"
 
-    def test_tumor_fallback_when_no_normal(self, tmp_path):
-        """Tumor call used when no normal sample is present."""
+    def test_tumor_primary_source(self, tmp_path):
+        """Tumor call used when it is the only sample."""
         tumor_tsv = _write_optitype_tsv(
             tmp_path / "tumor_result.tsv",
             a1="A*11:01", a2="A*11:01", reads=200,
@@ -243,6 +347,38 @@ class TestAggregate:
 
         qc_rows = list(csv.DictReader(out_qc.open(), delimiter="\t"))
         a_qc = next(r for r in qc_rows if r["locus"] == "A")
+        assert a_qc["source"] == "tumor"
         assert a_qc["discrepancy"] != ""
         assert "A*02:01" in a_qc["discrepancy"]
         assert "A*03:01" in a_qc["discrepancy"]
+
+
+# ---------------------------------------------------------------------------
+# _validate_vs_serology
+# ---------------------------------------------------------------------------
+
+class TestValidateVsSerology:
+    def test_exact_match(self):
+        result = _validate_vs_serology(
+            ["HLA-A*01:01", "HLA-A*01:01"],
+            ("HLA-A*01:01", "HLA-A*01:01"),
+        )
+        assert result == "match"
+
+    def test_match_with_null_allele_excluded(self):
+        result = _validate_vs_serology(
+            ["HLA-A*01:01", "HLA-A*01:01"],
+            ("HLA-A*01:01", "HLA-A*01:11N"),
+        )
+        assert result == "match (null allele excluded)"
+
+    def test_mismatch(self):
+        result = _validate_vs_serology(
+            ["HLA-A*02:01", "HLA-A*02:01"],
+            ("HLA-A*01:01", "HLA-A*01:01"),
+        )
+        assert result.startswith("mismatch")
+
+    def test_no_optitype_call_returns_empty(self):
+        assert _validate_vs_serology(None, ("HLA-A*01:01", "HLA-A*01:01")) == ""
+        assert _validate_vs_serology([], ("HLA-A*01:01", "HLA-A*01:01")) == ""


### PR DESCRIPTION
## Summary

- **Serology columns in samples TSV**: adds `serology_A1/A2`, `serology_B1/B2`, `serology_C1/C2` to all samples TSVs. Patient_002 carries Red Cross serology (A\*01:01/A\*01:11N, B\*08:01/B\*27:05, C\*01:02/C\*07:01) on the Blood Derived Normal row; tumor row stays empty (serology represents germline).
- **Revised allele priority**: tumor OptiType → serology → normal OptiType → fallback. Tumor is top priority as it reflects actual tumor HLA presentation including LOH. Serology replaces normal OptiType as the authoritative germline reference when available.
- **Null allele handling**: null alleles (e.g. A\*01:11N) are excluded from `alleles.tsv` (not expressed at cell surface) but preserved in `hla_qc.tsv` and shown in the report.
- **QC TSV extended**: `hla_qc.tsv` gains `serology_allele1`, `serology_allele2`, `serology_validation` columns.
- **Report**: adds conditional "Known alleles / validation" column with ✓/✗ badge and serology source badge (purple).

## Test plan

- [x] 22 HLA aggregation tests pass (updated for tumor-first + 8 new serology tests)
- [x] Full suite: 134 tests pass

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)