### PR TITLE
fix(alignment): pipeline hung on HISAT2 error — VM ran all night

### DIFF
--- a/workflow/rules/alignment.smk
+++ b/workflow/rules/alignment.smk
@@ -174,6 +174,14 @@ if config.get("alignment", {}).get("aligner") == "hisat2":
             set -euo pipefail
             mkdir -p $(dirname {output.junctions})
 
+            # Fail fast if the index is missing — avoids samtools hanging on a
+            # broken pipe, which would prevent Snakemake from writing the error
+            # to pipeline.log and leave the orchestrator polling indefinitely.
+            if [[ ! -f "{params.index_prefix}.1.ht2" ]]; then
+                echo "ERROR: HISAT2 index not found at {params.index_prefix}.*.ht2" | tee -a {log}
+                exit 1
+            fi
+
             if [[ -n "{input.fastq2}" ]]; then
                 FASTQ_ARGS="-1 {input.fastq1} -2 {input.fastq2}"
             else


### PR DESCRIPTION
## Summary
When the HISAT2 index was missing, HISAT2 exited immediately but `samtools sort` hung
on the broken pipe waiting for a SAM header that never came. Snakemake never received
an exit code, never wrote `"Exiting because"` to `pipeline.log`, and the orchestrator
kept polling indefinitely — leaving the VM running all night.

Added a pre-check at the top of `hisat2_align` that verifies the index exists before
starting the pipeline. On failure it exits immediately, Snakemake surfaces the error
to `pipeline.log`, and the orchestrator shuts the VM down.

## Test plan
- [ ] 200 tests passing.

Closes #131. Part of #123.

🤖 Generated with [Claude Code](https://claude.com/claude-code)