### PR TITLE
refactor(config): rename gpu.yaml → gpu_config.yaml (#158)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Dry-run with GPU config overlay
         run: |
           snakemake -n \
-            --configfile config/config.yaml config/gpu.yaml \
+            --configfile config/config.yaml config/gpu_config.yaml \
             --config samples_tsv=config/samples/patient_001_test.tsv
 
   pipeline-pytest:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,8 +36,8 @@ AlphaFold outputs all residues as a single chain (A). `relabel_pdb_chains()` in 
 In Snakemake 8, passing `--configfile` as **separate flags** (`--configfile A --configfile B`) causes the second invocation to replace the first due to argparse `nargs="+"` semantics. Only the last file is loaded.
 **Fix:** pass multiple config files in a **single** `--configfile` invocation:
 ```bash
-snakemake --configfile config/test_config.yaml config/gpu.yaml   # correct
-# NOT: --configfile config/test_config.yaml --configfile config/gpu.yaml
+snakemake --configfile config/test_config.yaml config/gpu_config.yaml   # correct
+# NOT: --configfile config/test_config.yaml --configfile config/gpu_config.yaml
 ```
 
 ## Config Migration Notes

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ snakemake --cores 100 --use-conda \
 ## Configuration
 
 All parameters live in `config/config.yaml`. For TCRdock, merge
-`config/gpu.yaml` via a single `--configfile` invocation.
+`config/gpu_config.yaml` via a single `--configfile` invocation.
 
 See [`docs/configuration.md`](docs/configuration.md) for the full parameter reference.
 
@@ -252,7 +252,7 @@ splice-neoepitope-pipeline/
 ├── Snakefile                         # Main Snakemake workflow
 ├── config/
 │   ├── config.yaml                   # Production configuration
-│   ├── gpu.yaml                      # GPU overlay (MHCflurry + TCRdock)
+│   ├── gpu_config.yaml               # GPU overlay (MHCflurry + TCRdock)
 │   ├── test_config.yaml              # chr22 test configuration
 │   └── samples/
 │       ├── patient_001.tsv           # Gastric cancer (SRR9143066/SRR9143065)

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -111,11 +111,11 @@ mhcflurry:
 # -----------------------------------------------------------------
 # TCRdock structural validation (Step 6 — optional, GPU required)
 # -----------------------------------------------------------------
-# Disabled by default. All settings live in config/gpu.yaml.
+# Disabled by default. All settings live in config/gpu_config.yaml.
 # Enable by passing that file as a second --configfile on the GPU VM:
 #
 #   snakemake --cores $(nproc) --use-conda --rerun-triggers mtime \
-#       --configfile config/config.yaml config/gpu.yaml
+#       --configfile config/config.yaml config/gpu_config.yaml
 #
 # See scripts/setup_vm.sh for GPU VM setup instructions.
 tcrdock:

--- a/config/gpu_config.yaml
+++ b/config/gpu_config.yaml
@@ -7,7 +7,7 @@
 # --configfile argument on the GPU VM:
 #
 #   snakemake --cores $(nproc) --use-conda --rerun-triggers mtime \
-#       --configfile config/config.yaml config/gpu.yaml
+#       --configfile config/config.yaml config/gpu_config.yaml
 #
 # Paths below match the output of scripts/setup_vm.sh.
 # DO NOT set tcrdock.enabled: true in config/config.yaml — keep that as the

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,7 +1,7 @@
 # Configuration Reference
 
 All pipeline parameters live in `config/config.yaml`. For GPU steps (MHCflurry + TCRdock),
-an overlay file `config/gpu.yaml` is merged at runtime.
+an overlay file `config/gpu_config.yaml` is merged at runtime.
 
 ---
 
@@ -94,13 +94,13 @@ mhcflurry:
 
 ## TCRdock Structural Validation (GPU)
 
-Disabled by default. Enable via the `config/gpu.yaml` overlay:
+Disabled by default. Enable via the `config/gpu_config.yaml` overlay:
 
 ```bash
-snakemake --configfile config/config.yaml config/gpu.yaml ...
+snakemake --configfile config/config.yaml config/gpu_config.yaml ...
 ```
 
-Key parameters (in `config/gpu.yaml`):
+Key parameters (in `config/gpu_config.yaml`):
 
 | Parameter | Default | Description |
 |-----------|---------|-------------|

--- a/docs/google_cloud_guide.md
+++ b/docs/google_cloud_guide.md
@@ -517,7 +517,7 @@ snakemake \
     --use-conda \
     --rerun-triggers code params \
     --rerun-incomplete \
-    --configfile config/config.yaml config/gpu.yaml \
+    --configfile config/config.yaml config/gpu_config.yaml \
     --config samples_tsv=config/samples/patient_001.tsv
 ```
 

--- a/scripts/run_cloud_gpu.sh
+++ b/scripts/run_cloud_gpu.sh
@@ -80,7 +80,7 @@ done
 # ---------------------------------------------------------------------------
 RESULTS_DIR="results"
 GCS_PATH="gs://${GCS_BUCKET}/results"
-GPU_CONFIG_FILE="config/gpu.yaml"
+GPU_CONFIG_FILE="config/gpu_config.yaml"
 
 case "${MODE}" in
     test)

--- a/scripts/setup_vm.sh
+++ b/scripts/setup_vm.sh
@@ -239,6 +239,6 @@ if [[ "${STANDALONE}" == true ]]; then
     log "  3. From a tmux session, run the full pipeline:"
     log "       cd $REPO_DIR"
     log "       snakemake --cores \$(nproc) --use-conda --rerun-triggers mtime \\"
-    log "           --configfile config/config.yaml config/gpu.yaml \\"
+    log "           --configfile config/config.yaml config/gpu_config.yaml \\"
     log "           2>&1 | tee pipeline.log"
 fi


### PR DESCRIPTION
## Summary

- Renames `config/gpu.yaml` → `config/gpu_config.yaml` for consistency with the `*_config.yaml` naming convention used by other config files, and to avoid confusion with conda env files in `workflow/envs/*.yaml`
- Updates all live references: `config/config.yaml`, `scripts/run_cloud_gpu.sh`, `scripts/setup_vm.sh`, `README.md`, `CLAUDE.md`, `docs/configuration.md`, `docs/google_cloud_guide.md`
- Historical entries in `research/lab_notebook.md` left unchanged (they are point-in-time records)

**Snakemake profile migration (Issue #158 step 2):** Evaluated and deferred. The file contains pipeline-level config values (TCRdock settings, fallback HLA/TCR alleles), not execution parameters. The `--configfile` overlay approach is semantically correct here; a Snakemake profile would be appropriate only if bundling executor/resource settings. No action needed.

## Test plan

- [ ] Confirm `run_cloud_gpu.sh` uses `GPU_CONFIG_FILE="config/gpu_config.yaml"` and the file exists at that path
- [ ] `grep -r "gpu\.yaml" config/ scripts/ docs/ README.md CLAUDE.md` returns no hits

Closes #158

🤖 Generated with [Claude Code](https://claude.com/claude-code)