### PR TITLE
fix(cloud): use rsync for GPU results download + add mtime to rerun-triggers

### DIFF
--- a/scripts/run_cloud_gpu.sh
+++ b/scripts/run_cloud_gpu.sh
@@ -482,9 +482,13 @@ ssh_cmd "${GPU_VM}" -- bash -s <<EOF
 set -euo pipefail
 cd "\$HOME/splice-neoepitope-pipeline"
 mkdir -p "${RESULTS_DIR}"
-gcloud storage cp -r "${GCS_PATH}/*" "${RESULTS_DIR}/"
+# rsync compares checksums (CRC32C) and only re-downloads files that changed on
+# GCS, preserving mtime of unchanged files. This allows --rerun-triggers mtime
+# to correctly detect when CPU-phase outputs (e.g. mhc_affinity.tsv) changed.
+gcloud storage rsync "${GCS_PATH}" "${RESULTS_DIR}" --recursive
 echo "Results download complete."
 mkdir -p ".snakemake/metadata"
+# Always overwrite metadata with the CPU VM's authoritative version (cp, not rsync).
 gcloud storage cp -r "gs://${GCS_BUCKET}/.snakemake/metadata/*" ".snakemake/metadata/" 2>/dev/null \
     && echo "Snakemake metadata download complete." \
     || echo "No snakemake metadata in GCS — Snakemake will re-check triggers on first run."
@@ -503,7 +507,7 @@ conda activate snakemake
 snakemake \
     --cores 1 \
     --use-conda \
-    --rerun-triggers code params \
+    --rerun-triggers mtime code params \
     --configfile ${CONFIG_FILE} config/tcrdock_gpu.yaml \
     --config samples_tsv=${SAMPLES} \
     -- \
@@ -522,7 +526,7 @@ tmux new-session -d -s tcrdock "
     snakemake \\
         --cores \$(nproc) \\
         --use-conda \\
-        --rerun-triggers code params \\
+        --rerun-triggers mtime code params \\
         --configfile ${CONFIG_FILE} config/tcrdock_gpu.yaml \\
         --config samples_tsv=${SAMPLES} \\
         2>&1 | tee tcrdock.log


### PR DESCRIPTION
## Summary

- **`gcloud storage rsync` instead of `gcloud storage cp`** for Phase 3 results download onto the GPU VM. `rsync` compares CRC32C checksums and only re-downloads files that actually changed on GCS, preserving mtime of unchanged files.
- **`--rerun-triggers mtime code params`** on both GPU-phase Snakemake invocations (was `code params` only). With mtime now reliable (unchanged files keep their mtime), Snakemake correctly detects when CPU-phase outputs like `mhc_affinity.tsv` were updated — e.g. after an allele priority change causes MHCflurry to re-run.
- **`.snakemake/metadata/` download unchanged** — still uses `cp` to always overwrite with the CPU VM's authoritative code/params baseline.

## Why this matters

Previously, if MHCflurry re-ran on the CPU VM (e.g. due to the serology/allele priority change in #76), the new `mhc_affinity.tsv` was uploaded to GCS but the GPU VM had no way to detect the content change — `code params` triggers only detect script/param changes, not input file changes. With `rsync` + `mtime`, the updated file gets a fresh timestamp on download and TCRdock correctly re-runs.

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)