### PR TITLE
feat(report): add report.tsv structured summary artifact (Issue #57 Phase 1)

### DIFF
--- a/workflow/rules/analysis.smk
+++ b/workflow/rules/analysis.smk
@@ -36,6 +36,9 @@ rule generate_report:
         report_html=os.path.join(
             _RES, "{patient_id}", "reports", "report.html"
         ),
+        report_tsv=os.path.join(
+            _RES, "{patient_id}", "reports", "report.tsv"
+        ),
     log:
         os.path.join(_LOGS, "{patient_id}", "analysis", "report.log"),
     params:

--- a/workflow/scripts/generate_report.py
+++ b/workflow/scripts/generate_report.py
@@ -513,6 +513,100 @@ def _build_structure_section(pdb_path: Path, pred_df: pd.DataFrame) -> str:
     )
 
 
+def _build_report_tsv(
+    patient_id: str,
+    origin_df: pd.DataFrame,
+    pred_df: pd.DataFrame,
+    hla_qc_tsv: str | None,
+    output_tsv: str | Path,
+    ic50_strong: float,
+    tcrdock_pdb: str | Path | None,
+) -> None:
+    """Write a structured summary TSV alongside the HTML report.
+
+    Schema: patient_id | stage | metric | value | notes
+    Stages: junction_filtering, mhc_prediction, top_candidate, hla_typing, tcrdock
+    """
+    rows: list[dict] = []
+
+    # --- junction_filtering ---
+    if not origin_df.empty:
+        for _, r in origin_df.iterrows():
+            sid = r.get("sample_id", "")
+            stype = r.get("sample_type", "")
+            note = f"{sid} ({stype})"
+            for metric in ("unannotated", "tumor_exclusive", "normal_shared"):
+                rows.append({
+                    "patient_id": patient_id, "stage": "junction_filtering",
+                    "metric": metric, "value": int(r.get(metric, 0)), "notes": note,
+                })
+
+    # --- mhc_prediction ---
+    if not pred_df.empty:
+        rows.append({
+            "patient_id": patient_id, "stage": "mhc_prediction",
+            "metric": "total_predictions", "value": len(pred_df), "notes": "",
+        })
+        binder_notes = {
+            "strong": f"IC50 < {int(ic50_strong)} nM",
+            "weak": "IC50 50–500 nM",
+            "non": "IC50 >= 500 nM",
+        }
+        for cls, cnt in pred_df["binder_class"].value_counts().items():
+            rows.append({
+                "patient_id": patient_id, "stage": "mhc_prediction",
+                "metric": str(cls), "value": int(cnt),
+                "notes": binder_notes.get(str(cls), ""),
+            })
+
+    # --- top_candidate ---
+    strong_df = pred_df[pred_df["binder_class"].isin(["strong", "weak"])].sort_values("ic50_nM") if not pred_df.empty else pd.DataFrame()
+    if not strong_df.empty:
+        top = strong_df.iloc[0]
+        for metric, col in [("peptide", "peptide"), ("allele", "allele"), ("ic50_nM", "ic50_nM"), ("binder_class", "binder_class")]:
+            rows.append({
+                "patient_id": patient_id, "stage": "top_candidate",
+                "metric": metric,
+                "value": round(float(top[col]), 2) if metric == "ic50_nM" else str(top[col]),
+                "notes": "top by IC50" if metric == "peptide" else "",
+            })
+
+    # --- hla_typing ---
+    if hla_qc_tsv:
+        try:
+            hla_df = pd.read_csv(hla_qc_tsv, sep="\t")
+            for _, r in hla_df.iterrows():
+                locus = str(r.get("locus", ""))
+                allele1 = str(r.get("allele1", ""))
+                allele2 = str(r.get("allele2", ""))
+                source = str(r.get("source", ""))
+                reads = r.get("reads", 0)
+                alleles = f"{allele1} / {allele2}" if allele1 != allele2 else allele1
+                rows.append({
+                    "patient_id": patient_id, "stage": "hla_typing",
+                    "metric": f"HLA-{locus}", "value": alleles,
+                    "notes": f"source: {source}, reads: {reads}",
+                })
+        except Exception as exc:
+            log.warning("Could not read HLA QC TSV for report.tsv: %s", exc)
+
+    # --- tcrdock ---
+    pdb_available = (
+        tcrdock_pdb is not None and Path(tcrdock_pdb).exists()
+    )
+    rows.append({
+        "patient_id": patient_id, "stage": "tcrdock",
+        "metric": "pdb_available", "value": str(pdb_available).lower(), "notes": "",
+    })
+
+    output_path = Path(output_tsv)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    pd.DataFrame(rows, columns=["patient_id", "stage", "metric", "value", "notes"]).to_csv(
+        output_path, sep="\t", index=False
+    )
+    log.info("Report TSV written to %s", output_path)
+
+
 def generate_report(
     novel_junctions_tsv: str | Path,
     predictions_tsv: str | Path,
@@ -521,8 +615,10 @@ def generate_report(
     hla_qc_tsv: str | None = None,
     ic50_strong: float = 50.0,
     tcrdock_pdb: str | Path | None = None,
+    output_tsv: str | Path | None = None,
+    patient_id: str = "",
 ) -> None:
-    """Generate the summary HTML report.
+    """Generate the summary HTML report and optional structured TSV.
 
     Args:
         novel_junctions_tsv: Classified junctions TSV (with junction_origin column).
@@ -534,6 +630,8 @@ def generate_report(
         ic50_strong:         Strong-binder IC50 threshold (nM).
         tcrdock_pdb:         TCRdock-predicted PDB file (optional). When provided,
                              an embedded Mol* 3D viewer is added to the report.
+        output_tsv:          Destination for the machine-readable summary TSV (optional).
+        patient_id:          Patient identifier written into every report.tsv row.
     """
     output_html = Path(output_html)
     output_html.parent.mkdir(parents=True, exist_ok=True)
@@ -610,6 +708,17 @@ def generate_report(
     output_html.write_text(report_html, encoding="utf-8")
     log.info("Report written to %s", output_html)
 
+    if output_tsv:
+        _build_report_tsv(
+            patient_id=patient_id or output_html.parts[-3],
+            origin_df=origin_df,
+            pred_df=pred_df,
+            hla_qc_tsv=hla_qc_tsv,
+            output_tsv=output_tsv,
+            ic50_strong=ic50_strong,
+            tcrdock_pdb=tcrdock_pdb,
+        )
+
 
 # ---------------------------------------------------------------------------
 # Snakemake / CLI entry point
@@ -627,6 +736,8 @@ def _snakemake_main() -> None:
         hla_qc_tsv=getattr(snakemake.input, "hla_qc", None),  # type: ignore[name-defined]  # noqa: F821
         ic50_strong=float(snakemake.params.ic50_strong),  # type: ignore[name-defined]  # noqa: F821
         tcrdock_pdb=getattr(snakemake.input, "pdb", None),  # type: ignore[name-defined]  # noqa: F821
+        output_tsv=snakemake.output.report_tsv,  # type: ignore[name-defined]  # noqa: F821
+        patient_id=snakemake.wildcards.patient_id,  # type: ignore[name-defined]  # noqa: F821
     )
 
 
@@ -641,6 +752,8 @@ def _cli_main() -> None:
     parser.add_argument("--hla-qc-tsv", default=None, help="HLA QC TSV from aggregate_hla_alleles")
     parser.add_argument("--tcrdock-pdb", default=None, help="TCRdock PDB file for 3D viewer")
     parser.add_argument("--ic50-strong", type=float, default=50.0)
+    parser.add_argument("--output-tsv", default=None, help="Output machine-readable summary TSV")
+    parser.add_argument("--patient-id", default="", help="Patient identifier for report.tsv rows")
     args = parser.parse_args()
 
     generate_report(
@@ -651,6 +764,8 @@ def _cli_main() -> None:
         hla_qc_tsv=args.hla_qc_tsv,
         ic50_strong=args.ic50_strong,
         tcrdock_pdb=args.tcrdock_pdb,
+        output_tsv=args.output_tsv,
+        patient_id=args.patient_id,
     )
 
 

--- a/workflow/tests/test_generate_report.py
+++ b/workflow/tests/test_generate_report.py
@@ -1,10 +1,12 @@
 """Tests for generate_report.py — HTML generation helpers."""
 
 import pandas as pd
+import pytest
 
 from generate_report import (
     _build_chain_legend,
     _build_compnd_records,
+    _build_report_tsv,
     _df_to_html,
     _extract_chain_ids,
 )
@@ -105,3 +107,125 @@ class TestBuildCompndRecords:
         result = _build_compnd_records(pdb, "PEP", "HLA")
         assert "alpha" in result
         assert "beta" in result
+
+
+# ---------------------------------------------------------------------------
+# Helpers for _build_report_tsv tests
+# ---------------------------------------------------------------------------
+
+def _make_origin_df(tumor_exclusive: int = 5, normal_shared: int = 2) -> pd.DataFrame:
+    return pd.DataFrame([{
+        "sample_id": "S1", "sample_type": "Primary Tumor",
+        "unannotated": tumor_exclusive + normal_shared,
+        "tumor_exclusive": tumor_exclusive,
+        "normal_shared": normal_shared,
+    }])
+
+
+def _make_pred_df(n_strong: int = 3, n_weak: int = 1, n_non: int = 10) -> pd.DataFrame:
+    rows = (
+        [{"peptide": f"PEP{i}", "allele": "HLA-A*02:01", "ic50_nM": float(i + 1),
+          "binder_class": "strong", "contig_key": f"k{i}", "start_nt": 0,
+          "percentile_rank": 0.5} for i in range(n_strong)]
+        + [{"peptide": f"PEP{i}", "allele": "HLA-A*02:01", "ic50_nM": float(100 + i),
+            "binder_class": "weak", "contig_key": f"k{i}", "start_nt": 0,
+            "percentile_rank": 1.5} for i in range(n_weak)]
+        + [{"peptide": f"PEP{i}", "allele": "HLA-A*02:01", "ic50_nM": float(1000 + i),
+            "binder_class": "non", "contig_key": f"k{i}", "start_nt": 0,
+            "percentile_rank": 10.0} for i in range(n_non)]
+    )
+    return pd.DataFrame(rows)
+
+
+class TestBuildReportTsv:
+    def test_output_file_is_created(self, tmp_path):
+        out = tmp_path / "report.tsv"
+        _build_report_tsv(
+            patient_id="p001",
+            origin_df=_make_origin_df(),
+            pred_df=_make_pred_df(),
+            hla_qc_tsv=None,
+            output_tsv=out,
+            ic50_strong=50.0,
+            tcrdock_pdb=None,
+        )
+        assert out.exists()
+
+    def test_output_has_expected_columns(self, tmp_path):
+        out = tmp_path / "report.tsv"
+        _build_report_tsv("p001", _make_origin_df(), _make_pred_df(), None, out, 50.0, None)
+        df = pd.read_csv(out, sep="\t")
+        assert list(df.columns) == ["patient_id", "stage", "metric", "value", "notes"]
+
+    def test_patient_id_in_every_row(self, tmp_path):
+        out = tmp_path / "report.tsv"
+        _build_report_tsv("patient_007", _make_origin_df(), _make_pred_df(), None, out, 50.0, None)
+        df = pd.read_csv(out, sep="\t")
+        assert (df["patient_id"] == "patient_007").all()
+
+    def test_junction_filtering_rows_present(self, tmp_path):
+        out = tmp_path / "report.tsv"
+        _build_report_tsv("p001", _make_origin_df(tumor_exclusive=7, normal_shared=3), _make_pred_df(), None, out, 50.0, None)
+        df = pd.read_csv(out, sep="\t")
+        jf = df[df["stage"] == "junction_filtering"]
+        te_row = jf[jf["metric"] == "tumor_exclusive"]
+        assert int(te_row["value"].iloc[0]) == 7
+
+    def test_mhc_prediction_counts_correct(self, tmp_path):
+        out = tmp_path / "report.tsv"
+        _build_report_tsv("p001", _make_origin_df(), _make_pred_df(n_strong=4, n_weak=2, n_non=5), None, out, 50.0, None)
+        df = pd.read_csv(out, sep="\t")
+        mhc = df[df["stage"] == "mhc_prediction"]
+        assert int(mhc[mhc["metric"] == "strong"]["value"].iloc[0]) == 4
+        assert int(mhc[mhc["metric"] == "non"]["value"].iloc[0]) == 5
+        assert int(mhc[mhc["metric"] == "total_predictions"]["value"].iloc[0]) == 11
+
+    def test_top_candidate_is_lowest_ic50(self, tmp_path):
+        out = tmp_path / "report.tsv"
+        _build_report_tsv("p001", _make_origin_df(), _make_pred_df(n_strong=3), None, out, 50.0, None)
+        df = pd.read_csv(out, sep="\t")
+        tc = df[df["stage"] == "top_candidate"]
+        peptide = tc[tc["metric"] == "peptide"]["value"].iloc[0]
+        ic50 = float(tc[tc["metric"] == "ic50_nM"]["value"].iloc[0])
+        assert ic50 == pytest.approx(1.0)
+        assert peptide == "PEP0"
+
+    def test_hla_typing_rows_from_qc_tsv(self, tmp_path):
+        hla_tsv = tmp_path / "hla_qc.tsv"
+        hla_df = pd.DataFrame([
+            {"locus": "A", "allele1": "HLA-A*02:01", "allele2": "HLA-A*24:02",
+             "source": "tumor", "reads": 500, "discrepancy": "",
+             "serology_allele1": "", "serology_allele2": "", "serology_validation": ""},
+        ])
+        hla_df.to_csv(hla_tsv, sep="\t", index=False)
+        out = tmp_path / "report.tsv"
+        _build_report_tsv("p001", _make_origin_df(), _make_pred_df(), str(hla_tsv), out, 50.0, None)
+        df = pd.read_csv(out, sep="\t")
+        hla = df[df["stage"] == "hla_typing"]
+        assert len(hla) == 1
+        assert hla["metric"].iloc[0] == "HLA-A"
+        assert "HLA-A*02:01" in hla["value"].iloc[0]
+        assert "source: tumor" in hla["notes"].iloc[0]
+
+    def test_tcrdock_pdb_available_false_when_no_pdb(self, tmp_path):
+        out = tmp_path / "report.tsv"
+        _build_report_tsv("p001", _make_origin_df(), _make_pred_df(), None, out, 50.0, None)
+        df = pd.read_csv(out, sep="\t")
+        row = df[(df["stage"] == "tcrdock") & (df["metric"] == "pdb_available")]
+        assert row["value"].iloc[0] == "false"
+
+    def test_tcrdock_pdb_available_true_when_pdb_exists(self, tmp_path):
+        pdb = tmp_path / "model.pdb"
+        pdb.write_text("ATOM\n")
+        out = tmp_path / "report.tsv"
+        _build_report_tsv("p001", _make_origin_df(), _make_pred_df(), None, out, 50.0, pdb)
+        df = pd.read_csv(out, sep="\t")
+        row = df[(df["stage"] == "tcrdock") & (df["metric"] == "pdb_available")]
+        assert row["value"].iloc[0] == "true"
+
+    def test_empty_predictions_skips_mhc_and_top_candidate(self, tmp_path):
+        out = tmp_path / "report.tsv"
+        _build_report_tsv("p001", _make_origin_df(), pd.DataFrame(), None, out, 50.0, None)
+        df = pd.read_csv(out, sep="\t")
+        assert df[df["stage"] == "mhc_prediction"].empty
+        assert df[df["stage"] == "top_candidate"].empty


### PR DESCRIPTION
## Summary

- Adds `_build_report_tsv()` to `generate_report.py` — writes a machine-readable TSV alongside `report.html`
- Schema: `patient_id | stage | metric | value | notes`
- Stages covered: `junction_filtering`, `mhc_prediction`, `top_candidate`, `hla_typing`, `tcrdock`
- Adds `report_tsv` as a declared Snakemake output in `analysis.smk`
- `generate_report()` gains two new optional params: `output_tsv` and `patient_id`
- CLI (`--output-tsv`, `--patient-id`) and Snakemake entry point both wired up

Phase 2 (refactor `report.html` to read from `report.tsv`) is tracked in #79.

Closes #57 (Phase 1).

## Test plan

- [x] 10 new pytest cases in `TestBuildReportTsv` covering: file creation, column schema, patient_id propagation, junction counts, binder counts, top candidate IC50, HLA rows from QC TSV, TCRdock pdb_available flag (true/false), empty predictions
- [x] All 144 tests pass (`pytest workflow/tests/ -q`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)