### PR TITLE
docs(news_log): 2026-05-02 PM entries + introduce time/editor sub-heading convention

### DIFF
--- a/research/lab_notebook.md
+++ b/research/lab_notebook.md
@@ -2,6 +2,40 @@
 
 ---
 
+## 2026-05-02
+
+### 10:06 UTC — Editor: PM
+
+#### Morning routine — introduced PM news as Step 0
+
+PM has been doing morning warmups (board recap, standup, triage) but never surfacing external context. Added Step 0 — PM news (web search before the board recap), scoped to GitHub Projects/Issues updates, PM tooling, methodology shifts. Each item logged to `research/news_log.md` to dedupe across roles. Updated `pm/feedback_morning_warmup.md` to codify the step + the new `## 📰 PM news` section header.
+
+Test-ran on first day with three queries (GitHub Projects updates, PM tooling news, software engineering methodology trends). Filtered listicles; kept items with concrete signal. Three made it through → see `research/news_log.md` for the full log.
+
+#### Issue #234 — GitHub MCP Server eval (XS, P2)
+
+Today's news surfaced that the [official GitHub MCP server](https://github.blog/changelog/2026-01-28-github-mcp-server-new-projects-tools-oauth-scope-filtering-and-new-features/) (Jan 2026) exposes typed `project_v2` mutation tools (Status, Priority, Size, Target date) at lower token cost than raw `gh api graphql`. Today PM uses hand-rolled GraphQL with hardcoded field IDs (e.g. `PVTSSF_lAHOB17eGc4BSomPzhAHGh8`). Every triage / re-arrangement burns context on boilerplate. [Issue #234](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/234) opened to evaluate migration; assigned to `i2 - S1 - Tool Landscape Evaluations`, P2 (strategic DX win, not blocking).
+
+#### Issue #235 — Anthropic 2026 Agentic Coding Trends Report skim (XS, P1)
+
+Anthropic published industry data on multi-agent coding workflows. Our PM/Sci/Dev split, file-based memory, markdown-standup pattern, and scope-discipline rules were designed iteratively without surveying industry patterns. Low-cost opportunity to sanity-check before they ossify. [Issue #235](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/235) — 30-min skim with 5 PM-flavoured cross-checks (role decomposition, coordination protocol, memory architecture, scope-discipline failure modes, handoff mechanics).
+
+**Why P1 (vs P2):** This is rare for a research/eval issue. Justified because the cross-check informs every future PM decision (and indirectly Sci/Dev workflows) at low cost. Catching divergences early is much cheaper than after the patterns are entrenched. Not blocking active work, but high information value per minute spent.
+
+#### Cerebrum vs project scope distinction
+
+User flagged that I'd labelled #235 "Cerebrum cross-checks" when it should have been "PM practices cross-checks". **Cerebrum** = the meta multi-agent framework above all projects/roles; **this project** = one instance using Cerebrum. Conflating them inflates scope (project-local issues become "Cerebrum architecture" reviews). Saved as shared memory `feedback_cerebrum_vs_project.md` so all roles get the rule. Reframed #235's title and body accordingly.
+
+#### News_log format extension — time + editor sub-heading
+
+Originally the news_log had one date section with bullets. With PM joining Sci/Dev as a logger, editor attribution was previously implicit and going to break down. Mirrored the lab-notebook format: each session adds a `### HH:MM UTC — Editor: <Role>` sub-heading under the date. Historical entries (pre-2026-05-02) kept as-is. Documented in `shared/reference_news_log.md` and `pm/feedback_morning_warmup.md`. Shipping convention: `docs/<role>/news-log-YYYY-MM-DD-HHMM` time-suffixed branch (no issue link), mirroring the multi-session lab-notebook pattern.
+
+#### Standup — Developer Pending re-raise cleared
+
+[Re-raised the closing-run issues #193/#194/#195 message](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues) after 3 days of no response. Developer acknowledged at 08:56 UTC — same response as Scientist (will populate when scoping each iteration's work). Standup is now fully clear.
+
+---
+
 ## 2026-05-01
 
 ### 18:30 UTC — Editor: Developer

--- a/research/news_log.md
+++ b/research/news_log.md
@@ -1,10 +1,23 @@
 # News Log
 
-Shared log of news surfaced in morning briefings. Prevents repeating the same item across sessions.
+Shared log of news surfaced in morning briefings. Prevents repeating the same item across sessions and roles (PM, Scientist, Developer all log here).
 
-**Format:** `- **Item** (date) — keywords. → action. *Role. Signal.*`
+**Format:**
+- `## YYYY-MM-DD` — date-level section (one per day; new dates at the top)
+- `### HH:MM UTC — Editor: <Role>` — time + editor attribution (one per session per day)
+- `- **Item** (date) — keywords. → action. *Role. Signal.*` — one bullet per item, nested under the time section
+
+Historical entries (before 2026-05-02) pre-date the time/editor sub-heading convention and are kept as-is.
 
 ---
+
+## 2026-05-02
+
+### 09:41 UTC — Editor: PM
+
+- **GitHub MCP Server — Projects tools** (2026-01-28) — official MCP exposes `project_v2` mutations (Status/Priority/Size/Target date) at lower token cost than raw `gh api graphql`. → [Issue #234](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/234) (PM eval, migrate hand-rolled GraphQL). *PM. tooling-relevant.*
+- **OpenAI Symphony** (2026-04, late April) — enterprise multi-agent orchestration; PM boards as control plane for coding agents. → No action; pattern-confirmation only for our PM/Sci/Dev split, product itself targets corporate audiences (not solo/research). *PM. methodology-signal.*
+- **Anthropic 2026 Agentic Coding Trends Report** (2026, PDF) — industry data on multi-agent coding workflows. → [Issue #235](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/235) (PM skim, 5 PM-practices cross-checks: role decomposition, coordination, memory, scope discipline, handoff). *PM. methodology-signal.*
 
 ## 2026-05-01
 


### PR DESCRIPTION
## Summary

- Adds today's PM news entries to `research/news_log.md` (3 items): GitHub MCP Server Projects tools, OpenAI Symphony, Anthropic 2026 Agentic Coding Trends Report.
- Introduces a `### HH:MM UTC — Editor: <Role>` sub-heading convention under each date section, since PM, Scientist, and Developer all log here and editor attribution was previously implicit. Mirrors the lab-notebook format.
- Historical entries (pre-2026-05-02) are kept as-is.

Linked issues (referenced, not closed): [#234](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/234) (GitHub MCP eval), [#235](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/235) (Anthropic report skim).

## Branch convention

Time-suffixed docs branch `docs/pm/news-log-2026-05-02-0939` — no issue link required, mirroring the multi-session lab-notebook convention. The news_log is a journal, not a deliverable tied to issue closure.

## Test plan

- [x] `news_log.md` renders correctly (date section newest-first; time/editor sub-heading visible)
- [x] Format documentation at top of file matches the new structure
- [x] No accidental edits to historical (pre-2026-05-02) entries