### PR TITLE
fix(tests): update stale contig/peptide length assertions (#110)

### DIFF
--- a/research/lab_notebook.md
+++ b/research/lab_notebook.md
@@ -4,6 +4,22 @@
 
 ## 2026-04-23
 
+### ~20:00 UTC
+
+#### Issue #110 — Fix stale integration test assertions (PR #113, branch `fix/issue-110-contig-length-test`)
+
+**Goal:** Update two integration test assertions that became stale after PR #99 changed flank size to `3 × (max_length − 1)` and introduced multi-length peptides.
+
+**Changes:**
+- `test_all_contigs_are_50nt` → `test_all_contigs_are_54nt`: contig length is now 54 nt (= 27 + 27 flanks with `peptide_lengths=[8, 9, 10]`, `max_length=10`)
+- `test_all_peptides_are_9mers` → `test_all_peptides_are_8_to_10mers`: pipeline produces 8-, 9-, and 10-mer peptides per config
+
+No functional code changes; tests updated to match current pipeline behaviour.
+
+**Note on branch base:** this branch was originally created off `feat/issue-97-cds-reading-frame` before #112 merged, making the PR appear to contain ~300 lines of #97 reading frame code. After #112 merged to main, the branch was rebased onto main — the diff is now exactly the 4-line test fix.
+
+---
+
 ### ~19:30 UTC
 
 #### PR #112 review fixes — issue #97

--- a/workflow/tests/test_integration.py
+++ b/workflow/tests/test_integration.py
@@ -95,13 +95,13 @@ class TestContigs:
         fa = (RESULTS / "contigs" / "contigs.fa").read_text()
         assert fa.count(">") > 0
 
-    def test_all_contigs_are_50nt(self):
+    def test_all_contigs_are_54nt(self):
         fa = (RESULTS / "contigs" / "contigs.fa").read_text()
         sequences = [
             line.strip() for line in fa.splitlines() if not line.startswith(">")
         ]
         for seq in sequences:
-            assert len(seq) == 50, f"Contig length {len(seq)} != 50: {seq[:20]}..."
+            assert len(seq) == 54, f"Contig length {len(seq)} != 54: {seq[:20]}..."
 
     def test_contigs_are_dna(self):
         fa = (RESULTS / "contigs" / "contigs.fa").read_text()
@@ -121,10 +121,10 @@ class TestPeptides:
         rows = _read_tsv(RESULTS / "peptides" / "peptides.tsv")
         assert len(rows) > 0
 
-    def test_all_peptides_are_9mers(self):
+    def test_all_peptides_are_8_to_10mers(self):
         rows = _read_tsv(RESULTS / "peptides" / "peptides.tsv")
         for r in rows:
-            assert len(r["peptide"]) == 9, f"Peptide length {len(r['peptide'])}: {r['peptide']}"
+            assert len(r["peptide"]) in (8, 9, 10), f"Unexpected peptide length {len(r['peptide'])}: {r['peptide']}"
 
     def test_peptides_are_amino_acids(self):
         rows = _read_tsv(RESULTS / "peptides" / "peptides.tsv")


### PR DESCRIPTION
## Summary

Two integration tests were asserting against the old 50 nt / 9-mer-only pipeline output, which became stale after PR #99 changed flank size to `3 × (max_length − 1)`:

- `test_all_contigs_are_50nt` → `test_all_contigs_are_54nt` (27 + 27 = 54 nt with `peptide_lengths: [8,9,10]`)
- `test_all_peptides_are_9mers` → `test_all_peptides_are_8_to_10mers` (mixed lengths now expected)

No functional code changes.

> **Note on branch base:** this branch was originally created off `feat/issue-97-cds-reading-frame` before #112 merged, making the PR appear to contain ~300 lines of #97 reading frame code. After #112 merged to main, the branch was rebased — the diff is now exactly the 4-line test fix.

## Test plan

- [x] All 25 integration tests pass

Closes #110.

🤖 Generated with [Claude Code](https://claude.com/claude-code)