### PR TITLE
chore: gitignore CLAUDE.local.md for per-worktree role binding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -222,3 +222,6 @@ pipeline.log
 
 # macOS metadata
 .DS_Store
+
+# Claude Code — per-machine, per-worktree notes (e.g. role binding, local paths)
+CLAUDE.local.md


### PR DESCRIPTION
## Summary

Adds `CLAUDE.local.md` to `.gitignore` so each git worktree can carry a personal, machine-specific Claude Code notes file without polluting the repo.

## Why

`CLAUDE.local.md` is the standard Claude Code mechanism for **personal, project-specific notes** that load alongside the committed `CLAUDE.md` but should NOT be shared with the team. We're adopting it per-worktree to:

1. **Bind each git worktree to its role** (Developer in main repo, PM in `-pm` worktree, Scientist in `-scientist` worktree) — so a Claude session knows immediately which role's scope applies, independent of `autoMemoryDirectory` configuration.
2. **Move machine-specific absolute paths out of the public cerebrum repo** — currently each role's cerebrum MEMORY.md hardcodes `/Users/jin-holee/...` paths, which would leak personal info if cerebrum is ever open-sourced. CLAUDE.local.md (gitignored, per-worktree) is the right home for these.

The cerebrum role MEMORY.md files will be updated separately to reference the path from CLAUDE.local.md generically rather than hardcoding it.

## Test plan

- [ ] Confirm the line is in `.gitignore`
- [ ] Confirm a freshly created `CLAUDE.local.md` in any worktree is ignored by `git status`

**Created by:** cerebrum session