### PR TITLE
feat(translation): configurable peptide lengths (8-mer, 9-mer, 10-mer)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,11 @@ snakemake --configfile config/test_config.yaml config/tcrdock_gpu.yaml   # corre
 # NOT: --configfile config/test_config.yaml --configfile config/tcrdock_gpu.yaml
 ```
 
+## Config Migration Notes
+
+### `assembly:` section removed (PR #99)
+The old `config.yaml` had an `assembly:` block (`upstream_nt`, `downstream_nt`, `contig_length`). These keys were replaced by `translation.peptide_lengths` in PR #99; flank size is now derived automatically as `3 * (max_length - 1)`. If you have a local override `config.yaml` still containing `assembly:`, Snakemake will silently ignore those keys — remove them to avoid confusion.
+
 ## Known Dependency Issues (Fixed)
 
 ### `hisat2.yaml` — samtools/libdeflate conflict

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -55,12 +55,13 @@ filtering:
   min_normal_reads: 2
 
 # -----------------------------------------------------------------
-# Contig assembly
+# Peptide translation
 # -----------------------------------------------------------------
-assembly:
-  upstream_nt:   26   # nt upstream of the splice junction
-  downstream_nt: 24   # nt downstream of the splice junction
-  contig_length: 50   # total contig length (upstream + downstream)
+# Peptide lengths to extract from each junction contig.
+# Contig flank size is derived automatically: flank_nt = 3 * (max_length - 1).
+# For [8, 9, 10] this gives symmetric 27 nt flanks (54 nt contigs).
+translation:
+  peptide_lengths: [8, 9, 10]
 
 # -----------------------------------------------------------------
 # blastp filter (Step 4b — optional but recommended)

--- a/docs/lab_notebook.md
+++ b/docs/lab_notebook.md
@@ -2,6 +2,63 @@
 
 ---
 
+## 2026-04-22
+
+### Issue #82 — Multi-length peptide extraction (8-mer, 9-mer, 10-mer)
+
+**Motivation:** MHC-I presents 8–10-mer peptides. Extracting only 9-mers misses a significant fraction of true binders.
+
+**Design:**
+- Replaced hardcoded 9-mer extraction in `translate_peptides.py` with a loop over a configurable `translation.peptide_lengths: [8, 9, 10]` list.
+- Contig flank is now auto-derived: `flank_nt = 3 * (max_length - 1)`. For max length 10 this gives symmetric 27/27 nt flanks (54 nt contigs), up from 26/24 (50 nt). The old 50 nt contigs were 3 nt too short to cover all 10-mer junction-spanning windows on the downstream side.
+- MHCflurry natively accepts 8–15-mers; blastp operates on whatever peptides it receives. No changes needed in either step.
+- 16 unit tests updated/added covering 8/9/10-mer start ranges and known-start sequences.
+
+**Local test results (chr22, patient_001_test):**
+
+| | 9-mer only | 8/9/10-mer |
+|---|---|---|
+| Unique peptides into MHCflurry | 1,339 | 4,045 (~3×) |
+| Total predictions (6 alleles) | 8,172 | 24,714 (~3×) |
+| Strong binders (≤50 nM) | 39 | 37 |
+| Weak binders (≤500 nM) | 290 | 502 (+73%) |
+
+**Follow-on issues filed:**
+- **Issue #97** — Use GENCODE CDS reading frame to restrict translation to the biologically relevant frame. Currently all 3 reading frames are used per junction; the correct frame can be determined from the GENCODE GTF for junctions where (a) the upstream donor maps unambiguously to a single CDS exon end, and (b) no other tumor-exclusive junction is detected upstream in the same gene. Both conditions must hold; overlap between genes and upstream frame-shifting junctions are edge cases requiring fallback to all 3 frames.
+- **Issue #98** — Replace blastp exact-match filter with a Python set-based k-mer lookup. On the production patient (424K unique peptides), blastp ran for >2 hours. A set of all k-mers from the Swiss-Prot FASTA built once at startup reduces this to seconds via O(1) lookup per peptide. Also supports near-self filtering in future (generate all 1-mismatch variants of query, check against exact set).
+
+---
+
+### Issue #89 — blastp filter against human reference proteome (PR #96, merged)
+
+**Overview:** Added `blastp_filter_peptides` rule between `translate_peptides` and `run_mhcflurry`. Excludes peptides with a 100% identity / 100% query coverage match in UniProt Swiss-Prot (self-peptides the immune system is tolerized to).
+
+**Cloud run debugging:**
+- *Run 1 — blastp silently skipped:* `mhc_affinity.tsv` existed from a pre-blastp run. With `--rerun-triggers mtime`, Snakemake never propagated upward to check for the missing `peptides_novel.tsv`. Fixed by deleting downstream outputs before re-running.
+- *Run 2 — `Error: Unknown argument: "perc_identity"`:* `-perc_identity` is a `blastn`-only flag; blastp 2.16.0 rejects it. Fixed: removed flag, now uses `-outfmt "6 qseqid sseqid pident"` + `-qcov_hsp_perc 100` (full coverage at search time) + Python `int(float(pident)) == 100` filtering. Added 15 unit tests.
+
+**Local test (9-mers):** 1,371 peptides → 9 self-peptides excluded (0.7%) → 1,362 novel passed to MHCflurry.
+
+---
+
+### PR #93 — Remove `gcs:` block and BAM upload fix
+
+Removed the `gcs:` block from `config/config.yaml` and `config/test_config.yaml` (BAM upload had been moved to `scripts/run_cloud_cpu.sh` and no longer read config). Also removed `temp()` + `upload_bam` from `alignment.smk` which was preventing BAM/BAI/BED files from reaching GCS.
+
+---
+
+### PR #94 — Snakefile refactor (Issue #92)
+
+Reduced the Snakefile to a minimal entry point: patient ID derivation and shared config moved into `common.smk`. Added a zero-rows guard in `_read_samples_tsv` that raises a clear `ValueError` on empty or missing TSV rather than a bare `IndexError`.
+
+---
+
+### PR #95 — Claude GitHub Actions workflows
+
+Added Claude Code Review and Claude PR Assistant GitHub Actions workflows (`.github/workflows/`).
+
+---
+
 ## 2026-04-21
 
 ### Patient_001 (gastric cancer) — GPU run completed

--- a/workflow/rules/assemble_contigs.smk
+++ b/workflow/rules/assemble_contigs.smk
@@ -1,10 +1,13 @@
 # =============================================================================
-# Rule module: Step 3 — Assemble 50 nt nucleotide contigs around splice junctions
+# Rule module: Step 3 — Assemble nucleotide contigs around splice junctions
 # =============================================================================
 
+_FLANK_NT = 3 * (max(config["translation"]["peptide_lengths"]) - 1)
+
 rule assemble_contigs:
-    """For each novel splice junction, extract a 50 nt contig centred on the
-    junction (26 nt upstream + 24 nt downstream) using bedtools getfasta.
+    """For each novel splice junction, extract a contig centred on the junction
+    using bedtools getfasta. Flank size is derived from the maximum configured
+    peptide length: flank_nt = 3 * (max_length - 1).
     Contigs that contain soft-clipped regions are excluded.
     Output: FASTA file of contigs per patient."""
     input:
@@ -17,8 +20,8 @@ rule assemble_contigs:
     log:
         os.path.join(_LOGS, "{patient_id}", "assemble_contigs", "assemble.log"),
     params:
-        upstream_nt=config["assembly"]["upstream_nt"],
-        downstream_nt=config["assembly"]["downstream_nt"],
+        upstream_nt=_FLANK_NT,
+        downstream_nt=_FLANK_NT,
     conda:
         "../envs/biotools.yaml"
     script:

--- a/workflow/rules/translate_peptides.smk
+++ b/workflow/rules/translate_peptides.smk
@@ -1,13 +1,13 @@
 # =============================================================================
-# Rule module: Step 4 — Extract junction-spanning 9-mers from contigs
+# Rule module: Step 4 — Extract junction-spanning peptides from contigs
 # =============================================================================
 
 rule translate_peptides:
-    """Extract junction-spanning 9-mer peptides directly from 50 nt contigs.
-    For each contig, all 27 nt windows satisfying the spanning condition
-    (first codon fully upstream, last codon fully downstream) are translated
-    in all three reading frames.
-    Output: TSV file of junction-spanning 9-mers per patient."""
+    """Extract junction-spanning peptides from junction contigs.
+    For each configured peptide length, all windows satisfying the spanning
+    condition (first codon fully upstream, last codon fully downstream) are
+    translated in all three reading frames.
+    Output: TSV file of junction-spanning peptides per patient."""
     input:
         contigs_fasta=rules.assemble_contigs.output.contigs_fasta,
     output:
@@ -17,7 +17,8 @@ rule translate_peptides:
     log:
         os.path.join(_LOGS, "{patient_id}", "translate_peptides", "translate.log"),
     params:
-        upstream_nt=config["assembly"]["upstream_nt"],
+        upstream_nt=_FLANK_NT,
+        peptide_lengths=config["translation"]["peptide_lengths"],
     conda:
         "../envs/python.yaml"
     script:

--- a/workflow/scripts/run_mhcflurry.py
+++ b/workflow/scripts/run_mhcflurry.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""run_mhcflurry.py — Wrapper to run MHCflurry 2.x on junction-spanning 9-mers.
+"""run_mhcflurry.py — Wrapper to run MHCflurry 2.x on junction-spanning peptides.
 
 MHCflurry is an open-source MHC-I binding predictor that achieves
 state-of-the-art performance.  Unlike NetMHCPan, it does not require
@@ -11,9 +11,9 @@ Reference:
   Cell Systems, 11(1), 42-48.e7.
 
 The script:
-  1. Reads junction-spanning 9-mers from the TSV produced by translate_peptides.py.
+  1. Reads junction-spanning peptides from the TSV produced by translate_peptides.py.
   2. Runs MHCflurry affinity prediction for each HLA allele.
-  3. Classifies each 9-mer as a strong binder (IC50 <= 50 nM), weak binder
+  3. Classifies each peptide as a strong binder (IC50 <= 50 nM), weak binder
      (IC50 <= 500 nM), or non-binder.
 
 Allele sources (in priority order):
@@ -252,13 +252,13 @@ def run_prediction(
     ic50_weak: float = 500.0,
     threads: int = 1,
 ) -> None:
-    """Run MHCflurry on junction-spanning 9-mers and write results to TSV.
+    """Run MHCflurry on junction-spanning peptides and write results to TSV.
 
     Predictions are run for every resolved allele and concatenated into a
     single output TSV (one row per peptide × allele combination).
 
     Args:
-        peptides_tsv:   TSV of junction-spanning 9-mers (contig_key, start_nt, peptide).
+        peptides_tsv:   TSV of junction-spanning peptides (contig_key, start_nt, peptide).
         output_tsv:     Destination TSV file.
         alleles:        HLA alleles to predict (MHCflurry format, e.g. ['HLA-A*02:01']).
                         Ignored when alleles_tsv is provided.
@@ -294,7 +294,7 @@ def run_prediction(
     output_tsv = Path(output_tsv)
     output_tsv.parent.mkdir(parents=True, exist_ok=True)
 
-    # Step 1: Read junction-spanning 9-mers
+    # Step 1: Read junction-spanning peptides
     peptides_df = pd.read_csv(peptides_tsv, sep="\t")
 
     if peptides_df.empty:
@@ -308,7 +308,7 @@ def run_prediction(
 
     unique_peptides = peptides_df["peptide"].unique().tolist()
     log.info(
-        "Extracted %d 9-mers (%d unique) from %s",
+        "Extracted %d peptides (%d unique) from %s",
         len(peptides_df), len(unique_peptides), peptides_tsv,
     )
 
@@ -376,7 +376,7 @@ def _snakemake_main() -> None:
 
 def _cli_main() -> None:
     parser = argparse.ArgumentParser(
-        description="Run MHCflurry epitope prediction on junction-spanning 9-mers."
+        description="Run MHCflurry epitope prediction on junction-spanning peptides."
     )
     parser.add_argument("--peptides-tsv", required=True, help="Input peptides TSV")
     parser.add_argument("--output", required=True, help="Output predictions TSV")

--- a/workflow/scripts/translate_peptides.py
+++ b/workflow/scripts/translate_peptides.py
@@ -1,18 +1,15 @@
 #!/usr/bin/env python3
-"""translate_peptides.py — Extract junction-spanning 9-mer peptides from 50 nt
-splice-junction contigs.
+"""translate_peptides.py — Extract junction-spanning peptides from splice-junction contigs.
 
-For each contig, the junction breakpoint sits at nucleotide ``upstream_nt``
-(default 26).  For each of the three reading frames (offsets 0, 1, 2), the
-script identifies all 27 nt windows (= 9 codons) whose first codon is fully
-upstream of the junction and whose last codon is fully downstream.
+For each contig, the junction breakpoint sits at nucleotide ``upstream_nt``.
+For each configured peptide length L and each of the three reading frames
+(offsets 0, 1, 2), the script identifies all L*3 nt windows whose first codon
+is fully upstream of the junction and whose last codon is fully downstream.
 
-Spanning condition for a window starting at nucleotide ``start``:
-    upstream_nt - 24  <=  start  <=  upstream_nt - 3
+Spanning condition for a window of length L starting at nucleotide ``start``:
+    upstream_nt - (L-1)*3  <=  start  <=  upstream_nt - 3
 
-With defaults (upstream_nt = 26):  2 <= start <= 23.
-
-Each valid window is translated directly to a 9-mer.  Windows containing a
+Each valid window is translated directly to an L-mer.  Windows containing a
 stop codon or ambiguous amino acid (X) are discarded.
 
 Output: TSV with columns  contig_key | start_nt | peptide
@@ -21,7 +18,7 @@ Usage (standalone):
   python translate_peptides.py \\
       --contigs-fasta results/contigs/patient_001/contigs.fa \\
       --output results/peptides/patient_001/peptides.tsv \\
-      --upstream-nt 26
+      --upstream-nt 27 --peptide-lengths 8 9 10
 
 Usage (Snakemake):
   Called automatically by the ``translate_peptides`` rule.
@@ -41,9 +38,7 @@ logging.basicConfig(
 )
 log = logging.getLogger(__name__)
 
-_PEPTIDE_LENGTH = 9
 _CODON_SIZE = 3
-_WINDOW_NT = _PEPTIDE_LENGTH * _CODON_SIZE  # 27 nt
 
 
 # ---------------------------------------------------------------------------
@@ -71,45 +66,50 @@ def _parse_fasta(fasta_path: str | Path) -> list[tuple[str, str]]:
 
 
 # ---------------------------------------------------------------------------
-# Junction-spanning 9-mer extraction
+# Junction-spanning peptide extraction
 # ---------------------------------------------------------------------------
 
-def extract_spanning_9mers(
+def extract_spanning_peptides(
     contig_seq: str,
-    upstream_nt: int = 26,
+    upstream_nt: int = 27,
+    peptide_lengths: list[int] | None = None,
     reading_frames: list[int] | None = None,
 ) -> list[tuple[int, str]]:
-    """Extract junction-spanning 9-mers from a 50 nt contig.
+    """Extract junction-spanning peptides from a junction contig.
 
-    For each reading frame, finds all 27 nt windows satisfying the spanning
-    condition: first codon fully upstream, last codon fully downstream.
+    For each peptide length and reading frame, finds all windows satisfying
+    the spanning condition: first codon fully upstream, last codon fully
+    downstream.
 
     Args:
-        contig_seq:     Nucleotide sequence (upper-case, typically 50 nt).
-        upstream_nt:    Position of the junction breakpoint (number of upstream
-                        nucleotides). Must match config[assembly][upstream_nt].
-        reading_frames: 0-based frame offsets to consider. Defaults to [0, 1, 2].
+        contig_seq:      Nucleotide sequence (upper-case).
+        upstream_nt:     Position of the junction breakpoint. Must equal
+                         3 * (max(peptide_lengths) - 1).
+        peptide_lengths: Amino acid lengths to extract. Defaults to [8, 9, 10].
+        reading_frames:  0-based frame offsets to consider. Defaults to [0, 1, 2].
 
     Returns:
-        List of (start_nt, peptide) tuples. start_nt is the 0-based nucleotide
-        start of the 27 nt window in the contig.
+        List of (start_nt, peptide) tuples.
     """
+    if peptide_lengths is None:
+        peptide_lengths = [8, 9, 10]
     if reading_frames is None:
         reading_frames = [0, 1, 2]
 
-    min_start = upstream_nt - (_PEPTIDE_LENGTH - 1) * _CODON_SIZE  # = 2 for defaults
-    max_start = upstream_nt - _CODON_SIZE                           # = 23 for defaults
-
     results: list[tuple[int, str]] = []
-    for frame in reading_frames:
-        start = frame
-        while start + _WINDOW_NT <= len(contig_seq):
-            if min_start <= start <= max_start:
-                window = contig_seq[start : start + _WINDOW_NT]
-                peptide = str(Seq(window).translate())
-                if "*" not in peptide and "X" not in peptide:
-                    results.append((start, peptide))
-            start += _CODON_SIZE
+    for length in peptide_lengths:
+        window_nt = length * _CODON_SIZE
+        min_start = upstream_nt - (length - 1) * _CODON_SIZE
+        max_start = upstream_nt - _CODON_SIZE
+        for frame in reading_frames:
+            start = frame
+            while start + window_nt <= len(contig_seq):
+                if min_start <= start <= max_start:
+                    window = contig_seq[start : start + window_nt]
+                    peptide = str(Seq(window).translate())
+                    if "*" not in peptide and "X" not in peptide:
+                        results.append((start, peptide))
+                start += _CODON_SIZE
 
     return results
 
@@ -121,18 +121,22 @@ def extract_spanning_9mers(
 def translate_all(
     contigs_fasta: str | Path,
     output_tsv: str | Path,
-    upstream_nt: int = 26,
+    upstream_nt: int = 27,
+    peptide_lengths: list[int] | None = None,
     reading_frames: list[int] | None = None,
 ) -> None:
-    """Extract junction-spanning 9-mers from all contigs and write to TSV.
+    """Extract junction-spanning peptides from all contigs and write to TSV.
 
     Args:
-        contigs_fasta:  Input FASTA of 50 nt contigs.
-        output_tsv:     Output TSV (columns: contig_key, start_nt, peptide).
-        upstream_nt:    Junction breakpoint position. Must match
-                        config[assembly][upstream_nt].
-        reading_frames: 0-based frame offsets. Defaults to [0, 1, 2].
+        contigs_fasta:   Input FASTA of junction contigs.
+        output_tsv:      Output TSV (columns: contig_key, start_nt, peptide).
+        upstream_nt:     Junction breakpoint position. Must equal
+                         3 * (max(peptide_lengths) - 1).
+        peptide_lengths: Amino acid lengths to extract. Defaults to [8, 9, 10].
+        reading_frames:  0-based frame offsets. Defaults to [0, 1, 2].
     """
+    if peptide_lengths is None:
+        peptide_lengths = [8, 9, 10]
     if reading_frames is None:
         reading_frames = [0, 1, 2]
 
@@ -142,8 +146,8 @@ def translate_all(
 
     records = _parse_fasta(contigs_fasta)
     log.info(
-        "Extracting junction-spanning 9-mers from %d contigs (upstream_nt=%d)",
-        len(records), upstream_nt,
+        "Extracting junction-spanning %s-mers from %d contigs (upstream_nt=%d)",
+        "/".join(str(l) for l in peptide_lengths), len(records), upstream_nt,
     )
 
     n_peptides = 0
@@ -153,12 +157,14 @@ def translate_all(
         for header, seq in records:
             if not seq:
                 continue
-            for start_nt, peptide in extract_spanning_9mers(seq, upstream_nt, reading_frames):
+            for start_nt, peptide in extract_spanning_peptides(
+                seq, upstream_nt, peptide_lengths, reading_frames
+            ):
                 writer.writerow([header, start_nt, peptide])
                 n_peptides += 1
 
     log.info(
-        "Wrote %d junction-spanning 9-mers from %d contigs to %s",
+        "Wrote %d junction-spanning peptides from %d contigs to %s",
         n_peptides, len(records), output_tsv,
     )
 
@@ -175,18 +181,23 @@ def _snakemake_main() -> None:
         contigs_fasta=snakemake.input.contigs_fasta,  # type: ignore[name-defined]  # noqa: F821
         output_tsv=snakemake.output.peptides_tsv,  # type: ignore[name-defined]  # noqa: F821
         upstream_nt=snakemake.params.upstream_nt,  # type: ignore[name-defined]  # noqa: F821
+        peptide_lengths=snakemake.params.peptide_lengths,  # type: ignore[name-defined]  # noqa: F821
     )
 
 
 def _cli_main() -> None:
     parser = argparse.ArgumentParser(
-        description="Extract junction-spanning 9-mers from 50 nt splice-junction contigs."
+        description="Extract junction-spanning peptides from splice-junction contigs."
     )
     parser.add_argument("--contigs-fasta", required=True, help="Input contigs FASTA")
     parser.add_argument("--output", required=True, help="Output peptides TSV")
     parser.add_argument(
-        "--upstream-nt", type=int, default=26,
-        help="Junction breakpoint position (default: 26)",
+        "--upstream-nt", type=int, default=27,
+        help="Junction breakpoint position (default: 27)",
+    )
+    parser.add_argument(
+        "--peptide-lengths", type=int, nargs="+", default=[8, 9, 10],
+        help="Peptide lengths to extract (default: 8 9 10)",
     )
     args = parser.parse_args()
 
@@ -194,6 +205,7 @@ def _cli_main() -> None:
         contigs_fasta=args.contigs_fasta,
         output_tsv=args.output,
         upstream_nt=args.upstream_nt,
+        peptide_lengths=args.peptide_lengths,
     )
 
 

--- a/workflow/scripts/translate_peptides.py
+++ b/workflow/scripts/translate_peptides.py
@@ -96,11 +96,19 @@ def extract_spanning_peptides(
     if reading_frames is None:
         reading_frames = [0, 1, 2]
 
+    expected_upstream = _CODON_SIZE * (max(peptide_lengths) - 1)
+    if upstream_nt != expected_upstream:
+        log.warning(
+            "upstream_nt=%d does not match 3*(max_length-1)=%d; "
+            "downstream coverage may be incomplete for the longest peptide length",
+            upstream_nt, expected_upstream,
+        )
+
     results: list[tuple[int, str]] = []
+    max_start = upstream_nt - _CODON_SIZE
     for length in peptide_lengths:
         window_nt = length * _CODON_SIZE
         min_start = upstream_nt - (length - 1) * _CODON_SIZE
-        max_start = upstream_nt - _CODON_SIZE
         for frame in reading_frames:
             start = frame
             while start + window_nt <= len(contig_seq):
@@ -147,7 +155,7 @@ def translate_all(
     records = _parse_fasta(contigs_fasta)
     log.info(
         "Extracting junction-spanning %s-mers from %d contigs (upstream_nt=%d)",
-        "/".join(str(l) for l in peptide_lengths), len(records), upstream_nt,
+        "/".join(str(plen) for plen in peptide_lengths), len(records), upstream_nt,
     )
 
     n_peptides = 0

--- a/workflow/tests/test_translate_peptides.py
+++ b/workflow/tests/test_translate_peptides.py
@@ -1,12 +1,13 @@
-"""Tests for translate_peptides.py — junction-spanning 9-mer extraction."""
+"""Tests for translate_peptides.py — junction-spanning peptide extraction."""
 
-from translate_peptides import extract_spanning_9mers
+from translate_peptides import extract_spanning_peptides
 
-# Default config: upstream_nt=26, so min_start=2, max_start=23
-UPSTREAM_NT = 26
+# Default config: upstream_nt=27, contig_length=54
+UPSTREAM_NT = 27
+CONTIG_LEN = 54
 
 
-def _no_stop_contig(length: int = 50) -> str:
+def _no_stop_contig(length: int = CONTIG_LEN) -> str:
     """Return a contig of given length with no stop codons in any frame.
 
     'GCC' * n: frame0=Ala, frame1=Pro (CCG), frame2=Arg (CGC) — all non-stop.
@@ -14,10 +15,10 @@ def _no_stop_contig(length: int = 50) -> str:
     return ("GCC" * (length // 3 + 1))[:length]
 
 
-class TestExtractSpanning9mers:
+class TestExtractSpanningPeptides:
     def test_returns_list_of_tuples(self):
-        seq = _no_stop_contig(50)
-        result = extract_spanning_9mers(seq, upstream_nt=UPSTREAM_NT)
+        seq = _no_stop_contig()
+        result = extract_spanning_peptides(seq, upstream_nt=UPSTREAM_NT, peptide_lengths=[9])
         assert isinstance(result, list)
         for item in result:
             start_nt, peptide = item
@@ -25,73 +26,107 @@ class TestExtractSpanning9mers:
             assert isinstance(peptide, str)
             assert len(peptide) == 9
 
-    def test_all_starts_within_valid_range(self):
-        # min_start=2, max_start=23
-        seq = _no_stop_contig(50)
-        result = extract_spanning_9mers(seq, upstream_nt=UPSTREAM_NT)
+    def test_9mer_starts_within_valid_range(self):
+        # For 9-mers: min_start=3, max_start=24
+        seq = _no_stop_contig()
+        result = extract_spanning_peptides(seq, upstream_nt=UPSTREAM_NT, peptide_lengths=[9])
         for start_nt, _ in result:
-            assert 2 <= start_nt <= 23, f"start_nt={start_nt} outside [2, 23]"
+            assert 3 <= start_nt <= 24, f"start_nt={start_nt} outside [3, 24]"
 
-    def test_frame0_start_zero_excluded(self):
-        # Frame 0 first window starts at 0 < min_start=2 → excluded
-        seq = _no_stop_contig(50)
-        result = extract_spanning_9mers(seq, upstream_nt=UPSTREAM_NT, reading_frames=[0])
+    def test_8mer_starts_within_valid_range(self):
+        # For 8-mers: min_start=27-21=6, max_start=24
+        seq = _no_stop_contig()
+        result = extract_spanning_peptides(seq, upstream_nt=UPSTREAM_NT, peptide_lengths=[8])
+        for start_nt, _ in result:
+            assert 6 <= start_nt <= 24, f"start_nt={start_nt} outside [6, 24]"
+
+    def test_10mer_starts_within_valid_range(self):
+        # For 10-mers: min_start=27-27=0, max_start=24
+        seq = _no_stop_contig()
+        result = extract_spanning_peptides(seq, upstream_nt=UPSTREAM_NT, peptide_lengths=[10])
+        for start_nt, _ in result:
+            assert 0 <= start_nt <= 24, f"start_nt={start_nt} outside [0, 24]"
+
+    def test_peptide_length_matches_requested(self):
+        seq = _no_stop_contig()
+        for length in [8, 9, 10]:
+            result = extract_spanning_peptides(seq, upstream_nt=UPSTREAM_NT, peptide_lengths=[length])
+            for _, peptide in result:
+                assert len(peptide) == length
+
+    def test_multi_length_contains_all_lengths(self):
+        seq = _no_stop_contig()
+        result = extract_spanning_peptides(seq, upstream_nt=UPSTREAM_NT, peptide_lengths=[8, 9, 10])
+        lengths_found = {len(p) for _, p in result}
+        assert lengths_found == {8, 9, 10}
+
+    def test_frame0_start_zero_excluded_for_9mer(self):
+        # Frame 0 first window starts at 0 < min_start=3 for 9-mers → excluded
+        seq = _no_stop_contig()
+        result = extract_spanning_peptides(seq, upstream_nt=UPSTREAM_NT, peptide_lengths=[9], reading_frames=[0])
         starts = [s for s, _ in result]
         assert 0 not in starts
 
-    def test_frame2_start_two_included(self):
-        # Frame 2 first window starts at 2 == min_start=2 → included
-        seq = _no_stop_contig(50)
-        result = extract_spanning_9mers(seq, upstream_nt=UPSTREAM_NT, reading_frames=[2])
+    def test_frame0_start_zero_included_for_10mer(self):
+        # For 10-mers: min_start=0, so start=0 in frame 0 → included
+        seq = _no_stop_contig()
+        result = extract_spanning_peptides(seq, upstream_nt=UPSTREAM_NT, peptide_lengths=[10], reading_frames=[0])
         starts = [s for s, _ in result]
-        assert 2 in starts
-
-    def test_window_start_24_excluded(self):
-        # start=24 > max_start=23 → excluded in all frames
-        seq = _no_stop_contig(50)
-        result = extract_spanning_9mers(seq, upstream_nt=UPSTREAM_NT)
-        starts = [s for s, _ in result]
-        assert 24 not in starts
+        assert 0 in starts
 
     def test_stop_codon_excluded(self):
-        # Insert a stop codon (TAA) starting at nt 6 (frame 0, window index 2).
-        # Any 27 nt window containing nt 6-8 is discarded for frame 0.
-        seq = list(_no_stop_contig(50))
-        seq[6], seq[7], seq[8] = "T", "A", "A"  # TAA at nt 6-8
-        result = extract_spanning_9mers("".join(seq), upstream_nt=UPSTREAM_NT, reading_frames=[0])
+        # Insert a stop codon (TAA) starting at nt 6 in frame 0.
+        # Any window containing nt 6-8 is discarded for frame 0.
+        seq = list(_no_stop_contig())
+        seq[6], seq[7], seq[8] = "T", "A", "A"
+        result = extract_spanning_peptides("".join(seq), upstream_nt=UPSTREAM_NT, peptide_lengths=[9], reading_frames=[0])
         for _, peptide in result:
             assert "*" not in peptide
 
     def test_x_ambiguous_excluded(self):
-        seq = list(_no_stop_contig(50))
-        # Write 'N' at nt 6-8 in frame 0 → will translate to X
+        seq = list(_no_stop_contig())
         seq[6], seq[7], seq[8] = "N", "N", "N"
-        result = extract_spanning_9mers("".join(seq), upstream_nt=UPSTREAM_NT, reading_frames=[0])
+        result = extract_spanning_peptides("".join(seq), upstream_nt=UPSTREAM_NT, peptide_lengths=[9], reading_frames=[0])
         for _, peptide in result:
             assert "X" not in peptide
 
     def test_short_contig_no_results(self):
-        # Contig shorter than 27 nt (min window size) → no results
-        result = extract_spanning_9mers("GCC" * 8, upstream_nt=UPSTREAM_NT)
+        # Contig shorter than 24 nt (min 8-mer window) → no results
+        result = extract_spanning_peptides("GCC" * 7, upstream_nt=UPSTREAM_NT)
         assert result == []
 
     def test_empty_sequence_returns_empty(self):
-        result = extract_spanning_9mers("", upstream_nt=UPSTREAM_NT)
+        result = extract_spanning_peptides("", upstream_nt=UPSTREAM_NT)
         assert result == []
 
     def test_single_frame_subset(self):
-        seq = _no_stop_contig(50)
-        all_frames = extract_spanning_9mers(seq, upstream_nt=UPSTREAM_NT, reading_frames=[0, 1, 2])
-        frame0_only = extract_spanning_9mers(seq, upstream_nt=UPSTREAM_NT, reading_frames=[0])
-        # frame0_only should be a strict subset
+        seq = _no_stop_contig()
+        all_frames = extract_spanning_peptides(seq, upstream_nt=UPSTREAM_NT, peptide_lengths=[9], reading_frames=[0, 1, 2])
+        frame0_only = extract_spanning_peptides(seq, upstream_nt=UPSTREAM_NT, peptide_lengths=[9], reading_frames=[0])
         assert set(frame0_only).issubset(set(all_frames))
         assert len(frame0_only) < len(all_frames)
 
-    def test_known_peptide_sequence(self):
-        # 50 nt of "AAA": all Lys (K) in frame 0.
-        # Valid starts in frame 0: 3, 6, 9, 12, 15, 18, 21.
-        seq = "A" * 50
-        result = extract_spanning_9mers(seq, upstream_nt=UPSTREAM_NT, reading_frames=[0])
+    def test_known_9mer_starts_frame0(self):
+        # 54 nt of "AAA": all Lys (K) in frame 0.
+        # For 9-mers with upstream_nt=27: valid frame-0 starts in [3, 24]: 3,6,...,24
+        seq = "A" * CONTIG_LEN
+        result = extract_spanning_peptides(seq, upstream_nt=UPSTREAM_NT, peptide_lengths=[9], reading_frames=[0])
         assert all(peptide == "K" * 9 for _, peptide in result)
         starts = sorted(s for s, _ in result)
-        assert starts == [3, 6, 9, 12, 15, 18, 21]
+        assert starts == [3, 6, 9, 12, 15, 18, 21, 24]
+
+    def test_known_10mer_starts_frame0(self):
+        # For 10-mers with upstream_nt=27: valid frame-0 starts in [0, 24]: 0,3,...,24
+        seq = "A" * CONTIG_LEN
+        result = extract_spanning_peptides(seq, upstream_nt=UPSTREAM_NT, peptide_lengths=[10], reading_frames=[0])
+        assert all(peptide == "K" * 10 for _, peptide in result)
+        starts = sorted(s for s, _ in result)
+        assert starts == [0, 3, 6, 9, 12, 15, 18, 21, 24]
+
+    def test_known_8mer_starts_frame0(self):
+        # For 8-mers with upstream_nt=27: valid frame-0 starts in [6, 24]: 6,9,...,24
+        seq = "A" * CONTIG_LEN
+        result = extract_spanning_peptides(seq, upstream_nt=UPSTREAM_NT, peptide_lengths=[8], reading_frames=[0])
+        assert all(peptide == "K" * 8 for _, peptide in result)
+        starts = sorted(s for s, _ in result)
+        assert starts == [6, 9, 12, 15, 18, 21, 24]


### PR DESCRIPTION
## Summary

- Replaces hardcoded 9-mer extraction with a configurable `translation.peptide_lengths: [8, 9, 10]` list
- Contig flank is now auto-derived as `flank_nt = 3 * (max_length - 1)`, giving symmetric 27/27 nt flanks (54 nt contigs) — the previous 26/24 (50 nt) was 3 nt too short for full 10-mer junction coverage on the downstream side
- MHCflurry and blastp require no changes — both already handle arbitrary peptide lengths
- Stale "9-mer" log references updated in `run_mhcflurry.py`

## Test plan

- [x] 16 unit tests pass: `.venv/bin/pytest workflow/tests/test_translate_peptides.py -v` — covers 8/9/10-mer start ranges, known exact start sequences for each length, stop codon / ambiguous AA exclusion
- [x] Local end-to-end run with `config/test_config.yaml`: 4,163 peptides extracted (vs 1,371 for 9-mers only) → 44 self-peptides excluded by blastp → 4,119 novel → MHCflurry: 24,714 predictions, 37 strong + 502 weak binders (vs 39 strong + 290 weak for 9-mers only)
- [x] Snakemake param-change detection confirmed: `before: 26,24 now: 27` triggers correct re-run of `assemble_contigs` and all downstream rules

Closes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)