### PR TITLE
docs(glossary): add 16 project-core + discussion abbreviations (#216)

### DIFF
--- a/research/glossary.md
+++ b/research/glossary.md
@@ -12,10 +12,56 @@ Project-relevant abbreviations and acronyms. The pipeline mixes biology, ML, bio
 
 **AFDB** — AlphaFold Database (alphafold.ebi.ac.uk). DeepMind/EBI's public repo of ~200M predicted protein structures. *Domain: bio.*
 
+## E
+
+**ENCODE** — Encyclopedia of DNA Elements. NIH consortium (since 2003) cataloging functional genome features via standardized high-throughput assays (RNA-seq, ChIP-seq, ATAC-seq, Hi-C, CAGE, bisulfite-seq, etc.). "ENCODE-style assays" = this standard set of functional genomics readouts, regardless of which project produced the data. *Domain: bio.*
+
 ## G
 
+**GATK** — Genome Analysis Toolkit (Broad Institute). Canonical somatic/germline variant calling suite; reference for the Panel of Normals (PoN) concept reused by neoepitope filtering. *Domain: bio.*
+
 **GKE** — Google Kubernetes Engine. Managed Kubernetes on GCP. *Domain: cloud.*
+
+**GPS** — Genotype Presentation Score. Project-specific scoring formula combining per-allele MHCflurry presentation percentiles into a single rank for the patient's genotype; primary ranking key for top neoepitope candidates. *Domain: pipeline.*
+
+**GTEx** — Genotype-Tissue Expression project. NIH consortium with healthy-tissue RNA-seq across ~50 tissues from ~1,000 donors; canonical reference for tissue-matched normal expression panels. *Domain: bio.*
+
+## H
+
+**HLA** — Human Leukocyte Antigen. Human MHC class I/II proteins (HLA-A/B/C class I; HLA-DR/DP/DQ class II); patient typing via OptiType drives MHCflurry's per-allele predictions. *Domain: bio.*
+
+## I
+
+**IC50** — half-maximal Inhibitory Concentration. Concentration (in nM) at which a peptide displaces 50% of a reference ligand from MHC; classic affinity metric, retained as informational column alongside the percentile-based presentation score. *Domain: bio.*
+
+## M
+
+**MHC** — Major Histocompatibility Complex. Cell-surface proteins that present peptides to T cells; class I (all nucleated cells, presents endogenous peptides) drives this pipeline. Human MHC = HLA. *Domain: bio.*
+
+## P
+
+**PAE** — Predicted Aligned Error. AlphaFold/TCRdock per-residue-pair error estimate (in Å); summarised globally to gauge inter-domain confidence (e.g. relative MHC↔TCR docking confidence). *Domain: bio.*
+
+**pLDDT** — predicted Local Distance Difference Test. Per-residue confidence score (0–100) emitted by AlphaFold/TCRdock; high pLDDT = the model is confident in that region's local geometry. *Domain: bio.*
+
+**pMHC** — peptide-MHC. The complex of a peptide bound in the MHC groove; the molecular target a TCR recognises. "TCR-pMHC interaction" = the central event in adaptive immune recognition. *Domain: bio.*
+
+**PoN** — Panel of Normals. Aggregated reference set of normal samples (originally GATK's somatic variant calling concept); used to filter recurrent germline variation / artefacts that single matched normals miss. *Domain: bio.*
+
+**PSI** — Percent Spliced In. Fraction of transcripts that include a given alternative exon/junction (vs skip); the standard quantitative readout of splicing in RNA-seq analyses. *Domain: bio.*
 
 ## S
 
 **SLURM** — Simple Linux Utility for Resource Management. The dominant HPC job scheduler in academia. *Domain: cloud.*
+
+## T
+
+**TCR** — T-Cell Receptor. Heterodimeric (α/β) receptor on T cells that recognises peptide-MHC complexes; modelled here via TCRdock for the top neoepitope candidate. *Domain: bio.*
+
+**TF** — Transcription Factor. DNA-binding regulatory protein controlling gene expression; binding sites are one of the modalities ENCODE-style assays (ChIP-seq) and predictors like AlphaGenome map. *Domain: bio.*
+
+## W
+
+**WES** — Whole Exome Sequencing. Sequencing restricted to protein-coding regions (~1–2% of the genome); cheaper than WGS, sufficient for variant calls in coding regions. *Domain: bio.*
+
+**WGS** — Whole Genome Sequencing. Sequencing of the entire genome (~3 Gbp human); alternative input for upstream filtering when matched-normal RNA-seq is missing. *Domain: bio.*


### PR DESCRIPTION
**Created by:** Developer

Closes [#216](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/216).

## Summary

Adds 16 entries to `research/glossary.md`. Two groups:

**Project-core terms** (long overdue — core pipeline vocabulary):
- **GPS** (Genotype Presentation Score, project's own coinage)
- **HLA**, **MHC**, **TCR**, **pMHC**, **IC50** (immunology core)
- **pLDDT**, **PAE** (AlphaFold / TCRdock confidence metrics)

**Discussion vocabulary** (surfaced in today's morning briefing + normal-filter rethink):
- **ENCODE**, **WGS**, **WES**, **GTEx**, **PoN**, **PSI**, **TF**, **GATK**

## Format

Every entry follows the established convention:

```
**ABBREV** — Expansion. One-line context. *Domain: bio | ml | cloud | pipeline | stats.*
```

Entries are grouped under `## <letter>` section headers and alphabetised within each section.

## Why now

Per the `developer/shared/feedback_glossary.md` rule (glossary auto-add on abbreviation questions), today's conversations triggered the additions. Project-core terms were bundled in to amortise the docs-PR ceremony — same effort whether one entry or sixteen.

## Test plan

- [x] Format consistent with existing entries (verified visually + by sample read)
- [x] Alphabetical ordering within sections
- [x] Pre-existing entries (AFDB, GKE, SLURM) untouched
- [x] No tests added (docs-only change)