### PR TITLE
docs(lab-notebook): 2026-04-28 entry for Issue #180 AFDB API audit

### DIFF
--- a/research/lab_notebook.md
+++ b/research/lab_notebook.md
@@ -4,6 +4,22 @@
 
 ## 2026-04-28
 
+### 14:51 UTC — Editor: Developer
+
+#### Issue #180 — verify TCRdock has no dependency on AFDB legacy API
+
+Audit confirmed no dependency. The AlphaFold Database (AFDB) legacy API retires June 2026, so any pipeline component fetching from `alphafold.ebi.ac.uk` would break — this issue checked whether we do.
+
+Findings:
+- Zero AFDB / `alphafold.ebi.ac.uk` references repo-wide (`grep -rni` across `*.py`, `*.sh`, `Dockerfile*`, `*.yaml`, `*.smk`).
+- `docker/Dockerfile.pipeline` downloads AlphaFold v2 params from Dropbox (TCRdock's curated hosting) at image build time, not from AFDB.
+- `workflow/scripts/run_tcrdock.py` imports no HTTP clients (`requests`, `httpx`, `urllib`, `http.client`) and shells out to no `wget`/`curl`. It invokes Docker and reads/writes local files.
+- Inference uses `--data_dir /opt/TCRdock/alphafold_params` (local container path, baked at build time).
+
+Conclusion: the June 2026 AFDB retirement does not affect us. Closed [Issue #180](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/180) with the audit details.
+
+---
+
 ### 13:30 UTC — Editor: Developer
 
 #### Issue #181 — add research/glossary.md


### PR DESCRIPTION
**Created by:** Developer

## Summary

Adds the 2026-04-28 lab notebook entry documenting the [Issue #180](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/180) AFDB legacy API audit. No code changes — lab notebook only.

The audit itself was a 5-min grep + read confirming TCRdock has no dependency on the AFDB legacy API (retiring June 2026). Full findings are on [Issue #180](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/180#issuecomment-4336384875).

## Test plan

- [x] Lab notebook entry renders correctly on GitHub
- [x] Entry is at the top of 2026-04-28 (above the 13:30 UTC entry, below the date heading)

Closes #180

🤖 Generated with [Claude Code](https://claude.com/claude-code)