### PR TITLE
docs(CLAUDE.md): pin GitHub project board ID + user-project gotcha

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,7 @@ Modernised reimplementation of a 2015 cancer neoepitope prediction pipeline (Jin
 - `run_cloud_gpu.sh` defaults to the current local branch; the VM git-pulls it automatically — no `--branch` flag needed unless deliberately running a different branch on the VM
 - **NVIDIA driver pinned to `nvidia-headless-570-server` (DKMS)** — do not upgrade. Driver ≥575 dropped P100 Pascal (SM 6.0) support. Image family `common-cu129-ubuntu-2204-nvidia-580` is used but the driver is overridden to 570 in the setup script.
 - Pipeline is run with `snakemake --cores $(nproc) --use-conda --rerun-triggers mtime` inside a `tmux` session
+- GitHub project board: user project #9 ("JH M Lee Lab") under user `Jin-HoMLee` — query via `gh api graphql` with `user(login: "Jin-HoMLee") { projectV2(number: 9) { ... } }` (it's a user project, not org)
 
 ## Pipeline Design Decisions
 

--- a/research/lab_notebook.md
+++ b/research/lab_notebook.md
@@ -4,6 +4,12 @@
 
 ## 2026-05-01
 
+### 18:30 UTC — Editor: Developer
+
+#### CLAUDE.md — pin GitHub project board ID
+
+Quick board scan surfaced that the project board ID isn't documented in-repo, and `gh api graphql` against `organization(login: "Jin-HoMLee")` silently returns null because it's a *user* project, not an org project. Added a one-liner to CLAUDE.md pinning project #9 + the correct GraphQL shape ([PR #231](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/231)).
+
 ### 17:52 UTC — Editor: Developer
 
 #### Issue #90 / PR #179 — closed without merging; revival deferred


### PR DESCRIPTION
## Summary
- Document the project board as user project #9 (`Jin-HoMLee`) in CLAUDE.md
- Pin the correct GraphQL query shape (`user(login: ...)`, not `organization(login: ...)`) — the latter returns null and silently wastes time

## Test plan
- [x] One-line addition to CLAUDE.md, no code changes
- [x] No tests / dry-run needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)