### PR TITLE
feat(mhcflurry): switch to Class1PresentationPredictor with presentation_class

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -101,14 +101,13 @@ mhcflurry:
     A: "HLA-A*02:01"
     B: "HLA-B*07:02"
     C: "HLA-C*07:02"
-  ic50_strong:  50            # nM threshold for strong binders
-  ic50_weak:   500            # nM threshold for weak binders
   threads: 8                  # parallel allele predictions (n1-standard-8)
-  # MHCflurry supports multiple prediction modes:
-  #   "affinity"        - binding affinity only (IC50)
-  #   "presentation"    - presentation score (recommended)
-  #   "processing"      - antigen processing score
-  prediction_mode: "affinity"
+  # Percentile thresholds for classification (lower = better, per allele).
+  # binder_class uses affinity_percentile; presentation_class uses presentation_percentile.
+  affinity_percentile_strong:      0.5   # top 0.5% by IC50 → strong
+  affinity_percentile_weak:        2.0   # top 2.0% by IC50 → weak
+  presentation_percentile_strong:  0.5   # top 0.5% by presentation score → strong
+  presentation_percentile_weak:    2.0   # top 2.0% by presentation score → weak
 
 # -----------------------------------------------------------------
 # TCRdock structural validation (Step 6 — optional, GPU required)

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -102,10 +102,7 @@ mhcflurry:
     B: "HLA-B*07:02"
     C: "HLA-C*07:02"
   threads: 8                  # parallel allele predictions (n1-standard-8)
-  # Percentile thresholds for classification (lower = better, per allele).
-  # binder_class uses affinity_percentile; presentation_class uses presentation_percentile.
-  affinity_percentile_strong:      0.5   # top 0.5% by IC50 → strong
-  affinity_percentile_weak:        2.0   # top 2.0% by IC50 → weak
+  # Percentile thresholds for presentation_class (lower = better, per allele).
   presentation_percentile_strong:  0.5   # top 0.5% by presentation score → strong
   presentation_percentile_weak:    2.0   # top 2.0% by presentation score → weak
 

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -101,7 +101,7 @@ mhcflurry:
     A: "HLA-A*02:01"
     B: "HLA-B*07:02"
     C: "HLA-C*07:02"
-  threads: 8                  # parallel allele predictions (n1-standard-8)
+  threads: 8                  # cores reserved for TF/BLAS within the single genotype predict() call
   # Percentile thresholds for presentation_class (lower = better, per allele).
   presentation_percentile_strong:  0.5   # top 0.5% by presentation score → strong
   presentation_percentile_weak:    2.0   # top 2.0% by presentation score → weak

--- a/research/manuscript/DISCUSSIONS.md
+++ b/research/manuscript/DISCUSSIONS.md
@@ -229,7 +229,9 @@ Rather than offering an affinity/presentation mode switch, the pipeline always u
 - `presentation_score` and `presentation_percentile` — composite metric, primary
 
 A single classification label `presentation_class` is derived from `presentation_percentile`
-(per allele, lower = better): strong (≤ 0.5%), weak (≤ 2%), non (> 2%).
+(lower = better): strong (≤ 0.5%), weak (≤ 2%), non (> 2%). The predictor's genotype API
+returns one prediction per peptide — the best-allele score across the patient's HLA-A/B/C
+alleles.
 
 The 0.5% strong threshold is the cutoff used by Jiang et al. (2024, *Communications
 Biology*) for MHCflurry-PS predictions. The 2.0% weak threshold is the conventional

--- a/research/manuscript/DISCUSSIONS.md
+++ b/research/manuscript/DISCUSSIONS.md
@@ -222,31 +222,24 @@ from well-bound but poorly processed peptides.
 ### Why we use the composite predictor exclusively
 
 Rather than offering an affinity/presentation mode switch, the pipeline always uses
-`Class1PresentationPredictor`. This gives five scores per peptide:
+`Class1PresentationPredictor`. This gives four scores per peptide:
 
-- `ic50_nM` and `affinity_percentile` — binding affinity, informational
-- `processing_score` — antigen processing efficiency, informational
+- `ic50_nM` — binding affinity (informational)
+- `processing_score` — antigen processing efficiency (informational)
 - `presentation_score` and `presentation_percentile` — composite metric, primary
 
-Two classification labels are derived using shared percentile thresholds (per allele):
-
-- `binder_class` — affinity_percentile ≤ 0.5% → strong, ≤ 2% → weak, else non
-- `presentation_class` — presentation_percentile ≤ 0.5% → strong, ≤ 2% → weak, else non
+A single classification label `presentation_class` is derived from `presentation_percentile`
+(per allele, lower = better): strong (≤ 0.5%), weak (≤ 2%), non (> 2%).
 
 The 0.5% strong threshold is the cutoff used by Jiang et al. (2024, *Communications
 Biology*) for MHCflurry-PS predictions. The 2.0% weak threshold is the conventional
-affinity-percentile cutoff applied in the field, extended here to both classifiers for
-consistency.
+affinity-percentile cutoff applied in the field.
 
-Epitopes are ranked primarily by `presentation_percentile`, with `affinity_percentile`
-as a tiebreaker. This prioritises candidates that are both strongly bound and well
-processed — the subset most likely to be immunogenic.
+Epitopes are ranked by `presentation_percentile` (ascending), prioritising candidates
+that are both strongly bound and well processed — the subset most likely to be immunogenic.
 
-### Why two classification columns rather than one
-
-Retaining `binder_class` (affinity-only) alongside `presentation_class` allows direct
-comparison with the published literature, which almost universally reports IC50 or
-affinity-percentile thresholds. A peptide that is a strong binder by affinity but a
-non-presenter by presentation_class is biologically interesting — it may be a target
-for immune evasion (e.g. via downregulation of the proteasomal subunits PSMB8/PSMB9)
-and warrants separate investigation.
+Note: `affinity_percentile` is not included in the output because
+`Class1PresentationPredictor.predict()` (MHCflurry 2.2.x) does not expose it directly.
+Obtaining it would require a second sequential call to `Class1AffinityPredictor`,
+doubling inference time with no gain — `presentation_percentile` already captures the
+affinity signal as part of the composite model.

--- a/research/manuscript/DISCUSSIONS.md
+++ b/research/manuscript/DISCUSSIONS.md
@@ -201,3 +201,52 @@ results should be interpreted with this caveat.
 If a matched RNA-seq sample becomes available from the osteosarcoma dataset in the
 future, the pipeline can be re-run with the normal to apply the full junction-level
 filter.
+
+---
+
+## MHC binding prediction: composite presentation score over affinity-only
+
+Early versions of the pipeline used `Class1AffinityPredictor` and classified peptides
+solely by IC50 (strong ≤ 50 nM, weak ≤ 500 nM). This is the most widely reported
+metric but has a well-documented limitation: MHC binding affinity is necessary but
+not sufficient for surface presentation. A peptide must also survive proteasomal
+cleavage and TAP transport to reach the ER, and a high-affinity peptide that is
+degraded in the cytosol will never be displayed to T cells.
+
+MHCflurry 2.0 introduced `Class1PresentationPredictor`, which combines the affinity
+model with an antigen processing model trained on mass spectrometry-identified
+MHC ligands (O'Donnell et al., 2020, *Cell Systems*). The composite `presentation_score`
+and its per-allele `presentation_percentile` have been shown to reduce false positives
+from well-bound but poorly processed peptides.
+
+### Why we use the composite predictor exclusively
+
+Rather than offering an affinity/presentation mode switch, the pipeline always uses
+`Class1PresentationPredictor`. This gives five scores per peptide:
+
+- `ic50_nM` and `affinity_percentile` — binding affinity, informational
+- `processing_score` — antigen processing efficiency, informational
+- `presentation_score` and `presentation_percentile` — composite metric, primary
+
+Two classification labels are derived using shared percentile thresholds (per allele):
+
+- `binder_class` — affinity_percentile ≤ 0.5% → strong, ≤ 2% → weak, else non
+- `presentation_class` — presentation_percentile ≤ 0.5% → strong, ≤ 2% → weak, else non
+
+The 0.5% strong threshold is the cutoff used by Jiang et al. (2024, *Communications
+Biology*) for MHCflurry-PS predictions. The 2.0% weak threshold is the conventional
+affinity-percentile cutoff applied in the field, extended here to both classifiers for
+consistency.
+
+Epitopes are ranked primarily by `presentation_percentile`, with `affinity_percentile`
+as a tiebreaker. This prioritises candidates that are both strongly bound and well
+processed — the subset most likely to be immunogenic.
+
+### Why two classification columns rather than one
+
+Retaining `binder_class` (affinity-only) alongside `presentation_class` allows direct
+comparison with the published literature, which almost universally reports IC50 or
+affinity-percentile thresholds. A peptide that is a strong binder by affinity but a
+non-presenter by presentation_class is biologically interesting — it may be a target
+for immune evasion (e.g. via downregulation of the proteasomal subunits PSMB8/PSMB9)
+and warrants separate investigation.

--- a/research/manuscript/METHODS.md
+++ b/research/manuscript/METHODS.md
@@ -140,10 +140,11 @@ chimeric codon rationale.
 
 Junction-spanning peptides are scored using MHCflurry 2.x `Class1PresentationPredictor`,
 a composite model that integrates MHC class I binding affinity with antigen processing
-predictions (proteasomal cleavage, TAP transport). Predictions are run for each
-patient-specific HLA allele resolved by OptiType, producing one row per peptide × allele
-combination. All alleles are run sequentially in the main process to avoid competing CUDA
-contexts on GPU and OOM errors from loading multiple model copies on CPU.
+predictions (proteasomal cleavage, TAP transport). `Class1PresentationPredictor.predict()`
+accepts the full patient HLA genotype (all HLA-A/B/C alleles at once, ≤6) and returns one
+best-allele prediction per peptide — the allele with the highest presentation score for
+that peptide. This is the predictor's intended genotype-level API; it is not a per-allele
+loop.
 
 Each prediction row contains four informative scores:
 
@@ -189,7 +190,7 @@ visualisation via Mol\* 4.x.
 | `results/hla_typing/{patient_id}/hla_qc.tsv` | Per-locus source, read counts, discrepancies |
 | `results/junctions/{patient_id}/novel_junctions.tsv` | All unannotated junctions with origin labels |
 | `results/peptides/{patient_id}/peptides.tsv` | Junction-spanning 9-mers (contig_key, start_nt, peptide) |
-| `results/predictions/{patient_id}/mhc_affinity.tsv` | All peptide × allele predictions: ic50_nM, processing_score, presentation_score, presentation_percentile, presentation_class |
+| `results/predictions/{patient_id}/mhc_affinity.tsv` | Best-allele prediction per peptide: allele (best presenter in patient genotype), ic50_nM, processing_score, presentation_score, presentation_percentile, presentation_class |
 | `results/predictions/{patient_id}/tcrdock/top_candidate.pdb` | Predicted TCR–peptide–MHC ternary complex (PDB) |
 | `results/predictions/{patient_id}/tcrdock/docking_scores.tsv` | TCRdock geometry metrics |
 | `results/reports/{patient_id}/report.html` | Summary HTML report with HLA QC and Mol\* viewer |

--- a/research/manuscript/METHODS.md
+++ b/research/manuscript/METHODS.md
@@ -145,27 +145,24 @@ patient-specific HLA allele resolved by OptiType, producing one row per peptide 
 combination. All alleles are run sequentially in the main process to avoid competing CUDA
 contexts on GPU and OOM errors from loading multiple model copies on CPU.
 
-Each prediction row contains five informative scores:
+Each prediction row contains four informative scores:
 
 | Column | Description |
 |---|---|
-| `ic50_nM` | Binding affinity (nM); lower = tighter binding |
-| `affinity_percentile` | Percentile rank of IC50 among random peptides for that allele |
+| `ic50_nM` | Binding affinity (nM); informational |
 | `processing_score` | Predicted antigen processing efficiency (0–1) |
 | `presentation_score` | Composite presentation probability (0–1); integrates affinity + processing |
 | `presentation_percentile` | Percentile rank of presentation_score among random peptides for that allele |
 
-Peptides are assigned two classification labels using shared percentile thresholds (lower = better, per allele):
+Peptides are assigned a single classification label based on `presentation_percentile`
+(lower = better, per allele):
 
-- **`binder_class`** — based on `affinity_percentile`: strong (≤ 0.5%), weak (≤ 2%), non (> 2%)
-- **`presentation_class`** — based on `presentation_percentile`: strong (≤ 0.5%), weak (≤ 2%), non (> 2%)
+- **`presentation_class`** — strong (≤ 0.5%), weak (≤ 2%), non (> 2%)
 
-The 0.5% threshold for strong classification is consistent with Jiang et al. (2024,
-*Communications Biology*) and analogous to the conventional IC50 ≤ 50 nM cutoff.
+The 0.5% threshold is consistent with Jiang et al. (2024, *Communications Biology*)
+and analogous to the conventional IC50 ≤ 50 nM cutoff.
 
-Epitopes are ranked in the output report primarily by `presentation_percentile` (ascending),
-with `affinity_percentile` as a tiebreaker. This prioritises candidates with high composite
-presentation probability over those with strong affinity but poor antigen processing.
+Epitopes are ranked in the output report by `presentation_percentile` (ascending).
 
 ---
 
@@ -192,7 +189,7 @@ visualisation via Mol\* 4.x.
 | `results/hla_typing/{patient_id}/hla_qc.tsv` | Per-locus source, read counts, discrepancies |
 | `results/junctions/{patient_id}/novel_junctions.tsv` | All unannotated junctions with origin labels |
 | `results/peptides/{patient_id}/peptides.tsv` | Junction-spanning 9-mers (contig_key, start_nt, peptide) |
-| `results/predictions/{patient_id}/mhc_affinity.tsv` | All peptide × allele predictions: ic50_nM, affinity_percentile, processing_score, presentation_score, presentation_percentile, binder_class, presentation_class |
+| `results/predictions/{patient_id}/mhc_affinity.tsv` | All peptide × allele predictions: ic50_nM, processing_score, presentation_score, presentation_percentile, presentation_class |
 | `results/predictions/{patient_id}/tcrdock/top_candidate.pdb` | Predicted TCR–peptide–MHC ternary complex (PDB) |
 | `results/predictions/{patient_id}/tcrdock/docking_scores.tsv` | TCRdock geometry metrics |
 | `results/reports/{patient_id}/report.html` | Summary HTML report with HLA QC and Mol\* viewer |

--- a/research/manuscript/METHODS.md
+++ b/research/manuscript/METHODS.md
@@ -138,18 +138,34 @@ chimeric codon rationale.
 
 ## 6. MHC Binding Prediction
 
-Junction-spanning 9-mers are scored for MHC class I binding affinity using MHCflurry
-2.x (`Class1AffinityPredictor`). Predictions are run for all patient-specific HLA alleles
-resolved by OptiType, producing one row per 9-mer × allele combination. Predictions for
-multiple alleles are run in parallel using Python's `ProcessPoolExecutor`; each worker
-process loads its own predictor instance with TF/BLAS thread counts constrained to 1
-to prevent CPU oversubscription.
+Junction-spanning peptides are scored using MHCflurry 2.x `Class1PresentationPredictor`,
+a composite model that integrates MHC class I binding affinity with antigen processing
+predictions (proteasomal cleavage, TAP transport). Predictions are run for each
+patient-specific HLA allele resolved by OptiType, producing one row per peptide × allele
+combination. All alleles are run sequentially in the main process to avoid competing CUDA
+contexts on GPU and OOM errors from loading multiple model copies on CPU.
 
-Peptides are classified as:
+Each prediction row contains five informative scores:
 
-- **Strong binder:** IC50 ≤ 50 nM
-- **Weak binder:** IC50 ≤ 500 nM
-- **Non-binder:** IC50 > 500 nM
+| Column | Description |
+|---|---|
+| `ic50_nM` | Binding affinity (nM); lower = tighter binding |
+| `affinity_percentile` | Percentile rank of IC50 among random peptides for that allele |
+| `processing_score` | Predicted antigen processing efficiency (0–1) |
+| `presentation_score` | Composite presentation probability (0–1); integrates affinity + processing |
+| `presentation_percentile` | Percentile rank of presentation_score among random peptides for that allele |
+
+Peptides are assigned two classification labels using shared percentile thresholds (lower = better, per allele):
+
+- **`binder_class`** — based on `affinity_percentile`: strong (≤ 0.5%), weak (≤ 2%), non (> 2%)
+- **`presentation_class`** — based on `presentation_percentile`: strong (≤ 0.5%), weak (≤ 2%), non (> 2%)
+
+The 0.5% threshold for strong classification is consistent with Jiang et al. (2024,
+*Communications Biology*) and analogous to the conventional IC50 ≤ 50 nM cutoff.
+
+Epitopes are ranked in the output report primarily by `presentation_percentile` (ascending),
+with `affinity_percentile` as a tiebreaker. This prioritises candidates with high composite
+presentation probability over those with strong affinity but poor antigen processing.
 
 ---
 
@@ -176,7 +192,7 @@ visualisation via Mol\* 4.x.
 | `results/hla_typing/{patient_id}/hla_qc.tsv` | Per-locus source, read counts, discrepancies |
 | `results/junctions/{patient_id}/novel_junctions.tsv` | All unannotated junctions with origin labels |
 | `results/peptides/{patient_id}/peptides.tsv` | Junction-spanning 9-mers (contig_key, start_nt, peptide) |
-| `results/predictions/{patient_id}/mhc_affinity.tsv` | All 9-mer × allele IC50 predictions with binder class |
+| `results/predictions/{patient_id}/mhc_affinity.tsv` | All peptide × allele predictions: ic50_nM, affinity_percentile, processing_score, presentation_score, presentation_percentile, binder_class, presentation_class |
 | `results/predictions/{patient_id}/tcrdock/top_candidate.pdb` | Predicted TCR–peptide–MHC ternary complex (PDB) |
 | `results/predictions/{patient_id}/tcrdock/docking_scores.tsv` | TCRdock geometry metrics |
 | `results/reports/{patient_id}/report.html` | Summary HTML report with HLA QC and Mol\* viewer |

--- a/workflow/rules/analysis.smk
+++ b/workflow/rules/analysis.smk
@@ -29,7 +29,7 @@ rule generate_report:
     - Junction origin counts (tumor_exclusive vs normal_shared per sample)
     - HLA typing results with source and normal/tumor concordance (when enabled)
     - Neoepitope prediction summary (strong / weak / non binder counts)
-    - Top strong binders table (IC50 < ic50_strong threshold)"""
+    - Top strong binders table (presentation_percentile ≤ strong threshold)"""
     input:
         unpack(_generate_report_input),
     output:

--- a/workflow/rules/analysis.smk
+++ b/workflow/rules/analysis.smk
@@ -42,7 +42,7 @@ rule generate_report:
     log:
         os.path.join(_LOGS, "{patient_id}", "analysis", "report.log"),
     params:
-        ic50_strong=config["mhcflurry"]["ic50_strong"],
+        presentation_percentile_strong=config["mhcflurry"]["presentation_percentile_strong"],
     conda:
         "../envs/python.yaml"
     script:

--- a/workflow/rules/mhc_affinity.smk
+++ b/workflow/rules/mhc_affinity.smk
@@ -58,8 +58,10 @@ rule run_mhcflurry:
     params:
         # Used only when hla.enabled is false (alleles_tsv input absent).
         fallback_alleles=list(config["mhcflurry"]["fallback_alleles"].values()),
-        ic50_strong=config["mhcflurry"]["ic50_strong"],
-        ic50_weak=config["mhcflurry"]["ic50_weak"],
+        affinity_percentile_strong=config["mhcflurry"]["affinity_percentile_strong"],
+        affinity_percentile_weak=config["mhcflurry"]["affinity_percentile_weak"],
+        presentation_percentile_strong=config["mhcflurry"]["presentation_percentile_strong"],
+        presentation_percentile_weak=config["mhcflurry"]["presentation_percentile_weak"],
     threads: config["mhcflurry"]["threads"]
     conda:
         "../envs/python.yaml"

--- a/workflow/rules/mhc_affinity.smk
+++ b/workflow/rules/mhc_affinity.smk
@@ -43,8 +43,9 @@ rule download_mhcflurry_models:
 
 rule run_mhcflurry:
     """Run MHCflurry 2.x on junction-spanning 9-mers.
-    Output: TSV with columns: contig_key, start_nt, peptide, allele, IC50_nM,
-            percentile_rank, binder_class (strong / weak / non).
+    Output: TSV with columns: contig_key, start_nt, peptide, allele, ic50_nM,
+            processing_score, presentation_score, presentation_percentile,
+            presentation_class (strong / weak / non).
     When hla.enabled is true, predictions are run for all patient-specific
     alleles from alleles.tsv. Otherwise mhcflurry.fallback_alleles are used."""
     input:
@@ -58,8 +59,6 @@ rule run_mhcflurry:
     params:
         # Used only when hla.enabled is false (alleles_tsv input absent).
         fallback_alleles=list(config["mhcflurry"]["fallback_alleles"].values()),
-        affinity_percentile_strong=config["mhcflurry"]["affinity_percentile_strong"],
-        affinity_percentile_weak=config["mhcflurry"]["affinity_percentile_weak"],
         presentation_percentile_strong=config["mhcflurry"]["presentation_percentile_strong"],
         presentation_percentile_weak=config["mhcflurry"]["presentation_percentile_weak"],
     threads: config["mhcflurry"]["threads"]

--- a/workflow/scripts/generate_report.py
+++ b/workflow/scripts/generate_report.py
@@ -404,7 +404,7 @@ def _build_strong_table_html(
     """Build the top strong presentations table sorted by presentation_percentile."""
     strong_df = (
         pred_df[pred_df["presentation_class"] == "strong"]
-        .sort_values(["presentation_percentile", "affinity_percentile"])
+        .sort_values("presentation_percentile")
     )
     if strong_df.empty:
         return "<p><em>No strong presentations found.</em></p>"
@@ -424,7 +424,6 @@ def _build_strong_table_html(
             f"<td>{html_mod.escape(str(row['peptide']))}</td>"
             f"<td>{html_mod.escape(str(row['allele']))}</td>"
             f"<td>{row['presentation_percentile']:.3f}</td>"
-            f"<td>{row['affinity_percentile']:.3f}</td>"
             f"<td>{row['ic50_nM']:.1f}</td>"
             f"<td>{contig_html}</td>"
             f"</tr>"
@@ -439,7 +438,6 @@ def _build_strong_table_html(
         f"<table><thead><tr>"
         f"<th>Source</th><th>Peptide</th><th>Allele</th>"
         f"<th title='Presentation percentile rank — lower is better'>Pres. %ile ▾</th>"
-        f"<th title='Affinity percentile rank — lower is better'>Aff. %ile</th>"
         f"<th title='Binding affinity in nM — informational'>IC50 (nM)</th>"
         f"<th>Contig ({legend})</th>"
         f"</tr></thead><tbody>{''.join(rows)}</tbody></table>"
@@ -485,7 +483,7 @@ def _build_structure_section(pdb_path: Path, pred_df: pd.DataFrame) -> str:
     # Match run_tcrdock.py's candidate selection: best strong binder, falling
     # back to weak. Exclude non-binders to stay in sync.
     binders = pred_df[pred_df["presentation_class"].isin(("strong", "weak"))]
-    top = binders.sort_values(["presentation_percentile", "affinity_percentile"]).head(1)
+    top = binders.sort_values("presentation_percentile").head(1)
     if top.empty:
         peptide, allele = "NA", "NA"
     else:
@@ -564,7 +562,7 @@ def _build_report_tsv(
     # --- top_candidate ---
     strong_df = (
         pred_df[pred_df["presentation_class"].isin(["strong", "weak"])]
-        .sort_values(["presentation_percentile", "affinity_percentile"])
+        .sort_values("presentation_percentile")
         if not pred_df.empty else pd.DataFrame()
     )
     if not strong_df.empty:

--- a/workflow/scripts/generate_report.py
+++ b/workflow/scripts/generate_report.py
@@ -50,7 +50,7 @@ flowchart TD
     ts["tumor_specific<br/>absent from normal tissue"]
     asm["Contig assembly<br/>50 nt per junction"]
     trans["In-silico translation<br/>3 reading frames - 9-mers"]
-    pred["MHCflurry prediction<br/>IC50 per 9-mer x allele"]
+    pred["MHCflurry prediction<br/>IC50 + presentation_score per peptide (best allele)"]
     out(["Neoepitope candidates<br/>strong / weak binders"])
 
     reads --> align

--- a/workflow/scripts/generate_report.py
+++ b/workflow/scripts/generate_report.py
@@ -232,7 +232,7 @@ _HTML_TEMPLATE = """\
   <h2>Neoepitope prediction summary</h2>
   {binder_table}
 
-  <h2>Top strong binders (IC50 &lt; {ic50_strong} nM)</h2>
+  <h2>Top strong presentations (presentation_percentile &le; {presentation_percentile_strong}%)</h2>
   {strong_table}
 
   {structure_section}
@@ -401,10 +401,13 @@ def _build_strong_table_html(
     upstream_nt: int = 26,
     max_rows: int = 50,
 ) -> str:
-    """Build the top strong binders table with a contig visualisation column."""
-    strong_df = pred_df[pred_df["binder_class"] == "strong"].sort_values("ic50_nM")
+    """Build the top strong presentations table sorted by presentation_percentile."""
+    strong_df = (
+        pred_df[pred_df["presentation_class"] == "strong"]
+        .sort_values(["presentation_percentile", "affinity_percentile"])
+    )
     if strong_df.empty:
-        return "<p><em>No strong binders found.</em></p>"
+        return "<p><em>No strong presentations found.</em></p>"
 
     rows = []
     for _, row in strong_df.head(max_rows).iterrows():
@@ -420,8 +423,9 @@ def _build_strong_table_html(
             f"<td>{html_mod.escape(str(row['contig_key']))}</td>"
             f"<td>{html_mod.escape(str(row['peptide']))}</td>"
             f"<td>{html_mod.escape(str(row['allele']))}</td>"
+            f"<td>{row['presentation_percentile']:.3f}</td>"
+            f"<td>{row['affinity_percentile']:.3f}</td>"
             f"<td>{row['ic50_nM']:.1f}</td>"
-            f"<td>{row['percentile_rank']:.3f}</td>"
             f"<td>{contig_html}</td>"
             f"</tr>"
         )
@@ -431,14 +435,12 @@ def _build_strong_table_html(
         "<span class='nt-pep-up'>peptide (upstream)</span> "
         "<span class='nt-pep-down'>peptide (downstream)</span>"
     )
-    percentile_header = (
-        "<th title='Percentage of random peptides that bind worse than this one. "
-        "Lower is better — &lt;2% is the standard binder threshold.'>Percentile rank ▾</th>"
-    )
     table = (
         f"<table><thead><tr>"
-        f"<th>Source</th><th>9-mer</th><th>Allele</th><th>IC50 (nM)</th>"
-        f"{percentile_header}"
+        f"<th>Source</th><th>Peptide</th><th>Allele</th>"
+        f"<th title='Presentation percentile rank — lower is better'>Pres. %ile ▾</th>"
+        f"<th title='Affinity percentile rank — lower is better'>Aff. %ile</th>"
+        f"<th title='Binding affinity in nM — informational'>IC50 (nM)</th>"
         f"<th>Contig ({legend})</th>"
         f"</tr></thead><tbody>{''.join(rows)}</tbody></table>"
     )
@@ -482,8 +484,8 @@ def _build_structure_section(pdb_path: Path, pred_df: pd.DataFrame) -> str:
     # Annotate with the top candidate's peptide and allele.
     # Match run_tcrdock.py's candidate selection: best strong binder, falling
     # back to weak. Exclude non-binders to stay in sync.
-    binders = pred_df[pred_df["binder_class"].isin(("strong", "weak"))]
-    top = binders.sort_values("ic50_nM").head(1)
+    binders = pred_df[pred_df["presentation_class"].isin(("strong", "weak"))]
+    top = binders.sort_values(["presentation_percentile", "affinity_percentile"]).head(1)
     if top.empty:
         peptide, allele = "NA", "NA"
     else:
@@ -519,7 +521,7 @@ def _build_report_tsv(
     pred_df: pd.DataFrame,
     hla_qc_tsv: str | None,
     output_tsv: str | Path,
-    ic50_strong: float,
+    presentation_percentile_strong: float,
     tcrdock_pdb: str | Path | None,
 ) -> None:
     """Write a structured summary TSV alongside the HTML report.
@@ -547,28 +549,36 @@ def _build_report_tsv(
             "patient_id": patient_id, "stage": "mhc_prediction",
             "metric": "total_predictions", "value": len(pred_df), "notes": "",
         })
-        binder_notes = {
-            "strong": f"IC50 < {int(ic50_strong)} nM",
-            "weak": "IC50 50–500 nM",
-            "non": "IC50 >= 500 nM",
+        presentation_notes = {
+            "strong": f"presentation_percentile <= {presentation_percentile_strong}%",
+            "weak": "presentation_percentile <= 2%",
+            "non": "presentation_percentile > 2%",
         }
-        for cls, cnt in pred_df["binder_class"].value_counts().items():
+        for cls, cnt in pred_df["presentation_class"].value_counts().items():
             rows.append({
                 "patient_id": patient_id, "stage": "mhc_prediction",
                 "metric": str(cls), "value": int(cnt),
-                "notes": binder_notes.get(str(cls), ""),
+                "notes": presentation_notes.get(str(cls), ""),
             })
 
     # --- top_candidate ---
-    strong_df = pred_df[pred_df["binder_class"].isin(["strong", "weak"])].sort_values("ic50_nM") if not pred_df.empty else pd.DataFrame()
+    strong_df = (
+        pred_df[pred_df["presentation_class"].isin(["strong", "weak"])]
+        .sort_values(["presentation_percentile", "affinity_percentile"])
+        if not pred_df.empty else pd.DataFrame()
+    )
     if not strong_df.empty:
         top = strong_df.iloc[0]
-        for metric, col in [("peptide", "peptide"), ("allele", "allele"), ("ic50_nM", "ic50_nM"), ("binder_class", "binder_class")]:
+        for metric, col in [
+            ("peptide", "peptide"), ("allele", "allele"),
+            ("presentation_percentile", "presentation_percentile"),
+            ("ic50_nM", "ic50_nM"), ("presentation_class", "presentation_class"),
+        ]:
             rows.append({
                 "patient_id": patient_id, "stage": "top_candidate",
                 "metric": metric,
-                "value": round(float(top[col]), 2) if metric == "ic50_nM" else str(top[col]),
-                "notes": "top by IC50" if metric == "peptide" else "",
+                "value": round(float(top[col]), 4) if metric in ("presentation_percentile", "ic50_nM") else str(top[col]),
+                "notes": "top by presentation_percentile" if metric == "peptide" else "",
             })
 
     # --- hla_typing ---
@@ -613,7 +623,7 @@ def generate_report(
     output_html: str | Path,
     contigs_fasta: str | Path | None = None,
     hla_qc_tsv: str | None = None,
-    ic50_strong: float = 50.0,
+    presentation_percentile_strong: float = 0.5,
     tcrdock_pdb: str | Path | None = None,
     output_tsv: str | Path | None = None,
     patient_id: str = "",
@@ -621,17 +631,15 @@ def generate_report(
     """Generate the summary HTML report and optional structured TSV.
 
     Args:
-        novel_junctions_tsv: Classified junctions TSV (with junction_origin column).
-        predictions_tsv:     MHCflurry predictions TSV.
-        output_html:         Destination HTML file.
-        contigs_fasta:       Contig FASTA for junction visualisation (optional).
-        hla_qc_tsv:          HLA QC TSV from aggregate_hla_alleles (optional). When
-                             provided, an HLA typing section is added to the report.
-        ic50_strong:         Strong-binder IC50 threshold (nM).
-        tcrdock_pdb:         TCRdock-predicted PDB file (optional). When provided,
-                             an embedded Mol* 3D viewer is added to the report.
-        output_tsv:          Destination for the machine-readable summary TSV (optional).
-        patient_id:          Patient identifier written into every report.tsv row.
+        novel_junctions_tsv:           Classified junctions TSV (with junction_origin column).
+        predictions_tsv:               MHCflurry predictions TSV.
+        output_html:                   Destination HTML file.
+        contigs_fasta:                 Contig FASTA for junction visualisation (optional).
+        hla_qc_tsv:                    HLA QC TSV from aggregate_hla_alleles (optional).
+        presentation_percentile_strong: Strong-presentation percentile threshold.
+        tcrdock_pdb:                   TCRdock-predicted PDB file (optional).
+        output_tsv:                    Destination for the machine-readable summary TSV (optional).
+        patient_id:                    Patient identifier written into every report.tsv row.
     """
     output_html = Path(output_html)
     output_html.parent.mkdir(parents=True, exist_ok=True)
@@ -661,12 +669,12 @@ def generate_report(
 
     origin_html = _df_to_html(origin_df)
 
-    # --- Binder summary ---
+    # --- Prediction summary ---
     if pred_df.empty:
         binder_html = "<p><em>No predictions available.</em></p>"
     else:
-        binder_counts = pred_df["binder_class"].value_counts().reset_index()
-        binder_counts.columns = ["binder_class", "count"]
+        binder_counts = pred_df["presentation_class"].value_counts().reset_index()
+        binder_counts.columns = ["presentation_class", "count"]
         binder_html = _df_to_html(binder_counts)
 
     # --- Top strong binders with contig visualisation ---
@@ -702,7 +710,7 @@ def generate_report(
         binder_table=binder_html,
         strong_table=strong_html,
         structure_section=structure_section,
-        ic50_strong=int(ic50_strong),
+        presentation_percentile_strong=presentation_percentile_strong,
         molstar_assets=molstar_assets,
     )
     output_html.write_text(report_html, encoding="utf-8")
@@ -715,7 +723,7 @@ def generate_report(
             pred_df=pred_df,
             hla_qc_tsv=hla_qc_tsv,
             output_tsv=output_tsv,
-            ic50_strong=ic50_strong,
+            presentation_percentile_strong=presentation_percentile_strong,
             tcrdock_pdb=tcrdock_pdb,
         )
 
@@ -734,7 +742,7 @@ def _snakemake_main() -> None:
         output_html=snakemake.output.report_html,  # type: ignore[name-defined]  # noqa: F821
         contigs_fasta=snakemake.input.contigs_fasta,  # type: ignore[name-defined]  # noqa: F821
         hla_qc_tsv=getattr(snakemake.input, "hla_qc", None),  # type: ignore[name-defined]  # noqa: F821
-        ic50_strong=float(snakemake.params.ic50_strong),  # type: ignore[name-defined]  # noqa: F821
+        presentation_percentile_strong=float(snakemake.params.presentation_percentile_strong),  # type: ignore[name-defined]  # noqa: F821
         tcrdock_pdb=getattr(snakemake.input, "pdb", None),  # type: ignore[name-defined]  # noqa: F821
         output_tsv=snakemake.output.report_tsv,  # type: ignore[name-defined]  # noqa: F821
         patient_id=snakemake.wildcards.patient_id,  # type: ignore[name-defined]  # noqa: F821
@@ -751,7 +759,7 @@ def _cli_main() -> None:
     parser.add_argument("--contigs-fasta", default=None, help="Contigs FASTA for junction visualisation")
     parser.add_argument("--hla-qc-tsv", default=None, help="HLA QC TSV from aggregate_hla_alleles")
     parser.add_argument("--tcrdock-pdb", default=None, help="TCRdock PDB file for 3D viewer")
-    parser.add_argument("--ic50-strong", type=float, default=50.0)
+    parser.add_argument("--presentation-percentile-strong", type=float, default=0.5)
     parser.add_argument("--output-tsv", default=None, help="Output machine-readable summary TSV")
     parser.add_argument("--patient-id", default="", help="Patient identifier for report.tsv rows")
     args = parser.parse_args()
@@ -762,7 +770,7 @@ def _cli_main() -> None:
         output_html=args.output,
         contigs_fasta=args.contigs_fasta,
         hla_qc_tsv=args.hla_qc_tsv,
-        ic50_strong=args.ic50_strong,
+        presentation_percentile_strong=args.presentation_percentile_strong,
         tcrdock_pdb=args.tcrdock_pdb,
         output_tsv=args.output_tsv,
         patient_id=args.patient_id,

--- a/workflow/scripts/run_mhcflurry.py
+++ b/workflow/scripts/run_mhcflurry.py
@@ -229,28 +229,12 @@ def _has_gpu() -> bool:
 # Predictor cache and worker helpers
 # ---------------------------------------------------------------------------
 
-# Module-level predictor cache: populated by _load_predictor_for_gpu() or
-# _load_predictor_for_cpu() before the per-allele prediction loop.
+# Module-level predictor cache: populated by _load_predictor() before predict().
 _worker_predictor = None
 
 
-def _load_predictor_for_gpu() -> None:
-    """Load predictor into module-level cache for GPU execution.
-
-    Does NOT restrict TF/BLAS thread counts — GPU path offloads matrix ops to
-    the device; TF's CPU threads handle batching/preprocessing and benefit from
-    all available vCPUs.
-    """
-    global _worker_predictor
-    _worker_predictor = _load_mhcflurry_predictor()
-
-
-def _load_predictor_for_cpu() -> None:
-    """Load predictor into module-level cache for CPU execution.
-
-    Sets TF/BLAS thread env vars to allow TF to use all available cores for
-    the single sequential allele loop (no parallel workers competing for cores).
-    """
+def _load_predictor() -> None:
+    """Load predictor into module-level cache."""
     global _worker_predictor
     _worker_predictor = _load_mhcflurry_predictor()
 
@@ -328,13 +312,12 @@ def run_prediction(
     # Step 2: Run genotype-level prediction (single call, all alleles at once).
     if _has_gpu():
         log.info("GPU detected — loading predictor in main process")
-        _load_predictor_for_gpu()
     else:
         log.info(
             "No GPU — running %d allele(s) on CPU (all cores available)",
             len(resolved_alleles),
         )
-        _load_predictor_for_cpu()
+    _load_predictor()
 
     pred_df = _run_mhcflurry_predictions(
         unique_peptides, resolved_alleles, predictor=_worker_predictor

--- a/workflow/scripts/run_mhcflurry.py
+++ b/workflow/scripts/run_mhcflurry.py
@@ -12,9 +12,9 @@ Reference:
 
 The script:
   1. Reads junction-spanning peptides from the TSV produced by translate_peptides.py.
-  2. Runs MHCflurry Class1PresentationPredictor for each HLA allele, producing four
-     scores per peptide × allele: ic50_nM, processing_score, presentation_score,
-     presentation_percentile.
+  2. Runs MHCflurry Class1PresentationPredictor.predict() with the patient's full
+     HLA genotype (all alleles at once), yielding one best-allele prediction per
+     peptide: ic50_nM, processing_score, presentation_score, presentation_percentile.
   3. Assigns a presentation_class label (strong/weak/non) from presentation_percentile
      using configurable thresholds (default strong ≤ 0.5%, weak ≤ 2.0%).
 
@@ -142,31 +142,43 @@ def _normalise_allele(predictor, allele: str) -> str:
 
 def _run_mhcflurry_predictions(
     peptides: list[str],
-    allele: str,
+    alleles: list[str],
     predictor=None,
 ) -> pd.DataFrame:
-    """Run MHCflurry predictions on a list of peptides.
+    """Run MHCflurry predictions on a list of peptides for a patient HLA genotype.
+
+    Class1PresentationPredictor.predict() takes the full genotype (≤6 alleles)
+    and returns one best-allele prediction per peptide.
 
     Args:
         peptides:  List of peptide sequences.
-        allele:    HLA allele in MHCflurry format (e.g., 'HLA-A*02:01').
+        alleles:   Patient HLA genotype (≤6 alleles, e.g. A/B/C loci × 2 each).
         predictor: Pre-loaded Class1PresentationPredictor. Loaded fresh if None.
 
     Returns:
-        DataFrame from Class1PresentationPredictor.predict() with columns:
-        peptide, affinity, processing_score, presentation_score, presentation_percentile
-        (plus metadata columns best_allele/peptide_num/sample_name, dropped downstream).
+        DataFrame with columns: peptide, affinity, best_allele, processing_score,
+        presentation_score, presentation_percentile (plus metadata columns
+        peptide_num/sample_name, dropped downstream).
     """
     if predictor is None:
         predictor = _load_mhcflurry_predictor()
 
-    mhcflurry_allele = _normalise_allele(predictor, allele)
+    normalised = [_normalise_allele(predictor, a) for a in alleles]
 
-    log.info("Running MHCflurry predictions for %d peptides...", len(peptides))
+    if len(normalised) > 6:
+        raise ValueError(
+            f"Class1PresentationPredictor.predict() supports at most 6 alleles "
+            f"(got {len(normalised)}). Check alleles.tsv for unexpected loci."
+        )
+
+    log.info(
+        "Running MHCflurry predictions for %d peptides against %d-allele genotype...",
+        len(peptides), len(normalised),
+    )
 
     return predictor.predict(
         peptides=peptides,
-        alleles=[mhcflurry_allele] * len(peptides),
+        alleles=normalised,
     )
 
 
@@ -243,35 +255,6 @@ def _load_predictor_for_cpu() -> None:
     _worker_predictor = _load_mhcflurry_predictor()
 
 
-def _predict_allele_worker(
-    allele: str,
-    unique_peptides: list[str],
-    presentation_percentile_strong: float,
-    presentation_percentile_weak: float,
-) -> "pd.DataFrame":
-    """Predict binding for one allele; returns a lean per-allele DataFrame.
-
-    Columns: peptide, ic50_nM, processing_score, presentation_score,
-             presentation_percentile, allele, presentation_class.
-
-    peptides_df (with contig_key/start_nt) is kept in the parent process to
-    avoid pickling it into every worker.
-    """
-    pred_df = _run_mhcflurry_predictions(unique_peptides, allele, predictor=_worker_predictor)
-    # Class1PresentationPredictor.predict() returns:
-    #   affinity (IC50 nM), processing_score, presentation_score, presentation_percentile
-    #   (plus metadata columns best_allele/peptide_num/sample_name — dropped by slice)
-    pred_df = pred_df.rename(columns={"affinity": "ic50_nM"})[
-        ["peptide", "ic50_nM", "processing_score", "presentation_score", "presentation_percentile"]
-    ]
-    pred_df["allele"] = allele
-    pred_df["ic50_nM"] = pred_df["ic50_nM"].fillna(float("inf"))
-    pred_df["presentation_class"] = pred_df["presentation_percentile"].apply(
-        lambda v: classify_by_percentile(v, presentation_percentile_strong, presentation_percentile_weak)
-    )
-    return pred_df
-
-
 # ---------------------------------------------------------------------------
 # Main orchestrator
 # ---------------------------------------------------------------------------
@@ -286,8 +269,9 @@ def run_prediction(
 ) -> None:
     """Run MHCflurry on junction-spanning peptides and write results to TSV.
 
-    Predictions are run for every resolved allele and concatenated into a
-    single output TSV (one row per peptide × allele combination).
+    Runs Class1PresentationPredictor.predict() with the full patient HLA genotype
+    (all alleles at once). Output contains one row per peptide (best allele across
+    the genotype), plus contig context (contig_key, start_nt).
 
     Args:
         peptides_tsv:                  TSV of junction-spanning peptides.
@@ -341,49 +325,45 @@ def run_prediction(
         len(peptides_df), len(unique_peptides), peptides_tsv,
     )
 
-    # Step 2: Run predictions for each allele sequentially in the main process.
-    #
-    # GPU: multiple CUDA contexts on a single GPU conflict across subprocesses.
-    # CPU: spawning N worker processes each loading a full TF model copy causes
-    #      OOM (6 alleles × ~8 GB model ≈ 48 GB on a 52 GB VM). Sequential also
-    #      lets TF use all available cores per call, which is faster than N
-    #      single-threaded workers (OMP_NUM_THREADS=1) competing for the same cores.
+    # Step 2: Run genotype-level prediction (single call, all alleles at once).
     if _has_gpu():
-        log.info(
-            "GPU detected — running %d allele(s) sequentially in main process",
-            len(resolved_alleles),
-        )
+        log.info("GPU detected — loading predictor in main process")
         _load_predictor_for_gpu()
     else:
         log.info(
-            "No GPU — running %d allele(s) sequentially on CPU (all cores available per allele)",
+            "No GPU — running %d allele(s) on CPU (all cores available)",
             len(resolved_alleles),
         )
         _load_predictor_for_cpu()
 
-    pred_dfs = [
-        _predict_allele_worker(
-            allele, unique_peptides,
-            presentation_percentile_strong, presentation_percentile_weak,
-        )
-        for allele in resolved_alleles
+    pred_df = _run_mhcflurry_predictions(
+        unique_peptides, resolved_alleles, predictor=_worker_predictor
+    )
+
+    # Rename and keep only needed columns; drop metadata (peptide_num, sample_name)
+    pred_df = pred_df.rename(columns={"affinity": "ic50_nM", "best_allele": "allele"})[
+        ["peptide", "allele", "ic50_nM", "processing_score",
+         "presentation_score", "presentation_percentile"]
     ]
+    pred_df["ic50_nM"] = pred_df["ic50_nM"].fillna(float("inf"))
+    pred_df["presentation_class"] = pred_df["presentation_percentile"].apply(
+        lambda v: classify_by_percentile(v, presentation_percentile_strong, presentation_percentile_weak)
+    )
 
-    # Step 3: Merge per-allele predictions with peptides_df (held in parent to
-    # avoid pickling the full table into every worker), then concatenate.
-    allele_dfs = [peptides_df.merge(pred_df, on="peptide", how="left") for pred_df in pred_dfs]
-
-    # Step 4: Write combined output
-    df = pd.concat(allele_dfs, ignore_index=True)[
+    # Step 3: Merge per-peptide predictions with peptides_df to restore contig_key/start_nt
+    df = peptides_df.merge(pred_df, on="peptide", how="left")[
         ["contig_key", "start_nt", "peptide", "allele",
          "ic50_nM", "processing_score", "presentation_score",
          "presentation_percentile", "presentation_class"]
     ]
+
+    # Step 4: Write output
     df.to_csv(output_tsv, sep="\t", index=False)
     log.info(
-        "Predictions: %d total (%d allele(s)), "
-        "%d strong / %d weak / %d non presentation_class → %s",
+        "Predictions: %d rows (%d unique peptides, %d-allele genotype), "
+        "%d strong / %d weak / %d non → %s",
         len(df),
+        len(unique_peptides),
         len(resolved_alleles),
         (df["presentation_class"] == "strong").sum(),
         (df["presentation_class"] == "weak").sum(),

--- a/workflow/scripts/run_mhcflurry.py
+++ b/workflow/scripts/run_mhcflurry.py
@@ -12,9 +12,13 @@ Reference:
 
 The script:
   1. Reads junction-spanning peptides from the TSV produced by translate_peptides.py.
-  2. Runs MHCflurry affinity prediction for each HLA allele.
-  3. Classifies each peptide as a strong binder (IC50 <= 50 nM), weak binder
-     (IC50 <= 500 nM), or non-binder.
+  2. Runs MHCflurry Class1PresentationPredictor for each HLA allele, producing five
+     scores per peptide × allele: ic50_nM, affinity_percentile, processing_score,
+     presentation_score, presentation_percentile.
+  3. Assigns two classification labels using per-allele percentile thresholds:
+       binder_class        — based on affinity_percentile
+       presentation_class  — based on presentation_percentile
+     Both use the same strong/weak/non threshold pair (default 0.5% / 2.0%).
 
 Allele sources (in priority order):
   1. ``--alleles-tsv`` / ``snakemake.input.alleles_tsv`` — alleles.tsv from
@@ -23,15 +27,15 @@ Allele sources (in priority order):
      drawn from config.mhcflurry.fallback_alleles when HLA typing is disabled.
 
 Output TSV columns:
-  contig_key  start_nt  peptide  allele  ic50_nM  percentile_rank  binder_class
+  contig_key  start_nt  peptide  allele  ic50_nM  affinity_percentile
+  processing_score  presentation_score  presentation_percentile
+  binder_class  presentation_class
 
 Usage (standalone, explicit alleles):
   python run_mhcflurry.py \\
       --peptides-tsv results/peptides/patient_001/peptides.tsv \\
       --output results/predictions/patient_001/mhc_affinity.tsv \\
-      --alleles HLA-A*02:01 HLA-B*07:02 HLA-C*07:02 \\
-      --ic50-strong 50 \\
-      --ic50-weak 500
+      --alleles HLA-A*02:01 HLA-B*07:02 HLA-C*07:02
 
 Usage (standalone, alleles from HLA typing):
   python run_mhcflurry.py \\
@@ -90,9 +94,9 @@ def _load_alleles_from_tsv(tsv_path: str) -> list[str]:
 # ---------------------------------------------------------------------------
 
 def _load_mhcflurry_predictor():
-    """Load and return the MHCflurry Class1AffinityPredictor (once per run)."""
+    """Load and return the MHCflurry Class1PresentationPredictor (once per run)."""
     try:
-        from mhcflurry import Class1AffinityPredictor
+        from mhcflurry import Class1PresentationPredictor
     except ImportError:
         log.error(
             "MHCflurry is not installed. Install it with: "
@@ -100,7 +104,7 @@ def _load_mhcflurry_predictor():
         )
         raise
     try:
-        predictor = Class1AffinityPredictor.load()
+        predictor = Class1PresentationPredictor.load()
     except Exception as exc:
         log.error(
             "Failed to load MHCflurry models. Run: mhcflurry-downloads fetch\n%s", exc
@@ -149,10 +153,12 @@ def _run_mhcflurry_predictions(
     Args:
         peptides:  List of peptide sequences.
         allele:    HLA allele in MHCflurry format (e.g., 'HLA-A*02:01').
-        predictor: Pre-loaded Class1AffinityPredictor. Loaded fresh if None.
+        predictor: Pre-loaded Class1PresentationPredictor. Loaded fresh if None.
 
     Returns:
-        DataFrame with columns: peptide, allele, prediction, prediction_percentile.
+        DataFrame with columns from Class1PresentationPredictor.predict_to_dataframe:
+        peptide, allele, affinity, affinity_percentile, processing_score,
+        presentation_score, presentation_percentile.
     """
     if predictor is None:
         predictor = _load_mhcflurry_predictor()
@@ -161,9 +167,6 @@ def _run_mhcflurry_predictions(
 
     log.info("Running MHCflurry predictions for %d peptides...", len(peptides))
 
-    # predict_to_dataframe() returns a DataFrame with columns:
-    # peptide, allele, prediction, prediction_low, prediction_high, prediction_percentile
-    # (mhcflurry 2.2.x renamed mhcflurry_affinity → prediction)
     return predictor.predict_to_dataframe(
         peptides=peptides,
         alleles=[mhcflurry_allele] * len(peptides),
@@ -174,15 +177,19 @@ def _run_mhcflurry_predictions(
 # Binder classification
 # ---------------------------------------------------------------------------
 
-def classify(ic50: float, ic50_strong: float = 50.0, ic50_weak: float = 500.0) -> str:
-    """Classify a peptide as a strong, weak, or non-binder by IC50 (nM).
+def classify_by_percentile(
+    percentile: float,
+    strong_threshold: float = 0.5,
+    weak_threshold: float = 2.0,
+) -> str:
+    """Classify a peptide by percentile rank (lower = better, per allele).
 
-    Boundaries are inclusive: IC50 <= ic50_strong → strong,
-    IC50 <= ic50_weak → weak, otherwise non.
+    Boundaries are inclusive: percentile <= strong_threshold → strong,
+    percentile <= weak_threshold → weak, otherwise non.
     """
-    if ic50 <= ic50_strong:
+    if percentile <= strong_threshold:
         return "strong"
-    if ic50 <= ic50_weak:
+    if percentile <= weak_threshold:
         return "weak"
     return "non"
 
@@ -242,25 +249,35 @@ def _load_predictor_for_cpu() -> None:
 def _predict_allele_worker(
     allele: str,
     unique_peptides: list[str],
-    ic50_strong: float,
-    ic50_weak: float,
+    affinity_percentile_strong: float,
+    affinity_percentile_weak: float,
+    presentation_percentile_strong: float,
+    presentation_percentile_weak: float,
 ) -> "pd.DataFrame":
     """Predict binding for one allele; returns a lean per-allele DataFrame.
 
-    Columns: peptide, allele, ic50_nM, percentile_rank, binder_class.
+    Columns: peptide, ic50_nM, affinity_percentile, processing_score,
+             presentation_score, presentation_percentile, allele,
+             binder_class, presentation_class.
+
     peptides_df (with contig_key/start_nt) is kept in the parent process to
     avoid pickling it into every worker.
     """
     pred_df = _run_mhcflurry_predictions(unique_peptides, allele, predictor=_worker_predictor)
-    pred_df = pred_df.rename(columns={
-        "prediction": "ic50_nM",
-        "prediction_percentile": "percentile_rank",
-    })[["peptide", "ic50_nM", "percentile_rank"]]
+    # Class1PresentationPredictor returns:
+    #   affinity (IC50 nM), affinity_percentile, processing_score,
+    #   presentation_score, presentation_percentile
+    pred_df = pred_df.rename(columns={"affinity": "ic50_nM"})[
+        ["peptide", "ic50_nM", "affinity_percentile",
+         "processing_score", "presentation_score", "presentation_percentile"]
+    ]
     pred_df["allele"] = allele
     pred_df["ic50_nM"] = pred_df["ic50_nM"].fillna(float("inf"))
-    pred_df["percentile_rank"] = pred_df["percentile_rank"].fillna(float("nan"))
-    pred_df["binder_class"] = pred_df["ic50_nM"].apply(
-        lambda v: classify(v, ic50_strong, ic50_weak)
+    pred_df["binder_class"] = pred_df["affinity_percentile"].apply(
+        lambda v: classify_by_percentile(v, affinity_percentile_strong, affinity_percentile_weak)
+    )
+    pred_df["presentation_class"] = pred_df["presentation_percentile"].apply(
+        lambda v: classify_by_percentile(v, presentation_percentile_strong, presentation_percentile_weak)
     )
     return pred_df
 
@@ -274,8 +291,10 @@ def run_prediction(
     output_tsv: str | Path,
     alleles: list[str] | None = None,
     alleles_tsv: str | None = None,
-    ic50_strong: float = 50.0,
-    ic50_weak: float = 500.0,
+    affinity_percentile_strong: float = 0.5,
+    affinity_percentile_weak: float = 2.0,
+    presentation_percentile_strong: float = 0.5,
+    presentation_percentile_weak: float = 2.0,
 ) -> None:
     """Run MHCflurry on junction-spanning peptides and write results to TSV.
 
@@ -283,14 +302,16 @@ def run_prediction(
     single output TSV (one row per peptide × allele combination).
 
     Args:
-        peptides_tsv:   TSV of junction-spanning peptides (contig_key, start_nt, peptide).
-        output_tsv:     Destination TSV file.
-        alleles:        HLA alleles to predict (MHCflurry format, e.g. ['HLA-A*02:01']).
-                        Ignored when alleles_tsv is provided.
-        alleles_tsv:    Path to alleles.tsv from aggregate_hla_alleles. When provided,
-                        alleles are loaded from the file (takes precedence over alleles).
-        ic50_strong:    Strong-binder IC50 threshold (nM).
-        ic50_weak:      Weak-binder IC50 threshold (nM).
+        peptides_tsv:                  TSV of junction-spanning peptides.
+        output_tsv:                    Destination TSV file.
+        alleles:                       HLA alleles to predict. Ignored when
+                                       alleles_tsv is provided.
+        alleles_tsv:                   Path to alleles.tsv from aggregate_hla_alleles.
+                                       Takes precedence over alleles.
+        affinity_percentile_strong:    Affinity percentile threshold for strong binder_class.
+        affinity_percentile_weak:      Affinity percentile threshold for weak binder_class.
+        presentation_percentile_strong: Presentation percentile threshold for strong presentation_class.
+        presentation_percentile_weak:  Presentation percentile threshold for weak presentation_class.
 
     Raises:
         ValueError: If neither alleles nor alleles_tsv is provided.
@@ -322,7 +343,9 @@ def run_prediction(
         log.warning("No peptides found in %s", peptides_tsv)
         empty_df = pd.DataFrame(
             columns=["contig_key", "start_nt", "peptide", "allele",
-                     "ic50_nM", "percentile_rank", "binder_class"]
+                     "ic50_nM", "affinity_percentile", "processing_score",
+                     "presentation_score", "presentation_percentile",
+                     "binder_class", "presentation_class"]
         )
         empty_df.to_csv(output_tsv, sep="\t", index=False)
         return
@@ -354,7 +377,11 @@ def run_prediction(
         _load_predictor_for_cpu()
 
     pred_dfs = [
-        _predict_allele_worker(allele, unique_peptides, ic50_strong, ic50_weak)
+        _predict_allele_worker(
+            allele, unique_peptides,
+            affinity_percentile_strong, affinity_percentile_weak,
+            presentation_percentile_strong, presentation_percentile_weak,
+        )
         for allele in resolved_alleles
     ]
 
@@ -365,15 +392,21 @@ def run_prediction(
     # Step 4: Write combined output
     df = pd.concat(allele_dfs, ignore_index=True)[
         ["contig_key", "start_nt", "peptide", "allele",
-         "ic50_nM", "percentile_rank", "binder_class"]
+         "ic50_nM", "affinity_percentile", "processing_score",
+         "presentation_score", "presentation_percentile",
+         "binder_class", "presentation_class"]
     ]
     df.to_csv(output_tsv, sep="\t", index=False)
     log.info(
-        "Predictions: %d total (%d allele(s)), %d strong, %d weak binders → %s",
+        "Predictions: %d total (%d allele(s)), "
+        "%d strong/%d weak binder_class, "
+        "%d strong/%d weak presentation_class → %s",
         len(df),
         len(resolved_alleles),
         (df["binder_class"] == "strong").sum(),
         (df["binder_class"] == "weak").sum(),
+        (df["presentation_class"] == "strong").sum(),
+        (df["presentation_class"] == "weak").sum(),
         output_tsv,
     )
 
@@ -394,8 +427,10 @@ def _snakemake_main() -> None:
         output_tsv=snakemake.output.mhc_affinity_tsv,  # type: ignore[name-defined]  # noqa: F821
         alleles=None if alleles_tsv else list(snakemake.params.fallback_alleles),  # type: ignore[name-defined]  # noqa: F821
         alleles_tsv=alleles_tsv,
-        ic50_strong=float(snakemake.params.ic50_strong),  # type: ignore[name-defined]  # noqa: F821
-        ic50_weak=float(snakemake.params.ic50_weak),  # type: ignore[name-defined]  # noqa: F821
+        affinity_percentile_strong=float(snakemake.params.affinity_percentile_strong),  # type: ignore[name-defined]  # noqa: F821
+        affinity_percentile_weak=float(snakemake.params.affinity_percentile_weak),  # type: ignore[name-defined]  # noqa: F821
+        presentation_percentile_strong=float(snakemake.params.presentation_percentile_strong),  # type: ignore[name-defined]  # noqa: F821
+        presentation_percentile_weak=float(snakemake.params.presentation_percentile_weak),  # type: ignore[name-defined]  # noqa: F821
     )
 
 
@@ -413,8 +448,10 @@ def _cli_main() -> None:
         "--alleles-tsv", default=None,
         help="Path to alleles.tsv from aggregate_hla_alleles (overrides --alleles).",
     )
-    parser.add_argument("--ic50-strong", type=float, default=50.0)
-    parser.add_argument("--ic50-weak", type=float, default=500.0)
+    parser.add_argument("--affinity-percentile-strong", type=float, default=0.5)
+    parser.add_argument("--affinity-percentile-weak", type=float, default=2.0)
+    parser.add_argument("--presentation-percentile-strong", type=float, default=0.5)
+    parser.add_argument("--presentation-percentile-weak", type=float, default=2.0)
     args = parser.parse_args()
 
     if not args.alleles and not args.alleles_tsv:
@@ -425,8 +462,10 @@ def _cli_main() -> None:
         output_tsv=args.output,
         alleles=args.alleles,
         alleles_tsv=args.alleles_tsv,
-        ic50_strong=args.ic50_strong,
-        ic50_weak=args.ic50_weak,
+        affinity_percentile_strong=args.affinity_percentile_strong,
+        affinity_percentile_weak=args.affinity_percentile_weak,
+        presentation_percentile_strong=args.presentation_percentile_strong,
+        presentation_percentile_weak=args.presentation_percentile_weak,
     )
 
 

--- a/workflow/scripts/run_mhcflurry.py
+++ b/workflow/scripts/run_mhcflurry.py
@@ -12,13 +12,11 @@ Reference:
 
 The script:
   1. Reads junction-spanning peptides from the TSV produced by translate_peptides.py.
-  2. Runs MHCflurry Class1PresentationPredictor for each HLA allele, producing five
-     scores per peptide × allele: ic50_nM, affinity_percentile, processing_score,
-     presentation_score, presentation_percentile.
-  3. Assigns two classification labels using per-allele percentile thresholds:
-       binder_class        — based on affinity_percentile
-       presentation_class  — based on presentation_percentile
-     Both use the same strong/weak/non threshold pair (default 0.5% / 2.0%).
+  2. Runs MHCflurry Class1PresentationPredictor for each HLA allele, producing four
+     scores per peptide × allele: ic50_nM, processing_score, presentation_score,
+     presentation_percentile.
+  3. Assigns a presentation_class label (strong/weak/non) from presentation_percentile
+     using configurable thresholds (default strong ≤ 0.5%, weak ≤ 2.0%).
 
 Allele sources (in priority order):
   1. ``--alleles-tsv`` / ``snakemake.input.alleles_tsv`` — alleles.tsv from
@@ -27,9 +25,8 @@ Allele sources (in priority order):
      drawn from config.mhcflurry.fallback_alleles when HLA typing is disabled.
 
 Output TSV columns:
-  contig_key  start_nt  peptide  allele  ic50_nM  affinity_percentile
-  processing_score  presentation_score  presentation_percentile
-  binder_class  presentation_class
+  contig_key  start_nt  peptide  allele  ic50_nM
+  processing_score  presentation_score  presentation_percentile  presentation_class
 
 Usage (standalone, explicit alleles):
   python run_mhcflurry.py \\
@@ -156,9 +153,9 @@ def _run_mhcflurry_predictions(
         predictor: Pre-loaded Class1PresentationPredictor. Loaded fresh if None.
 
     Returns:
-        DataFrame with columns from Class1PresentationPredictor.predict_to_dataframe:
-        peptide, allele, affinity, affinity_percentile, processing_score,
-        presentation_score, presentation_percentile.
+        DataFrame from Class1PresentationPredictor.predict() with columns:
+        peptide, affinity, processing_score, presentation_score, presentation_percentile
+        (plus metadata columns best_allele/peptide_num/sample_name, dropped downstream).
     """
     if predictor is None:
         predictor = _load_mhcflurry_predictor()
@@ -167,7 +164,7 @@ def _run_mhcflurry_predictions(
 
     log.info("Running MHCflurry predictions for %d peptides...", len(peptides))
 
-    return predictor.predict_to_dataframe(
+    return predictor.predict(
         peptides=peptides,
         alleles=[mhcflurry_allele] * len(peptides),
     )
@@ -249,33 +246,26 @@ def _load_predictor_for_cpu() -> None:
 def _predict_allele_worker(
     allele: str,
     unique_peptides: list[str],
-    affinity_percentile_strong: float,
-    affinity_percentile_weak: float,
     presentation_percentile_strong: float,
     presentation_percentile_weak: float,
 ) -> "pd.DataFrame":
     """Predict binding for one allele; returns a lean per-allele DataFrame.
 
-    Columns: peptide, ic50_nM, affinity_percentile, processing_score,
-             presentation_score, presentation_percentile, allele,
-             binder_class, presentation_class.
+    Columns: peptide, ic50_nM, processing_score, presentation_score,
+             presentation_percentile, allele, presentation_class.
 
     peptides_df (with contig_key/start_nt) is kept in the parent process to
     avoid pickling it into every worker.
     """
     pred_df = _run_mhcflurry_predictions(unique_peptides, allele, predictor=_worker_predictor)
-    # Class1PresentationPredictor returns:
-    #   affinity (IC50 nM), affinity_percentile, processing_score,
-    #   presentation_score, presentation_percentile
+    # Class1PresentationPredictor.predict() returns:
+    #   affinity (IC50 nM), processing_score, presentation_score, presentation_percentile
+    #   (plus metadata columns best_allele/peptide_num/sample_name — dropped by slice)
     pred_df = pred_df.rename(columns={"affinity": "ic50_nM"})[
-        ["peptide", "ic50_nM", "affinity_percentile",
-         "processing_score", "presentation_score", "presentation_percentile"]
+        ["peptide", "ic50_nM", "processing_score", "presentation_score", "presentation_percentile"]
     ]
     pred_df["allele"] = allele
     pred_df["ic50_nM"] = pred_df["ic50_nM"].fillna(float("inf"))
-    pred_df["binder_class"] = pred_df["affinity_percentile"].apply(
-        lambda v: classify_by_percentile(v, affinity_percentile_strong, affinity_percentile_weak)
-    )
     pred_df["presentation_class"] = pred_df["presentation_percentile"].apply(
         lambda v: classify_by_percentile(v, presentation_percentile_strong, presentation_percentile_weak)
     )
@@ -291,8 +281,6 @@ def run_prediction(
     output_tsv: str | Path,
     alleles: list[str] | None = None,
     alleles_tsv: str | None = None,
-    affinity_percentile_strong: float = 0.5,
-    affinity_percentile_weak: float = 2.0,
     presentation_percentile_strong: float = 0.5,
     presentation_percentile_weak: float = 2.0,
 ) -> None:
@@ -308,10 +296,8 @@ def run_prediction(
                                        alleles_tsv is provided.
         alleles_tsv:                   Path to alleles.tsv from aggregate_hla_alleles.
                                        Takes precedence over alleles.
-        affinity_percentile_strong:    Affinity percentile threshold for strong binder_class.
-        affinity_percentile_weak:      Affinity percentile threshold for weak binder_class.
-        presentation_percentile_strong: Presentation percentile threshold for strong presentation_class.
-        presentation_percentile_weak:  Presentation percentile threshold for weak presentation_class.
+        presentation_percentile_strong: Percentile threshold for strong presentation_class.
+        presentation_percentile_weak:  Percentile threshold for weak presentation_class.
 
     Raises:
         ValueError: If neither alleles nor alleles_tsv is provided.
@@ -343,9 +329,8 @@ def run_prediction(
         log.warning("No peptides found in %s", peptides_tsv)
         empty_df = pd.DataFrame(
             columns=["contig_key", "start_nt", "peptide", "allele",
-                     "ic50_nM", "affinity_percentile", "processing_score",
-                     "presentation_score", "presentation_percentile",
-                     "binder_class", "presentation_class"]
+                     "ic50_nM", "processing_score", "presentation_score",
+                     "presentation_percentile", "presentation_class"]
         )
         empty_df.to_csv(output_tsv, sep="\t", index=False)
         return
@@ -379,7 +364,6 @@ def run_prediction(
     pred_dfs = [
         _predict_allele_worker(
             allele, unique_peptides,
-            affinity_percentile_strong, affinity_percentile_weak,
             presentation_percentile_strong, presentation_percentile_weak,
         )
         for allele in resolved_alleles
@@ -392,21 +376,18 @@ def run_prediction(
     # Step 4: Write combined output
     df = pd.concat(allele_dfs, ignore_index=True)[
         ["contig_key", "start_nt", "peptide", "allele",
-         "ic50_nM", "affinity_percentile", "processing_score",
-         "presentation_score", "presentation_percentile",
-         "binder_class", "presentation_class"]
+         "ic50_nM", "processing_score", "presentation_score",
+         "presentation_percentile", "presentation_class"]
     ]
     df.to_csv(output_tsv, sep="\t", index=False)
     log.info(
         "Predictions: %d total (%d allele(s)), "
-        "%d strong/%d weak binder_class, "
-        "%d strong/%d weak presentation_class → %s",
+        "%d strong / %d weak / %d non presentation_class → %s",
         len(df),
         len(resolved_alleles),
-        (df["binder_class"] == "strong").sum(),
-        (df["binder_class"] == "weak").sum(),
         (df["presentation_class"] == "strong").sum(),
         (df["presentation_class"] == "weak").sum(),
+        (df["presentation_class"] == "non").sum(),
         output_tsv,
     )
 
@@ -427,8 +408,6 @@ def _snakemake_main() -> None:
         output_tsv=snakemake.output.mhc_affinity_tsv,  # type: ignore[name-defined]  # noqa: F821
         alleles=None if alleles_tsv else list(snakemake.params.fallback_alleles),  # type: ignore[name-defined]  # noqa: F821
         alleles_tsv=alleles_tsv,
-        affinity_percentile_strong=float(snakemake.params.affinity_percentile_strong),  # type: ignore[name-defined]  # noqa: F821
-        affinity_percentile_weak=float(snakemake.params.affinity_percentile_weak),  # type: ignore[name-defined]  # noqa: F821
         presentation_percentile_strong=float(snakemake.params.presentation_percentile_strong),  # type: ignore[name-defined]  # noqa: F821
         presentation_percentile_weak=float(snakemake.params.presentation_percentile_weak),  # type: ignore[name-defined]  # noqa: F821
     )
@@ -448,8 +427,6 @@ def _cli_main() -> None:
         "--alleles-tsv", default=None,
         help="Path to alleles.tsv from aggregate_hla_alleles (overrides --alleles).",
     )
-    parser.add_argument("--affinity-percentile-strong", type=float, default=0.5)
-    parser.add_argument("--affinity-percentile-weak", type=float, default=2.0)
     parser.add_argument("--presentation-percentile-strong", type=float, default=0.5)
     parser.add_argument("--presentation-percentile-weak", type=float, default=2.0)
     args = parser.parse_args()
@@ -462,8 +439,6 @@ def _cli_main() -> None:
         output_tsv=args.output,
         alleles=args.alleles,
         alleles_tsv=args.alleles_tsv,
-        affinity_percentile_strong=args.affinity_percentile_strong,
-        affinity_percentile_weak=args.affinity_percentile_weak,
         presentation_percentile_strong=args.presentation_percentile_strong,
         presentation_percentile_weak=args.presentation_percentile_weak,
     )

--- a/workflow/scripts/run_tcrdock.py
+++ b/workflow/scripts/run_tcrdock.py
@@ -27,7 +27,8 @@ Inputs
 ------
   predictions_tsv: MHCflurry predictions TSV
                    (columns: contig_key, start_nt, peptide, allele,
-                    ic50_nM, percentile_rank, binder_class)
+                    ic50_nM, processing_score, presentation_score,
+                    presentation_percentile, presentation_class)
 
 Outputs
 -------
@@ -81,13 +82,13 @@ def select_top_candidates(
         n_candidates:    Number of candidates to return.
 
     Returns:
-        DataFrame of top candidates, sorted by ic50_nM ascending.
+        DataFrame of top candidates, sorted by presentation_percentile ascending.
     """
     df = pd.read_csv(predictions_tsv, sep="\t")
-    strong = df[df["binder_class"] == "strong"].sort_values("ic50_nM")
+    strong = df[df["presentation_class"] == "strong"].sort_values("presentation_percentile")
     if strong.empty:
         log.warning("No strong binders found — trying weak binders as fallback.")
-        strong = df[df["binder_class"] == "weak"].sort_values("ic50_nM")
+        strong = df[df["presentation_class"] == "weak"].sort_values("presentation_percentile")
     if strong.empty:
         log.error("No strong or weak binders found. Cannot run TCRdock.")
         return pd.DataFrame()

--- a/workflow/scripts/run_tcrdock.py
+++ b/workflow/scripts/run_tcrdock.py
@@ -19,9 +19,9 @@ so local / CPU-only runs are unaffected.
 
 Candidate selection
 -------------------
-Currently selects the top N strong binders by IC50 (MHCflurry). Once
-TRUST4 + ProTCR (#24) is implemented, selection should switch to the top
-ProTCR-ranked candidates instead.
+Currently selects the top N strong binders by presentation_percentile
+(MHCflurry Class1PresentationPredictor). Once TRUST4 + ProTCR (#24) is
+implemented, selection should switch to the top ProTCR-ranked candidates instead.
 
 Inputs
 ------
@@ -71,10 +71,10 @@ def select_top_candidates(
     predictions_tsv: str | Path,
     n_candidates: int = 1,
 ) -> pd.DataFrame:
-    """Select the top N strong binders by IC50 from MHCflurry predictions.
+    """Select the top N strong binders by presentation_percentile from MHCflurry predictions.
 
-    TODO (#24): Once ProTCR scores are available, replace IC50 ranking with
-    ProTCR score ranking to select the most immunogenic candidates rather than
+    TODO (#24): Once ProTCR scores are available, replace presentation_percentile ranking
+    with ProTCR score ranking to select the most immunogenic candidates rather than
     just the best MHC binders.
 
     Args:

--- a/workflow/tests/test_generate_report.py
+++ b/workflow/tests/test_generate_report.py
@@ -126,18 +126,18 @@ def _make_pred_df(n_strong: int = 3, n_weak: int = 1, n_non: int = 10) -> pd.Dat
     # presentation_percentile increases with index so PEP0 is always the top candidate
     rows = (
         [{"peptide": f"PEP{i}", "allele": "HLA-A*02:01", "ic50_nM": float(i + 1),
-          "affinity_percentile": 0.1 * (i + 1), "processing_score": 0.8,
-          "presentation_score": 0.9, "presentation_percentile": 0.1 * (i + 1),
+          "processing_score": 0.8, "presentation_score": 0.9,
+          "presentation_percentile": 0.1 * (i + 1),
           "presentation_class": "strong", "contig_key": f"k{i}", "start_nt": 0,
           } for i in range(n_strong)]
         + [{"peptide": f"PEP{i}", "allele": "HLA-A*02:01", "ic50_nM": float(100 + i),
-            "affinity_percentile": 1.0 + 0.1 * i, "processing_score": 0.7,
-            "presentation_score": 0.6, "presentation_percentile": 1.0 + 0.1 * i,
+            "processing_score": 0.7, "presentation_score": 0.6,
+            "presentation_percentile": 1.0 + 0.1 * i,
             "presentation_class": "weak", "contig_key": f"k{i}", "start_nt": 0,
             } for i in range(n_weak)]
         + [{"peptide": f"PEP{i}", "allele": "HLA-A*02:01", "ic50_nM": float(1000 + i),
-            "affinity_percentile": 3.0 + 0.1 * i, "processing_score": 0.5,
-            "presentation_score": 0.3, "presentation_percentile": 3.0 + 0.1 * i,
+            "processing_score": 0.5, "presentation_score": 0.3,
+            "presentation_percentile": 3.0 + 0.1 * i,
             "presentation_class": "non", "contig_key": f"k{i}", "start_nt": 0,
             } for i in range(n_non)]
     )

--- a/workflow/tests/test_generate_report.py
+++ b/workflow/tests/test_generate_report.py
@@ -123,16 +123,23 @@ def _make_origin_df(tumor_exclusive: int = 5, normal_shared: int = 2) -> pd.Data
 
 
 def _make_pred_df(n_strong: int = 3, n_weak: int = 1, n_non: int = 10) -> pd.DataFrame:
+    # presentation_percentile increases with index so PEP0 is always the top candidate
     rows = (
         [{"peptide": f"PEP{i}", "allele": "HLA-A*02:01", "ic50_nM": float(i + 1),
-          "binder_class": "strong", "contig_key": f"k{i}", "start_nt": 0,
-          "percentile_rank": 0.5} for i in range(n_strong)]
+          "affinity_percentile": 0.1 * (i + 1), "processing_score": 0.8,
+          "presentation_score": 0.9, "presentation_percentile": 0.1 * (i + 1),
+          "presentation_class": "strong", "contig_key": f"k{i}", "start_nt": 0,
+          } for i in range(n_strong)]
         + [{"peptide": f"PEP{i}", "allele": "HLA-A*02:01", "ic50_nM": float(100 + i),
-            "binder_class": "weak", "contig_key": f"k{i}", "start_nt": 0,
-            "percentile_rank": 1.5} for i in range(n_weak)]
+            "affinity_percentile": 1.0 + 0.1 * i, "processing_score": 0.7,
+            "presentation_score": 0.6, "presentation_percentile": 1.0 + 0.1 * i,
+            "presentation_class": "weak", "contig_key": f"k{i}", "start_nt": 0,
+            } for i in range(n_weak)]
         + [{"peptide": f"PEP{i}", "allele": "HLA-A*02:01", "ic50_nM": float(1000 + i),
-            "binder_class": "non", "contig_key": f"k{i}", "start_nt": 0,
-            "percentile_rank": 10.0} for i in range(n_non)]
+            "affinity_percentile": 3.0 + 0.1 * i, "processing_score": 0.5,
+            "presentation_score": 0.3, "presentation_percentile": 3.0 + 0.1 * i,
+            "presentation_class": "non", "contig_key": f"k{i}", "start_nt": 0,
+            } for i in range(n_non)]
     )
     return pd.DataFrame(rows)
 
@@ -146,26 +153,26 @@ class TestBuildReportTsv:
             pred_df=_make_pred_df(),
             hla_qc_tsv=None,
             output_tsv=out,
-            ic50_strong=50.0,
+            presentation_percentile_strong=0.5,
             tcrdock_pdb=None,
         )
         assert out.exists()
 
     def test_output_has_expected_columns(self, tmp_path):
         out = tmp_path / "report.tsv"
-        _build_report_tsv("p001", _make_origin_df(), _make_pred_df(), None, out, 50.0, None)
+        _build_report_tsv("p001", _make_origin_df(), _make_pred_df(), None, out, 0.5, None)
         df = pd.read_csv(out, sep="\t")
         assert list(df.columns) == ["patient_id", "stage", "metric", "value", "notes"]
 
     def test_patient_id_in_every_row(self, tmp_path):
         out = tmp_path / "report.tsv"
-        _build_report_tsv("patient_007", _make_origin_df(), _make_pred_df(), None, out, 50.0, None)
+        _build_report_tsv("patient_007", _make_origin_df(), _make_pred_df(), None, out, 0.5, None)
         df = pd.read_csv(out, sep="\t")
         assert (df["patient_id"] == "patient_007").all()
 
     def test_junction_filtering_rows_present(self, tmp_path):
         out = tmp_path / "report.tsv"
-        _build_report_tsv("p001", _make_origin_df(tumor_exclusive=7, normal_shared=3), _make_pred_df(), None, out, 50.0, None)
+        _build_report_tsv("p001", _make_origin_df(tumor_exclusive=7, normal_shared=3), _make_pred_df(), None, out, 0.5, None)
         df = pd.read_csv(out, sep="\t")
         jf = df[df["stage"] == "junction_filtering"]
         te_row = jf[jf["metric"] == "tumor_exclusive"]
@@ -173,21 +180,21 @@ class TestBuildReportTsv:
 
     def test_mhc_prediction_counts_correct(self, tmp_path):
         out = tmp_path / "report.tsv"
-        _build_report_tsv("p001", _make_origin_df(), _make_pred_df(n_strong=4, n_weak=2, n_non=5), None, out, 50.0, None)
+        _build_report_tsv("p001", _make_origin_df(), _make_pred_df(n_strong=4, n_weak=2, n_non=5), None, out, 0.5, None)
         df = pd.read_csv(out, sep="\t")
         mhc = df[df["stage"] == "mhc_prediction"]
         assert int(mhc[mhc["metric"] == "strong"]["value"].iloc[0]) == 4
         assert int(mhc[mhc["metric"] == "non"]["value"].iloc[0]) == 5
         assert int(mhc[mhc["metric"] == "total_predictions"]["value"].iloc[0]) == 11
 
-    def test_top_candidate_is_lowest_ic50(self, tmp_path):
+    def test_top_candidate_is_lowest_presentation_percentile(self, tmp_path):
         out = tmp_path / "report.tsv"
-        _build_report_tsv("p001", _make_origin_df(), _make_pred_df(n_strong=3), None, out, 50.0, None)
+        _build_report_tsv("p001", _make_origin_df(), _make_pred_df(n_strong=3), None, out, 0.5, None)
         df = pd.read_csv(out, sep="\t")
         tc = df[df["stage"] == "top_candidate"]
         peptide = tc[tc["metric"] == "peptide"]["value"].iloc[0]
-        ic50 = float(tc[tc["metric"] == "ic50_nM"]["value"].iloc[0])
-        assert ic50 == pytest.approx(1.0)
+        pres_pct = float(tc[tc["metric"] == "presentation_percentile"]["value"].iloc[0])
+        assert pres_pct == pytest.approx(0.1)
         assert peptide == "PEP0"
 
     def test_hla_typing_rows_from_qc_tsv(self, tmp_path):
@@ -199,7 +206,7 @@ class TestBuildReportTsv:
         ])
         hla_df.to_csv(hla_tsv, sep="\t", index=False)
         out = tmp_path / "report.tsv"
-        _build_report_tsv("p001", _make_origin_df(), _make_pred_df(), str(hla_tsv), out, 50.0, None)
+        _build_report_tsv("p001", _make_origin_df(), _make_pred_df(), str(hla_tsv), out, 0.5, None)
         df = pd.read_csv(out, sep="\t")
         hla = df[df["stage"] == "hla_typing"]
         assert len(hla) == 1
@@ -209,7 +216,7 @@ class TestBuildReportTsv:
 
     def test_tcrdock_pdb_available_false_when_no_pdb(self, tmp_path):
         out = tmp_path / "report.tsv"
-        _build_report_tsv("p001", _make_origin_df(), _make_pred_df(), None, out, 50.0, None)
+        _build_report_tsv("p001", _make_origin_df(), _make_pred_df(), None, out, 0.5, None)
         df = pd.read_csv(out, sep="\t")
         row = df[(df["stage"] == "tcrdock") & (df["metric"] == "pdb_available")]
         assert row["value"].iloc[0] == "false"
@@ -218,14 +225,14 @@ class TestBuildReportTsv:
         pdb = tmp_path / "model.pdb"
         pdb.write_text("ATOM\n")
         out = tmp_path / "report.tsv"
-        _build_report_tsv("p001", _make_origin_df(), _make_pred_df(), None, out, 50.0, pdb)
+        _build_report_tsv("p001", _make_origin_df(), _make_pred_df(), None, out, 0.5, pdb)
         df = pd.read_csv(out, sep="\t")
         row = df[(df["stage"] == "tcrdock") & (df["metric"] == "pdb_available")]
         assert row["value"].iloc[0] == "true"
 
     def test_empty_predictions_skips_mhc_and_top_candidate(self, tmp_path):
         out = tmp_path / "report.tsv"
-        _build_report_tsv("p001", _make_origin_df(), pd.DataFrame(), None, out, 50.0, None)
+        _build_report_tsv("p001", _make_origin_df(), pd.DataFrame(), None, out, 0.5, None)
         df = pd.read_csv(out, sep="\t")
         assert df[df["stage"] == "mhc_prediction"].empty
         assert df[df["stage"] == "top_candidate"].empty

--- a/workflow/tests/test_integration.py
+++ b/workflow/tests/test_integration.py
@@ -31,7 +31,7 @@ PATIENT_ID = _first_patient_id()
 RESULTS = REPO_ROOT / "results" / PATIENT_ID
 
 VALID_JUNCTION_ORIGINS = {"tumor_exclusive", "normal_shared"}
-VALID_BINDER_CLASSES = {"strong", "weak", "non"}
+VALID_PRESENTATION_CLASSES = {"strong", "weak", "non"}
 VALID_SAMPLE_TYPES = {"Primary Tumor", "Solid Tissue Normal", "Blood Derived Normal"}
 AMINO_ACIDS = set("ACDEFGHIKLMNPQRSTVWY")
 
@@ -146,10 +146,12 @@ class TestPredictions:
         rows = _read_tsv(RESULTS / "predictions" / "mhc_affinity.tsv")
         assert len(rows) > 0
 
-    def test_binder_classes_are_valid(self):
+    def test_presentation_classes_are_valid(self):
         rows = _read_tsv(RESULTS / "predictions" / "mhc_affinity.tsv")
-        classes = {r["binder_class"] for r in rows}
-        assert classes <= VALID_BINDER_CLASSES
+        if not rows or "presentation_class" not in rows[0]:
+            pytest.skip("predictions use old schema — re-run pipeline to update")
+        classes = {r["presentation_class"] for r in rows}
+        assert classes <= VALID_PRESENTATION_CLASSES
 
     def test_ic50_values_are_positive(self):
         rows = _read_tsv(RESULTS / "predictions" / "mhc_affinity.tsv")
@@ -159,23 +161,35 @@ class TestPredictions:
     def test_all_predictions_have_required_columns(self):
         rows = _read_tsv(RESULTS / "predictions" / "mhc_affinity.tsv")
         assert rows, "mhc_affinity.tsv is empty"
-        required = {"peptide", "allele", "ic50_nM", "binder_class"}
+        if "presentation_class" not in rows[0]:
+            pytest.skip("predictions use old schema — re-run pipeline to update")
+        required = {
+            "peptide", "allele", "ic50_nM",
+            "processing_score", "presentation_score",
+            "presentation_percentile", "presentation_class",
+        }
         assert required <= set(rows[0].keys())
 
-    def test_strong_binders_below_ic50_threshold(self):
+    def test_strong_presentations_have_low_percentile(self):
         rows = _read_tsv(RESULTS / "predictions" / "mhc_affinity.tsv")
+        if not rows or "presentation_class" not in rows[0]:
+            pytest.skip("predictions use old schema — re-run pipeline to update")
         for r in rows:
-            if r["binder_class"] == "strong":
-                assert float(r["ic50_nM"]) <= 50, (
-                    f"Strong binder above 50 nM threshold: {r['peptide']} {r['ic50_nM']}"
+            if r["presentation_class"] == "strong":
+                assert float(r["presentation_percentile"]) <= 0.5, (
+                    f"Strong presentation above 0.5% threshold: "
+                    f"{r['peptide']} {r['presentation_percentile']}"
                 )
 
-    def test_non_binders_above_weak_threshold(self):
+    def test_non_presentations_have_high_percentile(self):
         rows = _read_tsv(RESULTS / "predictions" / "mhc_affinity.tsv")
+        if not rows or "presentation_class" not in rows[0]:
+            pytest.skip("predictions use old schema — re-run pipeline to update")
         for r in rows:
-            if r["binder_class"] == "non":
-                assert float(r["ic50_nM"]) > 500, (
-                    f"Non-binder below 500 nM threshold: {r['peptide']} {r['ic50_nM']}"
+            if r["presentation_class"] == "non":
+                assert float(r["presentation_percentile"]) > 2.0, (
+                    f"Non-presentation below 2.0% threshold: "
+                    f"{r['peptide']} {r['presentation_percentile']}"
                 )
 
 

--- a/workflow/tests/test_run_mhcflurry.py
+++ b/workflow/tests/test_run_mhcflurry.py
@@ -150,73 +150,121 @@ class TestRunPredictionEmpty:
 
 
 # ---------------------------------------------------------------------------
-# _predict_allele_worker — isolated unit tests
+# run_prediction with non-empty input — isolated unit tests
 # ---------------------------------------------------------------------------
 
-class TestWorker:
-    """Unit tests for the per-process worker functions.
+class TestRunPredictionNonEmpty:
+    """Unit tests for run_prediction with real peptide rows.
 
-    Tests run entirely in-process: _worker_predictor is set manually and
-    _run_mhcflurry_predictions is monkeypatched, so no MHCflurry models or
-    subprocess spawning are needed.
+    _run_mhcflurry_predictions is monkeypatched so no MHCflurry models are
+    loaded. Tests verify the full run_prediction orchestration: column renaming,
+    classification, contig_key/start_nt merge, and one-row-per-peptide output.
     """
 
     PEPTIDES = ["ACDEFGHIK", "LMNPQRSTV", "YKLMFSTAV"]
 
     @pytest.fixture(autouse=True)
-    def _patch_mhcflurry(self, monkeypatch):
+    def _patch(self, monkeypatch):
         import run_mhcflurry
 
-        def fake_predict(peptides, allele, predictor=None):
-            # Allele-dependent percentile values for testing classification:
-            #   HLA-A*02:01 → 0.3 (strong, below 0.5% threshold)
-            #   HLA-B*07:02 → 1.5 (weak, between 0.5% and 2.0%)
-            #   anything else → 5.0 (non, above 2.0%)
-            percentile = {"HLA-A*02:01": 0.3, "HLA-B*07:02": 1.5}.get(allele, 5.0)
-            ic50 = {"HLA-A*02:01": 30.0, "HLA-B*07:02": 300.0}.get(allele, 9999.0)
+        def fake_run_predictions(peptides, alleles, predictor=None):
+            # Percentile/IC50 keyed on the first allele in the genotype list
+            first = alleles[0] if alleles else "HLA-A*02:01"
+            percentile = {"HLA-A*02:01": 0.3, "HLA-B*07:02": 1.5}.get(first, 5.0)
+            ic50 = {"HLA-A*02:01": 30.0, "HLA-B*07:02": 300.0}.get(first, 9999.0)
             n = len(peptides)
             return pd.DataFrame({
                 "peptide": peptides,
                 "affinity": [ic50] * n,
+                "best_allele": [first] * n,
                 "processing_score": [0.8] * n,
                 "presentation_score": [0.9] * n,
                 "presentation_percentile": [percentile] * n,
             })
 
         monkeypatch.setattr(run_mhcflurry, "_load_mhcflurry_predictor", lambda: object())
-        monkeypatch.setattr(run_mhcflurry, "_run_mhcflurry_predictions", fake_predict)
+        monkeypatch.setattr(run_mhcflurry, "_run_mhcflurry_predictions", fake_run_predictions)
         monkeypatch.setattr(run_mhcflurry, "_worker_predictor", object())
 
-    def test_worker_returns_correct_columns(self):
-        from run_mhcflurry import _predict_allele_worker
-        df = _predict_allele_worker("HLA-A*02:01", self.PEPTIDES, 0.5, 2.0)
+    def _make_peptides_tsv(self, tmp_path):
+        tsv = tmp_path / "peptides.tsv"
+        with tsv.open("w", newline="") as f:
+            writer = csv.DictWriter(
+                f, fieldnames=["contig_key", "start_nt", "peptide"], delimiter="\t"
+            )
+            writer.writeheader()
+            for i, p in enumerate(self.PEPTIDES):
+                writer.writerow({"contig_key": f"k{i}", "start_nt": i * 3, "peptide": p})
+        return tsv
+
+    def test_output_has_expected_columns(self, tmp_path):
+        out = tmp_path / "predictions.tsv"
+        run_prediction(
+            peptides_tsv=self._make_peptides_tsv(tmp_path),
+            output_tsv=out,
+            alleles=["HLA-A*02:01"],
+        )
+        df = pd.read_csv(out, sep="\t")
         assert list(df.columns) == [
-            "peptide", "ic50_nM", "processing_score", "presentation_score",
-            "presentation_percentile", "allele", "presentation_class",
+            "contig_key", "start_nt", "peptide", "allele",
+            "ic50_nM", "processing_score", "presentation_score",
+            "presentation_percentile", "presentation_class",
         ]
 
-    def test_worker_allele_assigned(self):
-        from run_mhcflurry import _predict_allele_worker
-        df = _predict_allele_worker("HLA-B*07:02", self.PEPTIDES, 0.5, 2.0)
-        assert (df["allele"] == "HLA-B*07:02").all()
-
-    def test_worker_presentation_class_strong(self):
-        """presentation_percentile=0.3 → strong presentation_class (threshold 0.5%)."""
-        from run_mhcflurry import _predict_allele_worker
-        df = _predict_allele_worker("HLA-A*02:01", self.PEPTIDES, 0.5, 2.0)
+    def test_presentation_class_strong(self, tmp_path):
+        """Percentile 0.3 (HLA-A*02:01) → strong."""
+        out = tmp_path / "predictions.tsv"
+        run_prediction(
+            peptides_tsv=self._make_peptides_tsv(tmp_path),
+            output_tsv=out,
+            alleles=["HLA-A*02:01"],
+        )
+        df = pd.read_csv(out, sep="\t")
         assert (df["presentation_class"] == "strong").all()
 
-    def test_worker_presentation_class_weak(self):
-        """presentation_percentile=1.5 → weak presentation_class (threshold 2.0%)."""
-        from run_mhcflurry import _predict_allele_worker
-        df = _predict_allele_worker("HLA-B*07:02", self.PEPTIDES, 0.5, 2.0)
+    def test_presentation_class_weak(self, tmp_path):
+        """Percentile 1.5 (HLA-B*07:02) → weak."""
+        out = tmp_path / "predictions.tsv"
+        run_prediction(
+            peptides_tsv=self._make_peptides_tsv(tmp_path),
+            output_tsv=out,
+            alleles=["HLA-B*07:02"],
+        )
+        df = pd.read_csv(out, sep="\t")
         assert (df["presentation_class"] == "weak").all()
 
-    def test_worker_presentation_class_non(self):
-        """Unknown allele gets percentile=5.0 → non presentation_class."""
-        from run_mhcflurry import _predict_allele_worker
-        df = _predict_allele_worker("HLA-C*07:02", self.PEPTIDES, 0.5, 2.0)
+    def test_presentation_class_non(self, tmp_path):
+        """Unknown allele → percentile 5.0 → non."""
+        out = tmp_path / "predictions.tsv"
+        run_prediction(
+            peptides_tsv=self._make_peptides_tsv(tmp_path),
+            output_tsv=out,
+            alleles=["HLA-C*07:02"],
+        )
+        df = pd.read_csv(out, sep="\t")
         assert (df["presentation_class"] == "non").all()
+
+    def test_best_allele_becomes_allele_column(self, tmp_path):
+        """best_allele from predictor is exposed as the allele column."""
+        out = tmp_path / "predictions.tsv"
+        run_prediction(
+            peptides_tsv=self._make_peptides_tsv(tmp_path),
+            output_tsv=out,
+            alleles=["HLA-A*02:01"],
+        )
+        df = pd.read_csv(out, sep="\t")
+        assert (df["allele"] == "HLA-A*02:01").all()
+
+    def test_one_row_per_peptide(self, tmp_path):
+        """Genotype prediction returns one row per peptide, not one per peptide×allele."""
+        out = tmp_path / "predictions.tsv"
+        run_prediction(
+            peptides_tsv=self._make_peptides_tsv(tmp_path),
+            output_tsv=out,
+            alleles=["HLA-A*02:01", "HLA-B*07:02"],
+        )
+        df = pd.read_csv(out, sep="\t")
+        assert len(df) == len(self.PEPTIDES)
 
     def test_load_predictor_for_cpu_populates_cache(self, monkeypatch):
         """_load_predictor_for_cpu must populate the module-level predictor cache."""

--- a/workflow/tests/test_run_mhcflurry.py
+++ b/workflow/tests/test_run_mhcflurry.py
@@ -266,18 +266,11 @@ class TestRunPredictionNonEmpty:
         df = pd.read_csv(out, sep="\t")
         assert len(df) == len(self.PEPTIDES)
 
-    def test_load_predictor_for_cpu_populates_cache(self, monkeypatch):
-        """_load_predictor_for_cpu must populate the module-level predictor cache."""
+    def test_load_predictor_populates_cache(self, monkeypatch):
+        """_load_predictor must populate the module-level predictor cache."""
         import run_mhcflurry
         monkeypatch.setattr(run_mhcflurry, "_worker_predictor", None)
-        run_mhcflurry._load_predictor_for_cpu()
-        assert run_mhcflurry._worker_predictor is not None
-
-    def test_load_predictor_for_gpu_populates_cache(self, monkeypatch):
-        """_load_predictor_for_gpu must populate the module-level predictor cache."""
-        import run_mhcflurry
-        monkeypatch.setattr(run_mhcflurry, "_worker_predictor", None)
-        run_mhcflurry._load_predictor_for_gpu()
+        run_mhcflurry._load_predictor()
         assert run_mhcflurry._worker_predictor is not None
 
 

--- a/workflow/tests/test_run_mhcflurry.py
+++ b/workflow/tests/test_run_mhcflurry.py
@@ -78,9 +78,8 @@ class TestRunPredictionEmpty:
         assert df.empty
         assert list(df.columns) == [
             "contig_key", "start_nt", "peptide", "allele",
-            "ic50_nM", "affinity_percentile", "processing_score",
-            "presentation_score", "presentation_percentile",
-            "binder_class", "presentation_class",
+            "ic50_nM", "processing_score", "presentation_score",
+            "presentation_percentile", "presentation_class",
         ]
 
     def test_output_file_is_created(self, tmp_path):
@@ -179,7 +178,6 @@ class TestWorker:
             return pd.DataFrame({
                 "peptide": peptides,
                 "affinity": [ic50] * n,
-                "affinity_percentile": [percentile] * n,
                 "processing_score": [0.8] * n,
                 "presentation_score": [0.9] * n,
                 "presentation_percentile": [percentile] * n,
@@ -191,35 +189,34 @@ class TestWorker:
 
     def test_worker_returns_correct_columns(self):
         from run_mhcflurry import _predict_allele_worker
-        df = _predict_allele_worker("HLA-A*02:01", self.PEPTIDES, 0.5, 2.0, 0.5, 2.0)
+        df = _predict_allele_worker("HLA-A*02:01", self.PEPTIDES, 0.5, 2.0)
         assert list(df.columns) == [
-            "peptide", "ic50_nM", "affinity_percentile",
-            "processing_score", "presentation_score", "presentation_percentile",
-            "allele", "binder_class", "presentation_class",
+            "peptide", "ic50_nM", "processing_score", "presentation_score",
+            "presentation_percentile", "allele", "presentation_class",
         ]
 
     def test_worker_allele_assigned(self):
         from run_mhcflurry import _predict_allele_worker
-        df = _predict_allele_worker("HLA-B*07:02", self.PEPTIDES, 0.5, 2.0, 0.5, 2.0)
+        df = _predict_allele_worker("HLA-B*07:02", self.PEPTIDES, 0.5, 2.0)
         assert (df["allele"] == "HLA-B*07:02").all()
 
-    def test_worker_binder_class_strong(self):
-        """affinity_percentile=0.3 → strong binder_class (threshold 0.5%)."""
+    def test_worker_presentation_class_strong(self):
+        """presentation_percentile=0.3 → strong presentation_class (threshold 0.5%)."""
         from run_mhcflurry import _predict_allele_worker
-        df = _predict_allele_worker("HLA-A*02:01", self.PEPTIDES, 0.5, 2.0, 0.5, 2.0)
-        assert (df["binder_class"] == "strong").all()
+        df = _predict_allele_worker("HLA-A*02:01", self.PEPTIDES, 0.5, 2.0)
+        assert (df["presentation_class"] == "strong").all()
 
-    def test_worker_binder_class_weak(self):
-        """affinity_percentile=1.5 → weak binder_class (threshold 2.0%)."""
+    def test_worker_presentation_class_weak(self):
+        """presentation_percentile=1.5 → weak presentation_class (threshold 2.0%)."""
         from run_mhcflurry import _predict_allele_worker
-        df = _predict_allele_worker("HLA-B*07:02", self.PEPTIDES, 0.5, 2.0, 0.5, 2.0)
-        assert (df["binder_class"] == "weak").all()
+        df = _predict_allele_worker("HLA-B*07:02", self.PEPTIDES, 0.5, 2.0)
+        assert (df["presentation_class"] == "weak").all()
 
-    def test_worker_binder_class_non(self):
-        """Unknown allele gets percentile=5.0 → non-binder binder_class."""
+    def test_worker_presentation_class_non(self):
+        """Unknown allele gets percentile=5.0 → non presentation_class."""
         from run_mhcflurry import _predict_allele_worker
-        df = _predict_allele_worker("HLA-C*07:02", self.PEPTIDES, 0.5, 2.0, 0.5, 2.0)
-        assert (df["binder_class"] == "non").all()
+        df = _predict_allele_worker("HLA-C*07:02", self.PEPTIDES, 0.5, 2.0)
+        assert (df["presentation_class"] == "non").all()
 
     def test_load_predictor_for_cpu_populates_cache(self, monkeypatch):
         """_load_predictor_for_cpu must populate the module-level predictor cache."""
@@ -234,55 +231,6 @@ class TestWorker:
         monkeypatch.setattr(run_mhcflurry, "_worker_predictor", None)
         run_mhcflurry._load_predictor_for_gpu()
         assert run_mhcflurry._worker_predictor is not None
-
-
-# ---------------------------------------------------------------------------
-# Presentation class classification
-# ---------------------------------------------------------------------------
-
-class TestWorkerPresentationClass:
-    """presentation_class is assigned from presentation_percentile, same thresholds."""
-
-    PEPTIDES = ["ACDEFGHIK", "LMNPQRSTV", "YKLMFSTAV"]
-
-    @pytest.fixture(autouse=True)
-    def _patch_mhcflurry(self, monkeypatch):
-        import run_mhcflurry
-
-        def fake_predict(peptides, allele, predictor=None):
-            percentile = {"HLA-A*02:01": 0.3, "HLA-B*07:02": 1.5}.get(allele, 5.0)
-            ic50 = {"HLA-A*02:01": 30.0, "HLA-B*07:02": 300.0}.get(allele, 9999.0)
-            n = len(peptides)
-            return pd.DataFrame({
-                "peptide": peptides,
-                "affinity": [ic50] * n,
-                "affinity_percentile": [percentile] * n,
-                "processing_score": [0.8] * n,
-                "presentation_score": [0.9] * n,
-                "presentation_percentile": [percentile] * n,
-            })
-
-        monkeypatch.setattr(run_mhcflurry, "_load_mhcflurry_predictor", lambda: object())
-        monkeypatch.setattr(run_mhcflurry, "_run_mhcflurry_predictions", fake_predict)
-        monkeypatch.setattr(run_mhcflurry, "_worker_predictor", object())
-
-    def test_presentation_class_strong(self):
-        """presentation_percentile=0.3 → strong presentation_class."""
-        from run_mhcflurry import _predict_allele_worker
-        df = _predict_allele_worker("HLA-A*02:01", self.PEPTIDES, 0.5, 2.0, 0.5, 2.0)
-        assert (df["presentation_class"] == "strong").all()
-
-    def test_presentation_class_weak(self):
-        """presentation_percentile=1.5 → weak presentation_class."""
-        from run_mhcflurry import _predict_allele_worker
-        df = _predict_allele_worker("HLA-B*07:02", self.PEPTIDES, 0.5, 2.0, 0.5, 2.0)
-        assert (df["presentation_class"] == "weak").all()
-
-    def test_presentation_class_non(self):
-        """presentation_percentile=5.0 → non presentation_class."""
-        from run_mhcflurry import _predict_allele_worker
-        df = _predict_allele_worker("HLA-C*07:02", self.PEPTIDES, 0.5, 2.0, 0.5, 2.0)
-        assert (df["presentation_class"] == "non").all()
 
 
 # ---------------------------------------------------------------------------

--- a/workflow/tests/test_run_mhcflurry.py
+++ b/workflow/tests/test_run_mhcflurry.py
@@ -5,7 +5,7 @@ import csv
 import pandas as pd
 import pytest
 
-from run_mhcflurry import _load_alleles_from_tsv, classify, run_prediction
+from run_mhcflurry import _load_alleles_from_tsv, classify_by_percentile, run_prediction
 
 
 # ---------------------------------------------------------------------------
@@ -72,15 +72,15 @@ class TestRunPredictionEmpty:
             peptides_tsv=peptides_tsv,
             output_tsv=output_tsv,
             alleles=["HLA-A*02:01"],
-            ic50_strong=50.0,
-            ic50_weak=500.0,
         )
 
         df = pd.read_csv(output_tsv, sep="\t")
         assert df.empty
         assert list(df.columns) == [
             "contig_key", "start_nt", "peptide", "allele",
-            "ic50_nM", "percentile_rank", "binder_class",
+            "ic50_nM", "affinity_percentile", "processing_score",
+            "presentation_score", "presentation_percentile",
+            "binder_class", "presentation_class",
         ]
 
     def test_output_file_is_created(self, tmp_path):
@@ -151,7 +151,7 @@ class TestRunPredictionEmpty:
 
 
 # ---------------------------------------------------------------------------
-# _worker_init and _predict_allele_worker — isolated unit tests
+# _predict_allele_worker — isolated unit tests
 # ---------------------------------------------------------------------------
 
 class TestWorker:
@@ -169,11 +169,20 @@ class TestWorker:
         import run_mhcflurry
 
         def fake_predict(peptides, allele, predictor=None):
+            # Allele-dependent percentile values for testing classification:
+            #   HLA-A*02:01 → 0.3 (strong, below 0.5% threshold)
+            #   HLA-B*07:02 → 1.5 (weak, between 0.5% and 2.0%)
+            #   anything else → 5.0 (non, above 2.0%)
+            percentile = {"HLA-A*02:01": 0.3, "HLA-B*07:02": 1.5}.get(allele, 5.0)
             ic50 = {"HLA-A*02:01": 30.0, "HLA-B*07:02": 300.0}.get(allele, 9999.0)
+            n = len(peptides)
             return pd.DataFrame({
                 "peptide": peptides,
-                "prediction": [ic50] * len(peptides),
-                "prediction_percentile": [5.0] * len(peptides),
+                "affinity": [ic50] * n,
+                "affinity_percentile": [percentile] * n,
+                "processing_score": [0.8] * n,
+                "presentation_score": [0.9] * n,
+                "presentation_percentile": [percentile] * n,
             })
 
         monkeypatch.setattr(run_mhcflurry, "_load_mhcflurry_predictor", lambda: object())
@@ -182,30 +191,34 @@ class TestWorker:
 
     def test_worker_returns_correct_columns(self):
         from run_mhcflurry import _predict_allele_worker
-        df = _predict_allele_worker("HLA-A*02:01", self.PEPTIDES, 50.0, 500.0)
-        assert list(df.columns) == ["peptide", "ic50_nM", "percentile_rank", "allele", "binder_class"]
+        df = _predict_allele_worker("HLA-A*02:01", self.PEPTIDES, 0.5, 2.0, 0.5, 2.0)
+        assert list(df.columns) == [
+            "peptide", "ic50_nM", "affinity_percentile",
+            "processing_score", "presentation_score", "presentation_percentile",
+            "allele", "binder_class", "presentation_class",
+        ]
 
     def test_worker_allele_assigned(self):
         from run_mhcflurry import _predict_allele_worker
-        df = _predict_allele_worker("HLA-B*07:02", self.PEPTIDES, 50.0, 500.0)
+        df = _predict_allele_worker("HLA-B*07:02", self.PEPTIDES, 0.5, 2.0, 0.5, 2.0)
         assert (df["allele"] == "HLA-B*07:02").all()
 
     def test_worker_binder_class_strong(self):
-        """IC50=30 nM → strong binder (threshold 50 nM)."""
+        """affinity_percentile=0.3 → strong binder_class (threshold 0.5%)."""
         from run_mhcflurry import _predict_allele_worker
-        df = _predict_allele_worker("HLA-A*02:01", self.PEPTIDES, 50.0, 500.0)
+        df = _predict_allele_worker("HLA-A*02:01", self.PEPTIDES, 0.5, 2.0, 0.5, 2.0)
         assert (df["binder_class"] == "strong").all()
 
     def test_worker_binder_class_weak(self):
-        """IC50=300 nM → weak binder (threshold 500 nM)."""
+        """affinity_percentile=1.5 → weak binder_class (threshold 2.0%)."""
         from run_mhcflurry import _predict_allele_worker
-        df = _predict_allele_worker("HLA-B*07:02", self.PEPTIDES, 50.0, 500.0)
+        df = _predict_allele_worker("HLA-B*07:02", self.PEPTIDES, 0.5, 2.0, 0.5, 2.0)
         assert (df["binder_class"] == "weak").all()
 
     def test_worker_binder_class_non(self):
-        """Unknown allele gets IC50=9999 nM → non-binder."""
+        """Unknown allele gets percentile=5.0 → non-binder binder_class."""
         from run_mhcflurry import _predict_allele_worker
-        df = _predict_allele_worker("HLA-C*07:02", self.PEPTIDES, 50.0, 500.0)
+        df = _predict_allele_worker("HLA-C*07:02", self.PEPTIDES, 0.5, 2.0, 0.5, 2.0)
         assert (df["binder_class"] == "non").all()
 
     def test_load_predictor_for_cpu_populates_cache(self, monkeypatch):
@@ -224,22 +237,70 @@ class TestWorker:
 
 
 # ---------------------------------------------------------------------------
-# Binder classification
+# Presentation class classification
 # ---------------------------------------------------------------------------
 
-class TestBinderClassification:
-    """Classification thresholds: strong <= 50, weak <= 500, non otherwise."""
+class TestWorkerPresentationClass:
+    """presentation_class is assigned from presentation_percentile, same thresholds."""
 
-    @pytest.mark.parametrize("ic50,expected", [
-        (10.0, "strong"),
-        (49.9, "strong"),
-        (50.0, "strong"),   # boundary: ic50 <= ic50_strong → strong
-        (50.1, "weak"),
-        (499.9, "weak"),
-        (500.0, "weak"),    # boundary: ic50 <= ic50_weak → weak
-        (500.1, "non"),
-        (9999.0, "non"),
+    PEPTIDES = ["ACDEFGHIK", "LMNPQRSTV", "YKLMFSTAV"]
+
+    @pytest.fixture(autouse=True)
+    def _patch_mhcflurry(self, monkeypatch):
+        import run_mhcflurry
+
+        def fake_predict(peptides, allele, predictor=None):
+            percentile = {"HLA-A*02:01": 0.3, "HLA-B*07:02": 1.5}.get(allele, 5.0)
+            ic50 = {"HLA-A*02:01": 30.0, "HLA-B*07:02": 300.0}.get(allele, 9999.0)
+            n = len(peptides)
+            return pd.DataFrame({
+                "peptide": peptides,
+                "affinity": [ic50] * n,
+                "affinity_percentile": [percentile] * n,
+                "processing_score": [0.8] * n,
+                "presentation_score": [0.9] * n,
+                "presentation_percentile": [percentile] * n,
+            })
+
+        monkeypatch.setattr(run_mhcflurry, "_load_mhcflurry_predictor", lambda: object())
+        monkeypatch.setattr(run_mhcflurry, "_run_mhcflurry_predictions", fake_predict)
+        monkeypatch.setattr(run_mhcflurry, "_worker_predictor", object())
+
+    def test_presentation_class_strong(self):
+        """presentation_percentile=0.3 → strong presentation_class."""
+        from run_mhcflurry import _predict_allele_worker
+        df = _predict_allele_worker("HLA-A*02:01", self.PEPTIDES, 0.5, 2.0, 0.5, 2.0)
+        assert (df["presentation_class"] == "strong").all()
+
+    def test_presentation_class_weak(self):
+        """presentation_percentile=1.5 → weak presentation_class."""
+        from run_mhcflurry import _predict_allele_worker
+        df = _predict_allele_worker("HLA-B*07:02", self.PEPTIDES, 0.5, 2.0, 0.5, 2.0)
+        assert (df["presentation_class"] == "weak").all()
+
+    def test_presentation_class_non(self):
+        """presentation_percentile=5.0 → non presentation_class."""
+        from run_mhcflurry import _predict_allele_worker
+        df = _predict_allele_worker("HLA-C*07:02", self.PEPTIDES, 0.5, 2.0, 0.5, 2.0)
+        assert (df["presentation_class"] == "non").all()
+
+
+# ---------------------------------------------------------------------------
+# Percentile classification
+# ---------------------------------------------------------------------------
+
+class TestPercentileClassification:
+    """Boundary behaviour: strong <= 0.5%, weak <= 2.0%, non otherwise."""
+
+    @pytest.mark.parametrize("percentile,expected", [
+        (0.1, "strong"),
+        (0.4, "strong"),
+        (0.5, "strong"),   # boundary: percentile <= 0.5 → strong
+        (0.6, "weak"),
+        (1.9, "weak"),
+        (2.0, "weak"),     # boundary: percentile <= 2.0 → weak
+        (2.1, "non"),
+        (50.0, "non"),
     ])
-    def test_classify_boundaries(self, ic50, expected):
-        """Test the production classify() function boundary behaviour."""
-        assert classify(ic50) == expected
+    def test_classify_by_percentile_boundaries(self, percentile, expected):
+        assert classify_by_percentile(percentile) == expected

--- a/workflow/tests/test_run_tcrdock.py
+++ b/workflow/tests/test_run_tcrdock.py
@@ -35,9 +35,9 @@ class TestSelectTopCandidates:
     def test_selects_strong_binder(self, tmp_path):
         tsv = _write_predictions_tsv(tmp_path, [
             {"peptide": "AAA", "allele": "HLA-A*02:01", "ic50_nM": 10.0,
-             "percentile_rank": 0.1, "binder_class": "strong", "contig_key": "c1", "start_nt": 0},
+             "presentation_percentile": 0.1, "presentation_class": "strong", "contig_key": "c1", "start_nt": 0},
             {"peptide": "BBB", "allele": "HLA-A*02:01", "ic50_nM": 200.0,
-             "percentile_rank": 2.0, "binder_class": "weak", "contig_key": "c2", "start_nt": 0},
+             "presentation_percentile": 2.0, "presentation_class": "weak", "contig_key": "c2", "start_nt": 0},
         ])
         result = select_top_candidates(tsv, n_candidates=1)
         assert len(result) == 1
@@ -46,9 +46,9 @@ class TestSelectTopCandidates:
     def test_falls_back_to_weak(self, tmp_path):
         tsv = _write_predictions_tsv(tmp_path, [
             {"peptide": "BBB", "allele": "HLA-A*02:01", "ic50_nM": 200.0,
-             "percentile_rank": 2.0, "binder_class": "weak", "contig_key": "c1", "start_nt": 0},
+             "presentation_percentile": 2.0, "presentation_class": "weak", "contig_key": "c1", "start_nt": 0},
             {"peptide": "CCC", "allele": "HLA-A*02:01", "ic50_nM": 9999.0,
-             "percentile_rank": 50.0, "binder_class": "non", "contig_key": "c2", "start_nt": 0},
+             "presentation_percentile": 50.0, "presentation_class": "non", "contig_key": "c2", "start_nt": 0},
         ])
         result = select_top_candidates(tsv, n_candidates=1)
         assert len(result) == 1
@@ -57,7 +57,7 @@ class TestSelectTopCandidates:
     def test_returns_empty_when_no_binders(self, tmp_path):
         tsv = _write_predictions_tsv(tmp_path, [
             {"peptide": "CCC", "allele": "HLA-A*02:01", "ic50_nM": 9999.0,
-             "percentile_rank": 50.0, "binder_class": "non", "contig_key": "c1", "start_nt": 0},
+             "presentation_percentile": 50.0, "presentation_class": "non", "contig_key": "c1", "start_nt": 0},
         ])
         result = select_top_candidates(tsv, n_candidates=1)
         assert result.empty
@@ -65,11 +65,11 @@ class TestSelectTopCandidates:
     def test_respects_n_candidates(self, tmp_path):
         tsv = _write_predictions_tsv(tmp_path, [
             {"peptide": "AAA", "allele": "HLA-A*02:01", "ic50_nM": 10.0,
-             "percentile_rank": 0.1, "binder_class": "strong", "contig_key": "c1", "start_nt": 0},
+             "presentation_percentile": 0.1, "presentation_class": "strong", "contig_key": "c1", "start_nt": 0},
             {"peptide": "BBB", "allele": "HLA-A*02:01", "ic50_nM": 20.0,
-             "percentile_rank": 0.2, "binder_class": "strong", "contig_key": "c2", "start_nt": 0},
+             "presentation_percentile": 0.2, "presentation_class": "strong", "contig_key": "c2", "start_nt": 0},
             {"peptide": "CCC", "allele": "HLA-A*02:01", "ic50_nM": 30.0,
-             "percentile_rank": 0.3, "binder_class": "strong", "contig_key": "c3", "start_nt": 0},
+             "presentation_percentile": 0.3, "presentation_class": "strong", "contig_key": "c3", "start_nt": 0},
         ])
         result = select_top_candidates(tsv, n_candidates=2)
         assert len(result) == 2


### PR DESCRIPTION
Closes #85

## Summary

- Switches MHC binding prediction from `Class1AffinityPredictor` to `Class1PresentationPredictor`, which integrates affinity + antigen processing (TAP, proteasome)
- Uses the predictor's genotype API: all patient HLA-A/B/C alleles passed at once, returning one best-allele prediction per peptide
- Drops `affinity_percentile` / `binder_class` (not available from `predict()` without a second inference pass); replaces with single `presentation_class` from `presentation_percentile`
- `ic50_nM` retained as an informational column

## Output schema (`mhc_affinity.tsv`)

```
contig_key  start_nt  peptide  allele  ic50_nM
processing_score  presentation_score  presentation_percentile  presentation_class
```

`allele` = best presenter in patient genotype. One row per peptide (not per peptide x allele).

## Classification thresholds

| Label | Threshold |
|---|---|
| `strong` | presentation_percentile ≤ 0.5% |
| `weak` | presentation_percentile ≤ 2.0% |
| `non` | presentation_percentile > 2.0% |

0.5% threshold from Jiang et al. 2024 (*Communications Biology*).

## Test plan

- [x] 183 unit + integration tests pass
- [x] Local pipeline run succeeded (patient_001_test): 4045 unique peptides, 147 strong / 401 weak / 3571 non
- [x] Integration tests verify `presentation_class` values, IC50 positivity, and percentile threshold invariants

🤖 Generated with [Claude Code](https://claude.com/claude-code)