### PR TITLE
docs(alphagenome): primer + spike script (#223)

### DIFF
--- a/docs/alphagenome_primer.md
+++ b/docs/alphagenome_primer.md
@@ -1,0 +1,301 @@
+# AlphaGenome Primer — Reading the Output
+
+Reference for interpreting AlphaGenome predictions in the context of this
+pipeline (predicted-normal junction filter, [Issue #203](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/203)
+and follow-ups). Written after the [Issue #223](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/223)
+spike — working code lives in [`scripts/alphagenome_spike.py`](../scripts/alphagenome_spike.py).
+
+The numeric examples below come from one live API call against the spike
+script's chr22 test region. Numbers are illustrative; rerun the spike for
+fresh values.
+
+---
+
+## Table of Contents
+
+1. [What AlphaGenome is](#what-alphagenome-is)
+2. [Tracks — the core concept](#tracks--the-core-concept)
+3. [Output shape](#output-shape)
+4. [API methods — query shapes, not different assays](#api-methods--query-shapes-not-different-assays)
+5. [`data_source` is training-time provenance, not runtime](#data_source-is-training-time-provenance-not-runtime)
+6. [Per-track interpretation](#per-track-interpretation)
+7. [Operational details](#operational-details)
+8. [For the predicted-normal filter](#for-the-predicted-normal-filter)
+
+---
+
+## What AlphaGenome is
+
+AlphaGenome is DeepMind's sequence-to-regulation foundation model: it takes
+a DNA sequence as input and emits predicted functional-genomics measurements
+(RNA-seq, ATAC-seq, ChIP-seq, splice junctions, contact maps, etc.) in a
+single forward pass. **Free for non-commercial use** via Python SDK and
+hosted API; key obtained at <https://deepmind.google.com/science/alphagenome>.
+
+End-to-end means: there is no internal step where AlphaGenome simulates raw
+RNA-seq reads and re-analyses them. The model maps DNA → predicted assay
+summary statistic directly. **No internal aligner, no FASTQ generation, no
+runtime database lookups** — everything the model "knows" is baked into
+its trained weights.
+
+---
+
+## Tracks — the core concept
+
+A **track** is one output channel of the model. Each track corresponds to
+one specific (biosample × assay × consortium) combination the model was
+calibrated against during training.
+
+For example, one row of the metadata DataFrame:
+
+| metadata field | example value |
+|---|---|
+| `name` | `junction_CL:0000084 polyA plus RNA-seq` |
+| `ontology_curie` | `CL:0000084` (Cell Ontology — T-cell) |
+| `biosample_name` | `T-cell` |
+| `biosample_type` | `primary_cell` |
+| `biosample_life_stage` | `adult` |
+| `gtex_tissue` | (empty for ENCODE-derived tracks) |
+| `data_source` | `encode` |
+| `Assay title` | `polyA plus RNA-seq` |
+
+When we ask for `OutputType.SPLICE_JUNCTIONS`, we get **367 tracks** in
+total: 313 from ENCODE, 54 from GTEx; 195 trained on total RNA-seq, 172 on
+polyA-plus RNA-seq (counts from the spike output, current as of 2026-05-02).
+
+**Tracks are NOT sub-models.** AlphaGenome is one model with a shared
+backbone (the DNA encoder) and 367 lightweight output heads. All heads were
+trained jointly via multi-task learning. What the model learned about gene
+structure from ENCODE training data informs its GTEx predictions too —
+they share the encoder. That's why one inference call returns predictions
+for all 367 tracks at once in ~1–3 seconds.
+
+### Glossary terms used here
+
+- **Biosample** — consortium jargon for "the biological material the
+  experiment was performed on." Covers primary cells, immortalised cell
+  lines, in-vitro-differentiated cells, and bulk tissue samples. Broader
+  than "tissue."
+- **Assay** — what experimental measurement the track predicts: RNA-seq,
+  ATAC-seq, ChIP-seq, splice junctions, etc. Set by `OutputType` in the SDK.
+- **Consortium** — which lab/project produced the original measurements:
+  ENCODE (cell lines + primary cells + tissues), GTEx (postmortem human
+  tissues — our preferred source for "normal").
+- **RNA-seq protocols in the inventory:**
+  - *polyA plus RNA-seq* — captures only mature, polyadenylated mRNA
+  - *total RNA-seq* — captures all RNA species (mRNA + ncRNA + pre-mRNA)
+  Different protocols sample different RNA populations → different
+  junction signal.
+
+---
+
+## Output shape
+
+For `requested_outputs=[OutputType.SPLICE_JUNCTIONS]`, the SDK returns an
+`Output` (or `VariantOutput`) whose `.splice_junctions` is a `JunctionData`
+object with:
+
+- `.values` — the predicted-signal matrix, shape `(n_junctions, n_tracks)`
+- `.metadata` — DataFrame describing the tracks (one row per column of
+  `.values`), shape `(n_tracks, 8)`
+- `.interval` — the genomic region the prediction is for
+
+Concrete shape for the spike's chr22:42M-42.13M call to `predict_interval`:
+
+```
+.values: (6084, 367)        — 6084 candidate junctions × 367 tracks
+.metadata: (367, 8)         — 367 track descriptors
+
+                    track 0     track 1    ...   track 366
+                    (T-cell     (liver           (lung
+                    polyA)      total)           polyA)
+junction 0          0.04        0.92      ...    0.01
+junction 1          0.81        0.03      ...    0.78
+junction 2          0.00        0.51      ...    0.00
+...
+junction 6083       0.65        0.05      ...    0.41
+```
+
+**Critical: junctions are SHARED across tracks.** The model emits one set
+of candidate junctions (the rows) and provides per-track predicted signal
+for each (the columns). A junction with high signal in track A (T-cell)
+and low signal in track B (liver) is the model expressing tissue
+specificity. **Tissue specificity is a property of the score distribution
+within a column, not of the junction set.**
+
+---
+
+## API methods — query shapes, not different assays
+
+The SDK exposes several methods that look like they predict different
+things. They don't — what is predicted is controlled by `requested_outputs`,
+which is orthogonal to the API method. **You can request any `OutputType`
+through any API method.**
+
+| Method | Input | Returns |
+|---|---|---|
+| `predict_interval(interval)` | a genome `Interval` | `Output` — fetches reference, predicts on it |
+| `predict_sequence(sequence, interval=...)` | a raw DNA **string** + optional interval | `Output` — predicts on the string you provide |
+| `predict_variant(interval, variant)` | interval + one specified variant | `VariantOutput` with `.reference` and `.alternate` |
+| `predict_intervals(intervals)` | sequence of intervals | list of `Output`s (parallel batch) |
+| `predict_variants(intervals, variants)` | sequences of intervals + variants | list of `VariantOutput`s (parallel batch) |
+
+`predict_variant` does NOT generate variants — you specify exactly one
+variant as input, and the function returns predictions for both the
+reference and the variant-applied DNA. Same for `predict_variants`: it
+processes N user-specified variants independently in parallel, returning
+N separate `VariantOutput`s — it is **NOT** a multi-variant compositor.
+
+### Empirical: `predict_variant` filters to variant-affected junctions
+
+In the spike, `predict_interval` on a 131kb chr22 region returned **6084
+junctions**. `predict_variant` on the same interval (with one synthetic
+SNV) returned only **503 junctions** in both `.reference` and `.alternate`.
+
+We verified empirically that all 503 junctions show ref ≠ alt in at least
+one track (none have identical values across all 367 tracks). So
+`predict_variant` is filtering its output to **only the junctions where
+the variant has measurable effect somewhere in the (junctions × tracks)
+matrix** — not geographic windowing, not random sub-sampling.
+
+The inclusion threshold appears very lenient: in the spike, mean |ref − alt|
+across the 503 included junctions is ~0.00014. Effectively any non-zero
+variant effect, however small, qualifies a junction for output. This means
+the 503 number is **"all junctions with any model-detectable response to
+the variant"** — not a high-confidence "this variant matters here" set.
+The meaningful biological signal lives in the *magnitude* of ref-vs-alt
+deltas, not the count of returned junctions.
+
+---
+
+## `data_source` is training-time provenance, not runtime
+
+The `data_source` column in track metadata (`encode` / `gtex`) describes
+**which consortium produced the training data** that the corresponding
+output head was calibrated against — not a runtime input.
+
+At inference, AlphaGenome does NOT consult ENCODE or GTEx databases. The
+model performs a pure DNA-sequence forward pass; the consortium-trained
+patterns live in the model weights. No internet access to consortium
+archives is needed beyond the API call itself.
+
+Why this matters for our use case: GTEx profiled splicing in **healthy
+human tissues** from postmortem donors, which is exactly the "normal"
+baseline the predicted-normal filter wants. ENCODE's track inventory
+includes many cancer-derived cell lines (HeLa, K562) — useful for general
+regulatory inference but a poor proxy for "normal patient tissue."
+Filtering to `data_source == 'gtex'` gives us 54 tracks aligned with our
+question.
+
+---
+
+## Per-track interpretation
+
+For one track at one junction, the `.values[junction_i, track_j]` cell
+gives the model's predicted signal under the following counterfactual:
+
+> *If* the input DNA were transcribed in cells of biosample X, *and* you
+> ran assay Y on the resulting RNA, *then* the measured signal at junction
+> J would be approximately this value.
+
+The reference DNA is fixed across tracks — what varies is which cellular
+context (which output head) you're reading from. Tissue specificity is
+encoded in the model's weights (different output heads for different
+biosamples), not in the input.
+
+### Worked example
+
+```python
+md = output.splice_junctions.metadata
+liver_polya_idx = md[
+    (md["biosample_name"] == "liver")
+    & (md["Assay title"] == "polyA plus RNA-seq")
+    & (md["data_source"] == "gtex")
+].index[0]
+
+values = output.splice_junctions.values
+print(values[42, liver_polya_idx])   # → 0.81
+```
+
+Reading: "junction 42 (some donor → acceptor pair in chr22:42M-42.13M) is
+predicted to show signal ~0.81 under liver polyA-plus RNA-seq from GTEx."
+Higher value indicates a more confident prediction that the junction
+would be observed in that biological context.
+
+---
+
+## Operational details
+
+- **Required input lengths.** The model only accepts these region widths:
+  16384, 131072, 524288, 1048576 (powers-of-2-ish, up to 1Mb). Other
+  lengths raise `ValueError`. Pad or trim accordingly.
+- **Per-call latency.** ~1–3s wall-clock for a 131kb interval. Cost scales
+  modestly with input length thanks to the shared backbone.
+- **Rate limits.** Intentionally not documented; the team's posture per
+  the [community FAQ](https://www.alphagenomecommunity.com/t/what-are-the-alphagenome-api-limits/673)
+  is "increase parallel workers (default 5) until you see
+  `RESOURCE_EXHAUSTED`, then back off." `predict_intervals` and
+  `predict_variants` accept a `max_workers` parameter for batching.
+- **SDK install.** `pip install alphagenome` (PyPI; not source build).
+- **API key.** Set `ALPHAGENOME_API_KEY` in `.env`. Loader pattern matches
+  [`research/scripts/zotero_add.py`](../research/scripts/zotero_add.py)'s
+  `load_env`.
+
+Minimal usage:
+
+```python
+from alphagenome.data import genome
+from alphagenome.models import dna_client
+from alphagenome.models.dna_output import OutputType
+
+model = dna_client.create(API_KEY)
+interval = genome.Interval(chromosome="chr22", start=42_000_000, end=42_131_072)
+output = model.predict_interval(
+    interval=interval,
+    requested_outputs=[OutputType.SPLICE_JUNCTIONS],
+    ontology_terms=None,
+)
+junctions = output.splice_junctions.values   # shape (n_junctions, 367)
+metadata = output.splice_junctions.metadata  # DataFrame describing the tracks
+```
+
+See [`scripts/alphagenome_spike.py`](../scripts/alphagenome_spike.py) for a
+runnable end-to-end example with both interval and variant calls.
+
+---
+
+## For the predicted-normal filter
+
+Use case: filter tumor candidate junctions by checking whether they're
+predicted to have non-trivial signal in *any* healthy human tissue
+([Issue #212](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/212)).
+
+Sketch:
+
+```python
+# 1. Restrict to GTEx tracks (healthy human tissues).
+md = output.splice_junctions.metadata
+gtex_cols = md.index[md["data_source"] == "gtex"]   # 54 tracks
+gtex_signals = output.splice_junctions.values[:, gtex_cols]  # (n_junctions, 54)
+
+# 2. Aggregate across tissues — pan-tissue "any signal" check.
+max_signal_per_junction = gtex_signals.max(axis=1)   # (n_junctions,)
+
+# 3. Threshold (TBD by Scientist; coarse default to start with).
+predicted_normal = max_signal_per_junction > THRESHOLD
+```
+
+Reading: a tumor junction matching one of the model's `predicted_normal`
+candidates is plausibly normal splicing → filter out. A tumor junction the
+model predicts absent across all 54 GTEx tracks (low signal everywhere) is
+a better tumor-specific candidate.
+
+The threshold is the open design question for [Issue #212](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/212)
+and [Issue #224](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/224)
+— Scientist's call after the validation experiments in [Issue #203](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/203).
+
+For the experiment-specific tool choice (which API method to use, what to
+benchmark against), see Scientist's design in [#203](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/203)
+and the implementation in [#224](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/224)
+— this primer is intentionally scoped to "what AlphaGenome does," not "how
+to design experiments around it."

--- a/docs/alphagenome_primer.md
+++ b/docs/alphagenome_primer.md
@@ -156,15 +156,22 @@ We verified empirically that all 503 junctions show ref ≠ alt in at least
 one track (none have identical values across all 367 tracks). So
 `predict_variant` is filtering its output to **only the junctions where
 the variant has measurable effect somewhere in the (junctions × tracks)
-matrix** — not geographic windowing, not random sub-sampling.
+matrix** — not random sub-sampling. Geographic windowing (variants
+restricted to a window around their position) cannot be ruled out by this
+test alone, but the non-zero-delta rate makes effect-based filtering the
+more parsimonious explanation. We did not verify junction coordinates.
 
 The inclusion threshold appears very lenient: in the spike, mean |ref − alt|
-across the 503 included junctions is ~0.00014. Effectively any non-zero
-variant effect, however small, qualifies a junction for output. This means
-the 503 number is **"all junctions with any model-detectable response to
-the variant"** — not a high-confidence "this variant matters here" set.
-The meaningful biological signal lives in the *magnitude* of ref-vs-alt
-deltas, not the count of returned junctions.
+across the 503 included junctions is ~0.00014. **Caveat:** the spike SNV
+was a synthetic A→G at the interval midpoint — chosen for API plumbing,
+not designed to disrupt splicing. The tiny mean delta likely reflects
+micro-perturbations from a single nucleotide change, not the threshold's
+behaviour for biologically meaningful splice-disruptive variants (where
+deltas would be orders of magnitude larger). The threshold for those
+remains uncharacterised. What's clear is that the 503 number is
+**"any model-detectable response, however small"**, not a high-confidence
+"this variant matters here" set — meaningful biological signal lives in
+the *magnitude* of ref-vs-alt deltas, not the count of returned junctions.
 
 ---
 
@@ -226,9 +233,10 @@ would be observed in that biological context.
 
 ## Operational details
 
-- **Required input lengths.** The model only accepts these region widths:
-  16384, 131072, 524288, 1048576 (powers-of-2-ish, up to 1Mb). Other
-  lengths raise `ValueError`. Pad or trim accordingly.
+- **Required input lengths.** The model only accepts these four specific
+  region widths: **16384, 131072, 524288, 1048576**. Other powers of 2
+  (32768, 65536, 262144) and arbitrary lengths raise `ValueError`. Pad or
+  trim accordingly.
 - **Per-call latency.** ~1–3s wall-clock for a 131kb interval. Cost scales
   modestly with input length thanks to the shared backbone.
 - **Rate limits.** Intentionally not documented; the team's posture per

--- a/research/lab_notebook.md
+++ b/research/lab_notebook.md
@@ -4,6 +4,27 @@
 
 ## 2026-05-02
 
+### 20:32 UTC — Editor: Developer
+
+#### Issue #223 — live AlphaGenome API spike + primer doc
+
+User registered for the AlphaGenome API key in the same session, so the live test moved up from "next session" to now. Two-call probe in [`scripts/alphagenome_spike.py`](../scripts/alphagenome_spike.py) (committed under `scripts/` for [#224](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/224) reuse): one `predict_interval` and one `predict_variant` against a 131kb chr22 region. SDK is `pip install alphagenome` from PyPI; key loaded from `.env` as `ALPHAGENOME_API_KEY` matching the `zotero_add.py` `load_env` pattern.
+
+**Empirical findings, beyond the morning recon:**
+
+- **Latency**: 0.75–2.6s per call for a 131kb interval. Within the documented "<1s prediction" range (the rest is round-trip).
+- **Required input lengths are constrained to {16384, 131072, 524288, 1048576}** — not arbitrary. First call with 100k failed with a `ValueError`. Plumbing for [#224](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/224) needs to handle this. Documented in the primer.
+- **367 splice-junction tracks** total: 313 ENCODE + 54 GTEx; 195 total RNA-seq + 172 polyA-plus RNA-seq. The 54 GTEx tracks are the relevant subset for the predicted-normal filter ([#212](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/212)) since GTEx profiled healthy human tissues; ENCODE includes cancer-derived cell lines (HeLa/K562) that are poor "normal patient tissue" proxies.
+- **Output shape is `(n_junctions, n_tracks)`** — a matrix where junctions are SHARED across tracks and tissue specificity lives in the score distribution within each column. This was a major mental-model fix for me; I'd been imagining one set of junctions per track. Documented in the primer as a load-bearing concept.
+- **`predict_variant` filters output to variant-affected junctions**, empirically verified: `predict_interval` returned 6084 junctions, `predict_variant` returned 503; 503/503 of those have ref ≠ alt in at least one track (none have identical values across all 367). User correctly hypothesised this was an effect-based filter (not the geographic windowing I'd guessed). Inclusion threshold appears very lenient — mean |ref − alt| of ~0.00014 still qualifies. So the 503 number is "any model-detectable variant response" rather than "biologically meaningful effect" — meaningful signal for [#224](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/224) lives in delta magnitudes, not the count.
+- **`predict_variants` (plural) is batched single-variant queries, not a multi-variant compositor** — the docstring confirms "Variant outputs for each DNA interval and variant pair." Each variant is processed independently, returning N separate `VariantOutput`s with `max_workers` parallelism. So patient_001's combined germline-variant effect (Experiment 2) needs externally-built patient FASTA + `predict_sequence`, not `predict_variants`. The latter is the right tool for per-variant attribution (Experiment 3).
+
+**Documentation: [`docs/alphagenome_primer.md`](../docs/alphagenome_primer.md)** ships in this PR. ~290 lines covering tracks (the central concept), output shape, API methods as orthogonal query shapes (not different assays), `data_source` as training-time provenance, per-track interpretation, operational details, and the predicted-normal filter sketch. Iterated through several mental-model corrections with the user — the doc preserves the accurate framing rather than my initial half-right intuitions. Originally drafted with a "per-experiment API mapping" section; user pointed out [#203](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/203)'s Experiment 1 design is Sci's call and shouldn't be encoded in a Dev primer — section dropped; suggestion to refine Exp 1 (use GRCh38 + annotated-only ground truth instead of patient WGS + observed normal) will be posted separately on [#203](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/203) for Scientist.
+
+**Aggregation choice for the predicted-normal filter:** `max(axis=1)` over the 54 GTEx tracks — captures "if ANY healthy tissue shows signal, treat as normal" — aligned with Scientist's vaccine-CTL safety framing in [#211](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/211)/[#212](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/212). Mean would smooth tissue-specific normal signals toward zero and miss them — wrong direction for safety. Max is sensitive to single-track noise; top-k mean / quantile threshold are noise-robust alternatives Sci can pick if needed. Documented.
+
+**Closes [#223](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/223)** when this PR merges. [#224](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/224) and [#225](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/225) unblock for Scientist.
+
 ### 19:53 UTC — Editor: PM
 
 #### Issue #246 — implemented closure audit step in morning warmup + tightened "acceptance criteria visibly met"

--- a/research/lab_notebook.md
+++ b/research/lab_notebook.md
@@ -2,6 +2,26 @@
 
 ---
 
+## 2026-05-03
+
+### 18:12 UTC — Editor: Developer
+
+#### Issue #223 / PR #254 — review-cycle fixes
+
+`@claude` review on the AlphaGenome primer flagged three actionable items. All addressed in this commit:
+
+1. **Medium — "powers of 2" phrasing was misleading.** The primer (line 230) and the spike script (line 70) both said the four required input lengths were "powers of 2 ≤ 1Mb." Reviewer correctly pointed out that 2^15=32768, 2^16=65536, and 2^18=262144 are also powers of 2 but **not accepted** — only the four specific values 16384, 131072, 524288, 1048576 work. A reader taking the primer literally would expect the intermediate sizes to work and get a `ValueError`. Fixed both call sites to say "these four specific values" and explicitly list the rejected powers of 2.
+
+2. **Low — lenient-threshold caveat.** The primer described the spike's mean |ref − alt| of ~0.00014 as evidence the variant-affected-junction filter is "very lenient." Reviewer pointed out the spike SNV was a synthetic A→G chosen for API plumbing — not designed to disrupt splicing. So the tiny mean delta likely reflects micro-perturbations from a single nucleotide change, not characterisation of how the threshold behaves for biologically meaningful splice-disruptive variants (where deltas would be orders of magnitude larger). Added the caveat explicitly. Also added a one-line acknowledgment that geographic windowing wasn't ruled out by our test (the non-zero-delta rate just makes effect-based filtering the more parsimonious explanation).
+
+3. **Low — dead branch in `summarise_output()`.** The function used `getattr(val, "shape", None) is None` as a "this is a DataFrame, fall through to column listing" heuristic. But pandas DataFrames also have `.shape` (returns `(n_rows, n_cols)` tuple), so the column-listing else-branch was unreachable for `metadata` — instead the script printed `"metadata.shape: (367, 8)"`, which is less informative than the column inventory the comment promised. Fixed by handling `metadata` via its own explicit code path (always print columns) and looping the shape-printing only over `values + interval`. Verified with a mock-DataFrame smoke test.
+
+**Why this matters now:** the spike script is intended as a reusable probe for [#224](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/224)'s AlphaGenome validation notebook. Shipping with dead branches and misleading comments would be a paper-cut for whoever picks that issue up.
+
+**Verified:** smoke test confirms `summarise_output()` now prints the column list for DataFrames; primer + spike consistent on the input-length constraint. No tests changed (script is a one-off probe, not under pytest coverage). Closes [Issue #223](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/223) when this PR merges.
+
+---
+
 ## 2026-05-02
 
 ### 20:32 UTC — Editor: Developer

--- a/scripts/alphagenome_spike.py
+++ b/scripts/alphagenome_spike.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""alphagenome_spike.py — Live API smoke test for Issue #223.
+
+Verifies that the AlphaGenome API:
+  1. Authenticates with the key in $ALPHAGENOME_API_KEY (or .env).
+  2. Returns OutputType.SPLICE_JUNCTIONS for a small chr22 reference interval.
+  3. Returns variant-vs-reference junction outputs for a fake variant context.
+  4. Surfaces wall-clock latency for both calls.
+
+This is a one-shot probe — does not write any artefacts the pipeline depends on.
+Output goes to stdout so it can be pasted into the Issue #223 thread.
+"""
+
+import os
+import sys
+import time
+
+
+def load_env(path=".env"):
+    """Mirror research/scripts/zotero_add.py — minimal .env loader, stdlib only."""
+    if not os.path.exists(path):
+        return
+    with open(path) as f:
+        for line in f:
+            line = line.strip()
+            if line and not line.startswith("#") and "=" in line:
+                key, _, value = line.partition("=")
+                os.environ.setdefault(key.strip(), value.strip())
+
+
+def summarise_output(output, label):
+    """Print a compact summary of an Output object's splice junction track."""
+    print(f"\n  {label}:")
+    print(f"    output type: {type(output).__name__}")
+    sj = getattr(output, "splice_junctions", None)
+    if sj is None:
+        print("    splice_junctions: <attribute missing>")
+        return
+    print(f"    splice_junctions type: {type(sj).__name__}")
+    # TrackData objects expose .values (np.ndarray), .metadata (DataFrame),
+    # .interval (Interval). Probe each defensively in case the API surface
+    # differs from the README.
+    for attr in ("values", "metadata", "interval"):
+        if hasattr(sj, attr):
+            val = getattr(sj, attr)
+            shape = getattr(val, "shape", None)
+            if shape is not None:
+                print(f"    {attr}.shape: {shape}")
+            else:
+                # metadata is usually a DataFrame; show columns + row count
+                cols = getattr(val, "columns", None)
+                if cols is not None:
+                    print(f"    {attr}: DataFrame with {len(val)} rows, "
+                          f"columns={list(cols)[:8]}{'…' if len(cols) > 8 else ''}")
+                else:
+                    print(f"    {attr}: {val!r}")
+
+
+def main() -> int:
+    load_env()
+    api_key = os.environ.get("ALPHAGENOME_API_KEY")
+    if not api_key:
+        sys.exit("Error: ALPHAGENOME_API_KEY must be set in .env or environment.")
+
+    # Late imports so a missing-SDK error doesn't obscure the env-var check above.
+    from alphagenome.data import genome
+    from alphagenome.models import dna_client
+    from alphagenome.models.dna_output import OutputType
+
+    # AlphaGenome only accepts specific input lengths (powers of 2 ≤ 1 Mb):
+    # 16384, 131072, 524288, 1048576. We use 131072 (~128 kb) — smallest size
+    # that comfortably spans a typical multi-exon gene.
+    INTERVAL_WIDTH = 131_072
+    INTERVAL_START = 42_000_000
+    interval = genome.Interval(
+        chromosome="chr22",
+        start=INTERVAL_START,
+        end=INTERVAL_START + INTERVAL_WIDTH,
+    )
+    # Synthetic SNV inside the interval — does not need to be real for the probe;
+    # purpose is to verify the variant API path works and returns ref/alt outputs.
+    variant = genome.Variant(
+        chromosome="chr22",
+        position=INTERVAL_START + INTERVAL_WIDTH // 2,
+        reference_bases="A",
+        alternate_bases="G",
+    )
+
+    print(f"Creating client …")
+    model = dna_client.create(api_key)
+    print(f"  {type(model).__name__} ready.")
+    print(f"  Using SPLICE_JUNCTIONS output type "
+          f"({OutputType.SPLICE_JUNCTIONS.name}).")
+
+    print(f"\nCall 1 — predict_interval on {interval}")
+    t0 = time.perf_counter()
+    interval_output = model.predict_interval(
+        interval=interval,
+        requested_outputs=[OutputType.SPLICE_JUNCTIONS],
+        ontology_terms=None,
+    )
+    elapsed1 = time.perf_counter() - t0
+    print(f"  wall-clock: {elapsed1:.2f}s")
+    summarise_output(interval_output, "interval-only result")
+
+    print(f"\nCall 2 — predict_variant on {interval} with {variant}")
+    t0 = time.perf_counter()
+    variant_output = model.predict_variant(
+        interval=interval,
+        variant=variant,
+        requested_outputs=[OutputType.SPLICE_JUNCTIONS],
+        ontology_terms=None,
+    )
+    elapsed2 = time.perf_counter() - t0
+    print(f"  wall-clock: {elapsed2:.2f}s")
+    # VariantOutput exposes .reference and .alternate Output objects;
+    # show both so we can confirm the diff is observable.
+    if hasattr(variant_output, "reference"):
+        summarise_output(variant_output.reference, "variant.reference")
+    if hasattr(variant_output, "alternate"):
+        summarise_output(variant_output.alternate, "variant.alternate")
+    if not hasattr(variant_output, "reference"):
+        # Fallback if the API shape differs — dump non-private attrs.
+        print(f"  VariantOutput attrs: "
+              f"{[a for a in dir(variant_output) if not a.startswith('_')]}")
+
+    # Inspect track metadata so Scientist can plan tissue filters for #224/#225.
+    sj = interval_output.splice_junctions
+    md = getattr(sj, "metadata", None)
+    if md is not None and hasattr(md, "columns"):
+        print(f"\nTrack metadata: {len(md)} tracks, columns={list(md.columns)}")
+        if "data_source" in md.columns:
+            print(f"  data_source counts: "
+                  f"{md['data_source'].value_counts().to_dict()}")
+        if "Assay title" in md.columns:
+            print(f"  Assay title counts (top 5): "
+                  f"{md['Assay title'].value_counts().head(5).to_dict()}")
+
+    print(f"\nDone. Latency: predict_interval={elapsed1:.2f}s, "
+          f"predict_variant={elapsed2:.2f}s")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/alphagenome_spike.py
+++ b/scripts/alphagenome_spike.py
@@ -37,23 +37,25 @@ def summarise_output(output, label):
         print("    splice_junctions: <attribute missing>")
         return
     print(f"    splice_junctions type: {type(sj).__name__}")
-    # TrackData objects expose .values (np.ndarray), .metadata (DataFrame),
-    # .interval (Interval). Probe each defensively in case the API surface
-    # differs from the README.
-    for attr in ("values", "metadata", "interval"):
-        if hasattr(sj, attr):
-            val = getattr(sj, attr)
-            shape = getattr(val, "shape", None)
-            if shape is not None:
-                print(f"    {attr}.shape: {shape}")
-            else:
-                # metadata is usually a DataFrame; show columns + row count
-                cols = getattr(val, "columns", None)
-                if cols is not None:
-                    print(f"    {attr}: DataFrame with {len(val)} rows, "
-                          f"columns={list(cols)[:8]}{'…' if len(cols) > 8 else ''}")
-                else:
-                    print(f"    {attr}: {val!r}")
+    # JunctionData exposes .values (np.ndarray), .metadata (pd.DataFrame),
+    # .interval (Interval). For values + interval the shape is the useful
+    # summary; for metadata we surface column names directly because
+    # DataFrame.shape is also populated (e.g. (367, 8)) but less informative
+    # than the column inventory.
+    for attr in ("values", "interval"):
+        val = getattr(sj, attr, None)
+        if val is None:
+            continue
+        shape = getattr(val, "shape", None)
+        if shape is not None:
+            print(f"    {attr}.shape: {shape}")
+        else:
+            print(f"    {attr}: {val!r}")
+    md = getattr(sj, "metadata", None)
+    if md is not None:
+        cols = list(md.columns)
+        print(f"    metadata: DataFrame with {len(md)} rows, "
+              f"columns={cols[:8]}{'…' if len(cols) > 8 else ''}")
 
 
 def main() -> int:
@@ -67,9 +69,10 @@ def main() -> int:
     from alphagenome.models import dna_client
     from alphagenome.models.dna_output import OutputType
 
-    # AlphaGenome only accepts specific input lengths (powers of 2 ≤ 1 Mb):
-    # 16384, 131072, 524288, 1048576. We use 131072 (~128 kb) — smallest size
-    # that comfortably spans a typical multi-exon gene.
+    # AlphaGenome only accepts these four specific input lengths:
+    # 16384, 131072, 524288, 1048576. Other powers of 2 (e.g. 32768, 65536,
+    # 262144) raise ValueError. We use 131072 (~128 kb) — smallest size that
+    # comfortably spans a typical multi-exon gene.
     INTERVAL_WIDTH = 131_072
     INTERVAL_START = 42_000_000
     interval = genome.Interval(


### PR DESCRIPTION
## Summary

Closes #223. Three artefacts from the AlphaGenome API spike:

- **[`docs/alphagenome_primer.md`](docs/alphagenome_primer.md)** (new, ~290 lines) — reference for interpreting AlphaGenome predictions in the context of this pipeline. Reviewed iteratively with the user against several mental-model traps (tracks ≠ sub-models; API methods ≠ assays; `data_source` is training-time provenance not runtime; junctions are SHARED across tracks).
- **[`scripts/alphagenome_spike.py`](scripts/alphagenome_spike.py)** (new) — runnable two-call probe (`predict_interval` + `predict_variant`) used to generate the empirical findings in the primer. Reusable for #224.
- **`research/lab_notebook.md`** — 2026-05-02 20:32 UTC entry covering the live-test session and documentation work, separate from the morning's 18:18 UTC recon entry per the immutability rule.

## Empirical findings beyond the morning recon

- 367 splice-junction tracks (313 ENCODE + 54 GTEx); 195 total RNA-seq + 172 polyA-plus RNA-seq.
- Required input lengths constrained to **{16384, 131072, 524288, 1048576}** — not arbitrary (`ValueError` on others).
- `predict_variant` filters output to variant-affected junctions: 6084 → 503 junctions, 503/503 with non-zero delta in at least one track. Inclusion threshold appears very lenient (mean |ref − alt| of ~0.00014 still qualifies).
- `predict_variants` (plural) is batched single-variant queries — NOT a multi-variant compositor. Patient_001's combined germline effect (Experiment 2) needs externally-built patient FASTA + `predict_sequence`.

## Test plan
- [x] Spike script runs end-to-end against the live API (verified during the session).
- [x] Doc-only + new-script changes; no pipeline-rule modifications.
- [x] Lab notebook entry on this branch per the "before merge" rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)