### PR TITLE
refactor(mhc): rename mhc_affinity.tsv → mhc_presentation.tsv (#115)

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ results/
     ├── peptides/
     │   └── peptides.tsv              # Junction-spanning 9-mers
     ├── predictions/
-    │   ├── mhc_affinity.tsv          # MHCflurry results (one row per peptide, best allele)
+    │   ├── mhc_presentation.tsv      # MHCflurry results (one row per peptide, best allele)
     │   └── tcrdock/                  # (when TCRdock is enabled)
     │       ├── top_candidate.pdb     # Predicted TCR-pMHC ternary complex
     │       └── docking_scores.tsv    # pLDDT/PAE quality metrics

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -84,7 +84,7 @@ mhcflurry:
   presentation_percentile_weak:   2.0   # top 2.0% → weak
 ```
 
-`Class1PresentationPredictor.predict()` is called once with all patient alleles as a genotype (≤6). It returns one best-allele prediction per peptide — not one per peptide × allele. The `allele` column in `mhc_affinity.tsv` is the best presenter for that peptide across the patient's HLA-A/B/C genotype.
+`Class1PresentationPredictor.predict()` is called once with all patient alleles as a genotype (≤6). It returns one best-allele prediction per peptide — not one per peptide × allele. The `allele` column in `mhc_presentation.tsv` is the best presenter for that peptide across the patient's HLA-A/B/C genotype.
 
 ---
 

--- a/research/lab_notebook.md
+++ b/research/lab_notebook.md
@@ -4,6 +4,18 @@
 
 ## 2026-04-24
 
+### ~10:02 UTC
+
+#### Issue #115 — Rename `mhc_affinity.tsv` → `mhc_presentation.tsv` (PR #121, branch `feat/issue-115-rename-mhc-affinity-tsv`)
+
+**Motivation:** The output file was named after `Class1AffinityPredictor`, but the pipeline now uses `Class1PresentationPredictor` (since Issue #85). The name `mhc_affinity.tsv` was misleading — the primary ranking metric is `presentation_percentile`, not IC50.
+
+**Changes:** Pure mechanical rename across 9 files — output path in `mhc_affinity.smk`, Snakemake output key `mhc_affinity_tsv` → `mhc_presentation_tsv` in `mhc_affinity.smk`, `run_mhcflurry.py`, `structure.smk`; path references in `analysis.smk`, `generate_report.py`, `run_tcrdock.py`, `test_integration.py`; docs in `METHODS.md`, `configuration.md`, `README.md`. The `.smk` rule module filename (`mhc_affinity.smk`) is unchanged — it is the rule module for the MHC prediction step, not named after the output.
+
+**Testing:** 25/25 integration tests pass. Local test result file renamed from `mhc_affinity.tsv` → `mhc_presentation.tsv`.
+
+---
+
 ### ~08:49 UTC
 
 #### Hotfix — rename `ic50_strong` → `presentation_percentile_strong` in `structure.smk` (PR #117, branch `fix/structure-smk-ic50-key`)

--- a/research/manuscript/METHODS.md
+++ b/research/manuscript/METHODS.md
@@ -190,7 +190,7 @@ visualisation via Mol\* 4.x.
 | `results/hla_typing/{patient_id}/hla_qc.tsv` | Per-locus source, read counts, discrepancies |
 | `results/junctions/{patient_id}/novel_junctions.tsv` | All unannotated junctions with origin labels |
 | `results/peptides/{patient_id}/peptides.tsv` | Junction-spanning 9-mers (contig_key, start_nt, peptide) |
-| `results/predictions/{patient_id}/mhc_affinity.tsv` | Best-allele prediction per peptide: allele (best presenter in patient genotype), ic50_nM, processing_score, presentation_score, presentation_percentile, presentation_class |
+| `results/predictions/{patient_id}/mhc_presentation.tsv` | Best-allele prediction per peptide: allele (best presenter in patient genotype), ic50_nM, processing_score, presentation_score, presentation_percentile, presentation_class |
 | `results/predictions/{patient_id}/tcrdock/top_candidate.pdb` | Predicted TCR–peptide–MHC ternary complex (PDB) |
 | `results/predictions/{patient_id}/tcrdock/docking_scores.tsv` | TCRdock geometry metrics |
 | `results/reports/{patient_id}/report.html` | Summary HTML report with HLA QC and Mol\* viewer |

--- a/workflow/rules/analysis.smk
+++ b/workflow/rules/analysis.smk
@@ -11,7 +11,7 @@ def _generate_report_input(wildcards):
             _RES, wildcards.patient_id, "junctions", "novel_junctions.tsv"
         ),
         "predictions_tsv": os.path.join(
-            _RES, wildcards.patient_id, "predictions", "mhc_affinity.tsv"
+            _RES, wildcards.patient_id, "predictions", "mhc_presentation.tsv"
         ),
         "contigs_fasta": os.path.join(
             _RES, wildcards.patient_id, "contigs", "contigs.fa"

--- a/workflow/rules/mhc_affinity.smk
+++ b/workflow/rules/mhc_affinity.smk
@@ -51,8 +51,8 @@ rule run_mhcflurry:
     input:
         unpack(_run_mhcflurry_input),
     output:
-        mhc_affinity_tsv=os.path.join(
-            _RES, "{patient_id}", "predictions", "mhc_affinity.tsv"
+        mhc_presentation_tsv=os.path.join(
+            _RES, "{patient_id}", "predictions", "mhc_presentation.tsv"
         ),
     log:
         os.path.join(_LOGS, "{patient_id}", "mhc_affinity", "predict.log"),

--- a/workflow/rules/structure.smk
+++ b/workflow/rules/structure.smk
@@ -33,7 +33,7 @@ if _TCRDOCK_ENABLED:
         PDB structure and docking geometry scores.
         """
         input:
-            predictions_tsv=rules.run_mhcflurry.output.mhc_affinity_tsv,
+            predictions_tsv=rules.run_mhcflurry.output.mhc_presentation_tsv,
         output:
             pdb=os.path.join(
                 _RES, "{patient_id}", "predictions", "tcrdock", "top_candidate.pdb"

--- a/workflow/scripts/generate_report.py
+++ b/workflow/scripts/generate_report.py
@@ -10,7 +10,7 @@ Produces a self-contained HTML page showing:
 Usage (standalone):
   python generate_report.py \\
       --novel-junctions results/junctions/local/novel_junctions.tsv \\
-      --predictions results/predictions/local/mhc_affinity.tsv \\
+      --predictions results/predictions/local/mhc_presentation.tsv \\
       --output results/reports/local/report.html
 
 Usage (Snakemake):

--- a/workflow/scripts/run_mhcflurry.py
+++ b/workflow/scripts/run_mhcflurry.py
@@ -31,13 +31,13 @@ Output TSV columns:
 Usage (standalone, explicit alleles):
   python run_mhcflurry.py \\
       --peptides-tsv results/peptides/patient_001/peptides.tsv \\
-      --output results/predictions/patient_001/mhc_affinity.tsv \\
+      --output results/predictions/patient_001/mhc_presentation.tsv \\
       --alleles HLA-A*02:01 HLA-B*07:02 HLA-C*07:02
 
 Usage (standalone, alleles from HLA typing):
   python run_mhcflurry.py \\
       --peptides-tsv results/peptides/patient_001/peptides.tsv \\
-      --output results/predictions/patient_001/mhc_affinity.tsv \\
+      --output results/predictions/patient_001/mhc_presentation.tsv \\
       --alleles-tsv results/hla_typing/patient_001/alleles.tsv
 
 Usage (Snakemake):
@@ -368,7 +368,7 @@ def _snakemake_main() -> None:
     alleles_tsv = getattr(snakemake.input, "alleles_tsv", None)  # type: ignore[name-defined]  # noqa: F821
     run_prediction(
         peptides_tsv=snakemake.input.peptides_tsv,  # type: ignore[name-defined]  # noqa: F821
-        output_tsv=snakemake.output.mhc_affinity_tsv,  # type: ignore[name-defined]  # noqa: F821
+        output_tsv=snakemake.output.mhc_presentation_tsv,  # type: ignore[name-defined]  # noqa: F821
         alleles=None if alleles_tsv else list(snakemake.params.fallback_alleles),  # type: ignore[name-defined]  # noqa: F821
         alleles_tsv=alleles_tsv,
         presentation_percentile_strong=float(snakemake.params.presentation_percentile_strong),  # type: ignore[name-defined]  # noqa: F821

--- a/workflow/scripts/run_tcrdock.py
+++ b/workflow/scripts/run_tcrdock.py
@@ -39,7 +39,7 @@ Outputs
 
 Usage (standalone, Linux + GPU only):
   python run_tcrdock.py \\
-      --predictions-tsv results/predictions/local/mhc_affinity.tsv \\
+      --predictions-tsv results/predictions/local/mhc_presentation.tsv \\
       --output-pdb results/predictions/local/tcrdock/top_candidate.pdb \\
       --output-scores results/predictions/local/tcrdock/docking_scores.tsv
 

--- a/workflow/tests/test_integration.py
+++ b/workflow/tests/test_integration.py
@@ -140,27 +140,27 @@ class TestPeptides:
 
 class TestPredictions:
     def test_predictions_file_exists(self):
-        assert (RESULTS / "predictions" / "mhc_affinity.tsv").exists()
+        assert (RESULTS / "predictions" / "mhc_presentation.tsv").exists()
 
     def test_has_predictions(self):
-        rows = _read_tsv(RESULTS / "predictions" / "mhc_affinity.tsv")
+        rows = _read_tsv(RESULTS / "predictions" / "mhc_presentation.tsv")
         assert len(rows) > 0
 
     def test_presentation_classes_are_valid(self):
-        rows = _read_tsv(RESULTS / "predictions" / "mhc_affinity.tsv")
+        rows = _read_tsv(RESULTS / "predictions" / "mhc_presentation.tsv")
         if not rows or "presentation_class" not in rows[0]:
             pytest.skip("predictions use old schema — re-run pipeline to update")
         classes = {r["presentation_class"] for r in rows}
         assert classes <= VALID_PRESENTATION_CLASSES
 
     def test_ic50_values_are_positive(self):
-        rows = _read_tsv(RESULTS / "predictions" / "mhc_affinity.tsv")
+        rows = _read_tsv(RESULTS / "predictions" / "mhc_presentation.tsv")
         for r in rows:
             assert float(r["ic50_nM"]) > 0, f"Non-positive IC50: {r['ic50_nM']}"
 
     def test_all_predictions_have_required_columns(self):
-        rows = _read_tsv(RESULTS / "predictions" / "mhc_affinity.tsv")
-        assert rows, "mhc_affinity.tsv is empty"
+        rows = _read_tsv(RESULTS / "predictions" / "mhc_presentation.tsv")
+        assert rows, "mhc_presentation.tsv is empty"
         if "presentation_class" not in rows[0]:
             pytest.skip("predictions use old schema — re-run pipeline to update")
         required = {
@@ -171,7 +171,7 @@ class TestPredictions:
         assert required <= set(rows[0].keys())
 
     def test_strong_presentations_have_low_percentile(self):
-        rows = _read_tsv(RESULTS / "predictions" / "mhc_affinity.tsv")
+        rows = _read_tsv(RESULTS / "predictions" / "mhc_presentation.tsv")
         if not rows or "presentation_class" not in rows[0]:
             pytest.skip("predictions use old schema — re-run pipeline to update")
         for r in rows:
@@ -182,7 +182,7 @@ class TestPredictions:
                 )
 
     def test_non_presentations_have_high_percentile(self):
-        rows = _read_tsv(RESULTS / "predictions" / "mhc_affinity.tsv")
+        rows = _read_tsv(RESULTS / "predictions" / "mhc_presentation.tsv")
         if not rows or "presentation_class" not in rows[0]:
             pytest.skip("predictions use old schema — re-run pipeline to update")
         for r in rows:


### PR DESCRIPTION
## Summary

- Renames the MHCflurry output file from `mhc_affinity.tsv` → `mhc_presentation.tsv` to reflect that the output is from `Class1PresentationPredictor`, not `Class1AffinityPredictor`
- Renames the Snakemake output key `mhc_affinity_tsv` → `mhc_presentation_tsv` everywhere it is referenced
- Updates all downstream references: `analysis.smk`, `structure.smk`, `run_mhcflurry.py`, `generate_report.py`, `run_tcrdock.py`, `test_integration.py`, `METHODS.md`, `configuration.md`, `README.md`

Closes #115

## Test plan

- [x] All 25 integration tests pass (`pytest workflow/tests/test_integration.py -v`)
- [x] Existing test result file renamed (`results/patient_001_test/predictions/mhc_presentation.tsv`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)