### PR TITLE
ci: add Snakemake dry-run with GPU config overlay to catch tcrdock rule errors

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,27 @@ on:
     branches: [main]
 
 jobs:
-  test:
+  pipeline-snakemake-dry-run:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Install Snakemake
+        run: pip install "snakemake==8.30.0"
+
+      - name: Dry-run with GPU config overlay
+        run: |
+          snakemake -n \
+            --configfile config/config.yaml config/gpu.yaml \
+            --config samples_tsv=config/samples/patient_001_test.tsv
+
+  pipeline-pytest:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,6 +21,12 @@ jobs:
       - name: Install Snakemake
         run: pip install "snakemake==8.30.0"
 
+      - name: Create placeholder input files
+        run: |
+          mkdir -p data/test
+          touch data/test/SRR9143066_test.fastq.gz
+          touch data/test/SRR9143065_test.fastq.gz
+
       - name: Dry-run with GPU config overlay
         run: |
           snakemake -n \

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,9 +23,12 @@ jobs:
 
       - name: Create placeholder input files
         run: |
-          mkdir -p data/test
+          mkdir -p data/test resources
           touch data/test/SRR9143066_test.fastq.gz
           touch data/test/SRR9143065_test.fastq.gz
+          touch resources/gencode.v47.annotation.gtf.gz
+          touch resources/GRCh38.primary_assembly.genome.fa
+          touch resources/human_proteome.fasta
 
       - name: Dry-run with GPU config overlay
         run: |


### PR DESCRIPTION
## Summary

- Adds a `pipeline-snakemake-dry-run` CI job that runs `snakemake -n` with `gpu.yaml` merged in on every push/PR to main
- Catches config key errors in `structure.smk` rules guarded by `if _TCRDOCK_ENABLED:` — previously invisible to CI because `gpu.yaml` was never loaded
- Renames the existing `test` job to `pipeline-pytest` for clarity

## Why a separate job

`pipeline-snakemake-dry-run` and `pipeline-pytest` test different things: the dry-run validates the Snakemake workflow DAG and config key references (`.smk` files are not importable Python), while pytest tests Python script logic. Keeping them as separate jobs gives distinct named status checks in PR reviews.

## Motivation

The `KeyError: 'ic50_strong'` on the first cloud prod run (fixed in #117) was caused by a stale config key reference in a TCRdock rule block — missed because CI never loaded `gpu.yaml`. This job prevents that class of bug.

Closes #118

**Created by:** Developer

🤖 Generated with [Claude Code](https://claude.com/claude-code)