### PR TITLE
docs(notebook): add forgotten lab notebook entry for PR #173 merge

### DIFF
--- a/research/lab_notebook.md
+++ b/research/lab_notebook.md
@@ -16,6 +16,14 @@ Merged via PR #174 (replaced PR #170 which closed during a branch rename operati
 
 ---
 
+### 16:58 UTC — Editor: Scientist
+
+#### PR #173 — patient_002 Junction Filtering correction merged
+
+Reviewed by Claude (automated, LGTM, math verified). Both CI checks passed. Squash merged, branch deleted. Closes #172.
+
+---
+
 ### 15:43 UTC — Editor: Scientist
 
 #### Issue #172 — RESULTS.md patient_002 Junction Filtering corrected to valid post-#148 run


### PR DESCRIPTION
## Summary

- Adds the forgotten lab notebook entry for PR #173 (patient_002 Junction Filtering correction) which was reviewed and merged on 2026-04-27 16:58 UTC without its corresponding lab notebook documentation
- One-line entry following standard format

Closes #175.

## Test plan

- [ ] Confirm entry appears in chronological order (newest first within 2026-04-27)

🤖 Generated with [Claude Code](https://claude.com/claude-code)