### PR TITLE
feat(junctions): annotate novel junctions with CDS reading frame (#97)

### DIFF
--- a/research/lab_notebook.md
+++ b/research/lab_notebook.md
@@ -4,6 +4,38 @@
 
 ## 2026-04-23
 
+### ~18:30 UTC
+
+#### Issue #97 — CDS reading frame annotation for novel junctions (branch `feat/issue-97-cds-reading-frame`)
+
+**Goal:** Annotate each tumor-exclusive junction in `novel_junctions.tsv` with its canonical CDS reading frame, derived from the GENCODE GTF. This supports downstream biological interpretation without restricting translation.
+
+**Key design decisions:**
+
+1. **Annotation only, not restriction.** The `reading_frame` column is informational metadata. All three sense-strand frames are still translated downstream. Restricting translation to the CDS-derived frame would introduce false negatives in hypermutated tumors (MSI-high, POLE-mutant) where upstream frameshift indels, SVs, or chained novel junctions shift the active frame — precisely the tumors most likely to harbour actionable junction neoepitopes. These frame-altering events cannot be inferred from RNA-seq junction data alone.
+
+2. **Protein-coding transcripts only.** CDS records are filtered to `transcript_type "protein_coding"` in the GENCODE GTF. NMD and other non-translated isoforms are excluded to avoid spurious frame assignments from transcripts that are not translated by the ribosome.
+
+3. **Union of frames across transcripts.** When a donor site is annotated in multiple protein-coding transcripts with different reading frames, all attested frame offsets are retained (e.g. `"0,2"`). This is strictly more informative than falling back to all three frames when ambiguous.
+
+4. **No chained frame propagation.** If a second upstream novel junction shifts the reading frame before reaching the junction of interest, the propagated frame could in principle be computed as `(phase_B + L) % 3`. However, phasing two junctions to the same transcript is impossible from short-read RNA-seq without transcript assembly — left for a future improvement.
+
+5. **Sense-strand translation only.** For strand-specific RNA-seq (dUTP / first-strand), `bedtools getfasta -s` already reverse-complements minus-strand contigs so they represent the correct transcript sequence. Antisense translation of a strand-corrected contig has no established biological basis. Confirmed strand-specific for patient_001 (KAPA RNA HyperPrep Kit with RiboErase HMR, dUTP second-strand marking). **patient_002 strandedness not yet verified.**
+
+**Frame offset formula:**
+```
+phase_at_donor = (exon_length − gtf_frame) % 3
+frame_offset   = (−phase_at_donor) % 3          → 0, 1, or 2
+```
+`upstream_nt` is always divisible by 3 by pipeline design, so `frame_offset` equals the start position within the upstream codon context (0 = in-frame, 1 = +1 shift, 2 = +2 shift). Donor coordinate: `junction.start` for + strand, `junction.end` for − strand.
+
+**Changes:**
+- `workflow/scripts/filter_junctions.py`: new `_build_cds_donor_lookup(gtf_path)` + `reading_frame` column in output TSV; `classify_junctions()` accepts optional `gencode_gtf` arg; `--gencode-gtf` CLI flag added
+- `workflow/rules/filter_junctions.smk`: `gencode_gtf` added as explicit input to `filter_junctions` rule
+- `research/manuscript/METHODS.md` §5: updated to describe reading frame annotation subsection
+- `research/manuscript/DISCUSSIONS.md`: new section "Reading frame annotation: why translation is not restricted to the canonical frame"
+- `workflow/tests/test_filter_junctions.py`: 13 new tests (9 × `_build_cds_donor_lookup`, 4 × `reading_frame` column integration); all 156 tests pass
+
 ### ~13:30 UTC
 
 #### Issue #16 — Pre-built HISAT2 index (PR #111)

--- a/research/lab_notebook.md
+++ b/research/lab_notebook.md
@@ -4,6 +4,15 @@
 
 ## 2026-04-23
 
+### ~19:30 UTC
+
+#### PR #112 review fixes — issue #97
+
+- Removed redundant `gene_cds` intermediate `defaultdict` from `_build_cds_donor_lookup`; donor frames now computed in a single GTF parsing pass (halves peak memory on large GTFs)
+- Fixed misleading comment on GTF end coordinate: `# GTF end is 1-based inclusive = 0-based exclusive (no adjustment needed)`
+- Added `test_minus_strand_reading_frame_annotated` to `TestClassifyJunctionsReadingFrame` — covers the `donor_coord = junction.end` path through the full `classify_junctions` pipeline for a − strand junction
+- 157 tests pass
+
 ### ~18:30 UTC
 
 #### Issue #97 — CDS reading frame annotation for novel junctions (branch `feat/issue-97-cds-reading-frame`)

--- a/research/manuscript/DISCUSSIONS.md
+++ b/research/manuscript/DISCUSSIONS.md
@@ -76,6 +76,71 @@ from 24 to 26 nt (giving 26 + 26 = 52 nt contigs), providing chimeric codon cove
 
 ---
 
+## Reading frame annotation: why translation is not restricted to the canonical frame
+
+The pipeline annotates each tumor-exclusive junction with its canonical reading frame
+(derived from the GENCODE CDS, see Methods §5), but translates junction contigs in all
+three frames rather than restricting to the annotated one.
+
+### The case for restriction
+
+For a junction whose splice donor matches an annotated CDS exon end in a gene not
+otherwise perturbed by somatic mutations, the CDS-derived frame is the most likely frame
+being translated. Restricting translation to that frame would reduce the peptide candidate
+set by up to two-thirds for those junctions, lowering the false-positive burden on
+downstream MHC binding prediction.
+
+### Why restriction is not implemented
+
+Restricting to the canonical frame introduces **false negatives** — true neoepitopes
+permanently removed from the candidate set — in scenarios that are common in the tumors
+where junction-derived neoepitopes are most clinically relevant:
+
+- **Upstream frameshift indels.** A somatic insertion or deletion in an upstream exon of
+  the same gene shifts the reading frame for everything downstream. These events are
+  frequent in hypermutated tumors (MSI-high, POLE-mutant) and cannot be identified from
+  RNA-seq junction data alone; WGS or WES would be needed to account for them.
+- **Structural variants.** A gene fusion or large rearrangement can place exons in a
+  reading frame context that has no GENCODE counterpart.
+- **Upstream novel junctions.** A second tumor-exclusive junction upstream in the same
+  gene may shift the reading frame before reaching the junction of interest. Although the
+  pipeline detects co-occurring novel junctions in the same patient, short-read RNA-seq
+  cannot phase two junctions to the same transcript, making the propagated frame
+  unknowable without transcript assembly.
+- **Alternative reading frames.** Some loci encode multiple proteins in different frames
+  (e.g. CDKN2A p16/p14ARF). The CDS annotation captures only the canonical frame per
+  donor; ARF-frame peptides would be silently dropped by a hard restriction.
+
+In all of these cases, the biologically active frame in the tumor differs from the
+GENCODE-derived canonical frame. Crucially, the risk is highest in hypermutated tumors —
+precisely those expected to harbour the most actionable neoepitopes overall.
+
+### On six-frame (sense + antisense) translation
+
+Translating both strands of each contig was considered. For strand-specific libraries
+(e.g. dUTP second-strand marking, as confirmed for patient_001's gastric cancer samples:
+KAPA RNA HyperPrep with RiboErase), only the first-strand cDNA is amplified. HISAT2
+assigns the correct strand to all canonical GT-AG junctions via the XS auxiliary tag
+(derived from splice-site dinucleotide sequence). Genuine antisense transcription then
+appears as junctions on the opposite strand and is already translated in the correct
+orientation. Antisense translation of a strand-corrected contig would correspond to the
+non-transcribed DNA strand and has no established biological basis for MHC-I presentation.
+
+For non-stranded RNA-seq libraries, strand assignment relies entirely on splice-site
+sequence inference and may be incorrect for non-canonical splice sites. In that context,
+six-frame translation would be more appropriate. The strandedness of patient_002's
+osteosarcoma samples has not been verified; if those samples turn out to be non-stranded,
+the strand annotation of their junctions should be treated with caution.
+
+### Current approach
+
+Translation proceeds in all three sense-strand frames. The `reading_frame` annotation in
+`novel_junctions.tsv` is retained as metadata: it records the canonical CDS-derived frame
+for biological interpretation and downstream stratification of candidates, but does not
+gatekeep any peptide from analysis.
+
+---
+
 ## Normal sample filtering: junction level vs. peptide level
 
 Tumor-specific junctions are currently defined by absence in the matched normal sample

--- a/research/manuscript/METHODS.md
+++ b/research/manuscript/METHODS.md
@@ -84,15 +84,39 @@ of each call and any normal/tumor discrepancies (`hla_qc.tsv`) are written to
 
 ## 5. Contig Assembly and Translation
 
-For each tumor-specific junction, a 50 nt nucleotide contig is assembled by joining flanking sequences extracted from the GRCh38 reference genome (via `bedtools getfasta`):
-
-- 26 nt immediately upstream of the junction (last 26 nt of the upstream exon)
-- 24 nt immediately downstream of the junction (first 24 nt of the downstream exon)
+For each tumor-specific junction, a nucleotide contig is assembled by joining flanking
+sequences extracted from the GRCh38 reference genome (via `bedtools getfasta`). The flank
+size is `3 × (max_peptide_length − 1)` nucleotides on each side; with peptide lengths
+8–10 this gives 27 nt symmetric flanks (54 nt contigs).
 
 Contigs containing soft-clipped (lower-case) bases are excluded.
 
-For each contig, junction-spanning 9-mers are extracted directly in all three reading
-frames (offsets 0, 1, 2) and written to a TSV file (`contig_key`, `start_nt`, `peptide`).
+For each contig, junction-spanning peptides are extracted in all three reading frames
+(offsets 0, 1, 2) and written to a TSV file (`contig_key`, `start_nt`, `peptide`).
+
+### Canonical reading frame annotation
+
+For each tumor-exclusive junction, the GENCODE v47 CDS annotation is used to derive the
+**canonical reading frame** at the splice donor. Only `transcript_type "protein_coding"`
+CDS records are considered; NMD and other non-canonical isoforms are excluded.
+
+For a junction whose splice **donor** (5′ splice site) exactly matches the end of a
+protein-coding CDS exon, the frame offset is computed from the GTF `frame` field:
+
+```
+phase_at_donor = (exon_length − gtf_frame) mod 3
+frame_offset   = (−phase_at_donor)          mod 3
+```
+
+where `gtf_frame` encodes how many bases at the 5′ start of the CDS exon complete a codon
+from the previous exon. If a donor is covered by multiple protein-coding transcripts that
+disagree on the reading frame, the union of attested frame offsets is recorded. If the
+donor does not match any protein-coding CDS exon end, the `reading_frame` field is left
+empty.
+
+This annotation is written to the `reading_frame` column of `novel_junctions.tsv` and is
+available for downstream filtering and biological interpretation. It is **not** used to
+restrict the set of frames translated, for the reasons discussed in the Discussion.
 
 ### Junction-spanning filter
 

--- a/workflow/rules/filter_junctions.smk
+++ b/workflow/rules/filter_junctions.smk
@@ -57,6 +57,9 @@ rule filter_junctions:
       1. Keep junctions with read count > mean read count in that file
          (removes low-read background noise).
       2. Remove junctions present in the reference (GENCODE) junction list.
+      3. Annotate each tumor-exclusive junction with its canonical CDS reading
+         frame derived from the GENCODE GTF (informational; all three frames
+         are still translated downstream).
     The output is a TSV of novel junctions per sample.
 
     Works with both HISAT2 and STAR alignments."""
@@ -64,6 +67,7 @@ rule filter_junctions:
         junction_files=_get_junction_files_input,
         manifest=_get_manifest_input,
         reference_junctions=config["reference"]["junction_bed"],
+        gencode_gtf=config["reference"]["gencode_gtf"],
     output:
         novel_junctions=os.path.join(
             _RES, "{patient_id}", "junctions", "novel_junctions.tsv"

--- a/workflow/scripts/filter_junctions.py
+++ b/workflow/scripts/filter_junctions.py
@@ -12,14 +12,21 @@ When no normal sample is present, all unannotated tumor junctions are labeled
 `tumor_exclusive` with a warning.
 
 Output TSV columns:
-  junction_id  chrom  start  end  strand  mapped_reads  sample_id  sample_type  junction_origin
+  junction_id  chrom  start  end  strand  mapped_reads  sample_id  sample_type
+  junction_origin  reading_frame
+
+reading_frame (0, 1, or 2) is the canonical CDS reading frame at the splice donor,
+derived from the GENCODE GTF when gencode_gtf is supplied. Empty string means the frame
+could not be determined (novel donor, no protein-coding CDS match, or ambiguous). This
+annotation is informational only; all three frames are still translated downstream.
 
 Usage (standalone):
   python filter_junctions.py \\
       --junction-files results/{patient_id}/alignment/{sample_id}/junctions.tsv ... \\
       --manifest results/{patient_id}/alignment/manifest.tsv \\
       --reference-junctions resources/reference_junctions.bed \\
-      --output results/{patient_id}/junctions/novel_junctions.tsv
+      --output results/{patient_id}/junctions/novel_junctions.tsv \\
+      [--gencode-gtf resources/gencode.v47.annotation.gtf.gz]
 
 Usage (Snakemake):
   Called automatically by the ``filter_junctions`` rule.
@@ -27,7 +34,10 @@ Usage (Snakemake):
 
 import argparse
 import csv
+import gzip
 import logging
+import re
+from collections import defaultdict
 from pathlib import Path
 
 import pandas as pd
@@ -117,6 +127,87 @@ def _read_junction_file(file_path: str | Path) -> list[tuple[str, float]]:
 
 
 # ---------------------------------------------------------------------------
+# CDS reading frame lookup
+# ---------------------------------------------------------------------------
+
+def _open_gtf(path: str | Path):
+    """Return a file handle for a plain or gzip-compressed GTF."""
+    path = str(path)
+    return gzip.open(path, "rt") if path.endswith(".gz") else open(path)
+
+
+def _parse_gtf_attribute(attributes: str, key: str) -> str | None:
+    """Extract the value of a GTF attribute field by key."""
+    match = re.search(rf'{key}\s+"([^"]+)"', attributes)
+    return match.group(1) if match else None
+
+
+def _build_cds_donor_lookup(
+    gtf_path: str | Path,
+) -> dict[tuple[str, int, str], set[int]]:
+    """Parse protein-coding CDS records from a GENCODE GTF.
+
+    For each CDS exon end that acts as a splice donor, computes the canonical
+    reading frame offset within a junction contig (where upstream_nt is always
+    divisible by 3):
+
+        phase_at_donor = (exon_length - gtf_frame) % 3
+        frame_offset   = (-phase_at_donor) % 3   →  0, 1, or 2
+
+    Donor site coordinates (0-based):
+        + strand: junction.start == cds_exon_end0
+        − strand: junction.end   == cds_exon_start0
+
+    Returns:
+        dict mapping (chrom, donor_coord, strand) → set of frame offsets across
+        all protein-coding transcripts at that donor.  Only entries with at least
+        one frame offset are included.
+    """
+    gene_cds: dict[str, list[tuple[str, int, int, str, int]]] = defaultdict(list)
+
+    log.info("Parsing protein-coding CDS records from %s", gtf_path)
+    n_records = 0
+    with _open_gtf(gtf_path) as fh:
+        for line in fh:
+            if line.startswith("#"):
+                continue
+            fields = line.rstrip("\n").split("\t")
+            if len(fields) < 9 or fields[2] != "CDS":
+                continue
+            attrs = fields[8]
+            if _parse_gtf_attribute(attrs, "transcript_type") != "protein_coding":
+                continue
+            chrom = fields[0]
+            start0 = int(fields[3]) - 1   # GTF 1-based → 0-based
+            end0 = int(fields[4])          # GTF end is already 0-based exclusive
+            strand = fields[6]
+            try:
+                frame = int(fields[7])
+            except ValueError:
+                continue
+            gene_id = _parse_gtf_attribute(attrs, "gene_id")
+            if not gene_id:
+                continue
+            gene_cds[gene_id].append((chrom, start0, end0, strand, frame))
+            n_records += 1
+
+    log.info("Parsed %d protein-coding CDS records across %d genes", n_records, len(gene_cds))
+
+    donor_frames: dict[tuple[str, int, str], set[int]] = defaultdict(set)
+
+    for exons in gene_cds.values():
+        for chrom, start0, end0, strand, frame in exons:
+            exon_len = end0 - start0
+            phase = (exon_len - frame) % 3
+            frame_offset = (-phase) % 3
+            donor_coord = end0 if strand == "+" else start0
+            donor_frames[(chrom, donor_coord, strand)].add(frame_offset)
+
+    log.info("Built CDS donor frame lookup: %d unique donor sites", len(donor_frames))
+    return dict(donor_frames)
+
+
+# ---------------------------------------------------------------------------
 # Core classification logic
 # ---------------------------------------------------------------------------
 
@@ -164,6 +255,7 @@ def classify_junctions(
     reference_bed: str | Path,
     output_path: str | Path,
     min_normal_reads: int = 2,
+    gencode_gtf: str | Path | None = None,
 ) -> None:
     """Classify all junction quantification files by origin.
 
@@ -174,14 +266,22 @@ def classify_junctions(
     Normal samples are used only to build the exclusion set and do not
     appear in the output TSV.
 
+    When ``gencode_gtf`` is supplied, a ``reading_frame`` column (0/1/2 or
+    empty string) is added to the output TSV recording the canonical CDS
+    reading frame at the splice donor of each junction.  See
+    ``_build_cds_donor_lookup`` for details.
+
     Args:
         junction_files:   List of raw junction quantification TSV paths.
         manifest_path:    Manifest TSV mapping file_id → sample_type.
         reference_bed:    Path to reference junction BED file.
         output_path:      Destination TSV for classified junctions.
         min_normal_reads: Minimum reads required to trust a normal junction.
+        gencode_gtf:      Optional path to GENCODE GTF for reading frame
+                          annotation.  When None, reading_frame is always "".
     """
     ref_junctions = _load_reference_junctions(reference_bed)
+    donor_frames = _build_cds_donor_lookup(gencode_gtf) if gencode_gtf else {}
     manifest = _load_manifest(manifest_path)
 
     # Split files into tumor and normal
@@ -246,6 +346,10 @@ def classify_junctions(
                 origin = "tumor_exclusive"
                 n_tumor_exclusive += 1
 
+            donor_coord = start if strand == "+" else end
+            frames = donor_frames.get((chrom, donor_coord, strand), set())
+            reading_frame = ",".join(str(f) for f in sorted(frames)) if frames else ""
+
             all_classified.append(
                 {
                     "junction_id": junc_id,
@@ -257,6 +361,7 @@ def classify_junctions(
                     "sample_id": sample_id,
                     "sample_type": sample_type,
                     "junction_origin": origin,
+                    "reading_frame": reading_frame,
                 }
             )
 
@@ -270,6 +375,7 @@ def classify_junctions(
         columns=[
             "junction_id", "chrom", "start", "end", "strand",
             "mapped_reads", "sample_id", "sample_type", "junction_origin",
+            "reading_frame",
         ],
     )
     output_path = Path(output_path)
@@ -299,6 +405,7 @@ def _snakemake_main() -> None:
         reference_bed=snakemake.input.reference_junctions,  # type: ignore[name-defined]  # noqa: F821
         output_path=snakemake.output.novel_junctions,  # type: ignore[name-defined]  # noqa: F821
         min_normal_reads=snakemake.params.min_normal_reads,  # type: ignore[name-defined]  # noqa: F821
+        gencode_gtf=snakemake.input.gencode_gtf,  # type: ignore[name-defined]  # noqa: F821
     )
 
 
@@ -320,6 +427,10 @@ def _cli_main() -> None:
         "--min-normal-reads", type=int, default=2,
         help="Minimum reads to trust a junction in the normal sample (default: 2)",
     )
+    parser.add_argument(
+        "--gencode-gtf", default=None,
+        help="GENCODE GTF file for reading frame annotation (plain or .gz)",
+    )
     args = parser.parse_args()
 
     classify_junctions(
@@ -328,6 +439,7 @@ def _cli_main() -> None:
         reference_bed=args.reference_junctions,
         output_path=args.output,
         min_normal_reads=args.min_normal_reads,
+        gencode_gtf=args.gencode_gtf,
     )
 
 

--- a/workflow/scripts/filter_junctions.py
+++ b/workflow/scripts/filter_junctions.py
@@ -163,7 +163,7 @@ def _build_cds_donor_lookup(
         all protein-coding transcripts at that donor.  Only entries with at least
         one frame offset are included.
     """
-    gene_cds: dict[str, list[tuple[str, int, int, str, int]]] = defaultdict(list)
+    donor_frames: dict[tuple[str, int, str], set[int]] = defaultdict(set)
 
     log.info("Parsing protein-coding CDS records from %s", gtf_path)
     n_records = 0
@@ -179,31 +179,20 @@ def _build_cds_donor_lookup(
                 continue
             chrom = fields[0]
             start0 = int(fields[3]) - 1   # GTF 1-based → 0-based
-            end0 = int(fields[4])          # GTF end is already 0-based exclusive
+            end0 = int(fields[4])          # GTF end is 1-based inclusive = 0-based exclusive (no adjustment needed)
             strand = fields[6]
             try:
                 frame = int(fields[7])
             except ValueError:
                 continue
-            gene_id = _parse_gtf_attribute(attrs, "gene_id")
-            if not gene_id:
-                continue
-            gene_cds[gene_id].append((chrom, start0, end0, strand, frame))
-            n_records += 1
-
-    log.info("Parsed %d protein-coding CDS records across %d genes", n_records, len(gene_cds))
-
-    donor_frames: dict[tuple[str, int, str], set[int]] = defaultdict(set)
-
-    for exons in gene_cds.values():
-        for chrom, start0, end0, strand, frame in exons:
             exon_len = end0 - start0
             phase = (exon_len - frame) % 3
             frame_offset = (-phase) % 3
             donor_coord = end0 if strand == "+" else start0
             donor_frames[(chrom, donor_coord, strand)].add(frame_offset)
+            n_records += 1
 
-    log.info("Built CDS donor frame lookup: %d unique donor sites", len(donor_frames))
+    log.info("Parsed %d protein-coding CDS records, built %d unique donor sites", n_records, len(donor_frames))
     return dict(donor_frames)
 
 

--- a/workflow/tests/test_filter_junctions.py
+++ b/workflow/tests/test_filter_junctions.py
@@ -471,3 +471,29 @@ class TestClassifyJunctionsReadingFrame:
         )
         df = self._read_output(output)
         assert set(df.iloc[0]["reading_frame"].split(",")) == {"0", "1"}
+
+    def test_minus_strand_reading_frame_annotated(self, tmp_path):
+        # − strand: donor_coord = junction.end = cds_exon_start0
+        # Junction chr1:100:201:- → end=201, donor_coord=201
+        # CDS: start=202 (1-based) → start0=201, end0=300, len=99, frame=0
+        # phase=(99-0)%3=0, offset=(-0)%3=0 → reading_frame "0"
+        tumor_f = tmp_path / "tumor" / "junctions.tsv"
+        tumor_f.parent.mkdir()
+        self._write_junction_file(tumor_f, [("chr1:100:201:-", 100), ("chr1:400:500:-", 1)])
+        manifest = tmp_path / "manifest.tsv"
+        self._write_manifest(manifest, [("tumor", "Primary Tumor")])
+        ref_bed = tmp_path / "ref.bed"
+        ref_bed.write_text("")
+        gtf = tmp_path / "test.gtf"
+        _write_gtf(gtf, [
+            {"chrom": "chr1", "feature": "CDS", "start": 202, "end": 300,
+             "strand": "-", "frame": 0, "gene_id": "G1"},
+        ])
+        output = tmp_path / "novel.tsv"
+        classify_junctions(
+            junction_files=[tumor_f], manifest_path=manifest,
+            reference_bed=ref_bed, output_path=output, gencode_gtf=gtf,
+        )
+        df = self._read_output(output)
+        matched = df[df["junction_origin"] == "tumor_exclusive"]
+        assert matched.iloc[0]["reading_frame"] == "0"

--- a/workflow/tests/test_filter_junctions.py
+++ b/workflow/tests/test_filter_junctions.py
@@ -4,6 +4,7 @@ import pandas as pd
 import pytest
 
 from filter_junctions import (
+    _build_cds_donor_lookup,
     _build_normal_junction_set,
     _load_reference_junctions,
     _parse_junction_id,
@@ -263,3 +264,210 @@ class TestClassifyJunctions:
         df = pd.read_csv(output, sep="\t")
         assert len(df) == 1
         assert df.iloc[0]["junction_origin"] == "tumor_exclusive"
+        assert "reading_frame" in df.columns
+
+
+# ---------------------------------------------------------------------------
+# _build_cds_donor_lookup
+# ---------------------------------------------------------------------------
+
+def _write_gtf(path, records):
+    """Write minimal GTF records for testing the CDS donor lookup."""
+    lines = []
+    for r in records:
+        tx_type = r.get("tx_type", "protein_coding")
+        tx_id = r.get("tx_id", "ENST001")
+        attrs = (
+            f'gene_id "{r["gene_id"]}"; transcript_id "{tx_id}"; '
+            f'transcript_type "{tx_type}";'
+        )
+        lines.append(
+            f'{r["chrom"]}\tHAVANA\t{r["feature"]}\t{r["start"]}\t{r["end"]}'
+            f'\t.\t{r["strand"]}\t{r["frame"]}\t{attrs}\n'
+        )
+    path.write_text("".join(lines))
+
+
+class TestBuildCdsDonorLookup:
+    def test_plus_strand_clean_boundary(self, tmp_path):
+        # exon len=3, frame=0 → phase=0 → frame_offset=0; donor_coord=end0=102
+        gtf = tmp_path / "test.gtf"
+        _write_gtf(gtf, [{"chrom": "chr1", "feature": "CDS", "start": 100, "end": 102,
+                           "strand": "+", "frame": 0, "gene_id": "G1"}])
+        lookup = _build_cds_donor_lookup(gtf)
+        assert ("chr1", 102, "+") in lookup
+        assert lookup[("chr1", 102, "+")] == {0}
+
+    def test_plus_strand_phase1_gives_frame_offset_2(self, tmp_path):
+        # exon len=4, frame=0 → phase=1 → frame_offset=2; donor=103
+        gtf = tmp_path / "test.gtf"
+        _write_gtf(gtf, [{"chrom": "chr1", "feature": "CDS", "start": 100, "end": 103,
+                           "strand": "+", "frame": 0, "gene_id": "G1"}])
+        lookup = _build_cds_donor_lookup(gtf)
+        assert lookup[("chr1", 103, "+")] == {2}
+
+    def test_plus_strand_phase2_gives_frame_offset_1(self, tmp_path):
+        # exon len=5, frame=0 → phase=2 → frame_offset=1; donor=104
+        gtf = tmp_path / "test.gtf"
+        _write_gtf(gtf, [{"chrom": "chr1", "feature": "CDS", "start": 100, "end": 104,
+                           "strand": "+", "frame": 0, "gene_id": "G1"}])
+        lookup = _build_cds_donor_lookup(gtf)
+        assert lookup[("chr1", 104, "+")] == {1}
+
+    def test_nonzero_gtf_frame_shifts_phase(self, tmp_path):
+        # exon len=4, frame=1 → phase=(4-1)%3=0 → frame_offset=0
+        gtf = tmp_path / "test.gtf"
+        _write_gtf(gtf, [{"chrom": "chr1", "feature": "CDS", "start": 100, "end": 103,
+                           "strand": "+", "frame": 1, "gene_id": "G1"}])
+        lookup = _build_cds_donor_lookup(gtf)
+        assert lookup[("chr1", 103, "+")] == {0}
+
+    def test_minus_strand_donor_at_start0(self, tmp_path):
+        # − strand: donor_coord = start0 = int(start)-1 = 99; end0=102
+        gtf = tmp_path / "test.gtf"
+        _write_gtf(gtf, [{"chrom": "chr1", "feature": "CDS", "start": 100, "end": 102,
+                           "strand": "-", "frame": 0, "gene_id": "G1"}])
+        lookup = _build_cds_donor_lookup(gtf)
+        assert ("chr1", 99, "-") in lookup
+        assert ("chr1", 102, "-") not in lookup
+
+    def test_multi_transcript_same_frame_single_entry(self, tmp_path):
+        # Two transcripts, same donor and same frame → set with one element
+        gtf = tmp_path / "test.gtf"
+        _write_gtf(gtf, [
+            {"chrom": "chr1", "feature": "CDS", "start": 100, "end": 102,
+             "strand": "+", "frame": 0, "gene_id": "G1", "tx_id": "T1"},
+            {"chrom": "chr1", "feature": "CDS", "start": 100, "end": 102,
+             "strand": "+", "frame": 0, "gene_id": "G1", "tx_id": "T2"},
+        ])
+        lookup = _build_cds_donor_lookup(gtf)
+        assert lookup[("chr1", 102, "+")] == {0}
+
+    def test_two_genes_different_frames_at_same_donor_kept_as_union(self, tmp_path):
+        # Two genes, same donor coord 102 (end0), different frame offsets → both in set
+        # G1: start=100 (1-based) → start0=99, end0=102, len=3, phase=0, offset=0
+        # G2: start=99  (1-based) → start0=98, end0=102, len=4, phase=1, offset=2
+        gtf = tmp_path / "test.gtf"
+        _write_gtf(gtf, [
+            {"chrom": "chr1", "feature": "CDS", "start": 100, "end": 102,
+             "strand": "+", "frame": 0, "gene_id": "G1"},
+            {"chrom": "chr1", "feature": "CDS", "start": 99, "end": 102,
+             "strand": "+", "frame": 0, "gene_id": "G2"},
+        ])
+        lookup = _build_cds_donor_lookup(gtf)
+        assert lookup[("chr1", 102, "+")] == {0, 2}
+
+    def test_non_protein_coding_excluded(self, tmp_path):
+        gtf = tmp_path / "test.gtf"
+        _write_gtf(gtf, [{"chrom": "chr1", "feature": "CDS", "start": 100, "end": 102,
+                           "strand": "+", "frame": 0, "gene_id": "G1",
+                           "tx_type": "nonsense_mediated_decay"}])
+        lookup = _build_cds_donor_lookup(gtf)
+        assert ("chr1", 102, "+") not in lookup
+
+    def test_non_cds_feature_excluded(self, tmp_path):
+        gtf = tmp_path / "test.gtf"
+        _write_gtf(gtf, [{"chrom": "chr1", "feature": "exon", "start": 100, "end": 102,
+                           "strand": "+", "frame": 0, "gene_id": "G1"}])
+        lookup = _build_cds_donor_lookup(gtf)
+        assert len(lookup) == 0
+
+
+# ---------------------------------------------------------------------------
+# classify_junctions — reading_frame column
+# ---------------------------------------------------------------------------
+
+class TestClassifyJunctionsReadingFrame:
+    def _write_junction_file(self, path, rows):
+        path.write_text("".join(f"{jid}\t{reads}\n" for jid, reads in rows))
+
+    def _write_manifest(self, path, entries):
+        lines = ["file_id\tfile_name\tsample_type\tproject_id\n"]
+        for fid, stype in entries:
+            lines.append(f"{fid}\t{fid}.tsv\t{stype}\tlocal\n")
+        path.write_text("".join(lines))
+
+    def _read_output(self, path):
+        return pd.read_csv(path, sep="\t", dtype={"reading_frame": str}, keep_default_na=False)
+
+    def test_reading_frame_annotated_when_gtf_supplied(self, tmp_path):
+        # Junction chr1:201:300:+ → donor (0-based start) = 200
+        # GTF CDS: start=198 (1-based) → start0=197, end0=200, len=3, frame=0
+        # phase=0, frame_offset=0
+        tumor_f = tmp_path / "tumor" / "junctions.tsv"
+        tumor_f.parent.mkdir()
+        self._write_junction_file(tumor_f, [("chr1:201:300:+", 100), ("chr1:401:500:+", 1)])
+        manifest = tmp_path / "manifest.tsv"
+        self._write_manifest(manifest, [("tumor", "Primary Tumor")])
+        ref_bed = tmp_path / "ref.bed"
+        ref_bed.write_text("")
+        gtf = tmp_path / "test.gtf"
+        _write_gtf(gtf, [{"chrom": "chr1", "feature": "CDS", "start": 198, "end": 200,
+                           "strand": "+", "frame": 0, "gene_id": "G1"}])
+        output = tmp_path / "novel.tsv"
+        classify_junctions(
+            junction_files=[tumor_f], manifest_path=manifest,
+            reference_bed=ref_bed, output_path=output, gencode_gtf=gtf,
+        )
+        df = self._read_output(output)
+        assert df.iloc[0]["reading_frame"] == "0"
+
+    def test_reading_frame_empty_when_no_cds_match(self, tmp_path):
+        tumor_f = tmp_path / "tumor" / "junctions.tsv"
+        tumor_f.parent.mkdir()
+        self._write_junction_file(tumor_f, [("chr1:201:300:+", 100), ("chr1:401:500:+", 1)])
+        manifest = tmp_path / "manifest.tsv"
+        self._write_manifest(manifest, [("tumor", "Primary Tumor")])
+        ref_bed = tmp_path / "ref.bed"
+        ref_bed.write_text("")
+        gtf = tmp_path / "empty.gtf"
+        gtf.write_text("")
+        output = tmp_path / "novel.tsv"
+        classify_junctions(
+            junction_files=[tumor_f], manifest_path=manifest,
+            reference_bed=ref_bed, output_path=output, gencode_gtf=gtf,
+        )
+        df = self._read_output(output)
+        assert df.iloc[0]["reading_frame"] == ""
+
+    def test_reading_frame_empty_when_no_gtf(self, tmp_path):
+        tumor_f = tmp_path / "tumor" / "junctions.tsv"
+        tumor_f.parent.mkdir()
+        self._write_junction_file(tumor_f, [("chr1:201:300:+", 100), ("chr1:401:500:+", 1)])
+        manifest = tmp_path / "manifest.tsv"
+        self._write_manifest(manifest, [("tumor", "Primary Tumor")])
+        ref_bed = tmp_path / "ref.bed"
+        ref_bed.write_text("")
+        output = tmp_path / "novel.tsv"
+        classify_junctions(
+            junction_files=[tumor_f], manifest_path=manifest,
+            reference_bed=ref_bed, output_path=output,
+        )
+        df = self._read_output(output)
+        assert df.iloc[0]["reading_frame"] == ""
+
+    def test_multi_frame_union_written_sorted(self, tmp_path):
+        # Two genes share donor coord 200 (end0); different frame offsets → union
+        # G1: start=99 (1-based) → start0=98, end0=200, len=102, phase=0, offset=0
+        # G2: start=100 (1-based) → start0=99, end0=200, len=101, phase=2, offset=1
+        tumor_f = tmp_path / "tumor" / "junctions.tsv"
+        tumor_f.parent.mkdir()
+        self._write_junction_file(tumor_f, [("chr1:201:300:+", 100), ("chr1:401:500:+", 1)])
+        manifest = tmp_path / "manifest.tsv"
+        self._write_manifest(manifest, [("tumor", "Primary Tumor")])
+        ref_bed = tmp_path / "ref.bed"
+        ref_bed.write_text("")
+        gtf = tmp_path / "test.gtf"
+        _write_gtf(gtf, [
+            {"chrom": "chr1", "feature": "CDS", "start": 99, "end": 200,
+             "strand": "+", "frame": 0, "gene_id": "G1"},
+            {"chrom": "chr1", "feature": "CDS", "start": 100, "end": 200,
+             "strand": "+", "frame": 0, "gene_id": "G2"},
+        ])
+        output = tmp_path / "novel.tsv"
+        classify_junctions(
+            junction_files=[tumor_f], manifest_path=manifest,
+            reference_bed=ref_bed, output_path=output, gencode_gtf=gtf,
+        )
+        df = self._read_output(output)
+        assert set(df.iloc[0]["reading_frame"].split(",")) == {"0", "1"}


### PR DESCRIPTION
## Summary

- Adds `_build_cds_donor_lookup()` to `filter_junctions.py` — parses protein-coding CDS records from the GENCODE GTF and builds a `(chrom, donor_coord, strand) → set[frame_offset]` lookup
- `classify_junctions()` now writes a `reading_frame` column to `novel_junctions.tsv` (values: `"0"`, `"1"`, `"2"`, comma-separated union like `"0,2"`, or `""` when unknown)
- Annotation only — all three sense-strand frames are still translated downstream

## Key design decisions

**Why annotation-only (not restriction):** Restricting translation to the CDS-derived frame would introduce false negatives in hypermutated tumors (MSI-high, POLE-mutant) where upstream frameshift indels, SVs, or chained novel junctions shift the active reading frame — precisely the tumors most likely to harbour actionable junction neoepitopes. These frame-altering events cannot be inferred from RNA-seq junction data alone.

**Protein-coding filter:** CDS records filtered to `transcript_type "protein_coding"` to exclude NMD and other non-translated isoforms.

**Union of frames:** When a donor matches CDS exons from multiple transcripts with different frames, all attested offsets are retained (e.g. `"0,2"`).

**Frame formula:**
```
phase_at_donor = (exon_length − gtf_frame) % 3
frame_offset   = (−phase_at_donor) % 3   →  0, 1, or 2
```

## Test plan

- [x] 13 new tests: `TestBuildCdsDonorLookup` (9) + `TestClassifyJunctionsReadingFrame` (4)
- [x] All 156 tests pass (`pytest workflow/tests/test_filter_junctions.py`)
- [x] Full local pipeline run passes end-to-end with test config (12/12 steps)
- [x] Manuscript `METHODS.md` §5 and `DISCUSSIONS.md` updated with full design rationale

Closes #97.

🤖 Generated with [Claude Code](https://claude.com/claude-code)