### PR TITLE
docs: GTEx filter scientific rationale + patient_002 normal sample decision

### DIFF
--- a/research/lab_notebook.md
+++ b/research/lab_notebook.md
@@ -4,6 +4,50 @@
 
 ## 2026-04-24
 
+### ~22:00 UTC
+
+#### Issue #123 / #126 — patient_002 normal sample decision + GTEx filter design (Researcher session)
+
+**Context:** patient_002 (osteosarcoma IPISRC044) has no matched RNA-seq normal. Current
+production run uses Blood WES as proxy, yielding effectively no junction filtering (3 junctions
+overlapping tumour set — consistent with WES spliced reads being alignment artefacts).
+
+**Normal sample decision for current production run:**
+
+Longitudinal single-cell RNA-seq (PBMC, sorted CD3+ T cells) is available from the Hudson Lab:
+
+- Protocol: 10x Chromium (confirmed by Cell Ranger output + Seurat objects)
+- Time points: Jan 2025 – Dec 2025 (growing dataset)
+- Location: `hudson_lab/PBMC_scRNAseq/FASTQ` and `hudson_lab/PBMC_scRNAseq/cellranger`
+
+Decision: use **Jan 2025 Cell Ranger BAM** as the normal input for the current patient_002 run.
+Rationale:
+- CD3+ T cells are the primary TIL population contaminating solid tumour RNA-seq; filtering their
+  junctions directly targets the most relevant contamination source
+- Jan 2025 is the earliest (most treatment-naive) time point — least treatment-modified T cell state
+- 10x 3' capture gives sparse junction coverage, but still produces genuine biological splice junctions
+  unlike WES (which gave near-zero overlap)
+- This is an interim measure pending GTEx pan-tissue filter implementation (issue #126)
+
+Developer action: run regtools on the Jan 2025 Cell Ranger BAM (already genome-aligned; no
+re-alignment needed) and use resulting junction set as `normal_junctions` for patient_002.
+
+**GTEx pan-tissue filter — scientific rationale documented (issue #126):**
+
+A pan-tissue GTEx filter (not tissue-matched) is the correct long-term approach for a vaccination
+application. Key argument: vaccine-induced CTLs are systemic — they patrol all tissues, not only
+the tumour site. A junction present in any normal tissue could be presented on those cells, creating
+off-tumour autoimmune toxicity risk. Pan-tissue filtering serves dual purpose:
+
+1. Safety — excludes junctions expressed in any of ~54 GTEx tissue types
+2. Candidate quality — pan-tissue absence is a stronger tumour-exclusivity claim; precision over
+   recall is appropriate given 10–20 vaccine slot constraint
+
+Full rationale added to `research/manuscript/DISCUSSIONS.md` (section "Normal sample filtering →
+GTEx pan-tissue filter"). Issue #126 opened for Developer implementation.
+
+---
+
 ### ~18:30 UTC
 
 #### Issue #123 — M1 production cloud run: patient_001 started

--- a/research/manuscript/DISCUSSIONS.md
+++ b/research/manuscript/DISCUSSIONS.md
@@ -160,6 +160,50 @@ genomic locus. The junction-spanning filter addresses the most common version of
 (same-locus exonic sequence), but a cross-proteome BLAST check would be more thorough.
 This remains an open improvement.
 
+### GTEx pan-tissue filter: extending normal filtering for vaccination applications
+
+The matched normal RNA-seq provides a patient-specific junction filter, but is not always
+available. Patient_002 (osteosarcoma) has no matched RNA-seq normal; the WES proxy
+contributed only 3 overlapping junctions — effectively no filtering. A population-level
+reference is needed as a substitute or supplement.
+
+GTEx (V10) provides RNA-seq from approximately 54 distinct tissue types across ~900
+donors, with junction-level read counts available as pre-computed files. Rather than
+filtering against a single tissue matched to the tumour of origin, we argue that a
+**pan-tissue filter** — removing any junction present in any GTEx tissue — is the
+scientifically correct choice for a vaccination application.
+
+The reasoning follows directly from the clinical context. A personalised cancer vaccine
+induces a systemic cytotoxic T cell response: once primed, vaccine-specific T cells
+circulate and patrol all tissues, not only the tumour. A junction present in any normal
+tissue — regardless of organ — means the derived peptide is part of that tissue's
+normal transcriptome and could be presented on its cell surface. Vaccine-trained T cells
+targeting that peptide could therefore cause off-tumour autoimmune toxicity in any
+tissue expressing the junction. Restricting the normal filter to matched or
+mesenchymally-related tissues would leave these off-tumour risks unaddressed.
+
+The pan-tissue filter therefore serves two complementary purposes:
+
+- **Safety.** Junctions present in any GTEx tissue are excluded, reducing the
+  autoimmune risk to normal tissues from vaccine-induced T cells.
+- **Candidate quality.** A junction absent from all ~54 GTEx tissue types across the
+  population is a far stronger tumour-exclusivity claim than one filtered only against
+  a single matched normal or not filtered at all. Given the limited number of peptide
+  slots in a personalised vaccine formulation (10–20 candidates; Sahin et al.,
+  *Nature* 2017; Ott et al., *Nature* 2017), precision outweighs recall: the cost of
+  a wasted slot or an autoimmune adverse event exceeds the cost of a missed candidate.
+
+This conservative bias mirrors the logic applied to GPS-based candidate ranking: the
+clinical question — vaccination, not natural immunity prediction — determines both how
+candidates are ranked (GPS as the primary signal for HLA genotype coverage) and how
+they are filtered (pan-tissue normal reference for systemic safety).
+
+Note that junction-level filtering is a necessary but not sufficient safety check: it
+catches cases where the source splice event itself occurs in normal tissue, but does not
+address cross-reactivity between a tumour-exclusive peptide and a structurally similar
+normal peptide. The proteome-level BLAST check (see above) addresses that orthogonal
+concern.
+
 ---
 
 ## HISAT2 vs. STAR for novel junction detection


### PR DESCRIPTION
Closes #139. Part of #126.

## Changes
- `research/manuscript/DISCUSSIONS.md`: GTEx pan-tissue filter scientific rationale — argues for pan-tissue over tissue-matched filtering in a vaccination context (systemic CTL safety check + candidate quality signal)
- `research/lab_notebook.md`: 2026-04-24 Scientist entry — patient_002 interim normal decision (Jan 2025 CD3+ PBMC) + GTEx filter design rationale

## Note
Cherry-picked from `feat/issue-123-prod-cloud-run` to unblock that branch from docs-only commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)