### PR TITLE
docs(CLAUDE.md): MHC presentation vocabulary + HISAT2 cache invalidation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,19 @@ TCRdock runs inside a Docker container (`docker/Dockerfile.pipeline`) rather tha
 ### PDB chain relabelling
 AlphaFold outputs all residues as a single chain (A). `relabel_pdb_chains()` in `run_tcrdock.py` reassigns chain IDs (A=MHC, B=peptide, C=TCR-α, D=TCR-β) using per-chain sequence lengths from TCRdock's `alphafold_setup/targets.tsv`. The report injects PDB COMPND records so Mol* displays meaningful chain names in the sequence panel instead of "Polymer 1/2/3/4".
 
+## MHC Presentation Vocabulary
+
+This pipeline uses **`Class1PresentationPredictor`** (MHCflurry 2.x), which scores *presentation likelihood* — a combined estimate of binding affinity + antigen processing. It is distinct from the older `Class1AffinityPredictor` (affinity-only).
+
+Relevant output columns (use these names in code, reports, and prose):
+
+- `presentation_class` — `strong | weak | non`
+- `presentation_score`, `presentation_percentile`, `best_presentation_percentile`
+- `genotype_presentation_score`
+- `n_strong_alleles`
+
+Use **"presenter" / "top presenters" / "presentation percentile"** throughout. Avoid **"binder" / "top binders" / "binding affinity threshold"** — those refer to the affinity-only predictor we do not use as the primary ranker. IC50 (`ic50_nM`) is still emitted for reference but is a secondary metric.
+
 ## Snakemake 8 `--configfile` Gotcha
 In Snakemake 8, passing `--configfile` as **separate flags** (`--configfile A --configfile B`) causes the second invocation to replace the first due to argparse `nargs="+"` semantics. Only the last file is loaded.
 **Fix:** pass multiple config files in a **single** `--configfile` invocation:
@@ -39,6 +52,19 @@ In Snakemake 8, passing `--configfile` as **separate flags** (`--configfile A --
 snakemake --configfile config/test_config.yaml config/gpu_config.yaml   # correct
 # NOT: --configfile config/test_config.yaml --configfile config/gpu_config.yaml
 ```
+
+## HISAT2 Index Cache Invalidation
+
+Snakemake skips the index download if `resources/hisat2_index/` already exists (it checks for an `index.done` sentinel file). Changing `hisat2_prebuilt_url` in `config/config.yaml` does **not** invalidate this cache — the old index silently persists and will be used on the next run.
+
+**When changing `hisat2_prebuilt_url`:** delete the index directory on the VM before running:
+
+```bash
+gcloud compute ssh neoepitope-pipeline --zone=europe-west1-b --tunnel-through-iap \
+  --command="rm -rf ~/splice-neoepitope-pipeline/resources/hisat2_index/"
+```
+
+(The chromosome naming mismatch in Issue #148 was caused by this exact scenario.)
 
 ## Config Migration Notes
 


### PR DESCRIPTION
## Summary

- **MHC Presentation Vocabulary** — documents that this pipeline uses `Class1PresentationPredictor` (not `Class1AffinityPredictor`), lists the canonical output column names (`presentation_class`, `presentation_score`, `presentation_percentile`, `best_presentation_percentile`, `genotype_presentation_score`, `n_strong_alleles`), and establishes "presenter" / "top presenters" as correct terminology (not "binder").
- **HISAT2 Index Cache Invalidation** — documents the `index.done` sentinel-file behaviour: changing `hisat2_prebuilt_url` in `config/config.yaml` does **not** invalidate the cached index; the old index silently persists. Includes the `gcloud rm -rf` command needed before re-running. (Root cause of the Issue #148 chromosome naming mismatch.)

## Context

These were identified during a memory-system audit as codebase facts that belong in `CLAUDE.md` (stable, project-level, useful to any session) rather than in role-specific AI memory files (which are for AI behavior rules and evolving project state). Going forward, `CLAUDE.md` updates are the responsibility of the project roles (Developer, Scientist, PM) as part of their normal PRs.

## Test plan

- [ ] Verify `CLAUDE.md` renders correctly on GitHub
- [ ] Confirm column names match `workflow/scripts/run_mhcflurry.py` output
- [ ] Confirm HISAT2 cache path matches `config/config.yaml` `hisat2_prebuilt_url` key

**Created by:** cerebrum session