### PR TITLE
fix: rename ic50_strong → presentation_percentile_strong in structure.smk

### DIFF
--- a/workflow/rules/structure.smk
+++ b/workflow/rules/structure.smk
@@ -74,7 +74,7 @@ if _TCRDOCK_ENABLED:
         log:
             os.path.join(_LOGS, "{patient_id}", "structure", "report.log"),
         params:
-            ic50_strong=config["mhcflurry"]["ic50_strong"],
+            presentation_percentile_strong=config["mhcflurry"]["presentation_percentile_strong"],
         conda:
             "../envs/python.yaml"
         script:


### PR DESCRIPTION
## Summary

- `generate_report_with_structure` rule in `structure.smk` was still referencing the removed `config["mhcflurry"]["ic50_strong"]` key — a stale reference missed during the Issue #85 refactor
- Renamed to `presentation_percentile_strong` to match `analysis.smk` and the current config schema

## Why it was missed

The TCRdock rule block is guarded by `if _TCRDOCK_ENABLED:`, which is only true when `gpu.yaml` is merged in. Local tests and CI never enable TCRdock, so the broken config key was never evaluated until the cloud prod run.

A follow-up issue will add a Snakemake dry-run with the GPU config overlay to CI to catch this class of bug.

## Test plan

- [x] Cloud prod run completes past the `conda-cleanup-envs` step without `KeyError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)