### PR TITLE
feat(mhc): two-level MHC presentation prediction with genotype_presentation_score (Issue #119)

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -105,6 +105,8 @@ mhcflurry:
   # Percentile thresholds for presentation_class (lower = better, per allele).
   presentation_percentile_strong:  0.5   # top 0.5% by presentation score → strong
   presentation_percentile_weak:    2.0   # top 2.0% by presentation score → weak
+  # HLA-C weight in genotype_presentation_score formula (A/B = 1.0; C ≈ 0.5 surface density)
+  hla_c_weight:                    0.5
 
 # -----------------------------------------------------------------
 # TCRdock structural validation (Step 6 — optional, GPU required)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -82,9 +82,10 @@ mhcflurry:
   threads: 8                # cores reserved for TF/BLAS within the single genotype predict() call
   presentation_percentile_strong: 0.5   # top 0.5% → strong (Jiang et al. 2024)
   presentation_percentile_weak:   2.0   # top 2.0% → weak
+  hla_c_weight: 0.5         # weight for HLA-C in genotype_presentation_score (A/B = 1.0)
 ```
 
-`Class1PresentationPredictor.predict()` is called once with all patient alleles as a genotype (≤6). It returns one best-allele prediction per peptide — not one per peptide × allele. The `allele` column in `mhc_presentation.tsv` is the best presenter for that peptide across the patient's HLA-A/B/C genotype.
+`Class1PresentationPredictor.predict()` is called once with all patient alleles as a genotype (≤6) for best-allele predictions, then independently per allele to recover per-allele scores. The `best_allele` column in `mhc_presentation.tsv` is the best presenter for that peptide across the patient's HLA-A/B/C genotype. Per-allele scores are combined into `genotype_presentation_score` using the complementary-probability formula weighted by locus expression levels (`hla_c_weight` controls the HLA-C contribution; default 0.5 reflects ~50% lower surface density of HLA-C relative to HLA-A/B).
 
 ---
 

--- a/research/lab_notebook.md
+++ b/research/lab_notebook.md
@@ -4,6 +4,49 @@
 
 ## 2026-04-24
 
+### ~11:30 UTC
+
+#### Issue #119 — Allele breadth model: scientific design (Researcher session, branch `feat/issue-119-allele-breadth`)
+
+**Goal:** Develop and document the scientific rationale for a multi-allele breadth scoring
+model for `mhc_presentation.tsv`. No code changes — manuscript only.
+
+**Key scientific decisions:**
+
+- **Two-level architecture:** MHCflurry is a molecular-level predictor (one peptide × one
+  MHC allele → `presentation_score`). The breadth model is a separate genotype-level
+  combiner: `breadth_score = 1 − ∏(1 − wᵢ·pᵢ)`. These are distinct modelling layers.
+- **HLA-C weight:** enters at the genotype-combination level (surface density ~50% of
+  HLA-A/B), not at the molecular prediction level. Configurable (`w_C`, default 0.5).
+- **`presentation_score` in formula (not `presentation_percentile`):** `presentation_score`
+  is a calibrated absolute probability — the correct input for a complementary probability
+  formula. `presentation_percentile` is a rank statistic; using it would require an
+  arbitrary mapping. The two metrics can disagree (high breadth_score with all alleles in
+  non-binder percentile territory is possible for promiscuous alleles) — this is the
+  intended behaviour of the two-tier system.
+- **Committed ranking for cancer vaccine application:**
+  1. `breadth_score` — primary (multi-allele coverage, LOH robustness, vaccine slot efficiency)
+  2. `n_strong_alleles` — secondary (count of alleles at ≤ 0.5% percentile)
+  3. `best_presentation_percentile` — minimum quality gate only (not a ranking dimension);
+     filters candidates where no allele reaches weak-binder territory
+- **Immunodominance acknowledged but not dominant in vaccine context:** in natural
+  anti-tumour immunity, one very strong allele can dominate via intramolecular MHC groove
+  competition and immunodomination (Yewdell & Bennink, *Annu Rev Immunol* 1999; Chen &
+  McCluskey, *Adv Cancer Res* 2006). In therapeutic vaccination, immunodomination is largely
+  bypassed; HLA LOH and vaccine slot efficiency make breadth the primary criterion.
+
+**Manuscript changes (committed `c9d5eb3`, branch `feat/issue-119-allele-breadth`):**
+- `INTRODUCTION.md`: new section "HLA Genotype, Surface Expression, and Allele Breadth"
+- `DISCUSSIONS.md`: new section "Allele breadth and immunodominance: two complementary
+  ranking signals" (subsections: two-level architecture, immunodominance mechanisms,
+  vaccine application with committed table, calibration note)
+
+**METHODS.md:** not updated — Developer session responsibility after implementation.
+
+**Design spec for Developer session:** `memory/project_allele_breadth_design.md`
+
+---
+
 ### ~10:02 UTC
 
 #### Issue #115 — Rename `mhc_affinity.tsv` → `mhc_presentation.tsv` (PR #121, branch `feat/issue-115-rename-mhc-affinity-tsv`)

--- a/research/lab_notebook.md
+++ b/research/lab_notebook.md
@@ -4,6 +4,43 @@
 
 ## 2026-04-24
 
+### ~14:38 UTC
+
+#### Issue #119 — Two-level MHC presentation prediction: implementation (Developer session, PR #122, branch `feat/issue-119-allele-breadth`)
+
+**Goal:** Implement the allele breadth model designed in the Researcher session (~11:30 UTC) and open PR #122.
+
+**Done:**
+
+- Replaced `_compute_strong_alleles()` in `run_mhcflurry.py` with `_compute_per_allele_features()`: one `Class1PresentationPredictor.predict()` call per allele (single-element genotype list) to recover per-allele `presentation_score` and `presentation_percentile` discarded by the genotype API.
+- New `genotype_presentation_score` formula: `1 − ∏(1 − wᵢ·pᵢ)`, with `w(HLA-A) = w(HLA-B) = 1.0`, `w(HLA-C) = hla_c_weight` (default 0.5). New supporting columns: `n_strong_alleles`, `best_presentation_percentile`.
+- `allele` column renamed to `best_allele` throughout (`run_mhcflurry.py`, `generate_report.py`, `run_tcrdock.py`, tests).
+- Updated ranking in `generate_report.py` and `run_tcrdock.py`: GPS ↓ → `n_strong_alleles` ↓ → `best_presentation_percentile` ↑. Quality gate: `best_presentation_percentile > 2%` excluded from top-candidates list.
+- Added `mhcflurry.hla_c_weight: 0.5` to `config/config.yaml` and propagated through `mhc_affinity.smk` params.
+- `METHODS.md` Section 6 rewritten: two-level architecture, GPS formula in LaTeX, quality gate, ranking rule, full output column table.
+- `docs/configuration.md`: `hla_c_weight` documented with HLA-C surface density rationale.
+- Test suite: 186 passed, 1 skipped (stale integration pipeline output — schema-version skip guard added).
+
+**Key implementation detail:** The genotype API (`predict()` with all alleles at once) reports only the best-allele scores and silently discards all others. Per-allele scores must be recovered via separate single-allele calls. This dual-call design is why `_compute_per_allele_features` iterates over `resolved_alleles` individually.
+
+**Column name change mid-session:** `breadth_score` → `genotype_presentation_score` after Researcher consultation. All code, tests, and docs use the new name.
+
+**Local test run (chr22, patient_001_test):** Full pipeline completed. `mhc_presentation.tsv` has 24 columns (6 allele pairs + 3 breadth columns). Top hit: DVFGTPFSR / HLA-A\*33:03, GPS = 0.9996, best-allele percentile = 0.001%.
+
+**Commits (9, all on `feat/issue-119-allele-breadth`):**
+- `530ddfc` docs(manuscript): rename breadth_score → genotype_presentation_score
+- `a13fd30` feat(config): add mhcflurry.hla_c_weight config key and Snakemake param
+- `38b6ac8` feat(mhc): add per-allele genotype_presentation_score model (Issue #119)
+- `49b8e96` feat(report): update ranking to genotype_presentation_score, add quality gate
+- `b90c75d` feat(tcrdock): update candidate selection to genotype_presentation_score ranking
+- `291fd23` test(mhc): update tests for new output schema and add breadth feature tests
+- `3d8b903` test(report,tcrdock): update test data to best_allele; add breadth-aware tcrdock tests
+- `260da3a` test(integration): update required columns for new schema with skip guards
+- `f792ac1` docs(methods): update Section 6 for two-level MHC presentation prediction
+- `ac89bd2` docs(config): document hla_c_weight and update mhcflurry section
+
+---
+
 ### ~11:30 UTC
 
 #### Issue #119 — Allele breadth model: scientific design (Researcher session, branch `feat/issue-119-allele-breadth`)

--- a/research/lab_notebook.md
+++ b/research/lab_notebook.md
@@ -41,6 +41,43 @@
 
 ---
 
+### ~16:15 UTC
+
+#### Issue #119 — PR #122 review cycle (Developer session)
+
+**Reviewer comments (6):** stale docstring, GPS out-of-range clamping, hardcoded quality-gate threshold, GPS test gap in `generate_report.py`, hardcoded 9-mer `end_nt_incl`, misleading log message on quality-gate rejection.
+
+**Key design decisions made during review:**
+- `hla_c_weight` outside [0,1] → hard `ValueError` (own config, must be correct).
+- MHCflurry `presentation_score` outside [0,1] → warning only, no clamp (third-party output; out-of-range values cannot be reliably interpreted and should be fixed upstream).
+- "binder" → "presenter" terminology throughout `run_tcrdock.py` and tests.
+
+**Fix commits (8):**
+- `4366af0` fix(mhc): fix stale docstring and add hla_c_weight validation + score warning
+- `9f0b6c6` test(mhc): add tests for hla_c_weight validation and out-of-range score warning
+- `b73b27b` fix(rules): thread presentation_percentile_weak into report and tcrdock params
+- `94a480a` fix(report): replace hardcoded quality-gate 2.0 with configurable presentation_percentile_weak
+- `34f7aa5` fix(tcrdock): replace hardcoded quality-gate 2.0 with configurable presentation_percentile_weak
+- `1b08ebe` test(report): add GPS quality-gate and ranking tests for generate_report.py
+- `fe6e188` fix(report): compute end_nt_incl from peptide length instead of hardcoded 9-mer
+- `d0e7456` fix(tcrdock): distinguish no-presenters from quality-gate-empty in log messages
+
+**196 tests passing.** Re-review requested.
+
+---
+
+### ~16:42 UTC
+
+#### Issue #119 — PR #122 re-review fix + merge prep
+
+**Re-review verdict:** Ready to merge. Three minor observations: (1) `presentation_notes` strings in `_build_report_tsv` still hardcoded `"2%"` for `weak`/`non` entries despite `presentation_percentile_weak` parameter being available; (2) CLI parsers missing `--presentation-percentile-weak` flag; (3) `generate_report()` docstring missing the parameter.
+
+Fixed (1) now — `weak`/`non` entries converted to f-strings using `presentation_percentile_weak` (`18e1fac`). Items (2) and (3) deferred to follow-up issue.
+
+**29 tests passing** (generate_report suite).
+
+---
+
 ### ~11:30 UTC
 
 #### Issue #119 — Allele breadth model: scientific design (Researcher session, branch `feat/issue-119-allele-breadth`)

--- a/research/manuscript/DISCUSSIONS.md
+++ b/research/manuscript/DISCUSSIONS.md
@@ -245,3 +245,141 @@ Note: `affinity_percentile` is not included in the output because
 Obtaining it would require a second sequential call to `Class1AffinityPredictor`,
 doubling inference time with no gain — `presentation_percentile` already captures the
 affinity signal as part of the composite model.
+
+---
+
+## Allele breadth and immunodominance: two complementary ranking signals
+
+### MHCflurry as a molecular predictor: the need for a downstream genotype model
+
+MHCflurry operates at the molecular level: given one peptide and one MHC allele, it
+predicts the probability that this specific peptide–MHC pair results in surface
+presentation, integrating binding affinity with antigen processing efficiency
+(proteasomal cleavage, TAP transport) into a single `presentation_score`. This is a
+pairwise, molecule-level quantity. It does not model the patient's HLA genotype as a
+whole.
+
+The genotype-level convenience API (`Class1PresentationPredictor.predict()` with all
+alleles provided at once) runs this pairwise molecular prediction for each allele
+independently and returns a single best-allele attribution per peptide — the allele with
+the highest individual `presentation_score`. This is useful for identifying which allele
+is the primary presenter, but it is not a genotype-level biological model: it discards
+the real presentation events occurring simultaneously on the cell surface via all
+non-best alleles.
+
+The allele breadth model addresses exactly this gap. It operates at the genotype level,
+taking the per-allele molecular predictions from MHCflurry as inputs and combining them
+into a single estimate of the probability that at least one allele in the patient's full
+HLA genotype presents the peptide:
+
+```
+breadth_score = 1 − ∏ᵢ (1 − wᵢ × presentation_scoreᵢ)
+```
+
+This two-level architecture separates concerns cleanly: MHCflurry solves the molecular
+pairwise prediction problem; the breadth model solves the genotype-level combination
+problem. Crucially, the HLA-C locus weight (`wᵢ ≈ 0.5`) enters at the genotype level
+rather than the molecular level — HLA-C surface density is a property of how many
+molecules of each type are available on the cell, not a property of the individual
+peptide–MHC interaction that MHCflurry models.
+
+### Immunodominance as a structural limitation of breadth-only scoring
+
+The breadth score correctly captures the joint presentation probability across independent
+alleles. Different HLA alleles are entirely independent proteins with non-competing
+peptide-binding grooves, so each allele's contribution is additive and the complementary
+probability framework is exact. The score rises as additional alleles contribute and falls
+steeply when all alleles present the peptide poorly.
+
+A biologically relevant scenario reveals a structural limitation of this model. Consider
+a peptide with one exceptional allele (`presentation_score` p₁ = 0.9) and five weak
+alleles (p₂...₆ = 0.02). The breadth score is approximately 0.91. A second peptide with
+six moderate alleles (p = 0.5 each) scores approximately 0.98. The breadth model ranks
+the second peptide higher — yet in vivo the first may be far more immunologically potent.
+
+The mechanism is **immunodominance** (Yewdell & Bennink, *Annu Rev Immunol* 1999): the
+T cell response to a complex antigen is not flat across all possible epitopes but forms a
+strict hierarchy. Two independent mechanisms drive this:
+
+1. **Intramolecular competition.** Within a single allele, many peptides compete for the
+   limited pool of empty MHC class I grooves at the cell surface. A very high-affinity
+   peptide saturates the groove of its allele, generating a high density of stable,
+   long-lived pMHC complexes. T cell activation scales with pMHC surface density
+   (Valitutti et al., *Nature* 1995) and requires sustained TCR engagement above a
+   kinetic threshold (McKeithan, *PNAS* 1995). An allele with p₁ = 0.9 is therefore far
+   more likely to cross this activation threshold reliably than any individual weak allele.
+
+2. **Immunodomination.** Once a dominant T cell clone is activated and begins lysing
+   antigen-presenting cells (APCs), it can prevent those APCs from priming T cells
+   restricted to subdominant alleles (Chen & McCluskey, *Adv Cancer Res* 2006). The five
+   weak alleles in the scenario above do not directly compete with the dominant allele at
+   the MHC molecule level — their binding grooves are separate — but the dominant T cell
+   response can systemically suppress priming of subdominant clones by eliminating the
+   shared APC pool.
+
+The breadth score does not model either mechanism. Conversely, reporting only the
+best single-allele score (as in the original pipeline) ignores the genuine clinical
+benefit of multi-allele coverage: robustness to HLA loss of heterozygosity (LOH), broader
+T cell recruitment, and the ability to deliberately boost subdominant responses in a
+vaccine context.
+
+### Application to personalised cancer vaccine candidate selection
+
+This pipeline is designed for personalised cancer vaccination, which determines the
+committed role of each signal.
+
+In natural anti-tumour immunity, immunodomination enforces a strict epitope hierarchy:
+dominant T cell clones eliminate APCs before competing clones can be primed, and the
+resulting response is largely fixed by the tumour's antigen presentation dynamics. The
+dominance signal (`best_presentation_percentile`) is the more relevant lens in that
+context.
+
+In therapeutic vaccination, immunodomination is largely bypassed because each neoepitope
+is delivered as a discrete immunogen and T cell clones against each included epitope are
+primed independently. The degree of bypass depends on vaccine format: short direct-binding
+peptides, which compete with the endogenous peptidome for empty MHC grooves on APCs,
+achieve a more complete bypass of MHC-loading competition; mRNA vaccines re-enter
+intracellular antigen processing and are closer to the natural presentation pathway,
+partially restoring peptide competition for MHC grooves. In both formats, however, the
+APC-level suppression of subdominant T cell clones through cytotoxic killing is alleviated
+relative to natural immunity.
+
+Two further considerations commit personalised vaccine design to allele breadth as the
+primary ranking criterion:
+
+- **HLA LOH robustness.** Tumours under immune pressure — including vaccine-induced
+  pressure — frequently silence individual HLA alleles as an escape mechanism. A candidate
+  presented by multiple alleles remains targetable after partial HLA LOH; a single-allele
+  candidate may be rendered invisible by loss of that allele alone.
+- **Vaccine slot efficiency.** Personalised neoantigen vaccines include a limited number
+  of peptide candidates — typically 10–20 in current clinical trials (Sahin et al.,
+  *Nature* 2017; Ott et al., *Nature* 2017). Each slot should maximise coverage of the
+  patient's HLA genotype; `breadth_score` directly quantifies this.
+
+The committed role of each signal in this pipeline is therefore:
+
+| Signal | Role | Rationale |
+|--------|------|-----------|
+| `breadth_score` | **Primary ranking criterion** | Multi-allele coverage; LOH robustness; vaccine slot efficiency |
+| `n_strong_alleles` | **Secondary ranking criterion** | Number of alleles at clinically meaningful threshold; intuitive breadth summary |
+| `best_presentation_percentile` | **Minimum quality gate** | Ensures ≥1 allele generates sufficient pMHC density for T cell recognition at the tumour |
+
+`best_presentation_percentile` as a quality gate means a candidate is filtered out if no
+allele meets the weak-binder threshold (presentation_percentile ≤ 2%), regardless of its
+breadth_score — not used to rank candidates against one another.
+
+### Calibration note: presentation_score vs. presentation_percentile
+
+The `breadth_score` formula uses `presentation_score` (an absolute composite probability,
+0–1) as `pᵢ`, while the quality gate is defined via `presentation_percentile` (the rank
+of `presentation_score` among a large allele-specific random peptide set). These two
+metrics are calibrated on different scales and can disagree: for a promiscuous allele
+where many random peptides score well, a `presentation_score` of 0.4 may correspond to a
+`presentation_percentile` of 3–5% (non-binder territory). In such a case, six alleles
+each with `presentation_score = 0.4` would yield `breadth_score ≈ 0.95` while all alleles
+remain below the weak-binder percentile threshold. A peptide could therefore pass the
+`breadth_score` ranking stage but be eliminated by the quality gate — which is the
+intended behaviour, since the gate is designed to catch exactly this scenario. Future work
+could explore replacing `presentation_score` in the breadth formula with a calibrated
+transformation of `presentation_percentile` to achieve fully consistent allele-relative
+scoring throughout.

--- a/research/manuscript/DISCUSSIONS.md
+++ b/research/manuscript/DISCUSSIONS.md
@@ -267,35 +267,35 @@ is the primary presenter, but it is not a genotype-level biological model: it di
 the real presentation events occurring simultaneously on the cell surface via all
 non-best alleles.
 
-The allele breadth model addresses exactly this gap. It operates at the genotype level,
+The genotype presentation model addresses exactly this gap. It operates at the genotype level,
 taking the per-allele molecular predictions from MHCflurry as inputs and combining them
 into a single estimate of the probability that at least one allele in the patient's full
 HLA genotype presents the peptide:
 
 ```
-breadth_score = 1 − ∏ᵢ (1 − wᵢ × presentation_scoreᵢ)
+genotype_presentation_score = 1 − ∏ᵢ (1 − wᵢ × presentation_scoreᵢ)
 ```
 
 This two-level architecture separates concerns cleanly: MHCflurry solves the molecular
-pairwise prediction problem; the breadth model solves the genotype-level combination
-problem. Crucially, the HLA-C locus weight (`wᵢ ≈ 0.5`) enters at the genotype level
+pairwise prediction problem; the genotype presentation model solves the genotype-level
+combination problem. Crucially, the HLA-C locus weight (`wᵢ ≈ 0.5`) enters at the genotype level
 rather than the molecular level — HLA-C surface density is a property of how many
 molecules of each type are available on the cell, not a property of the individual
 peptide–MHC interaction that MHCflurry models.
 
 ### Immunodominance as a structural limitation of breadth-only scoring
 
-The breadth score correctly captures the joint presentation probability across independent
-alleles. Different HLA alleles are entirely independent proteins with non-competing
+The genotype presentation score correctly captures the joint presentation probability across
+independent alleles. Different HLA alleles are entirely independent proteins with non-competing
 peptide-binding grooves, so each allele's contribution is additive and the complementary
 probability framework is exact. The score rises as additional alleles contribute and falls
 steeply when all alleles present the peptide poorly.
 
 A biologically relevant scenario reveals a structural limitation of this model. Consider
 a peptide with one exceptional allele (`presentation_score` p₁ = 0.9) and five weak
-alleles (p₂...₆ = 0.02). The breadth score is approximately 0.91. A second peptide with
-six moderate alleles (p = 0.5 each) scores approximately 0.98. The breadth model ranks
-the second peptide higher — yet in vivo the first may be far more immunologically potent.
+alleles (p₂...₆ = 0.02). The genotype presentation score is approximately 0.91. A second
+peptide with six moderate alleles (p = 0.5 each) scores approximately 0.98. The genotype
+presentation model ranks the second peptide higher — yet in vivo the first may be far more immunologically potent.
 
 The mechanism is **immunodominance** (Yewdell & Bennink, *Annu Rev Immunol* 1999): the
 T cell response to a complex antigen is not flat across all possible epitopes but forms a
@@ -317,7 +317,7 @@ strict hierarchy. Two independent mechanisms drive this:
    response can systemically suppress priming of subdominant clones by eliminating the
    shared APC pool.
 
-The breadth score does not model either mechanism. Conversely, reporting only the
+The genotype presentation score does not model either mechanism. Conversely, reporting only the
 best single-allele score (as in the original pipeline) ignores the genuine clinical
 benefit of multi-allele coverage: robustness to HLA loss of heterozygosity (LOH), broader
 T cell recruitment, and the ability to deliberately boost subdominant responses in a
@@ -354,31 +354,32 @@ primary ranking criterion:
 - **Vaccine slot efficiency.** Personalised neoantigen vaccines include a limited number
   of peptide candidates — typically 10–20 in current clinical trials (Sahin et al.,
   *Nature* 2017; Ott et al., *Nature* 2017). Each slot should maximise coverage of the
-  patient's HLA genotype; `breadth_score` directly quantifies this.
+  patient's HLA genotype; `genotype_presentation_score` directly quantifies this.
 
 The committed role of each signal in this pipeline is therefore:
 
 | Signal | Role | Rationale |
 |--------|------|-----------|
-| `breadth_score` | **Primary ranking criterion** | Multi-allele coverage; LOH robustness; vaccine slot efficiency |
+| `genotype_presentation_score` | **Primary ranking criterion** | Multi-allele coverage; LOH robustness; vaccine slot efficiency |
 | `n_strong_alleles` | **Secondary ranking criterion** | Number of alleles at clinically meaningful threshold; intuitive breadth summary |
 | `best_presentation_percentile` | **Minimum quality gate** | Ensures ≥1 allele generates sufficient pMHC density for T cell recognition at the tumour |
 
 `best_presentation_percentile` as a quality gate means a candidate is filtered out if no
 allele meets the weak-binder threshold (presentation_percentile ≤ 2%), regardless of its
-breadth_score — not used to rank candidates against one another.
+genotype_presentation_score — not used to rank candidates against one another.
 
 ### Calibration note: presentation_score vs. presentation_percentile
 
-The `breadth_score` formula uses `presentation_score` (an absolute composite probability,
+The `genotype_presentation_score` formula uses `presentation_score` (an absolute composite probability,
 0–1) as `pᵢ`, while the quality gate is defined via `presentation_percentile` (the rank
 of `presentation_score` among a large allele-specific random peptide set). These two
 metrics are calibrated on different scales and can disagree: for a promiscuous allele
 where many random peptides score well, a `presentation_score` of 0.4 may correspond to a
 `presentation_percentile` of 3–5% (non-binder territory). In such a case, six alleles
-each with `presentation_score = 0.4` would yield `breadth_score ≈ 0.95` while all alleles
-remain below the weak-binder percentile threshold. A peptide could therefore pass the
-`breadth_score` ranking stage but be eliminated by the quality gate — which is the
+each with `presentation_score = 0.4` would yield `genotype_presentation_score ≈ 0.95`
+while all alleles remain below the weak-binder percentile threshold. A peptide could
+therefore pass the `genotype_presentation_score` ranking stage but be eliminated by the
+quality gate — which is the
 intended behaviour, since the gate is designed to catch exactly this scenario. Future work
 could explore replacing `presentation_score` in the breadth formula with a calibrated
 transformation of `presentation_percentile` to achieve fully consistent allele-relative

--- a/research/manuscript/DISCUSSIONS.md
+++ b/research/manuscript/DISCUSSIONS.md
@@ -285,17 +285,16 @@ peptide–MHC interaction that MHCflurry models.
 
 ### Immunodominance as a structural limitation of breadth-only scoring
 
-The genotype presentation score correctly captures the joint presentation probability across
-independent alleles. Different HLA alleles are entirely independent proteins with non-competing
+The genotype presentation score (GPS) correctly captures the joint presentation probability
+across independent alleles. Different HLA alleles are entirely independent proteins with non-competing
 peptide-binding grooves, so each allele's contribution is additive and the complementary
 probability framework is exact. The score rises as additional alleles contribute and falls
 steeply when all alleles present the peptide poorly.
 
 A biologically relevant scenario reveals a structural limitation of this model. Consider
 a peptide with one exceptional allele (`presentation_score` p₁ = 0.9) and five weak
-alleles (p₂...₆ = 0.02). The genotype presentation score is approximately 0.91. A second
-peptide with six moderate alleles (p = 0.5 each) scores approximately 0.98. The genotype
-presentation model ranks the second peptide higher — yet in vivo the first may be far more immunologically potent.
+alleles (p₂...₆ = 0.02). The GPS is approximately 0.91. A second peptide with six moderate alleles (p = 0.5 each)
+scores approximately 0.98. The genotype presentation model ranks the second peptide higher — yet in vivo the first may be far more immunologically potent.
 
 The mechanism is **immunodominance** (Yewdell & Bennink, *Annu Rev Immunol* 1999): the
 T cell response to a complex antigen is not flat across all possible epitopes but forms a
@@ -317,7 +316,7 @@ strict hierarchy. Two independent mechanisms drive this:
    response can systemically suppress priming of subdominant clones by eliminating the
    shared APC pool.
 
-The genotype presentation score does not model either mechanism. Conversely, reporting only the
+GPS does not model either mechanism. Conversely, reporting only the
 best single-allele score (as in the original pipeline) ignores the genuine clinical
 benefit of multi-allele coverage: robustness to HLA loss of heterozygosity (LOH), broader
 T cell recruitment, and the ability to deliberately boost subdominant responses in a

--- a/research/manuscript/INTRODUCTION.md
+++ b/research/manuscript/INTRODUCTION.md
@@ -69,7 +69,7 @@ discards biologically relevant information: a peptide that is presented at moder
 by all six of a patient's alleles may be a stronger immunotherapy target than a peptide
 presented at high affinity by only one.
 
-### Allele breadth as a ranking criterion
+### Genotype presentation score as a ranking criterion
 
 For a neoepitope to trigger a cytotoxic T cell response, at least one of the patient's HLA
 alleles must present it on the tumor cell surface. This is naturally framed as a
@@ -80,9 +80,9 @@ P(presented by ≥ 1 allele) = 1 − ∏ᵢ (1 − pᵢ)
 ```
 
 where `pᵢ` is the presentation probability for allele `i` (e.g. MHCflurry 2.x
-`presentation_score`). This breadth score rewards candidates that are broadly presented
-across the patient's genotype and rises steeply as additional alleles contribute, while
-each marginal allele at low affinity adds diminishing probability.
+`presentation_score`). This genotype presentation score rewards candidates that are broadly
+presented across the patient's genotype and rises steeply as additional alleles contribute,
+while each marginal allele at low affinity adds diminishing probability.
 
 Allele breadth is also clinically relevant beyond the initial ranking:
 
@@ -95,9 +95,9 @@ Allele breadth is also clinically relevant beyond the initial ranking:
   patient's repertoire.
 
 The integer count of alleles for which a peptide qualifies as a strong binder
-(`n_strong_alleles`) provides a secondary breadth signal: among peptides with equal
-breadth scores, a peptide classified as strong by three alleles is a biologically cleaner
-winner than one with one strong and five near-zero predictions.
+(`n_strong_alleles`) provides a secondary signal: among peptides with equal
+genotype presentation scores, a peptide classified as strong by three alleles is a
+biologically cleaner winner than one with one strong and five near-zero predictions.
 
 A complementary but distinct biological force is **immunodominance** — the well-documented
 hierarchy in which the strongest-binding epitope for the dominant allele tends to drive the
@@ -107,7 +107,7 @@ strong allele can elicit a more potent focused T cell response than a peptide wi
 breadth, through intramolecular competition of peptides for the available MHC grooves of
 that allele and through immunodomination — dominant T cell clones monopolising
 antigen-presenting cells and suppressing priming of clones restricted to weaker alleles
-(Chen & McCluskey, *Adv Cancer Res* 2006). The breadth score alone does not capture this.
+(Chen & McCluskey, *Adv Cancer Res* 2006). The genotype presentation score alone does not capture this.
 
 In the context of therapeutic cancer vaccination, however, immunodomination is largely
 bypassed: each neoepitope is delivered as a discrete immunogen, allowing independent
@@ -119,7 +119,7 @@ the APC — but the suppression of subdominant T cell clones through APC killing
 alleviated in either case. Combined with the threat of HLA loss of heterozygosity under
 immune pressure and the limited number of peptide slots in a personalised vaccine
 formulation (typically 10–20 candidates in current clinical trials; Sahin et al.,
-*Nature* 2017; Ott et al., *Nature* 2017), allele breadth becomes the committed primary
+*Nature* 2017; Ott et al., *Nature* 2017), the genotype presentation score becomes the committed primary
 ranking criterion for our application. `best_presentation_percentile` is retained not as a
 competing ranking dimension but as a minimum quality gate — at least one allele must reach
 strong or weak binder threshold to ensure sufficient pMHC density for vaccine-primed T
@@ -140,7 +140,7 @@ different expected surface densities depending on the allele's locus. Concretely
 HLA-C-restricted peptide predicted at the same score as an HLA-A-restricted peptide is
 expected to generate fewer pMHC complexes per cell and thus a lower T cell activation
 signal. Locus-level weights — HLA-A and HLA-B at 1.0, HLA-C at approximately 0.5 —
-scale the effective contribution of each allele to the breadth score. Within a locus,
+scale the effective contribution of each allele to the genotype presentation score. Within a locus,
 expression differences between individual alleles are comparatively small and are not
 captured by current predictors; intra-locus alleles are therefore weighted equally. The
 HLA-C weight is treated as a configurable parameter, as published estimates of the

--- a/research/manuscript/INTRODUCTION.md
+++ b/research/manuscript/INTRODUCTION.md
@@ -58,6 +58,96 @@ The reimplementation updates the toolchain to current standards:
 
 ---
 
+## HLA Genotype, Surface Expression, and Allele Breadth
+
+Each individual carries up to six HLA class I alleles — two from each of the HLA-A, HLA-B,
+and HLA-C loci — that are co-dominantly expressed on the surface of nucleated cells,
+including tumor cells. Each allele independently samples the intracellular peptide pool and
+presents a distinct but overlapping repertoire of peptides to CD8+ T cells. A neoepitope
+prediction pipeline that reports only the single best-scoring allele per peptide therefore
+discards biologically relevant information: a peptide that is presented at moderate affinity
+by all six of a patient's alleles may be a stronger immunotherapy target than a peptide
+presented at high affinity by only one.
+
+### Allele breadth as a ranking criterion
+
+For a neoepitope to trigger a cytotoxic T cell response, at least one of the patient's HLA
+alleles must present it on the tumor cell surface. This is naturally framed as a
+complementary probability:
+
+```
+P(presented by ≥ 1 allele) = 1 − ∏ᵢ (1 − pᵢ)
+```
+
+where `pᵢ` is the presentation probability for allele `i` (e.g. MHCflurry 2.x
+`presentation_score`). This breadth score rewards candidates that are broadly presented
+across the patient's genotype and rises steeply as additional alleles contribute, while
+each marginal allele at low affinity adds diminishing probability.
+
+Allele breadth is also clinically relevant beyond the initial ranking:
+
+- **Robustness to HLA loss of heterozygosity (LOH).** Tumors frequently downregulate or
+  delete individual HLA alleles as an immune evasion mechanism. A neoepitope presented by
+  multiple alleles remains visible to the immune system even if one allele is silenced.
+- **Broader T cell recruitment.** Each HLA allele constitutes an independent antigen
+  presentation pathway that can prime a distinct T cell clone. A peptide presented by
+  three alleles has three independent opportunities to engage a cognate T cell in the
+  patient's repertoire.
+
+The integer count of alleles for which a peptide qualifies as a strong binder
+(`n_strong_alleles`) provides a secondary breadth signal: among peptides with equal
+breadth scores, a peptide classified as strong by three alleles is a biologically cleaner
+winner than one with one strong and five near-zero predictions.
+
+A complementary but distinct biological force is **immunodominance** — the well-documented
+hierarchy in which the strongest-binding epitope for the dominant allele tends to drive the
+T cell response while weaker epitopes become subdominant or cryptic (Yewdell & Bennink,
+*Annu Rev Immunol* 1999). In natural anti-tumour immunity, a peptide with one exceptionally
+strong allele can elicit a more potent focused T cell response than a peptide with moderate
+breadth, through intramolecular competition of peptides for the available MHC grooves of
+that allele and through immunodomination — dominant T cell clones monopolising
+antigen-presenting cells and suppressing priming of clones restricted to weaker alleles
+(Chen & McCluskey, *Adv Cancer Res* 2006). The breadth score alone does not capture this.
+
+In the context of therapeutic cancer vaccination, however, immunodomination is largely
+bypassed: each neoepitope is delivered as a discrete immunogen, allowing independent
+priming of T cell clones without the APC-level competition that enforces immunodominance
+in natural immunity. The degree of bypass depends on vaccine format — short peptides
+competing directly with the endogenous peptidome for empty MHC grooves achieve a more
+complete bypass than mRNA vaccines, which re-enter intracellular antigen processing inside
+the APC — but the suppression of subdominant T cell clones through APC killing is
+alleviated in either case. Combined with the threat of HLA loss of heterozygosity under
+immune pressure and the limited number of peptide slots in a personalised vaccine
+formulation (typically 10–20 candidates in current clinical trials; Sahin et al.,
+*Nature* 2017; Ott et al., *Nature* 2017), allele breadth becomes the committed primary
+ranking criterion for our application. `best_presentation_percentile` is retained not as a
+competing ranking dimension but as a minimum quality gate — at least one allele must reach
+strong or weak binder threshold to ensure sufficient pMHC density for vaccine-primed T
+cells to recognise the tumour at the site of disease.
+
+### Differential surface expression across HLA loci
+
+HLA-A and HLA-B are expressed at broadly similar surface densities. HLA-C is
+constitutively expressed at approximately 10–50% of HLA-A/B levels across most cell types
+(Zemmour & Parham 1992; Trolle et al. 2016). Two mechanisms contribute: HLA-C has lower
+intrinsic affinity for β2-microglobulin, reducing pMHC complex stability, and HLA-C
+allotypes serve as ligands for killer immunoglobulin-like receptors (KIRs) on NK cells,
+with lower surface expression reflecting a balance between NK regulation and CD8+ T cell
+priming.
+
+For neoepitope ranking, this means that equivalent `presentation_score` values carry
+different expected surface densities depending on the allele's locus. Concretely, an
+HLA-C-restricted peptide predicted at the same score as an HLA-A-restricted peptide is
+expected to generate fewer pMHC complexes per cell and thus a lower T cell activation
+signal. Locus-level weights — HLA-A and HLA-B at 1.0, HLA-C at approximately 0.5 —
+scale the effective contribution of each allele to the breadth score. Within a locus,
+expression differences between individual alleles are comparatively small and are not
+captured by current predictors; intra-locus alleles are therefore weighted equally. The
+HLA-C weight is treated as a configurable parameter, as published estimates of the
+HLA-A/B:HLA-C expression ratio vary across cell types and between studies.
+
+---
+
 ## Study Design
 
 This pipeline is applied to matched tumor/normal RNA-seq pairs where available. The matched

--- a/research/manuscript/INTRODUCTION.md
+++ b/research/manuscript/INTRODUCTION.md
@@ -80,7 +80,7 @@ P(presented by ≥ 1 allele) = 1 − ∏ᵢ (1 − pᵢ)
 ```
 
 where `pᵢ` is the presentation probability for allele `i` (e.g. MHCflurry 2.x
-`presentation_score`). This genotype presentation score rewards candidates that are broadly
+`presentation_score`). This genotype presentation score (GPS) rewards candidates that are broadly
 presented across the patient's genotype and rises steeply as additional alleles contribute,
 while each marginal allele at low affinity adds diminishing probability.
 
@@ -96,7 +96,7 @@ Allele breadth is also clinically relevant beyond the initial ranking:
 
 The integer count of alleles for which a peptide qualifies as a strong binder
 (`n_strong_alleles`) provides a secondary signal: among peptides with equal
-genotype presentation scores, a peptide classified as strong by three alleles is a
+GPS, a peptide classified as strong by three alleles is a
 biologically cleaner winner than one with one strong and five near-zero predictions.
 
 A complementary but distinct biological force is **immunodominance** — the well-documented
@@ -107,7 +107,7 @@ strong allele can elicit a more potent focused T cell response than a peptide wi
 breadth, through intramolecular competition of peptides for the available MHC grooves of
 that allele and through immunodomination — dominant T cell clones monopolising
 antigen-presenting cells and suppressing priming of clones restricted to weaker alleles
-(Chen & McCluskey, *Adv Cancer Res* 2006). The genotype presentation score alone does not capture this.
+(Chen & McCluskey, *Adv Cancer Res* 2006). GPS alone does not capture this.
 
 In the context of therapeutic cancer vaccination, however, immunodomination is largely
 bypassed: each neoepitope is delivered as a discrete immunogen, allowing independent
@@ -119,7 +119,7 @@ the APC — but the suppression of subdominant T cell clones through APC killing
 alleviated in either case. Combined with the threat of HLA loss of heterozygosity under
 immune pressure and the limited number of peptide slots in a personalised vaccine
 formulation (typically 10–20 candidates in current clinical trials; Sahin et al.,
-*Nature* 2017; Ott et al., *Nature* 2017), the genotype presentation score becomes the committed primary
+*Nature* 2017; Ott et al., *Nature* 2017), GPS becomes the committed primary
 ranking criterion for our application. `best_presentation_percentile` is retained not as a
 competing ranking dimension but as a minimum quality gate — at least one allele must reach
 strong or weak binder threshold to ensure sufficient pMHC density for vaccine-primed T
@@ -140,7 +140,7 @@ different expected surface densities depending on the allele's locus. Concretely
 HLA-C-restricted peptide predicted at the same score as an HLA-A-restricted peptide is
 expected to generate fewer pMHC complexes per cell and thus a lower T cell activation
 signal. Locus-level weights — HLA-A and HLA-B at 1.0, HLA-C at approximately 0.5 —
-scale the effective contribution of each allele to the genotype presentation score. Within a locus,
+scale the effective contribution of each allele to the GPS. Within a locus,
 expression differences between individual alleles are comparatively small and are not
 captured by current predictors; intra-locus alleles are therefore weighted equally. The
 HLA-C weight is treated as a configurable parameter, as published estimates of the

--- a/research/manuscript/METHODS.md
+++ b/research/manuscript/METHODS.md
@@ -136,34 +136,63 @@ chimeric codon rationale.
 
 ---
 
-## 6. MHC Binding Prediction
+## 6. MHC Presentation Prediction
 
+Scoring proceeds in two levels.
+
+**Level 1 — molecular prediction (MHCflurry).**
 Junction-spanning peptides are scored using MHCflurry 2.x `Class1PresentationPredictor`,
 a composite model that integrates MHC class I binding affinity with antigen processing
-predictions (proteasomal cleavage, TAP transport). `Class1PresentationPredictor.predict()`
-accepts the full patient HLA genotype (all HLA-A/B/C alleles at once, ≤6) and returns one
-best-allele prediction per peptide — the allele with the highest presentation score for
-that peptide. This is the predictor's intended genotype-level API; it is not a per-allele
-loop.
+predictions (proteasomal cleavage, TAP transport). The predictor is called once with the
+full patient HLA genotype (all HLA-A/B/C alleles, ≤6) to obtain the best-allele
+prediction per peptide, and then called independently for each allele (one-allele genotype)
+to obtain per-allele `presentation_score` and `presentation_percentile`. This dual-call
+design is required because the genotype API reports only the best allele and discards scores
+for the remaining alleles; the per-allele calls recover those scores.
 
-Each prediction row contains four informative scores:
+Each prediction row contains the following scores:
 
 | Column | Description |
 |---|---|
+| `best_allele` | Allele with the highest presentation score in the patient genotype |
 | `ic50_nM` | Binding affinity (nM); informational |
 | `processing_score` | Predicted antigen processing efficiency (0–1) |
-| `presentation_score` | Composite presentation probability (0–1); integrates affinity + processing |
-| `presentation_percentile` | Percentile rank of presentation_score among random peptides for that allele |
+| `presentation_score` | Composite presentation probability (0–1) for the best allele |
+| `presentation_percentile` | Percentile rank of presentation_score for the best allele |
+| `{allele}_presentation_score` | Per-allele presentation probability (one column per allele) |
+| `{allele}_presentation_percentile` | Per-allele percentile rank (one column per allele) |
 
 Peptides are assigned a single classification label based on `presentation_percentile`
-(lower = better, per allele):
+(lower = better, best allele):
 
 - **`presentation_class`** — strong (≤ 0.5%), weak (≤ 2%), non (> 2%)
 
 The 0.5% threshold is consistent with Jiang et al. (2024, *Communications Biology*)
 and analogous to the conventional IC50 ≤ 50 nM cutoff.
 
-Epitopes are ranked in the output report by `presentation_percentile` (ascending).
+**Level 2 — genotype presentation score.**
+Per-allele scores are combined into a single genotype-level probability using a
+complementary-probability formula:
+
+$$\text{genotype\_presentation\_score} = 1 - \prod_{i} \left(1 - w_i \cdot p_i\right)$$
+
+where $p_i$ is the `presentation_score` of allele $i$ and $w_i$ is a locus weight
+($w_{\text{HLA-A}} = w_{\text{HLA-B}} = 1.0$; $w_{\text{HLA-C}} = 0.5$ by default,
+reflecting ~50% lower surface density of HLA-C relative to HLA-A/B (van Bergen et al.,
+2004)). The HLA-C weight is configurable via `config.mhcflurry.hla_c_weight`.
+
+Two supporting statistics are also computed:
+
+- **`n_strong_alleles`** — number of alleles with `presentation_percentile` ≤ 0.5%
+- **`best_presentation_percentile`** — minimum `presentation_percentile` across all alleles
+
+**Ranking and quality gate.**
+Candidates are ranked by `genotype_presentation_score` (descending) as the primary signal,
+with `n_strong_alleles` (descending) as a secondary tie-breaker and
+`best_presentation_percentile` (ascending) as a tertiary tie-breaker. A candidate is
+excluded from the top-candidates list if `best_presentation_percentile > 2%` (no allele
+reaches weak-binder threshold), providing a quality gate against high-GPS candidates
+composed entirely of non-binding alleles.
 
 ---
 
@@ -190,7 +219,7 @@ visualisation via Mol\* 4.x.
 | `results/hla_typing/{patient_id}/hla_qc.tsv` | Per-locus source, read counts, discrepancies |
 | `results/junctions/{patient_id}/novel_junctions.tsv` | All unannotated junctions with origin labels |
 | `results/peptides/{patient_id}/peptides.tsv` | Junction-spanning 9-mers (contig_key, start_nt, peptide) |
-| `results/predictions/{patient_id}/mhc_presentation.tsv` | Best-allele prediction per peptide: allele (best presenter in patient genotype), ic50_nM, processing_score, presentation_score, presentation_percentile, presentation_class |
+| `results/predictions/{patient_id}/mhc_presentation.tsv` | Per-peptide MHC presentation predictions: best_allele, ic50_nM, processing_score, presentation_score, presentation_percentile, presentation_class, per-allele presentation_score / presentation_percentile columns, genotype_presentation_score, n_strong_alleles, best_presentation_percentile |
 | `results/predictions/{patient_id}/tcrdock/top_candidate.pdb` | Predicted TCR–peptide–MHC ternary complex (PDB) |
 | `results/predictions/{patient_id}/tcrdock/docking_scores.tsv` | TCRdock geometry metrics |
 | `results/reports/{patient_id}/report.html` | Summary HTML report with HLA QC and Mol\* viewer |

--- a/workflow/rules/analysis.smk
+++ b/workflow/rules/analysis.smk
@@ -43,6 +43,7 @@ rule generate_report:
         os.path.join(_LOGS, "{patient_id}", "analysis", "report.log"),
     params:
         presentation_percentile_strong=config["mhcflurry"]["presentation_percentile_strong"],
+        presentation_percentile_weak=config["mhcflurry"]["presentation_percentile_weak"],
     conda:
         "../envs/python.yaml"
     script:

--- a/workflow/rules/mhc_affinity.smk
+++ b/workflow/rules/mhc_affinity.smk
@@ -42,10 +42,9 @@ rule download_mhcflurry_models:
 
 
 rule run_mhcflurry:
-    """Run MHCflurry 2.x on junction-spanning 9-mers.
-    Output: TSV with columns: contig_key, start_nt, peptide, allele, ic50_nM,
-            processing_score, presentation_score, presentation_percentile,
-            presentation_class (strong / weak / non).
+    """Run MHCflurry 2.x on junction-spanning peptides.
+    Output: TSV with per-allele presentation scores plus genotype_presentation_score,
+            n_strong_alleles, and best_presentation_percentile.
     When hla.enabled is true, predictions are run for all patient-specific
     alleles from alleles.tsv. Otherwise mhcflurry.fallback_alleles are used."""
     input:
@@ -61,6 +60,7 @@ rule run_mhcflurry:
         fallback_alleles=list(config["mhcflurry"]["fallback_alleles"].values()),
         presentation_percentile_strong=config["mhcflurry"]["presentation_percentile_strong"],
         presentation_percentile_weak=config["mhcflurry"]["presentation_percentile_weak"],
+        hla_c_weight=config["mhcflurry"]["hla_c_weight"],
     threads: config["mhcflurry"]["threads"]
     conda:
         "../envs/python.yaml"

--- a/workflow/rules/structure.smk
+++ b/workflow/rules/structure.smk
@@ -27,7 +27,8 @@ if _TCRDOCK_ENABLED:
     rule run_tcrdock:
         """Run TCRdock on the top strong-binding neoepitope candidate.
 
-        Selects the top N candidates by IC50 from MHCflurry predictions,
+        Selects the top N candidates ranked by genotype_presentation_score
+        (quality-gated by presentation_percentile_weak) from MHCflurry predictions,
         builds a TCRdock input TSV using the configured (or fallback) HLA
         allele and TCR sequences, runs TCRdock, and writes the predicted
         PDB structure and docking geometry scores.
@@ -48,6 +49,7 @@ if _TCRDOCK_ENABLED:
             docker_image=config["tcrdock"]["docker_image"],
             fallback_hla=config["tcrdock"]["fallback_hla"],
             fallback_tcr=config["tcrdock"]["fallback_tcr"],
+            presentation_percentile_weak=config["mhcflurry"]["presentation_percentile_weak"],
         conda:
             "../envs/python.yaml"
         script:
@@ -75,6 +77,7 @@ if _TCRDOCK_ENABLED:
             os.path.join(_LOGS, "{patient_id}", "structure", "report.log"),
         params:
             presentation_percentile_strong=config["mhcflurry"]["presentation_percentile_strong"],
+            presentation_percentile_weak=config["mhcflurry"]["presentation_percentile_weak"],
         conda:
             "../envs/python.yaml"
         script:

--- a/workflow/scripts/generate_report.py
+++ b/workflow/scripts/generate_report.py
@@ -582,8 +582,8 @@ def _build_report_tsv(
         })
         presentation_notes = {
             "strong": f"presentation_percentile <= {presentation_percentile_strong}%",
-            "weak": "presentation_percentile <= 2%",
-            "non": "presentation_percentile > 2%",
+            "weak": f"presentation_percentile <= {presentation_percentile_weak}%",
+            "non": f"presentation_percentile > {presentation_percentile_weak}%",
         }
         for cls, cnt in pred_df["presentation_class"].value_counts().items():
             rows.append({

--- a/workflow/scripts/generate_report.py
+++ b/workflow/scripts/generate_report.py
@@ -426,7 +426,7 @@ def _build_strong_table_html(
     for _, row in strong_df.head(max_rows).iterrows():
         contig_key = row["contig_key"]
         start_nt = int(row["start_nt"])
-        end_nt_incl = start_nt + 26  # 9 aa × 3 nt − 1
+        end_nt_incl = start_nt + len(row["peptide"]) * 3 - 1
 
         seq = contigs.get(contig_key, "")
         contig_html = _render_contig(seq, start_nt, end_nt_incl, upstream_nt) if seq else "<em>n/a</em>"

--- a/workflow/scripts/generate_report.py
+++ b/workflow/scripts/generate_report.py
@@ -400,13 +400,14 @@ def _build_strong_table_html(
     contigs: dict[str, str],
     upstream_nt: int = 26,
     max_rows: int = 50,
+    presentation_percentile_weak: float = 2.0,
 ) -> str:
     """Build the top strong presentations table ranked by genotype_presentation_score."""
     strong_df = pred_df[pred_df["presentation_class"] == "strong"].copy()
 
-    # Quality gate: at least one allele must reach weak-binder threshold (≤ 2%)
+    # Quality gate: at least one allele must reach weak-binder threshold
     if "best_presentation_percentile" in strong_df.columns:
-        strong_df = strong_df[strong_df["best_presentation_percentile"] <= 2.0]
+        strong_df = strong_df[strong_df["best_presentation_percentile"] <= presentation_percentile_weak]
 
     if strong_df.empty:
         return "<p><em>No strong presentations found.</em></p>"
@@ -482,7 +483,7 @@ def _df_to_html(df: pd.DataFrame, max_rows: int = 100) -> str:
 # Report generation
 # ---------------------------------------------------------------------------
 
-def _build_structure_section(pdb_path: Path, pred_df: pd.DataFrame) -> str:
+def _build_structure_section(pdb_path: Path, pred_df: pd.DataFrame, presentation_percentile_weak: float = 2.0) -> str:
     """Build the Mol* 3D viewer section for the top TCRdock candidate.
 
     The PDB is inlined as a JSON string so the HTML report is fully
@@ -506,7 +507,7 @@ def _build_structure_section(pdb_path: Path, pred_df: pd.DataFrame) -> str:
     # genotype_presentation_score desc → n_strong_alleles desc → best_presentation_percentile asc.
     binders = pred_df[pred_df["presentation_class"].isin(("strong", "weak"))].copy()
     if "best_presentation_percentile" in binders.columns:
-        binders = binders[binders["best_presentation_percentile"] <= 2.0]
+        binders = binders[binders["best_presentation_percentile"] <= presentation_percentile_weak]
     if "genotype_presentation_score" in binders.columns:
         binders = binders.sort_values(
             ["genotype_presentation_score", "n_strong_alleles", "best_presentation_percentile"],
@@ -552,6 +553,7 @@ def _build_report_tsv(
     output_tsv: str | Path,
     presentation_percentile_strong: float,
     tcrdock_pdb: str | Path | None,
+    presentation_percentile_weak: float = 2.0,
 ) -> None:
     """Write a structured summary TSV alongside the HTML report.
 
@@ -594,7 +596,7 @@ def _build_report_tsv(
     if not pred_df.empty:
         top_candidates = pred_df[pred_df["presentation_class"].isin(["strong", "weak"])].copy()
         if "best_presentation_percentile" in top_candidates.columns:
-            top_candidates = top_candidates[top_candidates["best_presentation_percentile"] <= 2.0]
+            top_candidates = top_candidates[top_candidates["best_presentation_percentile"] <= presentation_percentile_weak]
         if "genotype_presentation_score" in top_candidates.columns:
             top_candidates = top_candidates.sort_values(
                 ["genotype_presentation_score", "n_strong_alleles", "best_presentation_percentile"],
@@ -667,6 +669,7 @@ def generate_report(
     contigs_fasta: str | Path | None = None,
     hla_qc_tsv: str | None = None,
     presentation_percentile_strong: float = 0.5,
+    presentation_percentile_weak: float = 2.0,
     tcrdock_pdb: str | Path | None = None,
     output_tsv: str | Path | None = None,
     patient_id: str = "",
@@ -724,14 +727,14 @@ def generate_report(
     if pred_df.empty:
         strong_html = "<p><em>No predictions available.</em></p>"
     else:
-        strong_html = _build_strong_table_html(pred_df, contigs)
+        strong_html = _build_strong_table_html(pred_df, contigs, presentation_percentile_weak=presentation_percentile_weak)
 
     # --- HLA typing section (optional) ---
     hla_section = _build_hla_section(hla_qc_tsv) if hla_qc_tsv else ""
 
     # --- TCRdock 3D structure viewer (optional) ---
     if tcrdock_pdb is not None and Path(tcrdock_pdb).exists():
-        structure_section = _build_structure_section(Path(tcrdock_pdb), pred_df)
+        structure_section = _build_structure_section(Path(tcrdock_pdb), pred_df, presentation_percentile_weak=presentation_percentile_weak)
     else:
         structure_section = ""
 
@@ -768,6 +771,7 @@ def generate_report(
             output_tsv=output_tsv,
             presentation_percentile_strong=presentation_percentile_strong,
             tcrdock_pdb=tcrdock_pdb,
+            presentation_percentile_weak=presentation_percentile_weak,
         )
 
 
@@ -786,6 +790,7 @@ def _snakemake_main() -> None:
         contigs_fasta=snakemake.input.contigs_fasta,  # type: ignore[name-defined]  # noqa: F821
         hla_qc_tsv=getattr(snakemake.input, "hla_qc", None),  # type: ignore[name-defined]  # noqa: F821
         presentation_percentile_strong=float(snakemake.params.presentation_percentile_strong),  # type: ignore[name-defined]  # noqa: F821
+        presentation_percentile_weak=float(snakemake.params.presentation_percentile_weak),  # type: ignore[name-defined]  # noqa: F821
         tcrdock_pdb=getattr(snakemake.input, "pdb", None),  # type: ignore[name-defined]  # noqa: F821
         output_tsv=snakemake.output.report_tsv,  # type: ignore[name-defined]  # noqa: F821
         patient_id=snakemake.wildcards.patient_id,  # type: ignore[name-defined]  # noqa: F821

--- a/workflow/scripts/generate_report.py
+++ b/workflow/scripts/generate_report.py
@@ -401,13 +401,25 @@ def _build_strong_table_html(
     upstream_nt: int = 26,
     max_rows: int = 50,
 ) -> str:
-    """Build the top strong presentations table sorted by presentation_percentile."""
-    strong_df = (
-        pred_df[pred_df["presentation_class"] == "strong"]
-        .sort_values("presentation_percentile")
-    )
+    """Build the top strong presentations table ranked by genotype_presentation_score."""
+    strong_df = pred_df[pred_df["presentation_class"] == "strong"].copy()
+
+    # Quality gate: at least one allele must reach weak-binder threshold (≤ 2%)
+    if "best_presentation_percentile" in strong_df.columns:
+        strong_df = strong_df[strong_df["best_presentation_percentile"] <= 2.0]
+
     if strong_df.empty:
         return "<p><em>No strong presentations found.</em></p>"
+
+    # Ranking: genotype_presentation_score desc → n_strong_alleles desc → best_presentation_percentile asc
+    has_breadth_cols = "genotype_presentation_score" in strong_df.columns
+    if has_breadth_cols:
+        strong_df = strong_df.sort_values(
+            ["genotype_presentation_score", "n_strong_alleles", "best_presentation_percentile"],
+            ascending=[False, False, True],
+        )
+    else:
+        strong_df = strong_df.sort_values("presentation_percentile")
 
     rows = []
     for _, row in strong_df.head(max_rows).iterrows():
@@ -418,12 +430,17 @@ def _build_strong_table_html(
         seq = contigs.get(contig_key, "")
         contig_html = _render_contig(seq, start_nt, end_nt_incl, upstream_nt) if seq else "<em>n/a</em>"
 
+        gps_cell = (
+            f"<td>{row['genotype_presentation_score']:.4f}</td>"
+            if has_breadth_cols else ""
+        )
         rows.append(
             f"<tr>"
             f"<td>{html_mod.escape(str(row['contig_key']))}</td>"
             f"<td>{html_mod.escape(str(row['peptide']))}</td>"
-            f"<td>{html_mod.escape(str(row['allele']))}</td>"
+            f"<td>{html_mod.escape(str(row['best_allele']))}</td>"
             f"<td>{row['presentation_percentile']:.3f}</td>"
+            f"{gps_cell}"
             f"<td>{row['ic50_nM']:.1f}</td>"
             f"<td>{contig_html}</td>"
             f"</tr>"
@@ -434,10 +451,15 @@ def _build_strong_table_html(
         "<span class='nt-pep-up'>peptide (upstream)</span> "
         "<span class='nt-pep-down'>peptide (downstream)</span>"
     )
+    gps_header = (
+        "<th title='Probability ≥1 genotype allele presents peptide — primary rank'>GPS ▾</th>"
+        if has_breadth_cols else ""
+    )
     table = (
         f"<table><thead><tr>"
-        f"<th>Source</th><th>Peptide</th><th>Allele</th>"
-        f"<th title='Presentation percentile rank — lower is better'>Pres. %ile ▾</th>"
+        f"<th>Source</th><th>Peptide</th><th>Best Allele</th>"
+        f"<th title='Best-allele presentation percentile rank'>Best-allele %ile</th>"
+        f"{gps_header}"
         f"<th title='Binding affinity in nM — informational'>IC50 (nM)</th>"
         f"<th>Contig ({legend})</th>"
         f"</tr></thead><tbody>{''.join(rows)}</tbody></table>"
@@ -480,15 +502,24 @@ def _build_structure_section(pdb_path: Path, pred_df: pd.DataFrame) -> str:
         return "<p><em>Structure not available.</em></p>"
 
     # Annotate with the top candidate's peptide and allele.
-    # Match run_tcrdock.py's candidate selection: best strong binder, falling
-    # back to weak. Exclude non-binders to stay in sync.
-    binders = pred_df[pred_df["presentation_class"].isin(("strong", "weak"))]
-    top = binders.sort_values("presentation_percentile").head(1)
+    # Match run_tcrdock.py's candidate selection: quality-gated binders ranked by
+    # genotype_presentation_score desc → n_strong_alleles desc → best_presentation_percentile asc.
+    binders = pred_df[pred_df["presentation_class"].isin(("strong", "weak"))].copy()
+    if "best_presentation_percentile" in binders.columns:
+        binders = binders[binders["best_presentation_percentile"] <= 2.0]
+    if "genotype_presentation_score" in binders.columns:
+        binders = binders.sort_values(
+            ["genotype_presentation_score", "n_strong_alleles", "best_presentation_percentile"],
+            ascending=[False, False, True],
+        )
+    else:
+        binders = binders.sort_values("presentation_percentile")
+    top = binders.head(1)
     if top.empty:
         peptide, allele = "NA", "NA"
     else:
         peptide = html_mod.escape(str(top.iloc[0]["peptide"]))
-        allele  = html_mod.escape(str(top.iloc[0]["allele"]))
+        allele  = html_mod.escape(str(top.iloc[0]["best_allele"]))
 
     pdb_text = _build_compnd_records(pdb_text, peptide, allele)
 
@@ -560,23 +591,37 @@ def _build_report_tsv(
             })
 
     # --- top_candidate ---
-    strong_df = (
-        pred_df[pred_df["presentation_class"].isin(["strong", "weak"])]
-        .sort_values("presentation_percentile")
-        if not pred_df.empty else pd.DataFrame()
-    )
+    if not pred_df.empty:
+        top_candidates = pred_df[pred_df["presentation_class"].isin(["strong", "weak"])].copy()
+        if "best_presentation_percentile" in top_candidates.columns:
+            top_candidates = top_candidates[top_candidates["best_presentation_percentile"] <= 2.0]
+        if "genotype_presentation_score" in top_candidates.columns:
+            top_candidates = top_candidates.sort_values(
+                ["genotype_presentation_score", "n_strong_alleles", "best_presentation_percentile"],
+                ascending=[False, False, True],
+            )
+        else:
+            top_candidates = top_candidates.sort_values("presentation_percentile")
+        strong_df = top_candidates
+    else:
+        strong_df = pd.DataFrame()
+
     if not strong_df.empty:
         top = strong_df.iloc[0]
+        numeric_metrics = ("presentation_percentile", "ic50_nM", "genotype_presentation_score")
         for metric, col in [
-            ("peptide", "peptide"), ("allele", "allele"),
+            ("peptide", "peptide"), ("allele", "best_allele"),
             ("presentation_percentile", "presentation_percentile"),
+            ("genotype_presentation_score", "genotype_presentation_score"),
             ("ic50_nM", "ic50_nM"), ("presentation_class", "presentation_class"),
         ]:
+            if col not in top.index:
+                continue
             rows.append({
                 "patient_id": patient_id, "stage": "top_candidate",
                 "metric": metric,
-                "value": round(float(top[col]), 4) if metric in ("presentation_percentile", "ic50_nM") else str(top[col]),
-                "notes": "top by presentation_percentile" if metric == "peptide" else "",
+                "value": round(float(top[col]), 4) if metric in numeric_metrics else str(top[col]),
+                "notes": "top by genotype_presentation_score" if metric == "peptide" else "",
             })
 
     # --- hla_typing ---

--- a/workflow/scripts/run_mhcflurry.py
+++ b/workflow/scripts/run_mhcflurry.py
@@ -28,7 +28,7 @@ Output TSV columns:
   contig_key  start_nt  peptide  best_allele  ic50_nM
   processing_score  presentation_score  presentation_percentile  presentation_class
   {allele}_presentation_score  {allele}_presentation_percentile  (one pair per allele)
-  breadth_score  n_strong_alleles  best_presentation_percentile
+  genotype_presentation_score  n_strong_alleles  best_presentation_percentile
 
 Usage (standalone, explicit alleles):
   python run_mhcflurry.py \\
@@ -209,7 +209,14 @@ def _compute_per_allele_features(
         pep_to_score = result.set_index("peptide")["presentation_score"].to_dict()
         pep_to_pct = result.set_index("peptide")["presentation_percentile"].to_dict()
         for p in peptides:
-            per_allele[p][f"{allele}_presentation_score"] = pep_to_score.get(p, 0.0)
+            score = pep_to_score.get(p, 0.0)
+            if not 0.0 <= score <= 1.0:
+                log.warning(
+                    "MHCflurry returned presentation_score=%.6f for peptide %s / %s "
+                    "— outside the defined [0, 1] range; value will be used as-is.",
+                    score, p, allele,
+                )
+            per_allele[p][f"{allele}_presentation_score"] = score
             per_allele[p][f"{allele}_presentation_percentile"] = pep_to_pct.get(p, 100.0)
 
     rows = []
@@ -338,8 +345,15 @@ def run_prediction(
                                        density vs HLA-A/B).
 
     Raises:
-        ValueError: If neither alleles nor alleles_tsv is provided.
+        ValueError: If neither alleles nor alleles_tsv is provided, or if
+                    hla_c_weight is outside [0, 1].
     """
+    if not 0.0 <= hla_c_weight <= 1.0:
+        raise ValueError(
+            f"hla_c_weight must be in [0, 1]; got {hla_c_weight}. "
+            "Values outside this range cannot be interpreted as locus weights."
+        )
+
     # Resolve alleles: alleles_tsv > alleles (caller must supply one)
     if alleles_tsv:
         resolved_alleles = _load_alleles_from_tsv(alleles_tsv)

--- a/workflow/scripts/run_mhcflurry.py
+++ b/workflow/scripts/run_mhcflurry.py
@@ -25,8 +25,10 @@ Allele sources (in priority order):
      drawn from config.mhcflurry.fallback_alleles when HLA typing is disabled.
 
 Output TSV columns:
-  contig_key  start_nt  peptide  allele  ic50_nM
+  contig_key  start_nt  peptide  best_allele  ic50_nM
   processing_score  presentation_score  presentation_percentile  presentation_class
+  {allele}_presentation_score  {allele}_presentation_percentile  (one pair per allele)
+  breadth_score  n_strong_alleles  best_presentation_percentile
 
 Usage (standalone, explicit alleles):
   python run_mhcflurry.py \\
@@ -182,6 +184,69 @@ def _run_mhcflurry_predictions(
     )
 
 
+def _compute_per_allele_features(
+    peptides: list[str],
+    alleles: list[str],
+    hla_c_weight: float,
+    strong_threshold: float,
+) -> pd.DataFrame:
+    """Compute per-allele presentation scores and genotype-level features for each peptide.
+
+    Makes one predict([allele]) call per allele using the module-level predictor
+    cache, then computes:
+      - {allele}_presentation_score       — absolute presentation probability (0–1)
+      - {allele}_presentation_percentile  — rank percentile (lower = better)
+      - genotype_presentation_score       — 1 − ∏(1 − wᵢ·pᵢ), pᵢ = presentation_score
+      - n_strong_alleles                  — allele count with percentile ≤ strong_threshold
+      - best_presentation_percentile      — min percentile across all alleles
+
+    HLA-C alleles are weighted by hla_c_weight; HLA-A/B alleles by 1.0.
+    """
+    per_allele: dict[str, dict[str, float]] = {p: {} for p in peptides}
+
+    for allele in alleles:
+        result = _run_mhcflurry_predictions(peptides, [allele], predictor=_worker_predictor)
+        pep_to_score = result.set_index("peptide")["presentation_score"].to_dict()
+        pep_to_pct = result.set_index("peptide")["presentation_percentile"].to_dict()
+        for p in peptides:
+            per_allele[p][f"{allele}_presentation_score"] = pep_to_score.get(p, 0.0)
+            per_allele[p][f"{allele}_presentation_percentile"] = pep_to_pct.get(p, 100.0)
+
+    rows = []
+    for pep in peptides:
+        rec = per_allele[pep]
+
+        product = 1.0
+        n_strong = 0
+        best_pct = 100.0
+        for allele in alleles:
+            w = hla_c_weight if allele.startswith("HLA-C") else 1.0
+            p = rec.get(f"{allele}_presentation_score", 0.0)
+            pct = rec.get(f"{allele}_presentation_percentile", 100.0)
+            product *= (1.0 - w * p)
+            if pct <= strong_threshold:
+                n_strong += 1
+            if pct < best_pct:
+                best_pct = pct
+
+        row: dict = {"peptide": pep}
+        row.update(rec)
+        row["genotype_presentation_score"] = round(1.0 - product, 6)
+        row["n_strong_alleles"] = n_strong
+        row["best_presentation_percentile"] = best_pct
+        rows.append(row)
+
+    df = pd.DataFrame(rows)
+    log.info(
+        "Per-allele features: %d peptides, %d allele(s); "
+        "genotype_presentation_score range [%.4f, %.4f]; %d with n_strong_alleles >= 1",
+        len(peptides), len(alleles),
+        df["genotype_presentation_score"].min(), df["genotype_presentation_score"].max(),
+        (df["n_strong_alleles"] >= 1).sum(),
+    )
+    return df
+
+
 # ---------------------------------------------------------------------------
 # Binder classification
 # ---------------------------------------------------------------------------
@@ -250,12 +315,13 @@ def run_prediction(
     alleles_tsv: str | None = None,
     presentation_percentile_strong: float = 0.5,
     presentation_percentile_weak: float = 2.0,
+    hla_c_weight: float = 0.5,
 ) -> None:
     """Run MHCflurry on junction-spanning peptides and write results to TSV.
 
     Runs Class1PresentationPredictor.predict() with the full patient HLA genotype
-    (all alleles at once). Output contains one row per peptide (best allele across
-    the genotype), plus contig context (contig_key, start_nt).
+    (all alleles at once) for best-allele columns, then makes one per-allele call to
+    compute genotype_presentation_score and related breadth features.
 
     Args:
         peptides_tsv:                  TSV of junction-spanning peptides.
@@ -264,8 +330,12 @@ def run_prediction(
                                        alleles_tsv is provided.
         alleles_tsv:                   Path to alleles.tsv from aggregate_hla_alleles.
                                        Takes precedence over alleles.
-        presentation_percentile_strong: Percentile threshold for strong presentation_class.
+        presentation_percentile_strong: Percentile threshold for strong presentation_class
+                                       and n_strong_alleles counting.
         presentation_percentile_weak:  Percentile threshold for weak presentation_class.
+        hla_c_weight:                  Weight for HLA-C alleles in genotype_presentation_score
+                                       formula (default 0.5, reflecting ~50% lower surface
+                                       density vs HLA-A/B).
 
     Raises:
         ValueError: If neither alleles nor alleles_tsv is provided.
@@ -295,11 +365,16 @@ def run_prediction(
 
     if peptides_df.empty:
         log.warning("No peptides found in %s", peptides_tsv)
-        empty_df = pd.DataFrame(
-            columns=["contig_key", "start_nt", "peptide", "allele",
-                     "ic50_nM", "processing_score", "presentation_score",
-                     "presentation_percentile", "presentation_class"]
-        )
+        per_allele_cols: list[str] = []
+        for a in resolved_alleles:
+            per_allele_cols += [f"{a}_presentation_score", f"{a}_presentation_percentile"]
+        empty_df = pd.DataFrame(columns=[
+            "contig_key", "start_nt", "peptide", "best_allele",
+            "ic50_nM", "processing_score", "presentation_score",
+            "presentation_percentile", "presentation_class",
+        ] + per_allele_cols + [
+            "genotype_presentation_score", "n_strong_alleles", "best_presentation_percentile",
+        ])
         empty_df.to_csv(output_tsv, sep="\t", index=False)
         return
 
@@ -324,8 +399,8 @@ def run_prediction(
     )
 
     # Rename and keep only needed columns; drop metadata (peptide_num, sample_name)
-    pred_df = pred_df.rename(columns={"affinity": "ic50_nM", "best_allele": "allele"})[
-        ["peptide", "allele", "ic50_nM", "processing_score",
+    pred_df = pred_df.rename(columns={"affinity": "ic50_nM"})[
+        ["peptide", "best_allele", "ic50_nM", "processing_score",
          "presentation_score", "presentation_percentile"]
     ]
     pred_df["ic50_nM"] = pred_df["ic50_nM"].fillna(float("inf"))
@@ -333,21 +408,33 @@ def run_prediction(
         lambda v: classify_by_percentile(v, presentation_percentile_strong, presentation_percentile_weak)
     )
 
-    # Step 3: Merge per-peptide predictions with peptides_df to restore contig_key/start_nt
-    df = peptides_df.merge(pred_df, on="peptide", how="left")[
-        ["contig_key", "start_nt", "peptide", "allele",
+    # Step 3: Per-allele calls to compute genotype_presentation_score and breadth features
+    log.info(
+        "Running per-allele predictions for genotype features (%d allele(s))...",
+        len(resolved_alleles),
+    )
+    per_allele_df = _compute_per_allele_features(
+        unique_peptides, resolved_alleles, hla_c_weight, presentation_percentile_strong
+    )
+    pred_df = pred_df.merge(per_allele_df, on="peptide", how="left")
+
+    # Step 4: Merge with peptides_df to restore contig_key/start_nt, then write output
+    per_allele_extra_cols = [c for c in per_allele_df.columns if c != "peptide"]
+    output_cols = (
+        ["contig_key", "start_nt", "peptide", "best_allele",
          "ic50_nM", "processing_score", "presentation_score",
          "presentation_percentile", "presentation_class"]
-    ]
+        + per_allele_extra_cols
+    )
+    df = peptides_df.merge(pred_df, on="peptide", how="left")[output_cols]
 
-    # Step 4: Write output
     df.to_csv(output_tsv, sep="\t", index=False)
     log.info(
-        "Predictions: %d rows (%d unique peptides, %d-allele genotype), "
+        "Predictions: %d rows (%d unique peptides, %d allele(s)); "
+        "genotype_presentation_score range [%.4f, %.4f]; "
         "%d strong / %d weak / %d non → %s",
-        len(df),
-        len(unique_peptides),
-        len(resolved_alleles),
+        len(df), len(unique_peptides), len(resolved_alleles),
+        df["genotype_presentation_score"].min(), df["genotype_presentation_score"].max(),
         (df["presentation_class"] == "strong").sum(),
         (df["presentation_class"] == "weak").sum(),
         (df["presentation_class"] == "non").sum(),
@@ -373,6 +460,7 @@ def _snakemake_main() -> None:
         alleles_tsv=alleles_tsv,
         presentation_percentile_strong=float(snakemake.params.presentation_percentile_strong),  # type: ignore[name-defined]  # noqa: F821
         presentation_percentile_weak=float(snakemake.params.presentation_percentile_weak),  # type: ignore[name-defined]  # noqa: F821
+        hla_c_weight=float(snakemake.params.hla_c_weight),  # type: ignore[name-defined]  # noqa: F821
     )
 
 
@@ -392,6 +480,10 @@ def _cli_main() -> None:
     )
     parser.add_argument("--presentation-percentile-strong", type=float, default=0.5)
     parser.add_argument("--presentation-percentile-weak", type=float, default=2.0)
+    parser.add_argument(
+        "--hla-c-weight", type=float, default=0.5,
+        help="Weight for HLA-C alleles in genotype_presentation_score formula (default 0.5).",
+    )
     args = parser.parse_args()
 
     if not args.alleles and not args.alleles_tsv:
@@ -404,6 +496,7 @@ def _cli_main() -> None:
         alleles_tsv=args.alleles_tsv,
         presentation_percentile_strong=args.presentation_percentile_strong,
         presentation_percentile_weak=args.presentation_percentile_weak,
+        hla_c_weight=args.hla_c_weight,
     )
 
 

--- a/workflow/scripts/run_tcrdock.py
+++ b/workflow/scripts/run_tcrdock.py
@@ -73,10 +73,11 @@ log = logging.getLogger(__name__)
 def select_top_candidates(
     predictions_tsv: str | Path,
     n_candidates: int = 1,
+    presentation_percentile_weak: float = 2.0,
 ) -> pd.DataFrame:
     """Select top N candidates ranked by genotype_presentation_score from MHCflurry predictions.
 
-    Applies quality gate (best_presentation_percentile ≤ 2%) then ranks by:
+    Applies quality gate (best_presentation_percentile ≤ presentation_percentile_weak) then ranks by:
       1. genotype_presentation_score descending (primary)
       2. n_strong_alleles descending (secondary)
       3. best_presentation_percentile ascending (tertiary)
@@ -88,8 +89,10 @@ def select_top_candidates(
     ranking with ProTCR score ranking to select the most immunogenic candidates.
 
     Args:
-        predictions_tsv: MHCflurry predictions TSV.
-        n_candidates:    Number of candidates to return.
+        predictions_tsv:              MHCflurry predictions TSV.
+        n_candidates:                 Number of candidates to return.
+        presentation_percentile_weak: Quality-gate threshold; candidates where
+                                      best_presentation_percentile exceeds this are excluded.
 
     Returns:
         DataFrame of top candidates.
@@ -99,7 +102,7 @@ def select_top_candidates(
 
     # Quality gate: at least one allele must reach weak-binder threshold
     if "best_presentation_percentile" in candidates.columns:
-        candidates = candidates[candidates["best_presentation_percentile"] <= 2.0]
+        candidates = candidates[candidates["best_presentation_percentile"] <= presentation_percentile_weak]
 
     if candidates.empty:
         log.error("No strong or weak binders found. Cannot run TCRdock.")
@@ -421,6 +424,7 @@ def run_structural_validation(
     n_candidates: int = 1,
     fallback_hla: dict | None = None,
     fallback_tcr: dict | None = None,
+    presentation_percentile_weak: float = 2.0,
 ) -> None:
     """Run TCRdock structural validation on top neoepitope candidates.
 
@@ -446,7 +450,7 @@ def run_structural_validation(
     work_dir = output_pdb.parent / "tcrdock_workdir"
 
     # Step 1: Select top candidates
-    candidates = select_top_candidates(predictions_tsv, n_candidates)
+    candidates = select_top_candidates(predictions_tsv, n_candidates, presentation_percentile_weak=presentation_percentile_weak)
     if candidates.empty:
         log.error("No candidates available. Skipping TCRdock.")
         return
@@ -483,6 +487,7 @@ def _snakemake_main() -> None:
         n_candidates=snakemake.params.n_candidates,  # type: ignore[name-defined]  # noqa: F821
         fallback_hla=snakemake.params.fallback_hla,  # type: ignore[name-defined]  # noqa: F821
         fallback_tcr=snakemake.params.fallback_tcr,  # type: ignore[name-defined]  # noqa: F821
+        presentation_percentile_weak=float(snakemake.params.presentation_percentile_weak),  # type: ignore[name-defined]  # noqa: F821
     )
 
 

--- a/workflow/scripts/run_tcrdock.py
+++ b/workflow/scripts/run_tcrdock.py
@@ -100,13 +100,21 @@ def select_top_candidates(
     df = pd.read_csv(predictions_tsv, sep="\t")
     candidates = df[df["presentation_class"].isin(("strong", "weak"))].copy()
 
-    # Quality gate: at least one allele must reach weak-binder threshold
-    if "best_presentation_percentile" in candidates.columns:
-        candidates = candidates[candidates["best_presentation_percentile"] <= presentation_percentile_weak]
-
     if candidates.empty:
-        log.error("No strong or weak binders found. Cannot run TCRdock.")
+        log.error("No strong or weak presenters found in predictions. Cannot run TCRdock.")
         return pd.DataFrame()
+
+    # Quality gate: at least one allele must reach weak-presenter threshold
+    if "best_presentation_percentile" in candidates.columns:
+        n_before = len(candidates)
+        candidates = candidates[candidates["best_presentation_percentile"] <= presentation_percentile_weak]
+        if candidates.empty:
+            log.error(
+                "All %d strong/weak presenter(s) failed the quality gate "
+                "(best_presentation_percentile > %.1f%%). Cannot run TCRdock.",
+                n_before, presentation_percentile_weak,
+            )
+            return pd.DataFrame()
 
     if "genotype_presentation_score" in candidates.columns:
         candidates = candidates.sort_values(

--- a/workflow/scripts/run_tcrdock.py
+++ b/workflow/scripts/run_tcrdock.py
@@ -19,22 +19,25 @@ so local / CPU-only runs are unaffected.
 
 Candidate selection
 -------------------
-Currently selects the top N strong binders by presentation_percentile
-(MHCflurry Class1PresentationPredictor). Once TRUST4 + ProTCR (#24) is
+Currently selects the top N candidates ranked by genotype_presentation_score
+(MHCflurry allele breadth model, Issue #119). Once TRUST4 + ProTCR (#24) is
 implemented, selection should switch to the top ProTCR-ranked candidates instead.
 
 Inputs
 ------
   predictions_tsv: MHCflurry predictions TSV
-                   (columns: contig_key, start_nt, peptide, allele,
+                   (columns: contig_key, start_nt, peptide, best_allele,
                     ic50_nM, processing_score, presentation_score,
-                    presentation_percentile, presentation_class)
+                    presentation_percentile, presentation_class,
+                    genotype_presentation_score, n_strong_alleles,
+                    best_presentation_percentile, {allele}_presentation_score,
+                    {allele}_presentation_percentile)
 
 Outputs
 -------
   top_candidate.pdb    — predicted TCR-peptide-MHC ternary complex (PDB format)
   docking_scores.tsv   — docking geometry metrics per candidate
-                         (columns: peptide, allele, va_gene, vb_gene,
+                         (columns: peptide, best_allele, va_gene, vb_gene,
                           cdr3a, cdr3b, rmsd, tcr_pdb_rmsd, docking_geometry)
 
 Usage (standalone, Linux + GPU only):
@@ -71,28 +74,46 @@ def select_top_candidates(
     predictions_tsv: str | Path,
     n_candidates: int = 1,
 ) -> pd.DataFrame:
-    """Select the top N strong binders by presentation_percentile from MHCflurry predictions.
+    """Select top N candidates ranked by genotype_presentation_score from MHCflurry predictions.
 
-    TODO (#24): Once ProTCR scores are available, replace presentation_percentile ranking
-    with ProTCR score ranking to select the most immunogenic candidates rather than
-    just the best MHC binders.
+    Applies quality gate (best_presentation_percentile ≤ 2%) then ranks by:
+      1. genotype_presentation_score descending (primary)
+      2. n_strong_alleles descending (secondary)
+      3. best_presentation_percentile ascending (tertiary)
+
+    Falls back to presentation_percentile sort when breadth columns are absent
+    (e.g., output from an older pipeline run).
+
+    TODO (#24): Once ProTCR scores are available, replace genotype_presentation_score
+    ranking with ProTCR score ranking to select the most immunogenic candidates.
 
     Args:
         predictions_tsv: MHCflurry predictions TSV.
         n_candidates:    Number of candidates to return.
 
     Returns:
-        DataFrame of top candidates, sorted by presentation_percentile ascending.
+        DataFrame of top candidates.
     """
     df = pd.read_csv(predictions_tsv, sep="\t")
-    strong = df[df["presentation_class"] == "strong"].sort_values("presentation_percentile")
-    if strong.empty:
-        log.warning("No strong binders found — trying weak binders as fallback.")
-        strong = df[df["presentation_class"] == "weak"].sort_values("presentation_percentile")
-    if strong.empty:
+    candidates = df[df["presentation_class"].isin(("strong", "weak"))].copy()
+
+    # Quality gate: at least one allele must reach weak-binder threshold
+    if "best_presentation_percentile" in candidates.columns:
+        candidates = candidates[candidates["best_presentation_percentile"] <= 2.0]
+
+    if candidates.empty:
         log.error("No strong or weak binders found. Cannot run TCRdock.")
         return pd.DataFrame()
-    return strong.head(n_candidates).reset_index(drop=True)
+
+    if "genotype_presentation_score" in candidates.columns:
+        candidates = candidates.sort_values(
+            ["genotype_presentation_score", "n_strong_alleles", "best_presentation_percentile"],
+            ascending=[False, False, True],
+        )
+    else:
+        candidates = candidates.sort_values("presentation_percentile")
+
+    return candidates.head(n_candidates).reset_index(drop=True)
 
 
 # ---------------------------------------------------------------------------
@@ -134,7 +155,7 @@ def build_tcrdock_input(
 
     rows = []
     for i, row in candidates.iterrows():
-        allele = row.get("allele", fallback_hla["A"])
+        allele = row.get("best_allele", fallback_hla["A"])
         mhc = allele.replace("HLA-", "")  # "HLA-A*02:01" → "A*02:01"
         rows.append({
             "pdbid":     f"neoepitope_{i}",
@@ -433,7 +454,7 @@ def run_structural_validation(
     log.info(
         "Top %d candidate(s) selected for TCRdock:\n%s",
         len(candidates),
-        candidates[["peptide", "allele", "ic50_nM"]].to_string(index=False),
+        candidates[["peptide", "best_allele", "ic50_nM"]].to_string(index=False),
     )
 
     # Step 2: Build TCRdock input TSV

--- a/workflow/tests/test_generate_report.py
+++ b/workflow/tests/test_generate_report.py
@@ -125,17 +125,17 @@ def _make_origin_df(tumor_exclusive: int = 5, normal_shared: int = 2) -> pd.Data
 def _make_pred_df(n_strong: int = 3, n_weak: int = 1, n_non: int = 10) -> pd.DataFrame:
     # presentation_percentile increases with index so PEP0 is always the top candidate
     rows = (
-        [{"peptide": f"PEP{i}", "allele": "HLA-A*02:01", "ic50_nM": float(i + 1),
+        [{"peptide": f"PEP{i}", "best_allele": "HLA-A*02:01", "ic50_nM": float(i + 1),
           "processing_score": 0.8, "presentation_score": 0.9,
           "presentation_percentile": 0.1 * (i + 1),
           "presentation_class": "strong", "contig_key": f"k{i}", "start_nt": 0,
           } for i in range(n_strong)]
-        + [{"peptide": f"PEP{i}", "allele": "HLA-A*02:01", "ic50_nM": float(100 + i),
+        + [{"peptide": f"PEP{i}", "best_allele": "HLA-A*02:01", "ic50_nM": float(100 + i),
             "processing_score": 0.7, "presentation_score": 0.6,
             "presentation_percentile": 1.0 + 0.1 * i,
             "presentation_class": "weak", "contig_key": f"k{i}", "start_nt": 0,
             } for i in range(n_weak)]
-        + [{"peptide": f"PEP{i}", "allele": "HLA-A*02:01", "ic50_nM": float(1000 + i),
+        + [{"peptide": f"PEP{i}", "best_allele": "HLA-A*02:01", "ic50_nM": float(1000 + i),
             "processing_score": 0.5, "presentation_score": 0.3,
             "presentation_percentile": 3.0 + 0.1 * i,
             "presentation_class": "non", "contig_key": f"k{i}", "start_nt": 0,

--- a/workflow/tests/test_generate_report.py
+++ b/workflow/tests/test_generate_report.py
@@ -7,6 +7,7 @@ from generate_report import (
     _build_chain_legend,
     _build_compnd_records,
     _build_report_tsv,
+    _build_strong_table_html,
     _df_to_html,
     _extract_chain_ids,
 )
@@ -236,3 +237,93 @@ class TestBuildReportTsv:
         df = pd.read_csv(out, sep="\t")
         assert df[df["stage"] == "mhc_prediction"].empty
         assert df[df["stage"] == "top_candidate"].empty
+
+
+# ---------------------------------------------------------------------------
+# Helpers and tests for the GPS (genotype_presentation_score) code path
+# ---------------------------------------------------------------------------
+
+def _make_pred_df_with_gps(rows: list[dict]) -> pd.DataFrame:
+    """Build a predictions DataFrame that includes GPS columns."""
+    defaults = {
+        "best_allele": "HLA-A*02:01",
+        "ic50_nM": 50.0,
+        "processing_score": 0.8,
+        "presentation_score": 0.9,
+        "contig_key": "k0",
+        "start_nt": 0,
+    }
+    return pd.DataFrame([{**defaults, **r} for r in rows])
+
+
+class TestBuildStrongTableHtmlWithGps:
+    def test_quality_gate_excludes_high_best_percentile(self):
+        """Candidates where best_presentation_percentile > weak threshold are excluded."""
+        df = _make_pred_df_with_gps([
+            {"peptide": "ACDEFGHIK", "presentation_percentile": 0.1,
+             "presentation_class": "strong",
+             "genotype_presentation_score": 0.9, "n_strong_alleles": 1,
+             "best_presentation_percentile": 0.1},
+            {"peptide": "LMNPQRSTV", "presentation_percentile": 0.2,
+             "presentation_class": "strong",
+             "genotype_presentation_score": 0.95, "n_strong_alleles": 2,
+             "best_presentation_percentile": 3.0},  # fails gate
+        ])
+        html = _build_strong_table_html(df, {}, presentation_percentile_weak=2.0)
+        assert "ACDEFGHIK" in html
+        assert "LMNPQRSTV" not in html
+
+    def test_ranked_by_gps_descending(self):
+        """Candidate with higher GPS appears first in the table."""
+        df = _make_pred_df_with_gps([
+            {"peptide": "ACDEFGHIK", "presentation_percentile": 0.1,
+             "presentation_class": "strong",
+             "genotype_presentation_score": 0.7, "n_strong_alleles": 1,
+             "best_presentation_percentile": 0.1},
+            {"peptide": "LMNPQRSTV", "presentation_percentile": 0.4,
+             "presentation_class": "strong",
+             "genotype_presentation_score": 0.95, "n_strong_alleles": 3,
+             "best_presentation_percentile": 0.4},
+        ])
+        html = _build_strong_table_html(df, {}, presentation_percentile_weak=2.0)
+        assert html.index("LMNPQRSTV") < html.index("ACDEFGHIK")
+
+
+class TestBuildReportTsvWithGps:
+    def test_top_candidate_ranked_by_gps(self, tmp_path):
+        """When GPS columns present, top_candidate row reflects GPS-ranked winner."""
+        df = _make_pred_df_with_gps([
+            {"peptide": "ACDEFGHIK", "presentation_percentile": 0.1,
+             "presentation_class": "strong",
+             "genotype_presentation_score": 0.7, "n_strong_alleles": 1,
+             "best_presentation_percentile": 0.1},
+            {"peptide": "LMNPQRSTV", "presentation_percentile": 0.4,
+             "presentation_class": "strong",
+             "genotype_presentation_score": 0.95, "n_strong_alleles": 3,
+             "best_presentation_percentile": 0.4},
+        ])
+        out = tmp_path / "report.tsv"
+        _build_report_tsv("p001", _make_origin_df(), df, None, out, 0.5, None,
+                          presentation_percentile_weak=2.0)
+        result = pd.read_csv(out, sep="\t")
+        top = result[(result["stage"] == "top_candidate") & (result["metric"] == "peptide")]
+        assert top["value"].iloc[0] == "LMNPQRSTV"
+
+    def test_quality_gate_excludes_candidate_in_tsv(self, tmp_path):
+        """Candidate failing quality gate is not selected as top_candidate."""
+        df = _make_pred_df_with_gps([
+            {"peptide": "ACDEFGHIK", "presentation_percentile": 0.1,
+             "presentation_class": "strong",
+             "genotype_presentation_score": 0.95, "n_strong_alleles": 2,
+             "best_presentation_percentile": 3.0},  # fails gate
+            {"peptide": "LMNPQRSTV", "presentation_percentile": 0.4,
+             "presentation_class": "strong",
+             "genotype_presentation_score": 0.7, "n_strong_alleles": 1,
+             "best_presentation_percentile": 0.4},
+        ])
+        out = tmp_path / "report.tsv"
+        _build_report_tsv("p001", _make_origin_df(), df, None, out, 0.5, None,
+                          presentation_percentile_weak=2.0)
+        result = pd.read_csv(out, sep="\t")
+        top = result[(result["stage"] == "top_candidate") & (result["metric"] == "peptide")]
+        assert top["value"].iloc[0] == "LMNPQRSTV"

--- a/workflow/tests/test_integration.py
+++ b/workflow/tests/test_integration.py
@@ -161,14 +161,20 @@ class TestPredictions:
     def test_all_predictions_have_required_columns(self):
         rows = _read_tsv(RESULTS / "predictions" / "mhc_presentation.tsv")
         assert rows, "mhc_presentation.tsv is empty"
-        if "presentation_class" not in rows[0]:
+        if "presentation_class" not in rows[0] or "best_allele" not in rows[0]:
             pytest.skip("predictions use old schema — re-run pipeline to update")
-        required = {
-            "peptide", "allele", "ic50_nM",
+        required_base = {
+            "peptide", "best_allele", "ic50_nM",
             "processing_score", "presentation_score",
             "presentation_percentile", "presentation_class",
         }
-        assert required <= set(rows[0].keys())
+        assert required_base <= set(rows[0].keys())
+        if "genotype_presentation_score" not in rows[0]:
+            pytest.skip("predictions use pre-breadth schema — re-run pipeline to update")
+        required_breadth = {
+            "genotype_presentation_score", "n_strong_alleles", "best_presentation_percentile",
+        }
+        assert required_breadth <= set(rows[0].keys())
 
     def test_strong_presentations_have_low_percentile(self):
         rows = _read_tsv(RESULTS / "predictions" / "mhc_presentation.tsv")

--- a/workflow/tests/test_run_mhcflurry.py
+++ b/workflow/tests/test_run_mhcflurry.py
@@ -77,9 +77,11 @@ class TestRunPredictionEmpty:
         df = pd.read_csv(output_tsv, sep="\t")
         assert df.empty
         assert list(df.columns) == [
-            "contig_key", "start_nt", "peptide", "allele",
+            "contig_key", "start_nt", "peptide", "best_allele",
             "ic50_nM", "processing_score", "presentation_score",
             "presentation_percentile", "presentation_class",
+            "HLA-A*02:01_presentation_score", "HLA-A*02:01_presentation_percentile",
+            "genotype_presentation_score", "n_strong_alleles", "best_presentation_percentile",
         ]
 
     def test_output_file_is_created(self, tmp_path):
@@ -206,9 +208,11 @@ class TestRunPredictionNonEmpty:
         )
         df = pd.read_csv(out, sep="\t")
         assert list(df.columns) == [
-            "contig_key", "start_nt", "peptide", "allele",
+            "contig_key", "start_nt", "peptide", "best_allele",
             "ic50_nM", "processing_score", "presentation_score",
             "presentation_percentile", "presentation_class",
+            "HLA-A*02:01_presentation_score", "HLA-A*02:01_presentation_percentile",
+            "genotype_presentation_score", "n_strong_alleles", "best_presentation_percentile",
         ]
 
     def test_presentation_class_strong(self, tmp_path):
@@ -244,8 +248,8 @@ class TestRunPredictionNonEmpty:
         df = pd.read_csv(out, sep="\t")
         assert (df["presentation_class"] == "non").all()
 
-    def test_best_allele_becomes_allele_column(self, tmp_path):
-        """best_allele from predictor is exposed as the allele column."""
+    def test_best_allele_column_present(self, tmp_path):
+        """best_allele from predictor is retained as the best_allele column."""
         out = tmp_path / "predictions.tsv"
         run_prediction(
             peptides_tsv=self._make_peptides_tsv(tmp_path),
@@ -253,7 +257,8 @@ class TestRunPredictionNonEmpty:
             alleles=["HLA-A*02:01"],
         )
         df = pd.read_csv(out, sep="\t")
-        assert (df["allele"] == "HLA-A*02:01").all()
+        assert "best_allele" in df.columns
+        assert (df["best_allele"] == "HLA-A*02:01").all()
 
     def test_one_row_per_peptide(self, tmp_path):
         """Genotype prediction returns one row per peptide, not one per peptide×allele."""
@@ -265,6 +270,48 @@ class TestRunPredictionNonEmpty:
         )
         df = pd.read_csv(out, sep="\t")
         assert len(df) == len(self.PEPTIDES)
+
+    def test_per_allele_columns_present(self, tmp_path):
+        """Output has one score+percentile column pair per allele."""
+        out = tmp_path / "predictions.tsv"
+        run_prediction(
+            peptides_tsv=self._make_peptides_tsv(tmp_path),
+            output_tsv=out,
+            alleles=["HLA-A*02:01", "HLA-B*07:02"],
+        )
+        df = pd.read_csv(out, sep="\t")
+        for allele in ("HLA-A*02:01", "HLA-B*07:02"):
+            assert f"{allele}_presentation_score" in df.columns
+            assert f"{allele}_presentation_percentile" in df.columns
+
+    def test_genotype_presentation_score_computed(self, tmp_path):
+        """genotype_presentation_score = 1 − ∏(1 − wᵢ·pᵢ); fake score=0.9, w=1.0 → GPS=0.9."""
+        out = tmp_path / "predictions.tsv"
+        run_prediction(
+            peptides_tsv=self._make_peptides_tsv(tmp_path),
+            output_tsv=out,
+            alleles=["HLA-A*02:01"],
+        )
+        df = pd.read_csv(out, sep="\t")
+        # fake presentation_score = 0.9, w(A) = 1.0 → 1 - (1 - 0.9) = 0.9
+        n = len(self.PEPTIDES)
+        assert df["genotype_presentation_score"].to_list() == pytest.approx([0.9] * n, abs=1e-5)
+        assert (df["n_strong_alleles"] == 1).all()   # percentile 0.3 <= 0.5%
+        assert df["best_presentation_percentile"].to_list() == pytest.approx([0.3] * n, abs=1e-5)
+
+    def test_hla_c_weight_applied(self, tmp_path):
+        """HLA-C alleles use hla_c_weight (default 0.5), not 1.0."""
+        out = tmp_path / "predictions.tsv"
+        run_prediction(
+            peptides_tsv=self._make_peptides_tsv(tmp_path),
+            output_tsv=out,
+            alleles=["HLA-C*07:02"],
+            hla_c_weight=0.5,
+        )
+        df = pd.read_csv(out, sep="\t")
+        # fake presentation_score = 0.9, w(C) = 0.5 → 1 - (1 - 0.5*0.9) = 1 - 0.55 = 0.45
+        n = len(self.PEPTIDES)
+        assert df["genotype_presentation_score"].to_list() == pytest.approx([0.45] * n, abs=1e-5)
 
     def test_load_predictor_populates_cache(self, monkeypatch):
         """_load_predictor must populate the module-level predictor cache."""

--- a/workflow/tests/test_run_mhcflurry.py
+++ b/workflow/tests/test_run_mhcflurry.py
@@ -59,6 +59,33 @@ class TestLoadAllelesFromTsv:
 # run_prediction — empty input / file creation
 # ---------------------------------------------------------------------------
 
+class TestRunPredictionValidation:
+    """run_prediction should reject invalid config values before loading the model."""
+
+    def test_hla_c_weight_above_1_raises(self, tmp_path):
+        peptides_tsv = tmp_path / "peptides.tsv"
+        peptides_tsv.write_text("contig_key\tstart_nt\tpeptide\n")
+        with pytest.raises(ValueError, match="hla_c_weight"):
+            run_prediction(peptides_tsv=peptides_tsv, output_tsv=tmp_path / "out.tsv",
+                           alleles=["HLA-A*02:01"], hla_c_weight=1.5)
+
+    def test_hla_c_weight_below_0_raises(self, tmp_path):
+        peptides_tsv = tmp_path / "peptides.tsv"
+        peptides_tsv.write_text("contig_key\tstart_nt\tpeptide\n")
+        with pytest.raises(ValueError, match="hla_c_weight"):
+            run_prediction(peptides_tsv=peptides_tsv, output_tsv=tmp_path / "out.tsv",
+                           alleles=["HLA-A*02:01"], hla_c_weight=-0.1)
+
+    def test_hla_c_weight_boundary_values_accepted(self, tmp_path):
+        """0.0 and 1.0 are valid boundary values."""
+        peptides_tsv = tmp_path / "peptides.tsv"
+        peptides_tsv.write_text("contig_key\tstart_nt\tpeptide\n")
+        # Empty input short-circuits before model loading — just verify no ValueError
+        for w in (0.0, 1.0):
+            run_prediction(peptides_tsv=peptides_tsv, output_tsv=tmp_path / "out.tsv",
+                           alleles=["HLA-A*02:01"], hla_c_weight=w)
+
+
 class TestRunPredictionEmpty:
     """run_prediction should write an empty TSV when input has no rows."""
 
@@ -319,6 +346,45 @@ class TestRunPredictionNonEmpty:
         monkeypatch.setattr(run_mhcflurry, "_worker_predictor", None)
         run_mhcflurry._load_predictor()
         assert run_mhcflurry._worker_predictor is not None
+
+
+# ---------------------------------------------------------------------------
+# presentation_score out-of-range warning
+# ---------------------------------------------------------------------------
+
+class TestPresentationScoreOutOfRange:
+    """_compute_per_allele_features should warn when MHCflurry returns score outside [0, 1]."""
+
+    def test_warns_on_score_above_1(self, monkeypatch, tmp_path, caplog):
+        import logging
+        import run_mhcflurry
+
+        def fake_run_predictions(peptides, alleles, predictor=None):
+            return pd.DataFrame({
+                "peptide": peptides,
+                "affinity": [30.0] * len(peptides),
+                "best_allele": [alleles[0]] * len(peptides),
+                "processing_score": [0.8] * len(peptides),
+                "presentation_score": [1.05] * len(peptides),  # out of range
+                "presentation_percentile": [0.3] * len(peptides),
+            })
+
+        monkeypatch.setattr(run_mhcflurry, "_load_mhcflurry_predictor", lambda: object())
+        monkeypatch.setattr(run_mhcflurry, "_run_mhcflurry_predictions", fake_run_predictions)
+        monkeypatch.setattr(run_mhcflurry, "_worker_predictor", object())
+
+        peptides_tsv = tmp_path / "peptides.tsv"
+        peptides_tsv.write_text("contig_key\tstart_nt\tpeptide\nc1\t2\tACDEFGHIK\n")
+
+        with caplog.at_level(logging.WARNING, logger="run_mhcflurry"):
+            run_prediction(
+                peptides_tsv=peptides_tsv,
+                output_tsv=tmp_path / "out.tsv",
+                alleles=["HLA-A*02:01"],
+            )
+
+        assert any("presentation_score" in r.message and "1.05" in r.message
+                   for r in caplog.records if r.levelno == logging.WARNING)
 
 
 # ---------------------------------------------------------------------------

--- a/workflow/tests/test_run_tcrdock.py
+++ b/workflow/tests/test_run_tcrdock.py
@@ -32,7 +32,7 @@ _FLAT_PDB = (
 # ---------------------------------------------------------------------------
 
 class TestSelectTopCandidates:
-    def test_selects_strong_binder(self, tmp_path):
+    def test_selects_strong_presenter(self, tmp_path):
         tsv = _write_predictions_tsv(tmp_path, [
             {"peptide": "ACDEFGHIK", "best_allele": "HLA-A*02:01", "ic50_nM": 10.0,
              "presentation_percentile": 0.1, "presentation_class": "strong", "contig_key": "c1", "start_nt": 0},
@@ -43,8 +43,8 @@ class TestSelectTopCandidates:
         assert len(result) == 1
         assert result.iloc[0]["peptide"] == "ACDEFGHIK"
 
-    def test_includes_weak_binders(self, tmp_path):
-        """Weak binders are included in candidates (quality gate checked separately)."""
+    def test_includes_weak_presenters(self, tmp_path):
+        """Weak presenters are included in candidates (quality gate checked separately)."""
         tsv = _write_predictions_tsv(tmp_path, [
             {"peptide": "LMNPQRSTV", "best_allele": "HLA-A*02:01", "ic50_nM": 200.0,
              "presentation_percentile": 2.0, "presentation_class": "weak", "contig_key": "c1", "start_nt": 0},
@@ -55,7 +55,7 @@ class TestSelectTopCandidates:
         assert len(result) == 1
         assert result.iloc[0]["peptide"] == "LMNPQRSTV"
 
-    def test_returns_empty_when_no_binders(self, tmp_path):
+    def test_returns_empty_when_no_presenters(self, tmp_path):
         tsv = _write_predictions_tsv(tmp_path, [
             {"peptide": "YKLMFSTAV", "best_allele": "HLA-A*02:01", "ic50_nM": 9999.0,
              "presentation_percentile": 50.0, "presentation_class": "non", "contig_key": "c1", "start_nt": 0},
@@ -76,7 +76,7 @@ class TestSelectTopCandidates:
         assert len(result) == 2
         assert list(result["peptide"]) == ["ACDEFGHIK", "LMNPQRSTV"]
 
-    def test_quality_gate_filters_non_binder_percentile(self, tmp_path):
+    def test_quality_gate_filters_non_presenter_percentile(self, tmp_path):
         """Candidates where best_presentation_percentile > 2% are excluded."""
         tsv = _write_predictions_tsv(tmp_path, [
             {"peptide": "ACDEFGHIK", "best_allele": "HLA-A*02:01", "ic50_nM": 10.0,
@@ -95,7 +95,7 @@ class TestSelectTopCandidates:
         assert result.iloc[0]["peptide"] == "ACDEFGHIK"
 
     def test_ranked_by_genotype_presentation_score(self, tmp_path):
-        """When breadth columns present, candidates rank by genotype_presentation_score desc."""
+        """When GPS columns present, candidates rank by genotype_presentation_score desc."""
         tsv = _write_predictions_tsv(tmp_path, [
             {"peptide": "ACDEFGHIK", "best_allele": "HLA-A*02:01", "ic50_nM": 10.0,
              "presentation_percentile": 0.1, "presentation_class": "strong",
@@ -110,6 +110,21 @@ class TestSelectTopCandidates:
         ])
         result = select_top_candidates(tsv, n_candidates=1)
         assert result.iloc[0]["peptide"] == "LMNPQRSTV"  # higher GPS wins
+
+    def test_quality_gate_empty_logs_specific_message(self, tmp_path, caplog):
+        """When presenters exist but all fail quality gate, log distinguishes from no-presenters case."""
+        import logging
+        tsv = _write_predictions_tsv(tmp_path, [
+            {"peptide": "ACDEFGHIK", "best_allele": "HLA-A*02:01", "ic50_nM": 10.0,
+             "presentation_percentile": 0.1, "presentation_class": "strong",
+             "best_presentation_percentile": 3.0,  # fails gate
+             "genotype_presentation_score": 0.9, "n_strong_alleles": 1,
+             "contig_key": "c1", "start_nt": 0},
+        ])
+        with caplog.at_level(logging.ERROR, logger="run_tcrdock"):
+            result = select_top_candidates(tsv, n_candidates=1, presentation_percentile_weak=2.0)
+        assert result.empty
+        assert any("quality gate" in r.message for r in caplog.records if r.levelno == logging.ERROR)
 
 
 # ---------------------------------------------------------------------------

--- a/workflow/tests/test_run_tcrdock.py
+++ b/workflow/tests/test_run_tcrdock.py
@@ -34,29 +34,30 @@ _FLAT_PDB = (
 class TestSelectTopCandidates:
     def test_selects_strong_binder(self, tmp_path):
         tsv = _write_predictions_tsv(tmp_path, [
-            {"peptide": "AAA", "allele": "HLA-A*02:01", "ic50_nM": 10.0,
+            {"peptide": "ACDEFGHIK", "best_allele": "HLA-A*02:01", "ic50_nM": 10.0,
              "presentation_percentile": 0.1, "presentation_class": "strong", "contig_key": "c1", "start_nt": 0},
-            {"peptide": "BBB", "allele": "HLA-A*02:01", "ic50_nM": 200.0,
+            {"peptide": "LMNPQRSTV", "best_allele": "HLA-A*02:01", "ic50_nM": 200.0,
              "presentation_percentile": 2.0, "presentation_class": "weak", "contig_key": "c2", "start_nt": 0},
         ])
         result = select_top_candidates(tsv, n_candidates=1)
         assert len(result) == 1
-        assert result.iloc[0]["peptide"] == "AAA"
+        assert result.iloc[0]["peptide"] == "ACDEFGHIK"
 
-    def test_falls_back_to_weak(self, tmp_path):
+    def test_includes_weak_binders(self, tmp_path):
+        """Weak binders are included in candidates (quality gate checked separately)."""
         tsv = _write_predictions_tsv(tmp_path, [
-            {"peptide": "BBB", "allele": "HLA-A*02:01", "ic50_nM": 200.0,
+            {"peptide": "LMNPQRSTV", "best_allele": "HLA-A*02:01", "ic50_nM": 200.0,
              "presentation_percentile": 2.0, "presentation_class": "weak", "contig_key": "c1", "start_nt": 0},
-            {"peptide": "CCC", "allele": "HLA-A*02:01", "ic50_nM": 9999.0,
+            {"peptide": "YKLMFSTAV", "best_allele": "HLA-A*02:01", "ic50_nM": 9999.0,
              "presentation_percentile": 50.0, "presentation_class": "non", "contig_key": "c2", "start_nt": 0},
         ])
         result = select_top_candidates(tsv, n_candidates=1)
         assert len(result) == 1
-        assert result.iloc[0]["peptide"] == "BBB"
+        assert result.iloc[0]["peptide"] == "LMNPQRSTV"
 
     def test_returns_empty_when_no_binders(self, tmp_path):
         tsv = _write_predictions_tsv(tmp_path, [
-            {"peptide": "CCC", "allele": "HLA-A*02:01", "ic50_nM": 9999.0,
+            {"peptide": "YKLMFSTAV", "best_allele": "HLA-A*02:01", "ic50_nM": 9999.0,
              "presentation_percentile": 50.0, "presentation_class": "non", "contig_key": "c1", "start_nt": 0},
         ])
         result = select_top_candidates(tsv, n_candidates=1)
@@ -64,16 +65,51 @@ class TestSelectTopCandidates:
 
     def test_respects_n_candidates(self, tmp_path):
         tsv = _write_predictions_tsv(tmp_path, [
-            {"peptide": "AAA", "allele": "HLA-A*02:01", "ic50_nM": 10.0,
+            {"peptide": "ACDEFGHIK", "best_allele": "HLA-A*02:01", "ic50_nM": 10.0,
              "presentation_percentile": 0.1, "presentation_class": "strong", "contig_key": "c1", "start_nt": 0},
-            {"peptide": "BBB", "allele": "HLA-A*02:01", "ic50_nM": 20.0,
+            {"peptide": "LMNPQRSTV", "best_allele": "HLA-A*02:01", "ic50_nM": 20.0,
              "presentation_percentile": 0.2, "presentation_class": "strong", "contig_key": "c2", "start_nt": 0},
-            {"peptide": "CCC", "allele": "HLA-A*02:01", "ic50_nM": 30.0,
+            {"peptide": "YKLMFSTAV", "best_allele": "HLA-A*02:01", "ic50_nM": 30.0,
              "presentation_percentile": 0.3, "presentation_class": "strong", "contig_key": "c3", "start_nt": 0},
         ])
         result = select_top_candidates(tsv, n_candidates=2)
         assert len(result) == 2
-        assert list(result["peptide"]) == ["AAA", "BBB"]
+        assert list(result["peptide"]) == ["ACDEFGHIK", "LMNPQRSTV"]
+
+    def test_quality_gate_filters_non_binder_percentile(self, tmp_path):
+        """Candidates where best_presentation_percentile > 2% are excluded."""
+        tsv = _write_predictions_tsv(tmp_path, [
+            {"peptide": "ACDEFGHIK", "best_allele": "HLA-A*02:01", "ic50_nM": 10.0,
+             "presentation_percentile": 0.1, "presentation_class": "strong",
+             "best_presentation_percentile": 0.1,
+             "genotype_presentation_score": 0.9, "n_strong_alleles": 1,
+             "contig_key": "c1", "start_nt": 0},
+            {"peptide": "LMNPQRSTV", "best_allele": "HLA-A*02:01", "ic50_nM": 20.0,
+             "presentation_percentile": 0.2, "presentation_class": "strong",
+             "best_presentation_percentile": 3.0,  # fails quality gate
+             "genotype_presentation_score": 0.95, "n_strong_alleles": 2,
+             "contig_key": "c2", "start_nt": 0},
+        ])
+        result = select_top_candidates(tsv, n_candidates=5)
+        assert len(result) == 1
+        assert result.iloc[0]["peptide"] == "ACDEFGHIK"
+
+    def test_ranked_by_genotype_presentation_score(self, tmp_path):
+        """When breadth columns present, candidates rank by genotype_presentation_score desc."""
+        tsv = _write_predictions_tsv(tmp_path, [
+            {"peptide": "ACDEFGHIK", "best_allele": "HLA-A*02:01", "ic50_nM": 10.0,
+             "presentation_percentile": 0.1, "presentation_class": "strong",
+             "best_presentation_percentile": 0.1,
+             "genotype_presentation_score": 0.7, "n_strong_alleles": 1,
+             "contig_key": "c1", "start_nt": 0},
+            {"peptide": "LMNPQRSTV", "best_allele": "HLA-A*02:01", "ic50_nM": 200.0,
+             "presentation_percentile": 0.4, "presentation_class": "strong",
+             "best_presentation_percentile": 0.4,
+             "genotype_presentation_score": 0.95, "n_strong_alleles": 3,
+             "contig_key": "c2", "start_nt": 0},
+        ])
+        result = select_top_candidates(tsv, n_candidates=1)
+        assert result.iloc[0]["peptide"] == "LMNPQRSTV"  # higher GPS wins
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Replaces single-allele best-binder scoring with a two-level architecture: (1) per-allele MHCflurry `Class1PresentationPredictor` calls to recover per-allele `presentation_score` / `presentation_percentile`, and (2) a complementary-probability genotype model that combines them into `genotype_presentation_score`
- GPS formula: `1 − ∏(1 − wᵢ × pᵢ)` where `w(HLA-A) = w(HLA-B) = 1.0`, `w(HLA-C) = 0.5` (configurable via `mhcflurry.hla_c_weight`), reflecting ~50% lower HLA-C surface density (van Bergen et al. 2004)
- New output columns in `mhc_presentation.tsv`: `{allele}_presentation_score`, `{allele}_presentation_percentile`, `genotype_presentation_score`, `n_strong_alleles`, `best_presentation_percentile`; `allele` → `best_allele`
- New ranking in `generate_report.py` and `run_tcrdock.py`: GPS ↓ → `n_strong_alleles` ↓ → `best_presentation_percentile` ↑
- Quality gate: candidates with `best_presentation_percentile > 2%` (no allele reaches weak-binder threshold) excluded from top-candidates list
- Terminology: "MHC Binding Prediction" → "MHC Presentation Prediction" throughout METHODS, config, and report
- Test suite: 186 passed, 1 skipped (stale integration pipeline output); verified on local test run (chr22, patient_001_test) — 24 output columns correct, GPS=0.9996 for top hit DVFGTPFSR/HLA-A*33:03

## Files changed

| File | Change |
|------|--------|
| `workflow/scripts/run_mhcflurry.py` | New `_compute_per_allele_features()`; `hla_c_weight` param; new output columns |
| `config/config.yaml` + `mhc_affinity.smk` | `mhcflurry.hla_c_weight: 0.5` |
| `workflow/scripts/generate_report.py` | GPS ranking + quality gate + `best_allele` |
| `workflow/scripts/run_tcrdock.py` | GPS ranking + quality gate + `best_allele` |
| `workflow/tests/test_run_mhcflurry.py` | New column + breadth feature tests |
| `workflow/tests/test_generate_report.py` + `test_run_tcrdock.py` | `best_allele` + 9-mer peptides + GPS/quality-gate tests |
| `workflow/tests/test_integration.py` | New required columns with schema-version skip guards |
| `research/manuscript/METHODS.md` | Section 6 rewritten for two-level architecture |
| `docs/configuration.md` | `hla_c_weight` documented |

## Test plan

- [x] `.venv/bin/python -m pytest workflow/tests/ -v` — 186 passed, 1 skipped
- [x] Local full pipeline run (`config/test_config.yaml`) — `mhc_presentation.tsv` 24 columns correct, `report.html` GPS column and Best Allele header correct

Closes #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)