### PR TITLE
docs(glossary): add research/glossary.md with seed entries (#181)

### DIFF
--- a/research/glossary.md
+++ b/research/glossary.md
@@ -1,0 +1,21 @@
+# Glossary
+
+Project-relevant abbreviations and acronyms. The pipeline mixes biology, ML, bioinformatics, and cloud infrastructure — entries here aim to make onboarding (or returning to the project after time away) easier than re-asking each time.
+
+**Format:** `**ABBREV** — Expansion. One-line context. *Domain: bio | ml | cloud | pipeline | stats.*`
+
+**Scope:** project-relevant terms only. Skip generic web/programming acronyms (HTTP, REST, etc.).
+
+---
+
+## A
+
+**AFDB** — AlphaFold Database (alphafold.ebi.ac.uk). DeepMind/EBI's public repo of ~200M predicted protein structures. *Domain: bio.*
+
+## G
+
+**GKE** — Google Kubernetes Engine. Managed Kubernetes on GCP. *Domain: cloud.*
+
+## S
+
+**SLURM** — Simple Linux Utility for Resource Management. The dominant HPC job scheduler in academia. *Domain: cloud.*

--- a/research/lab_notebook.md
+++ b/research/lab_notebook.md
@@ -2,6 +2,16 @@
 
 ---
 
+## 2026-04-28
+
+### 13:30 UTC — Editor: Developer
+
+#### Issue #181 — add research/glossary.md
+
+Added `research/glossary.md` as a living dictionary of project-relevant abbreviations. Seeded with three entries that came up in conversation today (AFDB, GKE, SLURM). Format: alphabetical sections, `**ABBREV** — Expansion. One-line context. *Domain: bio | ml | cloud | pipeline | stats.*` Going forward, new abbreviations are added when they come up in conversation (rule saved in memory). Merged via PR #182.
+
+---
+
 ## 2026-04-27
 
 ### 17:17 UTC — Editor: Developer


### PR DESCRIPTION
**Created by:** Developer

## Summary

Adds `research/glossary.md` as a living dictionary of project-relevant abbreviations and acronyms. Seeded with three entries that came up in conversation today (2026-04-28):

- **AFDB** — AlphaFold Database. *Domain: bio.*
- **GKE** — Google Kubernetes Engine. *Domain: cloud.*
- **SLURM** — Simple Linux Utility for Resource Management. *Domain: cloud.*

## Why

The pipeline mixes biology, ML, bioinformatics, and cloud infrastructure — many domain-specific acronyms come up. A central glossary makes onboarding (or returning to the project after time away) easier than re-asking each time.

## Workflow going forward

A memory rule has been saved so that whenever a new abbreviation comes up in conversation, the assistant offers to add it to the glossary.

## Test plan

- [ ] Verify the file renders correctly on GitHub
- [ ] Skim — entries are alphabetical, format is consistent

Closes #181

🤖 Generated with [Claude Code](https://claude.com/claude-code)