### PR TITLE
docs: add research/news_log.md (shared news-dedup convention) (#219)

### DIFF
--- a/research/lab_notebook.md
+++ b/research/lab_notebook.md
@@ -4,6 +4,28 @@
 
 ## 2026-05-01
 
+### 11:52 UTC — Editor: Developer
+
+#### Issue #219 — `research/news_log.md` shared news-deduplication file
+
+Established a shared news log convention to prevent re-surfacing the same items across morning briefings (Developer + Scientist). Without it, repeated WebSearches over a single sprint hit the same tool releases / papers / deprecations and waste briefing time. Two cerebrum changes already landed this morning to wire the convention into the morning routine — this PR commits the actual file to the repo so both roles can read + append.
+
+**Format (minimal — won't grow unwieldy):**
+
+```
+- **Item** (date) — keywords. → action. *Role. Signal.*
+```
+
+- *Role* = Developer / Scientist / Both (whoever surfaced it)
+- *Signal* = pipeline-relevant / industry-standard / rising-trend / portfolio-differentiator (per `feedback_portfolio_lens.md`)
+- *Action* = Issue number opened, or "no action" / "no action; revisit if X"
+
+Initial entries cover items from this week's briefings: `uv 0.11.8 / ruff 0.15.7` (industry-standard, no action), HERMES (portfolio-differentiator, → [#218](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/218)), MHCflurry 2.2.0 (pipeline-relevant, no action — torch already compat), Snakemake 9.19.0 (pipeline-relevant, → [#200](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/200)), AlphaGenome (portfolio-differentiator, → [#203](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/203)), ImmSET (portfolio-differentiator, → [#201](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/201)).
+
+**Cerebrum side (already done, not in this PR):** `feedback_morning_routine.md` Phase 1 now starts with "read `research/news_log.md` before WebSearch"; new shared memory `reference_news_log.md` documents the convention; `developer/shared/MEMORY.md` lists the news log under a new "Always read before morning routine (Phase 1 — news)" section.
+
+[Issue #219](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/219) closed by the PR carrying this entry.
+
 ### 11:37 UTC — Editor: Developer
 
 #### Issue #79 / PR #210 — review-fix follow-up

--- a/research/news_log.md
+++ b/research/news_log.md
@@ -1,0 +1,20 @@
+# News Log
+
+Shared log of news surfaced in morning briefings. Prevents repeating the same item across sessions.
+
+**Format:** `- **Item** (date) — keywords. → action. *Role. Signal.*`
+
+---
+
+## 2026-05-01
+
+- **uv 0.11.8 / ruff 0.15.7** (2026-05) — Astral toolchain dominant, 126M+/mo downloads. → No action; revisit if CI linting added. *Developer. industry-standard.*
+- **HERMES** (2026-02, bioRxiv) — structure-based TCR-pMHC ML, zero domain training, 0.72 corr. → [Issue #218](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/218) (Scientist eval). *Both. portfolio-differentiator.*
+- **MHCflurry 2.2.0** (2026-03-26) — NumPy 2.0 compat, drops `numpy<2.0` pin. → No action; torch 2.4.1 already compat. *Developer. pipeline-relevant.*
+- **Snakemake 9.19.0** (2026-05) — 9.x steady; we're on 8.x. → [Issue #200](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/200). *Developer. pipeline-relevant.*
+
+## 2026-04-30
+
+- **AlphaGenome** (DeepMind 2025) — DNA→splicing/ATAC/Hi-C/CAGE prediction, 1Mbp context. → [Issue #203](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/203) (normal filter rethink). *Both. portfolio-differentiator.*
+- **ImmSET** (2026-03) — TCR-pMHC specificity prediction, no structural modelling. → [Issue #201](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/201) (Scientist eval). *Scientist. portfolio-differentiator.*
+- **Snakemake 9.x** (2025) — breaking changes vs 8.x (executor plugin API). → [Issue #200](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/200). *Developer. pipeline-relevant.*


### PR DESCRIPTION
Closes #219.

## Summary

- Adds `research/news_log.md` — shared persistent log of items surfaced in Developer + Scientist morning briefings.
- Minimal one-liner format `- **Item** (date) — keywords. → action. *Role. Signal.*` so the file doesn't grow unwieldy.
- Initial entries cover items already surfaced this week (uv/ruff, HERMES, MHCflurry 2.2.0, Snakemake 9.19.0, AlphaGenome, ImmSET) so the dedup check has something to match against from day one.
- Lab notebook entry included documenting the convention.

## Why now

The cerebrum-side wiring landed earlier today: `feedback_morning_routine.md` Phase 1 now reads this file before WebSearch, and a new `reference_news_log.md` shared memory documents the convention. Without the file in-repo, the dedup check has nothing to read.

## Test plan

- [x] File renders cleanly in GitHub markdown
- [x] Lab notebook entry follows the newest-first ordering rule
- [ ] Next morning briefing should consult this file first (verifiable behaviourally tomorrow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)