### PR TITLE
fix(docs): correct patient_002 Junction Filtering table to valid post-#148 run

### DIFF
--- a/research/lab_notebook.md
+++ b/research/lab_notebook.md
@@ -2,6 +2,28 @@
 
 ---
 
+## 2026-04-27
+
+### 15:43 UTC — Editor: Scientist
+
+#### Issue #172 — RESULTS.md patient_002 Junction Filtering corrected to valid post-#148 run
+
+The Junction Filtering table previously reflected the invalid pre-#148 run (total 347,046, annotated 291,131, unannotated 55,915, normal-shared 3, tumor-exclusive 55,912). Corrected to the valid post-#148 run numbers derived from `alignment/BG003082_T0/junctions.tsv` and `reports/report.tsv` on GCS:
+
+| Stage | Old (invalid) | New (valid) |
+|-------|--------------|-------------|
+| Total extracted | 347,046 | 364,168 |
+| Annotated | 291,131 (83.9%) | 305,254 (83.8%) |
+| Unannotated | 55,915 (16.1%) | 58,914 (16.2%) |
+| Normal-shared | 3 (~0.0%) | 0 (0.0%) |
+| Tumor-exclusive | 55,912 (16.1%) | 58,914 (16.2%) |
+
+`normal_shared = 0` is correct and expected: BG003082_N0_WES was used as the normal input and yielded valid HLA typing results, but WES data contains no RNA splice junctions so junction-level normal subtraction was not effective. Also updated Dataset section to reflect this accurately.
+
+Developer standup (2026-04-26 21:31 UTC, Q4) confirmed the valid run used no RNA-seq normal; the WES-yielding-0-junctions behaviour was separately clarified by the user.
+
+---
+
 ## 2026-04-26
 
 ### 22:40 UTC — Editor: Developer

--- a/research/manuscript/RESULTS.md
+++ b/research/manuscript/RESULTS.md
@@ -108,9 +108,9 @@ report, with chain labels A=MHC, B=peptide, C=TCR-α, D=TCR-β.
 
 BG003082 T0 tumor sample (Boston Gene, Nov 2022), paired-end RNA-seq (~10 GB).
 No matched RNA-seq normal was available. BG003082_N0_WES (whole-exome sequencing, DNA)
-was used as the normal input; WES-derived spliced HISAT2 alignments are largely
-alignment artifacts — see *Discussions* for implications. Processed with HISAT2
-alignment on GCP (n2-highmem-8).
+was used as the normal input for HLA typing (successful) but contributes no junctions
+to normal subtraction — WES contains no RNA splice junctions by design. Processed with
+HISAT2 alignment on GCP (n2-highmem-8).
 
 ### HLA Typing
 
@@ -132,15 +132,17 @@ accuracy in this pipeline.
 
 | Stage | Count | % of total extracted |
 |-------|-------|----------------------|
-| Total junctions extracted (tumor) | 347,046 | 100.0% |
-| Annotated (GENCODE v47, discarded) | 291,131 | 83.9% |
-| Unannotated | 55,915 | 16.1% |
-| Normal-shared (WES proxy, discarded) | 3 | ~0.0% |
-| **Tumor-exclusive candidates** | **55,912** | **16.1%** |
+| Total junctions extracted (tumor) | 364,168 | 100.0% |
+| Annotated (GENCODE v47, discarded) | 305,254 | 83.8% |
+| Unannotated | 58,914 | 16.2% |
+| Normal-shared (WES normal) | 0 | 0.0% |
+| **Tumor-exclusive candidates** | **58,914** | **16.2%** |
 
-The WES normal produced only 3 overlapping junctions (all likely alignment artifacts).
-Without RNA-seq-quality normal subtraction, a fraction of the 55,912 tumor-exclusive
-junctions may represent patient-specific but non-tumor splicing.
+BG003082_N0_WES was used as the normal input and yielded valid HLA typing results.
+However, WES data contains no RNA splice junctions, so `normal_shared = 0` is
+expected — junction-level normal subtraction was not effective. Without a matched
+RNA-seq normal, a fraction of the 58,914 tumor-exclusive junctions may represent
+tissue-specific or germline splicing rather than tumor-specific events.
 
 ### Peptide Translation
 


### PR DESCRIPTION
## Summary

- Corrects Junction Filtering table in `RESULTS.md` from the invalid pre-#148 run numbers to the valid post-#148 run numbers (total 364,168; annotated 305,254; unannotated 58,914; normal-shared 0; tumor-exclusive 58,914)
- Updates explanatory text: `normal_shared = 0` is expected — WES normal was used for HLA typing only; WES contains no RNA splice junctions by design
- Updates Dataset section to accurately describe WES normal contribution
- Adds lab notebook entry

Closes #172.

## Data sources

Numbers derived from GCS:
- Total extracted: row count of `gs://…/patient_002/alignment/BG003082_T0/junctions.tsv` (364,168)
- Annotated: total − unannotated = 364,168 − 58,914 = 305,254
- Unannotated / normal-shared / tumor-exclusive: `gs://…/patient_002/reports/report.tsv`

## Test plan

- [ ] Verify table numbers against GCS sources above
- [ ] Confirm prose accurately describes WES normal behaviour

🤖 Generated with [Claude Code](https://claude.com/claude-code)