### PR TITLE
polish(report): PR #210 review follow-ups (#221)

### DIFF
--- a/research/lab_notebook.md
+++ b/research/lab_notebook.md
@@ -4,6 +4,26 @@
 
 ## 2026-05-01
 
+### 14:51 UTC — Editor: Developer
+
+#### Issue #221 — PR #210 review-fix follow-ups
+
+Bundled the four lower-priority items deferred from PR #210 review into one PR. Reviewer flagged them as Low/Nit so the diff stays focused on the original refactor; this picks them up while context is fresh.
+
+**Items addressed:**
+
+1. **Test now actually verifies the artefact-driven path** (was Low-Medium). The original test claimed corrupted raw inputs shouldn't break HTML rendering but never corrupted anything — it ran `generate_report` once and asserted `<html` was in the output, a tautology that would pass whether the inversion was real or not. The reviewer's literal suggestion ("overwrite raw inputs with garbage, call generate_report with artefact paths") doesn't work because `generate_report` always reads raw inputs at the top of every call before writing artefacts — corrupting them just crashes the second call. Equivalent-strength approach: monkey-patch `_build_report_top_candidates_tsv` so that AFTER it writes the artefact we inject a sentinel peptide name ("SENTINELPEPTIDE") into the file. The HTML rendering happens after the writer and reads from the modified file. The sentinel would never appear in the HTML if the renderer fell back to raw `pred_df` — its presence proves the artefact path is genuinely active.
+
+2. **`effective_patient_id` path-derived fallback now warns.** When `patient_id` isn't passed, the function falls back to `output_html.parts[-3]` assuming the layout `…/{patient_id}/reports/report.html`. If that layout ever changes, every artefact row records the wrong patient ID silently. Added a `log.warning` when the fallback fires — the Snakemake path always passes `wildcards.patient_id`, so the warning only surfaces on ad-hoc CLI runs (which is when it's most useful).
+
+3. **`_build_report_3d_structure_tsv` gracefully handles column rename.** Was hardcoding `top.get("mhc", "")` for the allele. If TCRdock ever renames the column (or some local TCRdock version uses a different convention), the manifest silently records empty allele → 3D viewer shows "NA". One-liner change to `top.get("mhc") or top.get("allele", "")`.
+
+4. **Truncation-notice nit kicked to a proper Issue.** `_build_strong_table_html_from_top_candidates` (artefact path) can't say "Showing N of M rows" the way the raw `_build_strong_table_html` can — when the artefact is written, the writer caps to `TOP_CANDIDATES_LIMIT=10` and the original count is discarded. A literal parity fix needs a schema change in `report.tsv` to surface the pre-cap total. That's not trivial and not appropriate for a "nit" PR — opened [Issue #226](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/226) for the proper fix and added a docstring note linking to it.
+
+**Verified:** `pytest workflow/tests/test_generate_report.py` — 57/57 passing. The new sentinel test would fail if anyone broke the artefact-driven path, so it's a real regression guard now.
+
+[Issue #221](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/221) closed by the PR carrying this entry.
+
 ### 11:52 UTC — Editor: Developer
 
 #### Issue #219 — `research/news_log.md` shared news-deduplication file

--- a/workflow/scripts/generate_report.py
+++ b/workflow/scripts/generate_report.py
@@ -519,6 +519,12 @@ def _build_strong_table_html_from_top_candidates(top_candidates_df: pd.DataFrame
     The artefact is already quality-gated, sorted, capped, and carries a
     plain-text ``contig_peek`` that this function re-styles via
     ``_render_contig_peek``. No raw inputs needed.
+
+    Parity gap with ``_build_strong_table_html``: this renderer cannot emit a
+    "Showing N of M rows" notice because the writer caps the artefact at
+    ``TOP_CANDIDATES_LIMIT`` and the pre-cap total is lost. Tracked in
+    Issue #226 — fix is to surface the total in ``report.tsv``'s
+    ``mhc_prediction`` stage and render the notice from there.
     """
     if top_candidates_df is None or top_candidates_df.empty:
         return "<p><em>No strong presentations found.</em></p>"
@@ -1030,7 +1036,7 @@ def _build_report_3d_structure_tsv(
         "patient_id": patient_id,
         "rank": 1,
         "peptide": top.get("peptide", ""),
-        "allele": top.get("mhc", ""),
+        "allele": top.get("mhc") or top.get("allele", ""),
         "pdb_path": pdb_relative_path,
         "chain_A": _TCRDOCK_CHAIN_NAMES["A"],
         "chain_B": _TCRDOCK_CHAIN_NAMES["B"],
@@ -1216,7 +1222,17 @@ def generate_report(
             })
         origin_df = pd.DataFrame(origin_rows)
 
-    effective_patient_id = patient_id or output_html.parts[-3]
+    if patient_id:
+        effective_patient_id = patient_id
+    else:
+        effective_patient_id = output_html.parts[-3]
+        log.warning(
+            "patient_id not provided; falling back to output_html path component "
+            "[-3]=%r. This assumes output is …/{patient_id}/reports/report.html — "
+            "if the path layout changes, every artefact row will record the wrong "
+            "patient_id silently. Pass patient_id explicitly to be safe.",
+            effective_patient_id,
+        )
 
     # === Phase 2: write artefacts FIRST, then render HTML from them ===
 

--- a/workflow/tests/test_generate_report.py
+++ b/workflow/tests/test_generate_report.py
@@ -657,9 +657,13 @@ class TestGenerateReportEndToEnd:
             original_writer(*args, **kwargs)
             out_path = kwargs["output_tsv"]
             df = pd.read_csv(out_path, sep="\t")
-            if not df.empty:
-                df.loc[0, "peptide"] = sentinel
-                df.to_csv(out_path, sep="\t", index=False)
+            assert not df.empty, (
+                "test data must produce ≥1 presenter for sentinel injection — "
+                "if the artefact is empty, the sentinel is never written and "
+                "the assertion below would fail for the wrong reason"
+            )
+            df.loc[0, "peptide"] = sentinel
+            df.to_csv(out_path, sep="\t", index=False)
 
         monkeypatch.setattr(
             gr_mod, "_build_report_top_candidates_tsv", writer_with_sentinel

--- a/workflow/tests/test_generate_report.py
+++ b/workflow/tests/test_generate_report.py
@@ -631,9 +631,18 @@ class TestGenerateReportEndToEnd:
         # Top presenter peptide visible (PEP0 has lowest presentation_percentile)
         assert "PEP0" in html
 
-    def test_artefacts_drive_html_when_provided(self, tmp_path):
-        """Verify HTML reads from artefacts: corrupted raw inputs after artefact write
-        should NOT break HTML rendering. (Sanity check that the inversion is real.)"""
+    def test_html_reflects_artefact_contents_not_raw_pred_df(self, tmp_path, monkeypatch):
+        """Prove the strong-presenters HTML section reads from
+        report_top_candidates.tsv, not the raw pred_df.
+
+        Wrap the artefact writer so that AFTER it produces the file we inject a
+        sentinel peptide name into it. The HTML rendering happens after the
+        writer and (if the artefact path is genuinely active) reads from the
+        modified file. The sentinel can only appear in the HTML if the renderer
+        used the artefact — the raw pred_df never contains it.
+        """
+        import generate_report as gr_mod
+
         junc_tsv, pred_tsv, contigs_fa = self._write_inputs(tmp_path)
         out_dir = tmp_path / "results" / "p001" / "reports"
         out_dir.mkdir(parents=True)
@@ -641,7 +650,21 @@ class TestGenerateReportEndToEnd:
         tsv_out = out_dir / "report.tsv"
         top_out = out_dir / "report_top_candidates.tsv"
 
-        # Should produce a valid HTML report end to end
+        sentinel = "SENTINELPEPTIDE"
+        original_writer = gr_mod._build_report_top_candidates_tsv
+
+        def writer_with_sentinel(*args, **kwargs):
+            original_writer(*args, **kwargs)
+            out_path = kwargs["output_tsv"]
+            df = pd.read_csv(out_path, sep="\t")
+            if not df.empty:
+                df.loc[0, "peptide"] = sentinel
+                df.to_csv(out_path, sep="\t", index=False)
+
+        monkeypatch.setattr(
+            gr_mod, "_build_report_top_candidates_tsv", writer_with_sentinel
+        )
+
         generate_report(
             novel_junctions_tsv=str(junc_tsv),
             predictions_tsv=str(pred_tsv),
@@ -651,4 +674,11 @@ class TestGenerateReportEndToEnd:
             output_top_candidates_tsv=str(top_out),
             patient_id="p001",
         )
-        assert "<html" in html_out.read_text()
+
+        html = html_out.read_text()
+        assert sentinel in html, (
+            "HTML strong-presenters section must reflect artefact contents — "
+            "sentinel peptide was injected into report_top_candidates.tsv "
+            "after the writer ran, so its absence proves HTML is rendering "
+            "from raw pred_df instead of the artefact."
+        )


### PR DESCRIPTION
Closes #221.

## Summary

Bundled the four lower-priority items deferred from the [PR #210](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/210) review into one PR.

| Reviewer concern | Fix |
|------------------|-----|
| Low-Med — `test_artefacts_drive_html_when_provided` was tautological | Rewrote as `test_html_reflects_artefact_contents_not_raw_pred_df`: monkey-patch the artefact writer to inject a sentinel peptide name after write; assert it appears in the HTML. Sentinel can only reach HTML through the artefact path. |
| Low — silent `effective_patient_id` path-derived fallback | Added `log.warning` when the fallback fires (only ad-hoc CLI runs reach it; Snakemake always passes `patient_id`). |
| Low — hardcoded `"mhc"` column in `_build_report_3d_structure_tsv` | `top.get("mhc") or top.get("allele", "")` — gracefully handles upstream column rename. |
| Nit — no truncation notice on artefact-driven strong table | Docstring note + opened [Issue #226](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/226) for the proper fix (needs schema change to record pre-cap total). |

## Why the test rewrite isn't a literal "corrupt raw inputs" implementation

The reviewer suggested overwriting raw inputs with garbage and re-calling `generate_report` with artefact paths. That doesn't work with the actual code path — `generate_report` reads raw inputs at the top of every call before writing artefacts, so corrupting them just crashes the second call before the artefact path is exercised. The sentinel-injection approach proves the same architectural property (HTML reads from artefact, not raw `pred_df`) using a mechanic that fits the code.

## Test plan

- [x] `pytest workflow/tests/test_generate_report.py` — 57/57 passing
- [x] New sentinel test would fail if anyone broke the artefact-driven branch (manually verified by mental dry-run)
- [x] Lab notebook entry included

🤖 Generated with [Claude Code](https://claude.com/claude-code)