### PR TITLE
feat(report): add junction-funnel totals to report.tsv (#214)

### DIFF
--- a/research/lab_notebook.md
+++ b/research/lab_notebook.md
@@ -2,6 +2,22 @@
 
 ---
 
+## 2026-05-03
+
+### 15:26 UTC — Editor: Developer
+
+#### Issue #214 / PR #240 — round-3 fix: close the report.tsv funnel
+
+`@claude` round-2 review verified all four round-1 items as closed and approved correctness. One non-blocking design observation: `report.tsv` consumers (RESULTS.md authors) saw a non-closed funnel because the three patient-level totals (`junctions_extracted_total`, `junctions_annotated_discarded`, `junctions_unannotated_total`) didn't include `mean_reads_filtered` — that category only lived in `junction_filter_stats.tsv`, so anyone reading just `report.tsv` would see `extracted_total ≠ annotated_discarded + unannotated_total` with an unexplained gap.
+
+**Fix:** added `junctions_mean_reads_filtered` as a fourth `junction_filtering` row in `_build_report_tsv` (notes: "all tumor samples"). The four rows now reconcile arithmetically: `extracted_total = mean_reads_filtered + annotated_discarded + unannotated_total`. New test `test_junction_funnel_totals_reconcile_in_report_tsv` enforces this invariant on `report.tsv` (separate from the equivalent invariant on `junction_filter_stats.tsv` from round 1). Updated existing tests to include `mean_reads_filtered` rows in their fixture stats data and assert on the new row's value.
+
+**Why not done in round 1/2:** Issue #214's spec named exactly three metrics (extracted/annotated/unannotated). Round 1 implemented exactly what the spec said; round 2 fixed reconciliation in the upstream stats artefact. Round 3 closes the gap between "internal artefact reconciles" and "report.tsv consumers see a closed funnel" — reviewer flagged this in round 2 as non-blocking but worth a conscious decision.
+
+**Verified:** 98/98 tests pass; Snakemake dry-run clean; rule graph unchanged.
+
+---
+
 ## 2026-05-02
 
 ### 16:48 UTC — Editor: Developer

--- a/research/lab_notebook.md
+++ b/research/lab_notebook.md
@@ -2,6 +2,26 @@
 
 ---
 
+## 2026-05-02
+
+### 10:48 UTC — Editor: Developer
+
+#### Issue #214 — junction-funnel totals in report.tsv
+
+Fast-ship slice of [Issue #104](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/104), unblocks Scientist's RESULTS.md. Adds three patient-level rows to `report.tsv` under stage `junction_filtering`: `junctions_extracted_total`, `junctions_annotated_discarded`, `junctions_unannotated_total` (all sums across tumor samples; normals omitted by design — see brainstorming below).
+
+**Architecture:** new artefact `junction_filter_stats.tsv` per patient, written by `filter_junctions.py` alongside the existing `novel_junctions.tsv`. Long-format schema (`sample_id, sample_type, category, count`) where `category ∈ {junctions_raw, annotated_discarded, normal_shared, tumor_exclusive}`. `generate_report.py` reads this file (declared as new input on both `generate_report` and `generate_report_with_structure` via the shared `_generate_report_input` helper), aggregates by category, and emits the 3 patient-level totals. The original per-sample rows are preserved untouched.
+
+**Why a new artefact rather than re-reading BED:** `filter_junctions.py` already computes `n_annotated`, `n_normal_shared`, `n_tumor_exclusive` per tumor sample — they were just being logged and thrown away. Persisting them is a 5-line change. The alternative (re-reading BED in `generate_report` and re-classifying junctions) would duplicate the entire reference/normal-set classification logic.
+
+**Why tumor-only:** the spec row `junctions_unannotated_total = normal_shared + tumor_exclusive` is a tumor-classification concept — only tumor samples get split this way (normal samples are used as a filter set, not classified). User confirmed (a) tumor-only over (b)/(c) mixed scopes; flagged that normal-sample `junctions_extracted_total` could be useful in future via a separate Issue if needed.
+
+**Naming alignment with [Issue #215](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/215):** picked the long-format schema and category names (`junctions_raw`, `annotated_discarded`, etc.) to match #215's planned `filtering_stats.tsv`. When #215 ships, it can either supersede `junction_filter_stats.tsv` with the unified multi-step file, or aggregate it as one source among many. Migration cost stays small either way.
+
+**Tests:** 4 new tests in `test_filter_junctions.py` (schema, normal-omission, multi-sample, back-compat for callers without stats path) + 3 in `test_generate_report.py` (totals correctness, back-compat, notes-field convention). 233/233 total. Snakemake dry-run validates the rule graph: `filter_junctions` correctly triggers with the new output, downstream rules unchanged.
+
+---
+
 ## 2026-05-01
 
 ### 18:30 UTC — Editor: Developer

--- a/workflow/rules/analysis.smk
+++ b/workflow/rules/analysis.smk
@@ -10,6 +10,9 @@ def _generate_report_input(wildcards):
         "novel_junctions": os.path.join(
             _RES, wildcards.patient_id, "junctions", "novel_junctions.tsv"
         ),
+        "junction_filter_stats": os.path.join(
+            _RES, wildcards.patient_id, "junctions", "junction_filter_stats.tsv"
+        ),
         "predictions_tsv": os.path.join(
             _RES, wildcards.patient_id, "predictions", "mhc_presentation.tsv"
         ),

--- a/workflow/rules/filter_junctions.smk
+++ b/workflow/rules/filter_junctions.smk
@@ -72,6 +72,9 @@ rule filter_junctions:
         novel_junctions=os.path.join(
             _RES, "{patient_id}", "junctions", "novel_junctions.tsv"
         ),
+        stats=os.path.join(
+            _RES, "{patient_id}", "junctions", "junction_filter_stats.tsv"
+        ),
     log:
         os.path.join(_LOGS, "{patient_id}", "filter_junctions", "filter.log"),
     params:

--- a/workflow/scripts/filter_junctions.py
+++ b/workflow/scripts/filter_junctions.py
@@ -243,6 +243,7 @@ def classify_junctions(
     manifest_path: str | Path,
     reference_bed: str | Path,
     output_path: str | Path,
+    stats_output_path: str | Path | None = None,
     min_normal_reads: int = 2,
     gencode_gtf: str | Path | None = None,
 ) -> None:
@@ -260,14 +261,22 @@ def classify_junctions(
     reading frame at the splice donor of each junction.  See
     ``_build_cds_donor_lookup`` for details.
 
+    When ``stats_output_path`` is supplied, also writes a long-format
+    per-tumor-sample stats TSV (Issue #214) with columns:
+    ``sample_id, sample_type, category, count`` and categories
+    ``junctions_raw`` (pre mean-reads filter), ``annotated_discarded``,
+    ``normal_shared``, ``tumor_exclusive``. Normal samples are omitted.
+
     Args:
-        junction_files:   List of raw junction quantification TSV paths.
-        manifest_path:    Manifest TSV mapping file_id → sample_type.
-        reference_bed:    Path to reference junction BED file.
-        output_path:      Destination TSV for classified junctions.
-        min_normal_reads: Minimum reads required to trust a normal junction.
-        gencode_gtf:      Optional path to GENCODE GTF for reading frame
-                          annotation.  When None, reading_frame is always "".
+        junction_files:    List of raw junction quantification TSV paths.
+        manifest_path:     Manifest TSV mapping file_id → sample_type.
+        reference_bed:     Path to reference junction BED file.
+        output_path:       Destination TSV for classified junctions.
+        stats_output_path: Optional destination TSV for per-tumor-sample funnel
+                           counts. When None, no stats file is written.
+        min_normal_reads:  Minimum reads required to trust a normal junction.
+        gencode_gtf:       Optional path to GENCODE GTF for reading frame
+                           annotation.  When None, reading_frame is always "".
     """
     ref_junctions = _load_reference_junctions(reference_bed)
     donor_frames = _build_cds_donor_lookup(gencode_gtf) if gencode_gtf else {}
@@ -300,12 +309,15 @@ def classify_junctions(
 
     # Classify tumor junctions
     all_classified: list[dict] = []
+    stats_rows: list[dict] = []
 
     for path, sample_id, sample_type in tumor_files:
         rows = _read_junction_file(path)
         if not rows:
             log.warning("No data rows found in %s", path)
             continue
+
+        n_raw = len(rows)
 
         # Keep only junctions with read count above the per-file mean,
         # reducing noise from low-evidence junctions.
@@ -359,6 +371,19 @@ def classify_junctions(
             sample_id, n_annotated, n_normal_shared, n_tumor_exclusive,
         )
 
+        for category, count in (
+            ("junctions_raw", n_raw),
+            ("annotated_discarded", n_annotated),
+            ("normal_shared", n_normal_shared),
+            ("tumor_exclusive", n_tumor_exclusive),
+        ):
+            stats_rows.append({
+                "sample_id": sample_id,
+                "sample_type": sample_type,
+                "category": category,
+                "count": count,
+            })
+
     df = pd.DataFrame(
         all_classified,
         columns=[
@@ -379,6 +404,16 @@ def classify_junctions(
         (df["junction_origin"] == "normal_shared").sum() if not df.empty else 0,
     )
 
+    if stats_output_path is not None:
+        stats_df = pd.DataFrame(
+            stats_rows,
+            columns=["sample_id", "sample_type", "category", "count"],
+        )
+        stats_output_path = Path(stats_output_path)
+        stats_output_path.parent.mkdir(parents=True, exist_ok=True)
+        stats_df.to_csv(stats_output_path, sep="\t", index=False)
+        log.info("Wrote junction filter stats to %s (%d rows)", stats_output_path, len(stats_df))
+
 
 # ---------------------------------------------------------------------------
 # Snakemake / CLI entry point
@@ -393,6 +428,7 @@ def _snakemake_main() -> None:
         manifest_path=snakemake.input.manifest,  # type: ignore[name-defined]  # noqa: F821
         reference_bed=snakemake.input.reference_junctions,  # type: ignore[name-defined]  # noqa: F821
         output_path=snakemake.output.novel_junctions,  # type: ignore[name-defined]  # noqa: F821
+        stats_output_path=snakemake.output.stats,  # type: ignore[name-defined]  # noqa: F821
         min_normal_reads=snakemake.params.min_normal_reads,  # type: ignore[name-defined]  # noqa: F821
         gencode_gtf=snakemake.input.gencode_gtf,  # type: ignore[name-defined]  # noqa: F821
     )
@@ -413,6 +449,10 @@ def _cli_main() -> None:
     )
     parser.add_argument("--output", required=True, help="Output classified junctions TSV")
     parser.add_argument(
+        "--stats-output", default=None,
+        help="Optional output TSV for per-tumor-sample funnel counts",
+    )
+    parser.add_argument(
         "--min-normal-reads", type=int, default=2,
         help="Minimum reads to trust a junction in the normal sample (default: 2)",
     )
@@ -427,6 +467,7 @@ def _cli_main() -> None:
         manifest_path=args.manifest,
         reference_bed=args.reference_junctions,
         output_path=args.output,
+        stats_output_path=args.stats_output,
         min_normal_reads=args.min_normal_reads,
         gencode_gtf=args.gencode_gtf,
     )

--- a/workflow/scripts/generate_report.py
+++ b/workflow/scripts/generate_report.py
@@ -705,11 +705,13 @@ def _build_report_tsv(
     Schema: patient_id | stage | metric | value | notes
     Stages: junction_filtering, mhc_prediction, top_candidate, hla_typing, tcrdock
 
-    When ``junction_filter_stats_tsv`` is supplied, three patient-level funnel
+    When ``junction_filter_stats_tsv`` is supplied, four patient-level funnel
     totals are added under stage=``junction_filtering`` (Issue #214):
-    ``junctions_extracted_total``, ``junctions_annotated_discarded``,
-    ``junctions_unannotated_total``. These sum across tumor samples; normal
-    samples are intentionally omitted from the funnel.
+    ``junctions_extracted_total``, ``junctions_mean_reads_filtered``,
+    ``junctions_annotated_discarded``, ``junctions_unannotated_total``. These
+    sum across tumor samples; normal samples are intentionally omitted from
+    the funnel. The four rows reconcile arithmetically:
+    ``extracted_total = mean_reads_filtered + annotated_discarded + unannotated_total``.
     """
     rows: list[dict] = []
 
@@ -732,6 +734,7 @@ def _build_report_tsv(
             by_cat = stats_df.groupby("category")["count"].sum()
             for metric, source_cats in (
                 ("junctions_extracted_total", ("junctions_raw",)),
+                ("junctions_mean_reads_filtered", ("mean_reads_filtered",)),
                 ("junctions_annotated_discarded", ("annotated_discarded",)),
                 ("junctions_unannotated_total", ("normal_shared", "tumor_exclusive")),
             ):

--- a/workflow/scripts/generate_report.py
+++ b/workflow/scripts/generate_report.py
@@ -698,11 +698,18 @@ def _build_report_tsv(
     presentation_percentile_strong: float,
     tcrdock_pdb: str | Path | None,
     presentation_percentile_weak: float = 2.0,
+    junction_filter_stats_tsv: str | Path | None = None,
 ) -> None:
     """Write a structured summary TSV alongside the HTML report.
 
     Schema: patient_id | stage | metric | value | notes
     Stages: junction_filtering, mhc_prediction, top_candidate, hla_typing, tcrdock
+
+    When ``junction_filter_stats_tsv`` is supplied, three patient-level funnel
+    totals are added under stage=``junction_filtering`` (Issue #214):
+    ``junctions_extracted_total``, ``junctions_annotated_discarded``,
+    ``junctions_unannotated_total``. These sum across tumor samples; normal
+    samples are intentionally omitted from the funnel.
     """
     rows: list[dict] = []
 
@@ -716,6 +723,27 @@ def _build_report_tsv(
                 rows.append({
                     "patient_id": patient_id, "stage": "junction_filtering",
                     "metric": metric, "value": int(r.get(metric, 0)), "notes": note,
+                })
+
+    # --- junction_filtering: patient-level funnel totals (Issue #214) ---
+    if junction_filter_stats_tsv is not None:
+        try:
+            stats_df = pd.read_csv(junction_filter_stats_tsv, sep="\t")
+        except Exception as exc:
+            log.warning("Could not read junction_filter_stats TSV %s: %s",
+                        junction_filter_stats_tsv, exc)
+            stats_df = pd.DataFrame()
+        if not stats_df.empty:
+            by_cat = stats_df.groupby("category")["count"].sum()
+            for metric, source_cats in (
+                ("junctions_extracted_total", ("junctions_raw",)),
+                ("junctions_annotated_discarded", ("annotated_discarded",)),
+                ("junctions_unannotated_total", ("normal_shared", "tumor_exclusive")),
+            ):
+                value = int(sum(int(by_cat.get(c, 0)) for c in source_cats))
+                rows.append({
+                    "patient_id": patient_id, "stage": "junction_filtering",
+                    "metric": metric, "value": value, "notes": "all tumor samples",
                 })
 
     # --- mhc_prediction ---
@@ -1177,6 +1205,7 @@ def generate_report(
     output_tsv: str | Path | None = None,
     output_top_candidates_tsv: str | Path | None = None,
     output_3d_structure_tsv: str | Path | None = None,
+    junction_filter_stats_tsv: str | Path | None = None,
     patient_id: str = "",
 ) -> None:
     """Generate the summary HTML report and the machine-readable report artefacts.
@@ -1246,6 +1275,7 @@ def generate_report(
             presentation_percentile_strong=presentation_percentile_strong,
             tcrdock_pdb=tcrdock_pdb,
             presentation_percentile_weak=presentation_percentile_weak,
+            junction_filter_stats_tsv=junction_filter_stats_tsv,
         )
 
     if output_top_candidates_tsv:
@@ -1367,6 +1397,7 @@ def _snakemake_main() -> None:
         output_tsv=snakemake.output.report_tsv,  # type: ignore[name-defined]  # noqa: F821
         output_top_candidates_tsv=snakemake.output.report_top_candidates_tsv,  # type: ignore[name-defined]  # noqa: F821
         output_3d_structure_tsv=getattr(snakemake.output, "report_3d_structure_tsv", None),  # type: ignore[name-defined]  # noqa: F821
+        junction_filter_stats_tsv=getattr(snakemake.input, "junction_filter_stats", None),  # type: ignore[name-defined]  # noqa: F821
         patient_id=snakemake.wildcards.patient_id,  # type: ignore[name-defined]  # noqa: F821
     )
 
@@ -1384,6 +1415,8 @@ def _cli_main() -> None:
     parser.add_argument("--presentation-percentile-strong", type=float, default=0.5)
     parser.add_argument("--presentation-percentile-weak", type=float, default=2.0)
     parser.add_argument("--output-tsv", default=None, help="Output machine-readable summary TSV")
+    parser.add_argument("--junction-filter-stats", default=None,
+                        help="Per-tumor-sample junction funnel stats TSV (Issue #214)")
     parser.add_argument("--patient-id", default="", help="Patient identifier for report.tsv rows")
     args = parser.parse_args()
 
@@ -1397,6 +1430,7 @@ def _cli_main() -> None:
         presentation_percentile_weak=args.presentation_percentile_weak,
         tcrdock_pdb=args.tcrdock_pdb,
         output_tsv=args.output_tsv,
+        junction_filter_stats_tsv=args.junction_filter_stats,
         patient_id=args.patient_id,
     )
 

--- a/workflow/tests/test_filter_junctions.py
+++ b/workflow/tests/test_filter_junctions.py
@@ -268,6 +268,179 @@ class TestClassifyJunctions:
 
 
 # ---------------------------------------------------------------------------
+# classify_junctions — junction_filter_stats.tsv (Issue #214)
+# ---------------------------------------------------------------------------
+
+class TestClassifyJunctionsStats:
+    """Per-sample funnel counts surfaced for report.tsv (tumor samples only)."""
+
+    def _write_junction_file(self, path, rows):
+        path.write_text("".join(f"{jid}\t{reads}\n" for jid, reads in rows))
+
+    def _write_manifest(self, path, entries):
+        lines = ["file_id\tfile_name\tsample_type\tproject_id\n"]
+        for file_id, sample_type in entries:
+            lines.append(f"{file_id}\t{file_id}.tsv\t{sample_type}\tlocal\n")
+        path.write_text("".join(lines))
+
+    def _write_reference_bed(self, path, junctions):
+        lines = [f"{c}\t{s}\t{e}\tjunc\t0\t{st}\n" for c, s, e, st in junctions]
+        path.write_text("".join(lines))
+
+    def test_stats_tsv_schema_and_categories(self, tmp_path):
+        # Tumor sample with one annotated, one unannotated tumor_exclusive,
+        # one unannotated normal_shared. Plus a noise junction below the mean
+        # filter so the high-read ones survive.
+        tumor_f = tmp_path / "tumor" / "junctions.tsv"
+        normal_f = tmp_path / "normal" / "junctions.tsv"
+        tumor_f.parent.mkdir()
+        normal_f.parent.mkdir()
+
+        self._write_junction_file(tumor_f, [
+            ("chr22:101:200:+", 100),  # annotated → discarded
+            ("chr22:201:300:+", 100),  # unannotated, in normal → normal_shared
+            ("chr22:301:400:+", 100),  # unannotated, NOT in normal → tumor_exclusive
+            ("chr22:901:1000:+", 1),   # noise — below mean, filtered out
+        ])
+        self._write_junction_file(normal_f, [("chr22:201:300:+", 5)])
+
+        manifest = tmp_path / "manifest.tsv"
+        self._write_manifest(manifest, [
+            ("tumor", "Primary Tumor"),
+            ("normal", "Solid Tissue Normal"),
+        ])
+
+        ref_bed = tmp_path / "ref.bed"
+        self._write_reference_bed(ref_bed, [("chr22", 100, 200, "+")])
+
+        output = tmp_path / "novel.tsv"
+        stats_output = tmp_path / "junction_filter_stats.tsv"
+        classify_junctions(
+            junction_files=[tumor_f, normal_f],
+            manifest_path=manifest,
+            reference_bed=ref_bed,
+            output_path=output,
+            stats_output_path=stats_output,
+        )
+
+        stats = pd.read_csv(stats_output, sep="\t")
+        assert set(stats.columns) == {"sample_id", "sample_type", "category", "count"}
+
+        # Long-format: 4 rows per tumor sample
+        assert len(stats) == 4
+        assert (stats["sample_id"] == "tumor").all()
+        assert (stats["sample_type"] == "Primary Tumor").all()
+
+        by_cat = dict(zip(stats["category"], stats["count"]))
+        # junctions_raw is BEFORE the mean-reads filter — all 4 rows
+        assert by_cat["junctions_raw"] == 4
+        # After mean filter, 3 junctions survive: 1 annotated, 1 normal_shared, 1 tumor_exclusive
+        assert by_cat["annotated_discarded"] == 1
+        assert by_cat["normal_shared"] == 1
+        assert by_cat["tumor_exclusive"] == 1
+
+    def test_stats_tsv_omits_normal_samples(self, tmp_path):
+        tumor_f = tmp_path / "tumor" / "junctions.tsv"
+        normal_f = tmp_path / "normal" / "junctions.tsv"
+        tumor_f.parent.mkdir()
+        normal_f.parent.mkdir()
+
+        self._write_junction_file(tumor_f, [
+            ("chr22:201:300:+", 100),
+            ("chr22:401:500:+", 1),
+        ])
+        self._write_junction_file(normal_f, [
+            ("chr22:201:300:+", 5),
+            ("chr22:601:700:+", 5),
+        ])
+
+        manifest = tmp_path / "manifest.tsv"
+        self._write_manifest(manifest, [
+            ("tumor", "Primary Tumor"),
+            ("normal", "Solid Tissue Normal"),
+        ])
+
+        ref_bed = tmp_path / "ref.bed"
+        self._write_reference_bed(ref_bed, [])
+
+        output = tmp_path / "novel.tsv"
+        stats_output = tmp_path / "junction_filter_stats.tsv"
+        classify_junctions(
+            junction_files=[tumor_f, normal_f],
+            manifest_path=manifest,
+            reference_bed=ref_bed,
+            output_path=output,
+            stats_output_path=stats_output,
+        )
+
+        stats = pd.read_csv(stats_output, sep="\t")
+        # No rows for the normal sample even though it has 2 raw junctions
+        assert "normal" not in set(stats["sample_id"])
+
+    def test_multi_tumor_samples_each_get_their_own_rows(self, tmp_path):
+        tumor1 = tmp_path / "tumor1" / "junctions.tsv"
+        tumor2 = tmp_path / "tumor2" / "junctions.tsv"
+        tumor1.parent.mkdir()
+        tumor2.parent.mkdir()
+
+        self._write_junction_file(tumor1, [
+            ("chr22:201:300:+", 100),
+            ("chr22:401:500:+", 1),
+        ])
+        self._write_junction_file(tumor2, [
+            ("chr22:301:400:+", 100),
+            ("chr22:501:600:+", 1),
+        ])
+
+        manifest = tmp_path / "manifest.tsv"
+        self._write_manifest(manifest, [
+            ("tumor1", "Primary Tumor"),
+            ("tumor2", "Primary Tumor"),
+        ])
+
+        ref_bed = tmp_path / "ref.bed"
+        self._write_reference_bed(ref_bed, [])
+
+        output = tmp_path / "novel.tsv"
+        stats_output = tmp_path / "junction_filter_stats.tsv"
+        classify_junctions(
+            junction_files=[tumor1, tumor2],
+            manifest_path=manifest,
+            reference_bed=ref_bed,
+            output_path=output,
+            stats_output_path=stats_output,
+        )
+
+        stats = pd.read_csv(stats_output, sep="\t")
+        # 4 categories × 2 samples = 8 rows
+        assert len(stats) == 8
+        assert set(stats["sample_id"]) == {"tumor1", "tumor2"}
+
+    def test_stats_tsv_optional(self, tmp_path):
+        """Existing callers that don't pass stats_output_path still work."""
+        tumor_f = tmp_path / "tumor" / "junctions.tsv"
+        tumor_f.parent.mkdir()
+        self._write_junction_file(tumor_f, [
+            ("chr22:201:300:+", 100),
+            ("chr22:401:500:+", 1),
+        ])
+        manifest = tmp_path / "manifest.tsv"
+        self._write_manifest(manifest, [("tumor", "Primary Tumor")])
+        ref_bed = tmp_path / "ref.bed"
+        self._write_reference_bed(ref_bed, [])
+
+        output = tmp_path / "novel.tsv"
+        # No stats_output_path — should not raise
+        classify_junctions(
+            junction_files=[tumor_f],
+            manifest_path=manifest,
+            reference_bed=ref_bed,
+            output_path=output,
+        )
+        assert output.exists()
+
+
+# ---------------------------------------------------------------------------
 # _build_cds_donor_lookup
 # ---------------------------------------------------------------------------
 

--- a/workflow/tests/test_generate_report.py
+++ b/workflow/tests/test_generate_report.py
@@ -253,15 +253,18 @@ class TestBuildReportTsv:
 
     def test_junction_funnel_totals_emitted_when_stats_provided(self, tmp_path):
         stats = tmp_path / "junction_filter_stats.tsv"
+        # Each sample has mean_reads_filtered too — the funnel must reconcile.
         self._write_stats_tsv(stats, [
             ("S1", "Primary Tumor", "junctions_raw", 1000),
-            ("S1", "Primary Tumor", "annotated_discarded", 800),
-            ("S1", "Primary Tumor", "normal_shared", 50),
-            ("S1", "Primary Tumor", "tumor_exclusive", 150),
+            ("S1", "Primary Tumor", "mean_reads_filtered", 100),
+            ("S1", "Primary Tumor", "annotated_discarded", 750),
+            ("S1", "Primary Tumor", "normal_shared", 40),
+            ("S1", "Primary Tumor", "tumor_exclusive", 110),
             ("S2", "Primary Tumor", "junctions_raw", 500),
-            ("S2", "Primary Tumor", "annotated_discarded", 400),
+            ("S2", "Primary Tumor", "mean_reads_filtered", 50),
+            ("S2", "Primary Tumor", "annotated_discarded", 370),
             ("S2", "Primary Tumor", "normal_shared", 20),
-            ("S2", "Primary Tumor", "tumor_exclusive", 80),
+            ("S2", "Primary Tumor", "tumor_exclusive", 60),
         ])
         out = tmp_path / "report.tsv"
         _build_report_tsv(
@@ -278,12 +281,43 @@ class TestBuildReportTsv:
         jf = df[df["stage"] == "junction_filtering"].set_index("metric")["value"]
         # Patient-level totals are sums across the 2 tumor samples
         assert int(jf["junctions_extracted_total"]) == 1500
-        assert int(jf["junctions_annotated_discarded"]) == 1200
+        assert int(jf["junctions_mean_reads_filtered"]) == 150
+        assert int(jf["junctions_annotated_discarded"]) == 1120
         # unannotated_total = normal_shared + tumor_exclusive across samples
-        assert int(jf["junctions_unannotated_total"]) == 50 + 150 + 20 + 80
+        assert int(jf["junctions_unannotated_total"]) == 40 + 110 + 20 + 60
+
+    def test_junction_funnel_totals_reconcile_in_report_tsv(self, tmp_path):
+        """report.tsv consumers should see a closed funnel (PR #240 review observation)."""
+        stats = tmp_path / "junction_filter_stats.tsv"
+        self._write_stats_tsv(stats, [
+            ("S1", "Primary Tumor", "junctions_raw", 1000),
+            ("S1", "Primary Tumor", "mean_reads_filtered", 100),
+            ("S1", "Primary Tumor", "annotated_discarded", 750),
+            ("S1", "Primary Tumor", "normal_shared", 40),
+            ("S1", "Primary Tumor", "tumor_exclusive", 110),
+        ])
+        out = tmp_path / "report.tsv"
+        _build_report_tsv(
+            patient_id="p001",
+            origin_df=_make_origin_df(),
+            pred_df=_make_pred_df(),
+            hla_qc_tsv=None,
+            output_tsv=out,
+            presentation_percentile_strong=0.5,
+            tcrdock_pdb=None,
+            junction_filter_stats_tsv=stats,
+        )
+        df = pd.read_csv(out, sep="\t")
+        jf = df[df["stage"] == "junction_filtering"].set_index("metric")["value"]
+        # extracted_total == mean_reads_filtered + annotated_discarded + unannotated_total
+        assert int(jf["junctions_extracted_total"]) == (
+            int(jf["junctions_mean_reads_filtered"])
+            + int(jf["junctions_annotated_discarded"])
+            + int(jf["junctions_unannotated_total"])
+        )
 
     def test_junction_funnel_totals_omitted_when_no_stats_path(self, tmp_path):
-        """Without stats path, the 3 new totals must not appear (back-compat)."""
+        """Without stats path, the 4 new totals must not appear (back-compat)."""
         out = tmp_path / "report.tsv"
         _build_report_tsv(
             patient_id="p001",
@@ -297,15 +331,17 @@ class TestBuildReportTsv:
         df = pd.read_csv(out, sep="\t")
         metrics = set(df[df["stage"] == "junction_filtering"]["metric"])
         assert "junctions_extracted_total" not in metrics
+        assert "junctions_mean_reads_filtered" not in metrics
         assert "junctions_annotated_discarded" not in metrics
         assert "junctions_unannotated_total" not in metrics
 
     def test_junction_funnel_totals_marked_as_patient_level(self, tmp_path):
-        """The 3 new rows should have a notes value distinguishing them from per-sample rows."""
+        """The 4 new rows should have a notes value distinguishing them from per-sample rows."""
         stats = tmp_path / "junction_filter_stats.tsv"
         self._write_stats_tsv(stats, [
             ("S1", "Primary Tumor", "junctions_raw", 100),
-            ("S1", "Primary Tumor", "annotated_discarded", 80),
+            ("S1", "Primary Tumor", "mean_reads_filtered", 10),
+            ("S1", "Primary Tumor", "annotated_discarded", 70),
             ("S1", "Primary Tumor", "normal_shared", 5),
             ("S1", "Primary Tumor", "tumor_exclusive", 15),
         ])
@@ -323,11 +359,12 @@ class TestBuildReportTsv:
         df = pd.read_csv(out, sep="\t")
         totals = df[df["metric"].isin([
             "junctions_extracted_total",
+            "junctions_mean_reads_filtered",
             "junctions_annotated_discarded",
             "junctions_unannotated_total",
         ])]
-        # All 3 rows present
-        assert len(totals) == 3
+        # All 4 rows present
+        assert len(totals) == 4
         # Notes field distinguishes them from per-sample rows (which carry sample_id)
         assert (totals["notes"] == "all tumor samples").all()
 

--- a/workflow/tests/test_generate_report.py
+++ b/workflow/tests/test_generate_report.py
@@ -244,6 +244,93 @@ class TestBuildReportTsv:
         assert df[df["stage"] == "mhc_prediction"].empty
         assert df[df["stage"] == "top_candidate"].empty
 
+    # ---------- Junction-funnel patient-level totals (Issue #214) ----------
+
+    def _write_stats_tsv(self, path, rows):
+        """rows: list of (sample_id, sample_type, category, count) tuples."""
+        df = pd.DataFrame(rows, columns=["sample_id", "sample_type", "category", "count"])
+        df.to_csv(path, sep="\t", index=False)
+
+    def test_junction_funnel_totals_emitted_when_stats_provided(self, tmp_path):
+        stats = tmp_path / "junction_filter_stats.tsv"
+        self._write_stats_tsv(stats, [
+            ("S1", "Primary Tumor", "junctions_raw", 1000),
+            ("S1", "Primary Tumor", "annotated_discarded", 800),
+            ("S1", "Primary Tumor", "normal_shared", 50),
+            ("S1", "Primary Tumor", "tumor_exclusive", 150),
+            ("S2", "Primary Tumor", "junctions_raw", 500),
+            ("S2", "Primary Tumor", "annotated_discarded", 400),
+            ("S2", "Primary Tumor", "normal_shared", 20),
+            ("S2", "Primary Tumor", "tumor_exclusive", 80),
+        ])
+        out = tmp_path / "report.tsv"
+        _build_report_tsv(
+            patient_id="p001",
+            origin_df=_make_origin_df(),
+            pred_df=_make_pred_df(),
+            hla_qc_tsv=None,
+            output_tsv=out,
+            presentation_percentile_strong=0.5,
+            tcrdock_pdb=None,
+            junction_filter_stats_tsv=stats,
+        )
+        df = pd.read_csv(out, sep="\t")
+        jf = df[df["stage"] == "junction_filtering"].set_index("metric")["value"]
+        # Patient-level totals are sums across the 2 tumor samples
+        assert int(jf["junctions_extracted_total"]) == 1500
+        assert int(jf["junctions_annotated_discarded"]) == 1200
+        # unannotated_total = normal_shared + tumor_exclusive across samples
+        assert int(jf["junctions_unannotated_total"]) == 50 + 150 + 20 + 80
+
+    def test_junction_funnel_totals_omitted_when_no_stats_path(self, tmp_path):
+        """Without stats path, the 3 new totals must not appear (back-compat)."""
+        out = tmp_path / "report.tsv"
+        _build_report_tsv(
+            patient_id="p001",
+            origin_df=_make_origin_df(),
+            pred_df=_make_pred_df(),
+            hla_qc_tsv=None,
+            output_tsv=out,
+            presentation_percentile_strong=0.5,
+            tcrdock_pdb=None,
+        )
+        df = pd.read_csv(out, sep="\t")
+        metrics = set(df[df["stage"] == "junction_filtering"]["metric"])
+        assert "junctions_extracted_total" not in metrics
+        assert "junctions_annotated_discarded" not in metrics
+        assert "junctions_unannotated_total" not in metrics
+
+    def test_junction_funnel_totals_marked_as_patient_level(self, tmp_path):
+        """The 3 new rows should have a notes value distinguishing them from per-sample rows."""
+        stats = tmp_path / "junction_filter_stats.tsv"
+        self._write_stats_tsv(stats, [
+            ("S1", "Primary Tumor", "junctions_raw", 100),
+            ("S1", "Primary Tumor", "annotated_discarded", 80),
+            ("S1", "Primary Tumor", "normal_shared", 5),
+            ("S1", "Primary Tumor", "tumor_exclusive", 15),
+        ])
+        out = tmp_path / "report.tsv"
+        _build_report_tsv(
+            patient_id="p001",
+            origin_df=_make_origin_df(),
+            pred_df=_make_pred_df(),
+            hla_qc_tsv=None,
+            output_tsv=out,
+            presentation_percentile_strong=0.5,
+            tcrdock_pdb=None,
+            junction_filter_stats_tsv=stats,
+        )
+        df = pd.read_csv(out, sep="\t")
+        totals = df[df["metric"].isin([
+            "junctions_extracted_total",
+            "junctions_annotated_discarded",
+            "junctions_unannotated_total",
+        ])]
+        # All 3 rows present
+        assert len(totals) == 3
+        # Notes field distinguishes them from per-sample rows (which carry sample_id)
+        assert (totals["notes"] == "all tumor samples").all()
+
 
 class TestLoadReportTsv:
     """Round-trip: writer output must load into the projections HTML rendering needs."""


### PR DESCRIPTION
## Summary

Closes #214. Fast-ship slice of [Issue #104](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/104) — unblocks Scientist's RESULTS.md by surfacing 3 patient-level junction-funnel totals in `report.tsv`.

**New rows in `report.tsv`** (stage = `junction_filtering`, notes = `"all tumor samples"`):
- `junctions_extracted_total` — sum across tumor samples, raw regtools output, pre mean-reads filter
- `junctions_annotated_discarded` — sum across tumor samples, GENCODE-annotated junctions discarded
- `junctions_unannotated_total` — sum across tumor samples, `normal_shared + tumor_exclusive`

Per-sample junction_filtering rows are unchanged.

## Architecture

`filter_junctions.py` now also writes a long-format per-tumor-sample stats TSV at `results/{patient_id}/junctions/junction_filter_stats.tsv` (alongside the existing `novel_junctions.tsv`). Schema:

| sample_id | sample_type | category | count |
|---|---|---|---|
| S1 | Primary Tumor | junctions_raw | 1000 |
| S1 | Primary Tumor | annotated_discarded | 800 |
| S1 | Primary Tumor | normal_shared | 50 |
| S1 | Primary Tumor | tumor_exclusive | 150 |

`generate_report.py` reads this artefact (declared as a new input on both `generate_report` and `generate_report_with_structure` via the shared `_generate_report_input` helper), aggregates by category, and emits the 3 patient-level totals.

**Tumor-only by design.** The spec row `junctions_unannotated_total = normal_shared + tumor_exclusive` is a tumor-classification concept; normal samples are used as a filter set rather than classified. Confirmed in brainstorming.

**Schema alignment with #215.** Category names (`junctions_raw`, `annotated_discarded`, ...) match Issue #215's planned `filtering_stats.tsv` vocabulary. When #215 ships, it can either supersede this file or aggregate it as one of several per-step sources — migration cost stays small either way.

## Test plan

- [x] 4 new unit tests in `test_filter_junctions.py` (schema/categories, normal-omission, multi-sample, back-compat for callers without stats path)
- [x] 3 new unit tests in `test_generate_report.py` (totals correctness, back-compat without stats path, notes-field convention)
- [x] Full test suite: 233/233 passing
- [x] Snakemake dry-run with test config validates the rule graph
- [ ] Cloud run on patient_001 to verify end-to-end (deferred to next prod run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)