### PR TITLE
docs(CLAUDE.md): GCP infrastructure details, Snakemake conda activation, STAR local constraint

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,10 @@ Modernised reimplementation of a 2015 cancer neoepitope prediction pipeline (Jin
 ## Infrastructure
 - Running on GCP Compute Engine VMs — see `docs/google_cloud_guide.md` for full setup
 - Current production VMs: `neoepitope-pipeline` (n1-highmem-8 + P100, Phase 1), `pipeline-spot-gpu` (n1-standard-4 + P100, Phase 3); zone `europe-west1-b` (us-central1 has been exhausted in the past)
+- `neoepitope-orchestrator` (e2-micro) — lightweight companion VM that starts and manages the pipeline VM in detached mode; stays running cheaply between pipeline runs
+- GCS bucket: `gs://splice-neoepitope-project` — results at `.../results/<patient_id>/`, logs at `.../logs/`
+- `run_cloud_gpu.sh` defaults to the current local branch; the VM git-pulls it automatically — no `--branch` flag needed unless deliberately running a different branch on the VM
+- **NVIDIA driver pinned to `nvidia-headless-570-server` (DKMS)** — do not upgrade. Driver ≥575 dropped P100 Pascal (SM 6.0) support. Image family `common-cu129-ubuntu-2204-nvidia-580` is used but the driver is overridden to 570 in the setup script.
 - Pipeline is run with `snakemake --cores $(nproc) --use-conda --rerun-triggers mtime` inside a `tmux` session
 
 ## Pipeline Design Decisions
@@ -44,6 +48,19 @@ Relevant output columns (use these names in code, reports, and prose):
 - `n_strong_alleles`
 
 Use **"presenter" / "top presenters" / "presentation percentile"** throughout. Avoid **"binder" / "top binders" / "binding affinity threshold"** — those refer to the affinity-only predictor we do not use as the primary ranker. IC50 (`ic50_nM`) is still emitted for reference but is a secondary metric.
+
+## Snakemake Conda Activation
+
+Always activate the environment explicitly before invoking Snakemake:
+
+```bash
+conda activate snakemake
+snakemake --cores $(nproc) --use-conda ...
+```
+
+**Do not** use `conda run -n snakemake snakemake ...` — `conda run` buffers all stdout, hiding real-time log output during the run.
+
+**Conda env cleanup after `workflow/envs/*.yaml` changes:** Automatic cleanup was removed from `run_cloud_gpu.sh`. When any `workflow/envs/*.yaml` file changes, manually delete the affected old environment on the VM before running — old envs will not be rebuilt automatically and stale cached packages will be used instead.
 
 ## Snakemake 8 `--configfile` Gotcha
 In Snakemake 8, passing `--configfile` as **separate flags** (`--configfile A --configfile B`) causes the second invocation to replace the first due to argparse `nargs="+"` semantics. Only the last file is loaded.
@@ -124,3 +141,4 @@ snakemake --cores 4 --use-conda --configfile config/test_config.yaml
 - Both samples are single-end Illumina HiSeq 3000; HISAT2 handles this via `-U` mode
 - HISAT2 index stored in `resources/test/hisat2_index/` (separate from production)
 - All test outputs go to `results/test/` and `logs/test/`
+- **STAR is not usable for local development** — its genome index build requires >8 GB RAM, exceeding the M1 8 GB limit. HISAT2 was chosen for local testing specifically because its index fits within available memory.


### PR DESCRIPTION
## Summary

- **Infrastructure** — adds `neoepitope-orchestrator` VM description, GCS bucket URI + paths, `run_cloud_gpu.sh` branch default behaviour, and NVIDIA driver pin warning (driver ≥575 drops P100 Pascal SM 6.0 support — do not upgrade).
- **Snakemake Conda Activation** (new section) — documents that `conda activate snakemake` + direct invocation is required; `conda run -n snakemake` buffers all stdout and hides real-time logs. Also documents that automatic conda env cleanup was removed from `run_cloud_gpu.sh` — manual cleanup needed when `workflow/envs/*.yaml` files change.
- **Local Test Dataset** — notes that STAR is not usable locally; its genome index build exceeds the M1 8 GB RAM limit, which is why HISAT2 was chosen.

## Context

Second round of memory-to-CLAUDE.md migrations. These were identified as stable codebase facts living in role-specific AI memory files (`reference_gcs_bucket.md`, `user_hardware.md`, `feedback_snakemake_invocation.md`, `feedback_conda_cleanup.md`, `feedback_run_cloud_gpu_branch.md`). Those memory files will be deleted from the cerebrum repo once this PR merges.

## Test plan

- [ ] Verify `CLAUDE.md` renders correctly on GitHub
- [ ] Confirm GCS bucket URI matches `scripts/run_cloud_gpu.sh`
- [ ] Confirm NVIDIA driver version matches VM setup scripts
- [ ] Confirm `conda run` buffering note matches observed behaviour

**Created by:** cerebrum session