### PR TITLE
fix(cloud): conda-cleanup-envs removes all environments on every run

### DIFF
--- a/scripts/run_cloud_gpu.sh
+++ b/scripts/run_cloud_gpu.sh
@@ -318,7 +318,7 @@ set -euo pipefail
 cd "\$HOME/splice-neoepitope-pipeline"
 source "\$HOME/miniforge3/etc/profile.d/conda.sh"
 conda activate snakemake
-snakemake --conda-cleanup-envs --configfile ${CONFIG_FILE} ${GPU_CONFIG_FILE} --config samples_tsv=${SAMPLES}
+snakemake --conda-cleanup-envs --use-conda --configfile ${CONFIG_FILE} ${GPU_CONFIG_FILE} --config samples_tsv=${SAMPLES}
 EOF
 
 # ---------------------------------------------------------------------------

--- a/scripts/run_cloud_gpu.sh
+++ b/scripts/run_cloud_gpu.sh
@@ -310,18 +310,6 @@ REMOTE
 fi
 
 # ---------------------------------------------------------------------------
-# Clean up stale conda environments before running the pipeline
-# ---------------------------------------------------------------------------
-log "Cleaning up stale conda environments on ${PIPELINE_VM}..."
-ssh_cmd "${PIPELINE_VM}" -- bash -s <<EOF
-set -euo pipefail
-cd "\$HOME/splice-neoepitope-pipeline"
-source "\$HOME/miniforge3/etc/profile.d/conda.sh"
-conda activate snakemake
-snakemake --conda-cleanup-envs --use-conda --configfile ${CONFIG_FILE} ${GPU_CONFIG_FILE} --config samples_tsv=${SAMPLES}
-EOF
-
-# ---------------------------------------------------------------------------
 # Pull branch and start pipeline
 # ---------------------------------------------------------------------------
 log "Pulling branch '${BRANCH}' and starting pipeline on ${PIPELINE_VM}..."


### PR DESCRIPTION
## Summary
- After a completed run, all pipeline outputs exist and Snakemake builds an empty DAG — causing `--conda-cleanup-envs` to treat every environment as unused and delete all 4 (~5 min rebuild on next run).
- First attempted fix: add `--use-conda` flag. This didn't help — the empty DAG issue remains regardless.
- Final fix: remove the cleanup step entirely. Env hashes are deterministic from yaml content and only go stale when `workflow/envs/*.yaml` files change — manual cleanup is the right approach in that case.

## Test plan
- [x] patient_001 re-run: no conda env deletion in orchestrator log.
- [x] 200 tests passing.

Closes #130. Part of #123.

🤖 Generated with [Claude Code](https://claude.com/claude-code)