### PR TITLE
docs(scientist): patient_002 results in RESULTS.md and lab notebook entry

### DIFF
--- a/research/lab_notebook.md
+++ b/research/lab_notebook.md
@@ -44,6 +44,36 @@ Merged notebook environment scaffold for `research/notebooks/`:
 
 ---
 
+### 18:15 UTC — Editor: Scientist
+
+#### Issues #162–165 — patient_002 results analysis (valid run, post Issue #148)
+
+First scientific analysis session for patient_002 (BG003082, osteosarcoma). Full analysis in `research/notebooks/patient_002_results.ipynb`.
+
+**Key findings:**
+
+- Top candidate: **FADLRPLLL / HLA-C\*01:02** — IC50 33.2 nM, presentation_percentile 0.0045%, GPS 0.9999, strong presenter across 4/5 alleles.
+- **HLA-C dominance:** HLA-C\*01:02 + HLA-C\*07:01 account for ~69% of all 67,935 strong-presenting peptides despite 0.5× locus weight in GPS. Three hypotheses: (a) broader HLA-C groove/promiscuity, (b) osteosarcoma splice motifs enriched for HLA-C, (c) MHCflurry percentile calibration less precise for HLA-C (sparser training data). Sent to Developer for investigation.
+- **HLA-A\*01:01 nearly silent:** median presentation percentile 8.5% among strong presenters — contributes almost nothing to GPS for this patient.
+- **GPS is discriminating:** mean 0.101, median 0.026; only 1.1% of 2.3M predictions exceed GPS > 0.9. Formula works as designed.
+- **GPS inflation edge case (minor):** 174 candidates (0.7% of GPS > 0.9) have `n_strong_alleles = 0` with best_percentile ~0.5–0.55%. Quality gate (2%) does not catch these. Flagged to Developer to consider adding `n_strong_alleles ≥ 1` as a hard filter.
+- **Minimum junction read support is 174** — suspiciously high. Awaiting Developer confirmation of whether a min-reads filter is applied.
+- **Peptide translation:** 2,330,687 total (703,106 × 8-mer, 781,159 × 9-mer, 846,422 × 10-mer), 2,313,700 unique. 9-mer count differs by 265 from a prior run (781,424) — untracked discrepancy, motivates run registry (Issue TBD).
+
+**Actions taken:**
+
+- Created `research/notebooks/patient_002_results.ipynb` (Issue #164).
+- Set up `research/.venv` (Python 3.14.4 via pyenv) + `research/requirements.txt` + `research/README.md` notebook section (Issue #163).
+- Updated `research/manuscript/RESULTS.md` patient_002 section: MHC presentation + GPS, peptide translation, top candidate FADLRPLLL, TCRdock. Junction Filtering table on hold pending Developer confirmation of WES normal usage (Issue #165).
+- Opened Issue #161 (local GCS cache for notebooks); drafted run registry issue for Developer review in standup.
+- Terminology convention established: "presenters/presenting" replaces "binders/binding" throughout.
+
+**Open / pending:**
+- Developer standup: min read filter, GPS gate, HLA-C calibration, WES normal confirmation, run registry engineering input.
+- RESULTS.md Junction Filtering: on hold.
+
+---
+
 ### 17:03 UTC — Editor: Developer
 
 #### Issue #148 — PR #152 review fixes (assemble_contigs.py + alignment.smk)

--- a/research/lab_notebook.md
+++ b/research/lab_notebook.md
@@ -4,6 +4,18 @@
 
 ## 2026-04-26
 
+### 22:18 UTC — Editor: Scientist
+
+#### PR #168 — review fixes (docs/scientist/issue-165-patient-002-documentation)
+
+Three items addressed before merge:
+
+1. **Weak threshold label clarified** — `Weak (percentile ≤ 2.0%)` → `Weak (0.5% < percentile ≤ 2.0%)` to make the exclusive band unambiguous.
+2. **GPS phrasing fixed** — `exceeded GPS > 0.9` → `had GPS > 0.9` (redundant double-negative removed).
+3. **9-mer discrepancy** — added WES proxy normal usage as a second possible cause alongside the #148 fix.
+
+---
+
 ### 21:50 UTC — Editor: Scientist
 
 #### PR #167 — review fixes (feat/scientist/issue-164-patient-002-notebook)

--- a/research/manuscript/RESULTS.md
+++ b/research/manuscript/RESULTS.md
@@ -158,8 +158,8 @@ complete-codon junction-spanning filter applied.
 
 99.3% of peptides are unique sequences. A previous run (older pipeline version)
 reported 781,424 9-mers; the 265-peptide discrepancy is untracked — likely due to
-the HISAT2 chr-naming fix (#148) altering junction calls. Motivates the run registry
-(Issue TBD).
+the HISAT2 chr-naming fix (#148) altering junction calls and/or the difference in
+normal input (WES proxy vs. no normal). Motivates the run registry (Issue TBD).
 
 ### MHC Presentation Predictions
 
@@ -170,7 +170,7 @@ MHCflurry 2.x `Class1PresentationPredictor` was run for all five expressed HLA a
 | Presentation class | Count | % of total |
 |---|---|---|
 | Strong (percentile ≤ 0.5%) | 67,935 | 2.9% |
-| Weak (percentile ≤ 2.0%) | 222,823 | 9.6% |
+| Weak (0.5% < percentile ≤ 2.0%) | 222,823 | 9.6% |
 | Non (percentile > 2.0%) | 2,039,929 | 87.5% |
 | **Total predictions** | **2,330,687** | — |
 
@@ -198,7 +198,7 @@ where $p_i$ is per-allele `presentation_score` and $w_i$ is the locus weight
 the probability that at least one allele in the patient's genotype presents the peptide.
 
 GPS distribution across all 2,330,687 predictions: mean 0.101, median 0.026.
-Only 24,961 peptides (1.1%) exceeded GPS > 0.9, confirming the metric is
+Only 24,961 peptides (1.1%) had GPS > 0.9, confirming the metric is
 discriminating. An inflation edge case was identified: 174 candidates (0.7% of
 GPS > 0.9) had `n_strong_alleles = 0` with `best_presentation_percentile` ~0.5–0.55%,
 just above the strong threshold. The current quality gate does not catch these;

--- a/research/manuscript/RESULTS.md
+++ b/research/manuscript/RESULTS.md
@@ -144,49 +144,92 @@ junctions may represent patient-specific but non-tumor splicing.
 
 ### Peptide Translation
 
-Junction-spanning 9-mers were extracted from 50 nt contigs across all three reading
-frames with the complete-codon junction-spanning filter applied.
+Junction-spanning peptides were extracted from contigs assembled at each
+tumor-exclusive junction, across all three reading frames, with the
+complete-codon junction-spanning filter applied.
 
-| Metric | Count |
+| Length | Count |
 |--------|-------|
-| Total 9-mers | 781,424 |
-| Unique 9-mer sequences | 775,440 |
+| 8-mer | 703,106 |
+| 9-mer | 781,159 |
+| 10-mer | 846,422 |
+| **Total** | **2,330,687** |
+| **Unique sequences** | **2,313,700** |
 
-### MHC Binding Predictions
+99.3% of peptides are unique sequences. A previous run (older pipeline version)
+reported 781,424 9-mers; the 265-peptide discrepancy is untracked — likely due to
+the HISAT2 chr-naming fix (#148) altering junction calls. Motivates the run registry
+(Issue TBD).
 
-MHCflurry 2.x was run for all six OptiType-called HLA alleles.
+### MHC Presentation Predictions
 
-| Binder class | Count | % of total |
+MHCflurry 2.x `Class1PresentationPredictor` was run for all five expressed HLA alleles
+(HLA-A homozygous A\*01:01 counted once). Presentation class is defined by
+`presentation_percentile`: strong ≤ 0.5%, weak ≤ 2.0%.
+
+| Presentation class | Count | % of total |
 |---|---|---|
-| Strong (IC50 ≤ 50 nM) | 12,430 | 0.32% |
-| Weak (IC50 ≤ 500 nM) | 211,418 | 5.41% |
-| Non-binder (IC50 > 500 nM) | 3,683,272 | 94.27% |
-| **Total predictions** | **3,907,120** | — |
+| Strong (percentile ≤ 0.5%) | 67,935 | 2.9% |
+| Weak (percentile ≤ 2.0%) | 222,823 | 9.6% |
+| Non (percentile > 2.0%) | 2,039,929 | 87.5% |
+| **Total predictions** | **2,330,687** | — |
 
-Best strong binder per allele:
+Strong presenters per allele (best-allele attribution):
 
-| Allele | Peptide | IC50 |
-|--------|---------|------|
-| HLA-A\*01:01 | TTDPVQALY | 23.9 nM |
-| HLA-B\*08:01 | HAYTKIHSL | 29.5 nM |
-| HLA-B\*27:05 | GRFSKVHTF | 45.0 nM |
-| HLA-C\*01:02 | AAPPHPLSL | 17.9 nM |
-| HLA-C\*07:01 | YRIDRTLSL | 22.7 nM |
+| Allele | Strong-presenting peptides | % of total strong |
+|--------|---------------------------|-------------------|
+| HLA-C\*01:02 | 26,236 | 38.6% |
+| HLA-C\*07:01 | 20,443 | 30.1% |
+| HLA-B\*08:01 | 11,477 | 16.9% |
+| HLA-B\*27:05 | 5,193 | 7.6% |
+| HLA-A\*01:01 | 4,586 | 6.8% |
+
+HLA-C alleles dominated the strong-presenter set (~69% combined). HLA-A\*01:01 was
+nearly silent (median presentation percentile 8.5% among strong presenters).
+
+### Genotype Presentation Score (GPS)
+
+Each peptide was scored with the Genotype Presentation Score:
+
+$$\text{GPS} = 1 - \prod_{i} (1 - w_i \cdot p_i)$$
+
+where $p_i$ is per-allele `presentation_score` and $w_i$ is the locus weight
+(HLA-A/B = 1.0, HLA-C = 0.5, reflecting ~50% lower surface density). GPS estimates
+the probability that at least one allele in the patient's genotype presents the peptide.
+
+GPS distribution across all 2,330,687 predictions: mean 0.101, median 0.026.
+Only 24,961 peptides (1.1%) exceeded GPS > 0.9, confirming the metric is
+discriminating. An inflation edge case was identified: 174 candidates (0.7% of
+GPS > 0.9) had `n_strong_alleles = 0` with `best_presentation_percentile` ~0.5–0.55%,
+just above the strong threshold. The current quality gate does not catch these;
+an additional `n_strong_alleles ≥ 1` filter is under consideration.
 
 ### Top Neoepitope Candidate
 
-**TTDPVQALY / HLA-A\*01:01, IC50 = 23.9 nM (strong binder)**
+**FADLRPLLL / HLA-C\*01:02**
 
-Top predicted binder for the expressed HLA-A allele. HLA-C\*01:02 produced the
-highest-affinity prediction overall (AAPPHPLSL, 17.9 nM), consistent with
-HLA-C\*01:02 peptide-binding preferences.
+| Metric | Value |
+|--------|-------|
+| IC50 | 33.2 nM |
+| Presentation percentile | 0.0045% |
+| GPS | 0.9999 |
+| n_strong_alleles | 4 of 5 |
+| Presentation class | strong |
+
+FADLRPLLL ranks first by GPS and is presented as strong by 4 of 5 patient alleles.
+Its presentation percentile places it in the top 0.005% of all HLA-C\*01:02-presented
+peptides. HLA-C\*01:02 was also the dominant allele in a pre-#148 (invalidated) run,
+suggesting it is a consistently strong presenter for splice-junction-derived 9-mers
+in this patient.
+
+Without a matched RNA-seq normal, the originating junction cannot be confirmed as
+absent from healthy osteoblasts or mesenchymal stem cells.
 
 ### Structural Validation (TCRdock)
 
-TCRdock was run on this sample. Due to a sentinel bug (since fixed in issue #65),
-the structural prediction used a fallback allele (HLA-A\*02:01) rather than the
-patient's actual HLA-A\*01:01, and the submitted peptide (FMSGFLYFV) is a non-binder
-for all six patient alleles (IC50 > 2,200 nM across all alleles). The predicted
-structure (pLDDT 92.25) is retained as a technical demonstration of the GPU
-infrastructure but should not be interpreted as a biologically meaningful prediction
-for this patient. A corrected TCRdock run with TTDPVQALY / HLA-A\*01:01 is planned.
+TCRdock was run on FADLRPLLL / HLA-C\*01:02, the top GPS-ranked candidate.
+The predicted TCR–peptide–MHC ternary complex structure was successfully generated
+and is available in `results/patient_002/predictions/tcrdock/`.
+
+*Structural interpretation (pLDDT, CDR3 contacts) to be added after Developer
+review of the PDB output.*


### PR DESCRIPTION
## Summary
- Updates `research/manuscript/RESULTS.md` patient_002 section with valid post-#148 results: peptide translation counts (8/9/10-mer), MHC presentation predictions (percentile-based), GPS subsection with formula and validation, top candidate FADLRPLLL/HLA-C*01:02
- Adds 2026-04-26 18:15 UTC Scientist lab notebook entry covering key findings, actions, and open questions

## Test plan
- [x] RESULTS.md patient_002 top candidate matches notebook output (FADLRPLLL/HLA-C*01:02, GPS=0.9999)
- [x] GPS formula in RESULTS.md matches implementation in pipeline
- [x] Lab notebook entry timestamped correctly and at top of 2026-04-26 section (superseded by several other entries over the day)

**Note:** Junction Filtering table update is on hold pending Developer confirmation of WES normal usage in the valid post-#148 run (see team standup question 4).

Closes #165

🤖 Generated with [Claude Code](https://claude.com/claude-code)