### PR TITLE
feat(cloud): VM data cleanup + NVIDIA driver fixes for common-cu129 image

### DIFF
--- a/research/lab_notebook.md
+++ b/research/lab_notebook.md
@@ -4,6 +4,36 @@
 
 ## 2026-04-25
 
+### ~16:56 UTC — Editor: Developer
+
+#### Issue #136 — VM data cleanup + NVIDIA driver fixes for common-cu129 image
+
+**Context:** patient_002 run restarted after morning disk resize. Left running while user went to lunch (~12:00 UTC).
+
+**NVIDIA driver failures — three iterations (~13:00–15:00 UTC)**
+
+The `ubuntu-accelerator-2204-amd64-with-nvidia-570` Deep Learning VM image was retired by Google; the replacement is `common-cu129-ubuntu-2204-nvidia-580`. The new image ships driver 580, which lacks GSP firmware support for P100 (Pascal SM 6.0). Three driver downgrade attempts were needed before a working configuration was found:
+
+| Attempt | Package | Failure reason |
+|---------|---------|----------------|
+| 1 | `nvidia-driver-570-server` | Pulls display dependencies (`libgbm1`, `libxcb-*`, `libnvidia-egl-wayland1`) absent on headless VMs |
+| 2 | `nvidia-headless-no-dkms-570-server` | Pre-compiled kernel modules don't match GCP kernel (`6.8.0-1053-gcp`) on `common-cu129` image — `nvidia-smi` fails with "driver not loaded" |
+| 3 | `nvidia-headless-570-server` (DKMS) | **Works** — DKMS recompiles modules against the running kernel at install time |
+
+`IMAGE_FAMILY` in `run_cloud_gpu.sh` updated to `common-cu129-ubuntu-2204-nvidia-580`. Driver downgrade block updated to install the DKMS variant. Three commits on `feat/issue-136-vm-data-cleanup`; PR #151 opened.
+
+**patient_002 pipeline completed (~15:00–15:46 UTC)**
+
+TCRdock rerun manually with `snakemake --forcerun run_tcrdock` after DKMS driver confirmed active. All 22 Snakemake steps finished. Results and logs uploaded to GCS at ~15:46 UTC.
+
+Top candidate: **NSISRPSSL / HLA-C\*01:02, ic50\_nM=39.77, pLDDT=91.99**
+
+**Issue #148 discovered — results invalid: chromosome naming mismatch (~16:00 UTC)**
+
+Report showed only ~800 total neoepitopes (expected thousands). Root cause: `hisat2_prebuilt_url` in `config/config.yaml` used `grch38_tran.tar.gz` (ENSEMBL naming, no `chr` prefix) while the genome FASTA uses UCSC naming (`chr` prefix). `bedtools getfasta` returned empty sequences → 56,735 of 56,774 junctions skipped in `assemble_contigs.py` → only 18 contigs → 783 peptides. patient_001 was unaffected as it predates the config key and built the index locally from the UCSC FASTA. Fix: `hg38_tran.tar.gz` on `fix/issue-148-hisat2-chr-naming`. **Today's patient_002 results are invalid; full rerun required after Issue #148 is merged.**
+
+---
+
 ### ~15:00 UTC — Editor: Scientist
 
 #### TCR-pMHC binding prediction — field overview and structural improvement plan (Issue #86)

--- a/scripts/run_cloud_gpu.sh
+++ b/scripts/run_cloud_gpu.sh
@@ -299,11 +299,13 @@ wait_for_ssh "${PIPELINE_VM}"
 # Downgrade NVIDIA driver to 570-server for P100 (Pascal SM 6.0) compatibility
 # Driver 580+ requires GSP firmware which P100 lacks. Idempotent — skipped if
 # 570-server is already installed (e.g. VM reused from a previous run).
+# Use headless (no-dkms) variant: full nvidia-driver-570-server pulls in display
+# dependencies (libgbm1, libxcb-*, libnvidia-egl-wayland1) absent on headless VMs.
 # ---------------------------------------------------------------------------
-if ! ssh_cmd "${PIPELINE_VM}" -- dpkg -s nvidia-driver-570-server &>/dev/null; then
-    log "Downgrading NVIDIA driver to 570-server for P100 compatibility..."
-    ssh_cmd "${PIPELINE_VM}" -- sudo apt-get install -y -q --allow-downgrades nvidia-driver-570-server
-    ssh_cmd "${PIPELINE_VM}" -- sudo apt-get purge -y -q 'nvidia-driver-580*' 2>/dev/null || true
+if ! ssh_cmd "${PIPELINE_VM}" -- dpkg -s nvidia-headless-no-dkms-570-server &>/dev/null; then
+    log "Downgrading NVIDIA driver to 570-server (headless) for P100 compatibility..."
+    ssh_cmd "${PIPELINE_VM}" -- sudo apt-get purge -y -q 'nvidia-driver-580*' 'nvidia-headless-no-dkms-580*' 'nvidia-utils-580*' 2>/dev/null || true
+    ssh_cmd "${PIPELINE_VM}" -- sudo apt-get install -y -q --no-install-recommends nvidia-headless-no-dkms-570-server nvidia-utils-570-server
     log "Rebooting VM to load driver 570..."
     ssh_cmd "${PIPELINE_VM}" -- sudo reboot || true
     sleep 60

--- a/scripts/run_cloud_gpu.sh
+++ b/scripts/run_cloud_gpu.sh
@@ -299,13 +299,14 @@ wait_for_ssh "${PIPELINE_VM}"
 # Downgrade NVIDIA driver to 570-server for P100 (Pascal SM 6.0) compatibility
 # Driver 580+ requires GSP firmware which P100 lacks. Idempotent — skipped if
 # 570-server is already installed (e.g. VM reused from a previous run).
-# Use headless (no-dkms) variant: full nvidia-driver-570-server pulls in display
-# dependencies (libgbm1, libxcb-*, libnvidia-egl-wayland1) absent on headless VMs.
+# Use headless DKMS variant: nvidia-headless-no-dkms-570-server pre-compiled
+# modules don't match the GCP kernel (6.8.0-*-gcp) on common-cu129 images.
+# DKMS recompiles against the running kernel at install time.
 # ---------------------------------------------------------------------------
-if ! ssh_cmd "${PIPELINE_VM}" -- dpkg -s nvidia-headless-no-dkms-570-server &>/dev/null; then
-    log "Downgrading NVIDIA driver to 570-server (headless) for P100 compatibility..."
+if ! ssh_cmd "${PIPELINE_VM}" -- dpkg -s nvidia-headless-570-server &>/dev/null; then
+    log "Downgrading NVIDIA driver to 570-server (DKMS) for P100 compatibility..."
     ssh_cmd "${PIPELINE_VM}" -- sudo apt-get purge -y -q 'nvidia-driver-580*' 'nvidia-headless-no-dkms-580*' 'nvidia-utils-580*' 2>/dev/null || true
-    ssh_cmd "${PIPELINE_VM}" -- sudo apt-get install -y -q --no-install-recommends nvidia-headless-no-dkms-570-server nvidia-utils-570-server
+    ssh_cmd "${PIPELINE_VM}" -- sudo apt-get install -y -q --no-install-recommends nvidia-headless-570-server nvidia-utils-570-server
     log "Rebooting VM to load driver 570..."
     ssh_cmd "${PIPELINE_VM}" -- sudo reboot || true
     sleep 60

--- a/scripts/run_cloud_gpu.sh
+++ b/scripts/run_cloud_gpu.sh
@@ -42,7 +42,7 @@ ZONE="europe-west1-b"
 MACHINE_TYPE="n1-highmem-8"   # n1 required for P100; 52 GB RAM for OptiType (~36 GB peak)
 ACCELERATOR="type=nvidia-tesla-p100,count=1"  # T4 quota is 0/0 in europe-west1; P100 standard quota (NVIDIA_P100_GPUS >= 1) required
 DISK_SIZE="200GB"              # pipeline data + Docker image (~25 GB) + reference data
-IMAGE_FAMILY="ubuntu-accelerator-2204-amd64-with-nvidia-570"  # driver 570 supports P100; common-cu128/570 retired, common-cu129/580 drops P100 GSP firmware
+IMAGE_FAMILY="common-cu129-ubuntu-2204-nvidia-580"  # only available Ubuntu 22.04 DL image; driver downgraded to 570-server below for P100 (Pascal) compatibility
 IMAGE_PROJECT="deeplearning-platform-release"
 REPO_URL="https://github.com/Jin-HoMLee/splice-neoepitope-pipeline.git"
 ORCH_VM="neoepitope-orchestrator"
@@ -294,6 +294,22 @@ else
 fi
 
 wait_for_ssh "${PIPELINE_VM}"
+
+# ---------------------------------------------------------------------------
+# Downgrade NVIDIA driver to 570-server for P100 (Pascal SM 6.0) compatibility
+# Driver 580+ requires GSP firmware which P100 lacks. Idempotent — skipped if
+# 570-server is already installed (e.g. VM reused from a previous run).
+# ---------------------------------------------------------------------------
+if ! ssh_cmd "${PIPELINE_VM}" -- dpkg -s nvidia-driver-570-server &>/dev/null; then
+    log "Downgrading NVIDIA driver to 570-server for P100 compatibility..."
+    ssh_cmd "${PIPELINE_VM}" -- sudo apt-get install -y -q --allow-downgrades nvidia-driver-570-server
+    ssh_cmd "${PIPELINE_VM}" -- sudo apt-get purge -y -q 'nvidia-driver-580*' 2>/dev/null || true
+    log "Rebooting VM to load driver 570..."
+    ssh_cmd "${PIPELINE_VM}" -- sudo reboot || true
+    sleep 60
+    wait_for_ssh "${PIPELINE_VM}"
+    log "VM rebooted — NVIDIA driver 570 active."
+fi
 
 # ---------------------------------------------------------------------------
 # Setup VM (idempotent — skips steps already done)

--- a/scripts/run_cloud_gpu.sh
+++ b/scripts/run_cloud_gpu.sh
@@ -97,6 +97,7 @@ case "${MODE}" in
         echo "ERROR: --mode must be 'test' or 'prod', got '${MODE}'" >&2
         exit 1 ;;
 esac
+PATIENT_ID=$(basename "${SAMPLES}" .tsv)
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -386,6 +387,27 @@ gcloud storage cp -r "${RESULTS_DIR}" "${GCS_PATH%/*}/"
 echo "Results upload complete."
 [[ -d "logs" ]] && gcloud storage cp -r "logs" "gs://${GCS_BUCKET}/" && echo "Logs upload complete."
 [[ -f "pipeline.log" ]] && gcloud storage cp "pipeline.log" "gs://${GCS_BUCKET}/logs/pipeline.log" && echo "Pipeline log uploaded."
+EOF
+
+# ---------------------------------------------------------------------------
+# Clean up per-patient data from VM (runs only after confirmed GCS upload)
+# ---------------------------------------------------------------------------
+log ""
+log "=== Cleaning up per-patient data from VM ==="
+
+ssh_cmd "${PIPELINE_VM}" -- bash -s <<EOF
+set -euo pipefail
+cd "\$HOME/splice-neoepitope-pipeline"
+if [[ -d "data/${PATIENT_ID}" ]]; then
+    rm -rf "data/${PATIENT_ID}"
+    echo "Deleted data/${PATIENT_ID}/"
+fi
+if [[ -d "results/${PATIENT_ID}/alignment" ]]; then
+    find "results/${PATIENT_ID}/alignment" -type f \
+        \( -name "*.bam" -o -name "*.bam.bai" -o -name "*.bed" \) -delete
+    echo "Deleted alignment intermediates for ${PATIENT_ID}"
+fi
+echo "VM cleanup complete."
 EOF
 
 # ===========================================================================


### PR DESCRIPTION
Closes #136

## Summary
- Deletes per-patient FASTQs and BAMs from the pipeline VM after confirmed GCS upload, preventing disk exhaustion on multi-patient runs
- Downgrades NVIDIA driver from 580 to 570-server for P100 (Pascal SM 6.0) compatibility — driver 580+ requires GSP firmware which P100 lacks
- Switches from `nvidia-headless-no-dkms-570-server` to `nvidia-headless-570-server` (DKMS) — pre-compiled no-dkms modules don't match the GCP kernel (`6.8.0-*-gcp`) on the `common-cu129` image; DKMS recompiles against the running kernel at install time

## Test plan
- [x] DKMS driver install verified working on live VM (`neoepitope-pipeline`, europe-west1-b, kernel `6.8.0-1053-gcp`)
- [x] TCRdock ran successfully with driver 570 DKMS active (patient_002 run 2026-04-25)

🤖 Generated with [Claude Code](https://claude.com/claude-code)