### PR TITLE
refactor(snakefile): reduce to minimal entry point; move shared config to common.smk

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -32,41 +32,6 @@
 
 configfile: "config/config.yaml"
 
-import csv
-import os
-
-# ── convenience aliases ──────────────────────────────────────────────────────
-# All patient outputs are rooted at _RES/{patient_id}/<step>/
-_RES  = config["output"]["results_dir"]
-_LOGS = config["output"]["logs"]
-
-# Derive patient IDs from the samples TSV — the TSV is the single source of
-# truth for what to run. All rows sharing the same patient_id are treated as
-# a matched set (e.g. tumor + normal for one patient).
-def _read_patient_ids(samples_tsv):
-    patient_ids = set()
-    with open(samples_tsv) as f:
-        for row in csv.DictReader(f, delimiter="\t"):
-            pid = (row.get("patient_id") or "").strip()
-            if not pid or pid.startswith("#"):
-                continue
-            patient_ids.add(pid)
-    return sorted(patient_ids)
-
-if "samples_tsv" not in config:
-    raise ValueError(
-        "samples_tsv is required. Pass it at runtime:\n"
-        "  snakemake --config samples_tsv=config/samples/<patient>.tsv\n"
-        "  or set it in a configfile (e.g. config/test_config.yaml)."
-    )
-
-PATIENT_IDS = _read_patient_ids(config["samples_tsv"])
-
-wildcard_constraints:
-    patient_id="[^/]+",
-    sample="[^/]+",
-
-
 # ── include rule modules ─────────────────────────────────────────────────────
 include: "workflow/rules/common.smk"
 include: "workflow/rules/download.smk"
@@ -83,9 +48,10 @@ include: "workflow/rules/structure.smk"
 if config.get("tcrdock", {}).get("enabled", False):
     ruleorder: generate_report_with_structure > generate_report
 
-
 # ── final target ─────────────────────────────────────────────────────────────
+# _read_samples_tsv (common.smk) validates exactly one patient per run.
+PATIENT_ID = _read_samples_tsv(config["samples_tsv"])[0]["patient_id"]
+
 rule all:
     input:
-        expand(os.path.join(_RES, "{patient_id}", "reports", "report.html"), patient_id=PATIENT_IDS),
-
+        os.path.join(_RES, PATIENT_ID, "reports", "report.html"),

--- a/Snakefile
+++ b/Snakefile
@@ -54,4 +54,4 @@ PATIENT_ID = _read_samples_tsv(config["samples_tsv"])[0]["patient_id"]
 
 rule all:
     input:
-        os.path.join(_RES, PATIENT_ID, "reports", "report.html"),
+        f"{_RES}/{PATIENT_ID}/reports/report.html",

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -11,6 +11,22 @@ import csv
 import os
 from pathlib import Path
 
+# ── Config validation ─────────────────────────────────────────────────────────
+if "samples_tsv" not in config:
+    raise ValueError(
+        "samples_tsv is required. Pass it at runtime:\n"
+        "  snakemake --config samples_tsv=config/samples/<patient>.tsv\n"
+        "  or set it in a configfile (e.g. config/test_config.yaml)."
+    )
+
+# ── Config aliases ────────────────────────────────────────────────────────────
+_RES  = config["output"]["results_dir"]
+_LOGS = config["output"]["logs"]
+
+# ── Wildcard constraints ──────────────────────────────────────────────────────
+wildcard_constraints:
+    patient_id="[^/]+",
+    sample="[^/]+",
 
 # ── Sample manifest reader ────────────────────────────────────────────────────
 
@@ -22,6 +38,9 @@ def _read_samples_tsv(samples_tsv, patient_id=None):
         patient_id:  if given, return only rows matching this patient
 
     Returns a list of dicts (one per sample row).
+
+    Raises ValueError if the TSV contains more than one patient_id and no
+    patient_id filter is given — each run must target exactly one patient.
     """
     samples_path = Path(samples_tsv)
     if not samples_path.exists():
@@ -34,7 +53,15 @@ def _read_samples_tsv(samples_tsv, patient_id=None):
                 continue
             row["patient_id"] = pid
             rows.append(row)
-    if patient_id is not None:
+    if patient_id is None:
+        unique_patients = {r["patient_id"] for r in rows}
+        if len(unique_patients) > 1:
+            raise ValueError(
+                f"samples_tsv must contain exactly one patient_id per run, "
+                f"found {len(unique_patients)}: {', '.join(sorted(unique_patients))}.\n"
+                "Run the pipeline separately for each patient."
+            )
+    else:
         rows = [r for r in rows if r["patient_id"] == patient_id]
     return rows
 

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -55,6 +55,10 @@ def _read_samples_tsv(samples_tsv, patient_id=None):
             rows.append(row)
     if patient_id is None:
         unique_patients = {r["patient_id"] for r in rows}
+        if len(unique_patients) == 0:
+            raise ValueError(
+                f"samples_tsv '{samples_tsv}' contains no valid sample rows."
+            )
         if len(unique_patients) > 1:
             raise ValueError(
                 f"samples_tsv must contain exactly one patient_id per run, "


### PR DESCRIPTION
## Summary

- Move `_RES`/`_LOGS` aliases, `wildcard_constraints`, and `samples_tsv` validation from the Snakefile into `common.smk` where they belong
- Add single-patient enforcement in `_read_samples_tsv`: raises `ValueError` if TSV contains more than one `patient_id` (one run = one patient)
- Replace `PATIENT_IDS` list + `expand()` with a scalar `PATIENT_ID` and a direct path in `rule all`
- Snakefile is now purely: `configfile`, includes, `ruleorder`, `PATIENT_ID`, and `rule all`

Closes #92

## Test plan

- [ ] Dry-run with test config passes: `snakemake --configfile config/test_config.yaml -n`
- [ ] Passing a multi-patient TSV raises a clear `ValueError` at parse time

🤖 Generated with [Claude Code](https://claude.com/claude-code)