### PR TITLE
docs: update sample manifest, HLA config, and cloud guide

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -66,6 +66,9 @@ hla:
 
 When `hla.enabled: false`, the fallback alleles below are used for all predictions.
 
+**Allele priority order:** tumor OptiType → serology → normal/blood OptiType → fallback.
+Tumor calls are preferred as they reflect what the tumor cell actually presents, including any HLA loss-of-heterozygosity. Clinical serology alleles (Red Cross / WGS germline typing) are specified as `serology_A1/A2` … `serology_C1/C2` columns in the samples TSV — see [`docs/data_preparation.md`](data_preparation.md). Null alleles (e.g. `HLA-A*01:11N`) are excluded from prediction but retained in the QC output (`hla_qc.tsv`).
+
 ---
 
 ## Epitope Prediction (MHCflurry)

--- a/docs/data_preparation.md
+++ b/docs/data_preparation.md
@@ -64,7 +64,7 @@ snakemake ... --config samples_tsv=config/samples/patient_001.tsv
 ### Format
 
 ```tsv
-patient_id	sample_id	sample_type	fastq1	fastq2
+patient_id	sample_id	sample_type	fastq1	fastq2	serology_A1	serology_A2	serology_B1	serology_B2	serology_C1	serology_C2
 patient_001	SRR9143066	Primary Tumor	https://ftp.sra.ebi.ac.uk/.../SRR9143066.fastq.gz
 patient_001	SRR9143065	Solid Tissue Normal	https://ftp.sra.ebi.ac.uk/.../SRR9143065.fastq.gz
 ```
@@ -76,14 +76,21 @@ patient_001	SRR9143065	Solid Tissue Normal	https://ftp.sra.ebi.ac.uk/.../SRR9143
 | `sample_type` | Yes | `"Primary Tumor"`, `"Solid Tissue Normal"`, or `"Blood Derived Normal"` |
 | `fastq1` | Yes | Read 1 FASTQ — local path, `gs://` URI, or `https://` URL |
 | `fastq2` | No | Read 2 FASTQ for paired-end data; leave empty for single-end |
+| `serology_A1` / `serology_A2` | No | Known HLA-A alleles from clinical serology (e.g. `HLA-A*02:01`) |
+| `serology_B1` / `serology_B2` | No | Known HLA-B alleles from clinical serology |
+| `serology_C1` / `serology_C2` | No | Known HLA-C alleles from clinical serology |
+
+Serology values are per-patient germline alleles — only the normal/blood row needs to carry them; the tumor row should be left empty. Null alleles (e.g. `HLA-A*01:11N`) are accepted: they are excluded from prediction but shown in the QC output.
 
 ### Sample type roles
 
 | Sample type | Junction filtering | HLA typing |
 |-------------|-------------------|------------|
-| `Primary Tumor` | Source of candidate junctions | Yes |
-| `Solid Tissue Normal` | Filters out junctions present in normal | Yes |
-| `Blood Derived Normal` | Not used for junction filtering | Yes (preferred for germline HLA calls) |
+| `Primary Tumor` | Source of candidate junctions | OptiType call used first (reflects tumor HLA, including any LOH) |
+| `Solid Tissue Normal` | Filters out junctions present in normal tissue | OptiType call used if no tumor call and no serology |
+| `Blood Derived Normal` | Not used for junction filtering | OptiType call used if no tumor call and no serology |
+
+HLA allele priority order: **tumor OptiType → serology → normal/blood OptiType → fallback**. Tumor calls are preferred because HLA loss-of-heterozygosity (LOH) can occur in the tumor and affect what is actually presented. Serology (Red Cross / WGS germline typing) takes priority over normal OptiType when available.
 
 When no normal sample is present, all unannotated junctions are labelled
 `tumor_exclusive` with a warning — the pipeline still runs.

--- a/docs/google_cloud_guide.md
+++ b/docs/google_cloud_guide.md
@@ -460,16 +460,13 @@ bash scripts/run_cloud_gpu.sh --mode prod --branch main --zone europe-west1-b
 
 ### Retrieving results
 
-The bucket name is derived from your GCP project ID (`<PROJECT_ID>-tcrdock-handoff`):
+The bucket is `splice-neoepitope-project` (set in `run_cloud_gpu.sh`):
 
 ```bash
-# Test
-gcloud storage cp -r gs://<PROJECT_ID>-tcrdock-handoff/results/test/reports ./tcrdock_report
-open tcrdock_report/local/report.html
-
-# Production
-gcloud storage cp -r gs://<PROJECT_ID>-tcrdock-handoff/results/reports ./tcrdock_report
-open tcrdock_report/local/report.html
+# Download the reports folder for a patient (replace patient_001 as needed)
+gcloud storage cp -r gs://splice-neoepitope-project/results/patient_001/reports ./reports
+open reports/report.html      # interactive HTML report
+# reports/report.tsv          # machine-readable summary (patient_id | stage | metric | value | notes)
 ```
 
 ### How it works
@@ -477,12 +474,13 @@ open tcrdock_report/local/report.html
 1. **CPU VM** is created (or started) automatically. `setup_cloud.sh` installs
    conda + Snakemake. The pipeline runs steps 1–5 in a tmux session while the
    script polls `pipeline.log` for completion.
-2. Results are uploaded to `gs://<PROJECT_ID>-tcrdock-handoff/` and the CPU VM is stopped.
+2. Results are uploaded to `gs://splice-neoepitope-project/` and the CPU VM is stopped.
 3. A **GPU Spot VM** (n1-standard-4 + NVIDIA T4) is created.
    `setup_tcrdock_vm.sh` builds the TCRdock Docker image (~25 GB: CUDA 11.8,
-   AlphaFold params, BLAST). Results are downloaded from GCS, TCRdock runs,
-   and the HTML report is regenerated with the embedded Mol* 3D viewer. Final
-   results are uploaded to GCS and the VM auto-stops.
+   AlphaFold params, BLAST). Results are downloaded from GCS via `gcloud storage rsync`
+   (checksum-based — unchanged files keep their mtime so Snakemake skips them).
+   TCRdock runs, the HTML report and `report.tsv` are regenerated with the embedded
+   Mol* 3D viewer. Final results are uploaded to GCS and the VM auto-stops.
 
 ### Detached mode
 


### PR DESCRIPTION
## Summary

- **`data_preparation.md`**: adds serology columns to the sample manifest format and column table; updates the HLA typing roles table to reflect the tumor-first priority order introduced in #59
- **`configuration.md`**: adds the HLA allele priority order (tumor OptiType → serology → normal → fallback) with a cross-reference to the samples TSV serology columns
- **`google_cloud_guide.md`**: fixes the bucket name (was a stale `<PROJECT_ID>-tcrdock-handoff` placeholder, now `splice-neoepitope-project`); fixes result paths to include `{patient_id}`; adds `report.tsv` to the retrieval example; mentions `gcloud storage rsync` in the "How it works" description (#77)

## Test plan

- [x] All three docs render correctly as Markdown
- [x] No code changes — docs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)