### PR TITLE
feat(alignment): download pre-built HISAT2 grch38_tran index instead of building from scratch (issue #16)

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -43,7 +43,8 @@ reference:
 #   "hisat2" — Lower memory (~8 GB), good for laptops/small servers
 alignment:
   aligner: "hisat2"                           # "star" (32 GB RAM) or "hisat2" (8 GB RAM)
-  hisat2_index_dir: "resources/hisat2_index"  # where the prebuilt HISAT2 index lives
+  hisat2_index_dir: "resources/hisat2_index"  # where the HISAT2 index lives
+  hisat2_prebuilt_url: "https://genome-idx.s3.amazonaws.com/hisat/grch38_tran.tar.gz"  # leave empty to build from genome_fasta
   star_index_dir: "resources/star_index"      # where the prebuilt STAR index lives
   threads: 8          # threads for index build + alignment
 

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -44,7 +44,7 @@ reference:
 alignment:
   aligner: "hisat2"                           # "star" (32 GB RAM) or "hisat2" (8 GB RAM)
   hisat2_index_dir: "resources/hisat2_index"  # where the HISAT2 index lives
-  hisat2_prebuilt_url: "https://genome-idx.s3.amazonaws.com/hisat/grch38_tran.tar.gz"  # leave empty to build from genome_fasta
+  hisat2_prebuilt_url: "https://genome-idx.s3.amazonaws.com/hisat/grch38_tran.tar.gz"  # leave empty to build from genome_fasta; delete resources/hisat2_index/ to force re-download
   star_index_dir: "resources/star_index"      # where the prebuilt STAR index lives
   threads: 8          # threads for index build + alignment
 

--- a/config/test_config.yaml
+++ b/config/test_config.yaml
@@ -31,6 +31,7 @@ reference:
 
 alignment:
   hisat2_index_dir: "resources/test/hisat2_index"   # separate from production index
+  hisat2_prebuilt_url: ""                            # build from chr22 FASTA (no pre-built available)
   star_index_dir: "resources/test/star_index"        # separate from production index
   threads: 4      # M1 MacBook Air (8 GB RAM) — leave headroom for other processes
 

--- a/research/lab_notebook.md
+++ b/research/lab_notebook.md
@@ -4,6 +4,51 @@
 
 ## 2026-04-23
 
+### ~13:30 UTC
+
+#### Issue #16 — Pre-built HISAT2 index (PR #111)
+
+**Goal:** Replace the 60–90 min `hisat2-build` step with a download of the official pre-built `grch38_tran` index (~10–15 min).
+
+**Changes:**
+- Added `alignment.hisat2_prebuilt_url` config key; production config points to `grch38_tran.tar.gz` on the HISAT2 S3 mirror; test config sets it empty to keep building from the chr22 FASTA
+- Replaced `hisat2_index` rule with conditional `hisat2_download_index` (URL set) / `hisat2_index` (URL empty) branching; introduced `_HISAT2_INDEX_PREFIX` (`genome_tran` vs `genome`) used by `hisat2_align`
+- `grch38_tran` includes GENCODE splice sites baked in — strictly better than the plain genome index previously built from scratch
+
+**Validation:**
+- Tarball URL confirmed reachable; structure verified locally (`tar -tz`): top-level `grch38_tran/` with `genome_tran.{1..8}.ht2`
+- Snakemake dry runs confirmed correct rule selection for both empty and non-empty URL
+- Cloud extraction test on `hisat2-index-test` (e2-standard-4, europe-west1-b): all 8 `.ht2` files extracted correctly via `--strip-components=1`
+- 143 unit tests pass
+
+**Post-review fixes:** wrapped `curl | tar` in subshell for correct log capture; added `--retry 3`; added `resources: mem_mb=1000`; added re-download comment in config.
+
+### ~12:52 UTC
+
+#### Known limitation — contig assembly uses reference genome, not patient reads
+
+`assemble_contigs.smk` uses `bedtools getfasta` on GRCh38 to extract flanking sequences around novel junction coordinates. It does not assemble from patient RNA-seq reads.
+
+**Implication:** somatic SNVs or indels in the exon flanks are ignored. Predicted peptide sequences assume wild-type exonic context around the junction.
+
+**Why acceptable for now:** the neoepitope signal is primarily from the novel exon–exon junction itself. Flank mutations are a second-order effect; reference extraction is standard in comparable published pipelines.
+
+**Future improvement:** in hypermutated tumors (MSI-high, POLE-mutant), flank mutations could meaningfully alter predicted peptides. A future direction would be to extract junction-spanning reads from the BAM and assemble the local haplotype directly.
+
+### ~12:41 UTC
+
+#### Issue #107 — Single-VM consolidation merged (PR #109)
+
+**Goal:** Eliminate the two-VM / three-phase architecture (CPU alignment VM + GPU TCRdock VM with GCS handoff) in favour of a single consolidated VM.
+
+**Changes:**
+- Deleted `scripts/setup_cloud.sh` and `scripts/setup_tcrdock_vm.sh`; replaced with unified `scripts/setup_vm.sh` (8-step idempotent setup: deps → GPU check → Docker + NVIDIA Container Toolkit → Miniforge3 → snakemake env → repo clone → TCRdock image build → reference data)
+- Rewrote `scripts/run_cloud_gpu.sh` to manage a single `neoepitope-pipeline` VM (n1-highmem-8 + P100, 200 GB); Snakemake runs alignment → MHCflurry (GPU) → TCRdock (Docker/GPU) → report in one session with no GCS handoff
+- Renamed `config/tcrdock_gpu.yaml` → `config/gpu.yaml` (overlay now enables MHCflurry GPU acceleration in addition to TCRdock); introduced `GPU_CONFIG_FILE` variable in `run_cloud_gpu.sh`; factored out mode-independent settings (`RESULTS_DIR`, `GCS_PATH`) from `case` block
+- Fixed `--conda-cleanup-envs` call missing the GPU overlay; added `nvidia-container-toolkit` apt install fallback; forwarded `--keep-vm` through detach re-invocation
+
+**Validated:** end-to-end cloud run on `neoepitope-pipeline` VM (2026-04-23, alignment → MHCflurry 7.72M predictions → TCRdock → HTML report).
+
 ### 09:40 UTC
 
 #### Issue #105 — GPU MHCflurry validation (patient_001)
@@ -42,32 +87,6 @@
 3. **NVIDIA driver 580 incompatible with P100:** Driver 580 requires GSP firmware; P100 (Pascal, SM 6.0) lacks it. Fixed by in-place downgrade to driver 570 (`apt-get install nvidia-driver-570-server && purge *580* && reboot`) — no VM deletion needed.
 4. **PyTorch SM 6.0 mismatch:** PyTorch 2.5+ dropped SM 6.0 (P100/Pascal) support. Pinned `torch>=2.0,<2.5` in `python.yaml` (installs 2.4.1). Also rewrote `_has_gpu()` to use a PyTorch smoke-test kernel instead of TensorFlow — TF reported GPU available even when PyTorch kernels would fail on SM mismatch.
 5. **Orphan sentinel file:** `.snakemake/conda/080a2daa..._.env_setup_done` existed without the actual env directory → Snakemake skipped rebuild → `ModuleNotFoundError: No module named 'mhcflurry'`. Fixed by deleting the orphan sentinel.
-
-### ~12:41 UTC
-
-#### Issue #107 — Single-VM consolidation merged (PR #109)
-
-**Goal:** Eliminate the two-VM / three-phase architecture (CPU alignment VM + GPU TCRdock VM with GCS handoff) in favour of a single consolidated VM.
-
-**Changes:**
-- Deleted `scripts/setup_cloud.sh` and `scripts/setup_tcrdock_vm.sh`; replaced with unified `scripts/setup_vm.sh` (8-step idempotent setup: deps → GPU check → Docker + NVIDIA Container Toolkit → Miniforge3 → snakemake env → repo clone → TCRdock image build → reference data)
-- Rewrote `scripts/run_cloud_gpu.sh` to manage a single `neoepitope-pipeline` VM (n1-highmem-8 + P100, 200 GB); Snakemake runs alignment → MHCflurry (GPU) → TCRdock (Docker/GPU) → report in one session with no GCS handoff
-- Renamed `config/tcrdock_gpu.yaml` → `config/gpu.yaml` (overlay now enables MHCflurry GPU acceleration in addition to TCRdock); introduced `GPU_CONFIG_FILE` variable in `run_cloud_gpu.sh`; factored out mode-independent settings (`RESULTS_DIR`, `GCS_PATH`) from `case` block
-- Fixed `--conda-cleanup-envs` call missing the GPU overlay; added `nvidia-container-toolkit` apt install fallback; forwarded `--keep-vm` through detach re-invocation
-
-**Validated:** end-to-end cloud run on `neoepitope-pipeline` VM (2026-04-23, alignment → MHCflurry 7.72M predictions → TCRdock → HTML report).
-
-### ~12:52 UTC
-
-#### Known limitation — contig assembly uses reference genome, not patient reads
-
-`assemble_contigs.smk` uses `bedtools getfasta` on GRCh38 to extract flanking sequences around novel junction coordinates. It does not assemble from patient RNA-seq reads.
-
-**Implication:** somatic SNVs or indels in the exon flanks are ignored. Predicted peptide sequences assume wild-type exonic context around the junction.
-
-**Why acceptable for now:** the neoepitope signal is primarily from the novel exon–exon junction itself. Flank mutations are a second-order effect; reference extraction is standard in comparable published pipelines.
-
-**Future improvement:** in hypermutated tumors (MSI-high, POLE-mutant), flank mutations could meaningfully alter predicted peptides. A future direction would be to extract junction-spanning reads from the BAM and assemble the local haplotype directly.
 
 ---
 

--- a/research/lab_notebook.md
+++ b/research/lab_notebook.md
@@ -43,6 +43,32 @@
 4. **PyTorch SM 6.0 mismatch:** PyTorch 2.5+ dropped SM 6.0 (P100/Pascal) support. Pinned `torch>=2.0,<2.5` in `python.yaml` (installs 2.4.1). Also rewrote `_has_gpu()` to use a PyTorch smoke-test kernel instead of TensorFlow — TF reported GPU available even when PyTorch kernels would fail on SM mismatch.
 5. **Orphan sentinel file:** `.snakemake/conda/080a2daa..._.env_setup_done` existed without the actual env directory → Snakemake skipped rebuild → `ModuleNotFoundError: No module named 'mhcflurry'`. Fixed by deleting the orphan sentinel.
 
+### ~12:41 UTC
+
+#### Issue #107 — Single-VM consolidation merged (PR #109)
+
+**Goal:** Eliminate the two-VM / three-phase architecture (CPU alignment VM + GPU TCRdock VM with GCS handoff) in favour of a single consolidated VM.
+
+**Changes:**
+- Deleted `scripts/setup_cloud.sh` and `scripts/setup_tcrdock_vm.sh`; replaced with unified `scripts/setup_vm.sh` (8-step idempotent setup: deps → GPU check → Docker + NVIDIA Container Toolkit → Miniforge3 → snakemake env → repo clone → TCRdock image build → reference data)
+- Rewrote `scripts/run_cloud_gpu.sh` to manage a single `neoepitope-pipeline` VM (n1-highmem-8 + P100, 200 GB); Snakemake runs alignment → MHCflurry (GPU) → TCRdock (Docker/GPU) → report in one session with no GCS handoff
+- Renamed `config/tcrdock_gpu.yaml` → `config/gpu.yaml` (overlay now enables MHCflurry GPU acceleration in addition to TCRdock); introduced `GPU_CONFIG_FILE` variable in `run_cloud_gpu.sh`; factored out mode-independent settings (`RESULTS_DIR`, `GCS_PATH`) from `case` block
+- Fixed `--conda-cleanup-envs` call missing the GPU overlay; added `nvidia-container-toolkit` apt install fallback; forwarded `--keep-vm` through detach re-invocation
+
+**Validated:** end-to-end cloud run on `neoepitope-pipeline` VM (2026-04-23, alignment → MHCflurry 7.72M predictions → TCRdock → HTML report).
+
+### ~12:52 UTC
+
+#### Known limitation — contig assembly uses reference genome, not patient reads
+
+`assemble_contigs.smk` uses `bedtools getfasta` on GRCh38 to extract flanking sequences around novel junction coordinates. It does not assemble from patient RNA-seq reads.
+
+**Implication:** somatic SNVs or indels in the exon flanks are ignored. Predicted peptide sequences assume wild-type exonic context around the junction.
+
+**Why acceptable for now:** the neoepitope signal is primarily from the novel exon–exon junction itself. Flank mutations are a second-order effect; reference extraction is standard in comparable published pipelines.
+
+**Future improvement:** in hypermutated tumors (MSI-high, POLE-mutant), flank mutations could meaningfully alter predicted peptides. A future direction would be to extract junction-spanning reads from the BAM and assemble the local haplotype directly.
+
 ---
 
 ## 2026-04-22

--- a/research/manuscript/METHODS.md
+++ b/research/manuscript/METHODS.md
@@ -84,7 +84,7 @@ of each call and any normal/tumor discrepancies (`hla_qc.tsv`) are written to
 
 ## 5. Contig Assembly and Translation
 
-For each tumor-specific junction, a 50 nt nucleotide contig is assembled by joining:
+For each tumor-specific junction, a 50 nt nucleotide contig is assembled by joining flanking sequences extracted from the GRCh38 reference genome (via `bedtools getfasta`):
 
 - 26 nt immediately upstream of the junction (last 26 nt of the upstream exon)
 - 24 nt immediately downstream of the junction (first 24 nt of the downstream exon)
@@ -161,6 +161,7 @@ visualisation via Mol\* 4.x.
 
 ## Known Limitations and Future Work
 
+- **Reference-based contig assembly:** flanking exon sequences are extracted from the GRCh38 reference genome rather than assembled from patient reads. Somatic SNVs or indels within the exon flanks are therefore not captured, and predicted peptides assume a wild-type exonic context. This is a standard simplification; the dominant neoepitope signal arises from the novel exon–exon junction sequence itself. In hypermutated tumors (e.g. MSI-high, POLE-mutant), read-based local assembly would improve accuracy.
 - **No proteome filter:** peptides are not cross-referenced against the full human
   proteome beyond the junction-spanning filter. A BLAST or exact-match check against
   the reference proteome would catch any remaining false positives.

--- a/research/manuscript/METHODS.md
+++ b/research/manuscript/METHODS.md
@@ -168,8 +168,7 @@ visualisation via Mol\* 4.x.
 - **HISAT2 vs STAR:** STAR has been shown to detect more novel splice junctions in
   benchmarks. Future production runs will compare results between the two aligners
   (issue #17).
-- **Pre-built genome index:** the HISAT2 index is currently built from scratch on each
-  new VM run (~60–90 min). Using a pre-built index (issue #16) would reduce startup time.
+- **Pre-built genome index:** the HISAT2 `genome_tran` index (GRCh38 + GENCODE splice sites) is downloaded from the HISAT2 S3 mirror at pipeline start rather than built from scratch, saving ~60–90 min per VM. The chr22 test configuration still builds from the local FASTA.
 - **HLA typing from RNA-seq:** OptiType is run on RNA-seq reads, which may have lower
   HLA coverage than WES/WGS. Low read depth (< 30 reads per locus) triggers fallback
   to configured default alleles with a warning.

--- a/workflow/rules/alignment.smk
+++ b/workflow/rules/alignment.smk
@@ -74,37 +74,64 @@ if config.get("alignment", {}).get("aligner") == "hisat2":
     _HISAT2_INDEX_DIR = config.get("alignment", {}).get(
         "hisat2_index_dir", "resources/hisat2_index"
     )
+    _HISAT2_PREBUILT_URL = config.get("alignment", {}).get("hisat2_prebuilt_url", "")
 
-    rule hisat2_index:
-        """Build HISAT2 genome index (one-time; reused for all samples).
+    if _HISAT2_PREBUILT_URL:
+        # genome_tran index: GRCh38 + GENCODE splice sites baked in.
+        # Files unpack as genome_tran.N.ht2 directly into the index dir.
+        _HISAT2_INDEX_PREFIX = os.path.join(_HISAT2_INDEX_DIR, "genome_tran")
 
-        Requires ~8 GB RAM for the full human genome, or ~1 GB for a
-        single-chromosome test reference (e.g. chr22).
-        """
-        input:
-            genome=config["reference"]["genome_fasta"],
-        output:
-            index_dir=directory(_HISAT2_INDEX_DIR),
-            done=touch(os.path.join(_HISAT2_INDEX_DIR, "index.done")),
-        log:
-            os.path.join(_LOGS, "alignment", "hisat2_index.log"),
-        threads: config.get("alignment", {}).get("threads", 8)
-        resources:
-            mem_mb=8000,
-        conda:
-            "../envs/hisat2.yaml"
-        params:
-            index_prefix=os.path.join(_HISAT2_INDEX_DIR, "genome"),
-        shell:
+        rule hisat2_download_index:
+            """Download pre-built HISAT2 GRCh38 index (genome_tran, with splice sites)."""
+            output:
+                index_dir=directory(_HISAT2_INDEX_DIR),
+                done=touch(os.path.join(_HISAT2_INDEX_DIR, "index.done")),
+            log:
+                os.path.join(_LOGS, "alignment", "hisat2_index.log"),
+            params:
+                url=_HISAT2_PREBUILT_URL,
+            shell:
+                """
+                set -euo pipefail
+                mkdir -p {output.index_dir}
+                curl --fail -L --progress-bar {params.url} \
+                    | tar -xz --strip-components=1 -C {output.index_dir} \
+                    2>&1 | tee {log}
+                """
+
+    else:
+        _HISAT2_INDEX_PREFIX = os.path.join(_HISAT2_INDEX_DIR, "genome")
+
+        rule hisat2_index:
+            """Build HISAT2 genome index (one-time; reused for all samples).
+
+            Requires ~8 GB RAM for the full human genome, or ~1 GB for a
+            single-chromosome test reference (e.g. chr22).
             """
-            set -euo pipefail
-            mkdir -p {output.index_dir}
-            hisat2-build \\
-                -p {threads} \\
-                {input.genome} \\
-                {params.index_prefix} \\
-                2>&1 | tee {log}
-            """
+            input:
+                genome=config["reference"]["genome_fasta"],
+            output:
+                index_dir=directory(_HISAT2_INDEX_DIR),
+                done=touch(os.path.join(_HISAT2_INDEX_DIR, "index.done")),
+            log:
+                os.path.join(_LOGS, "alignment", "hisat2_index.log"),
+            threads: config.get("alignment", {}).get("threads", 8)
+            resources:
+                mem_mb=8000,
+            conda:
+                "../envs/hisat2.yaml"
+            params:
+                index_prefix=_HISAT2_INDEX_PREFIX,
+            shell:
+                """
+                set -euo pipefail
+                mkdir -p {output.index_dir}
+                hisat2-build \\
+                    -p {threads} \\
+                    {input.genome} \\
+                    {params.index_prefix} \\
+                    2>&1 | tee {log}
+                """
 
 
     rule hisat2_align:
@@ -132,7 +159,7 @@ if config.get("alignment", {}).get("aligner") == "hisat2":
         log:
             os.path.join(_LOGS, "{patient_id}", "alignment", "{sample}_align.log"),
         params:
-            index_prefix=os.path.join(_HISAT2_INDEX_DIR, "genome"),
+            index_prefix=_HISAT2_INDEX_PREFIX,
         threads: config.get("alignment", {}).get("threads", 8)
         resources:
             mem_mb=20000,

--- a/workflow/rules/alignment.smk
+++ b/workflow/rules/alignment.smk
@@ -90,12 +90,16 @@ if config.get("alignment", {}).get("aligner") == "hisat2":
                 os.path.join(_LOGS, "alignment", "hisat2_index.log"),
             params:
                 url=_HISAT2_PREBUILT_URL,
+            resources:
+                mem_mb=1000,
             shell:
                 """
                 set -euo pipefail
                 mkdir -p {output.index_dir}
-                curl --fail -L --progress-bar {params.url} \
-                    | tar -xz --strip-components=1 -C {output.index_dir} \
+                ( curl --fail -L --no-progress-meter \
+                    --retry 3 --retry-connrefused --retry-delay 5 \
+                    {params.url} \
+                    | tar -xz --strip-components=1 -C {output.index_dir} ) \
                     2>&1 | tee {log}
                 """
 


### PR DESCRIPTION
## Summary

- Replaces the `hisat2_index` rule (builds from GRCh38 FASTA, ~60–90 min) with `hisat2_download_index` (downloads the official pre-built `grch38_tran` index from the HISAT2 S3 mirror, ~10–15 min)
- Controlled by `alignment.hisat2_prebuilt_url` in config — set to the `grch38_tran` URL in `config/config.yaml`, empty in `config/test_config.yaml` (chr22 test still builds from local FASTA as before)
- Introduces `_HISAT2_INDEX_PREFIX` variable (`genome_tran` for downloads, `genome` for local builds) so `hisat2_align` uses the correct index prefix in both paths
- `grch38_tran` includes GENCODE splice sites baked in, which is strictly better than the plain genome index we were building previously
- Notes the reference-based contig assembly limitation in `research/manuscript/METHODS.md`

Closes #16.

## Test plan

- [x] Tarball URL confirmed reachable and returns HTTP 200
- [x] Tarball structure verified: top-level `grch38_tran/` directory with `genome_tran.N.ht2` files — `--strip-components=1` correctly lands them in the index dir
- [x] Snakemake dry run (empty URL): `hisat2_index` rule selected ✓
- [x] Snakemake dry run (URL set): `hisat2_download_index` rule selected ✓
- [x] 143 unit/integration tests pass (pre-existing `test_all_contigs_are_50nt` failure tracked in #110, unrelated to this PR)
- [x] Cloud validation: start a cheap non-GPU VM (e.g. `e2-standard-4`), run `snakemake ... resources/hisat2_index/index.done`, verify `genome_tran.{1..8}.ht2` files are present

🤖 Generated with [Claude Code](https://claude.com/claude-code)