### PR TITLE
Fixes for "feat(report): add report.tsv structured summary artifact (Issue #57 Phase 1)"

### DIFF
--- a/workflow/rules/structure.smk
+++ b/workflow/rules/structure.smk
@@ -68,6 +68,9 @@ if _TCRDOCK_ENABLED:
             report_html=os.path.join(
                 _RES, "{patient_id}", "reports", "report.html"
             ),
+            report_tsv=os.path.join(
+                _RES, "{patient_id}", "reports", "report.tsv"
+            ),
         log:
             os.path.join(_LOGS, "{patient_id}", "structure", "report.log"),
         params:


### PR DESCRIPTION
Add report_tsv in structure.smk as output for generate_report rule to enable TSV report generation alongside HTML report (it was only added in analysis.smk and resulted in an AttributeError). 