### PR TITLE
docs(news-log): Scientist 2026-05-03 14:07 UTC entries

### DIFF
--- a/research/news_log.md
+++ b/research/news_log.md
@@ -11,6 +11,15 @@ Historical entries (before 2026-05-02) pre-date the time/editor sub-heading conv
 
 ---
 
+## 2026-05-03
+
+### 14:07 UTC — Editor: Scientist
+
+- **Autogene cevumeran 6-year follow-up** (AACR 2026 abstract, Balachandran/MSK) — ~90% of immune-responders alive at ~6 years post-vaccination in Phase 1 PDAC trial; durable CD8+ T-cell repertoire. → No issue (DISCUSSION reference for clinical translation breadth). *Scientist. clinical-validation.*
+- **Rojas et al. — original Phase 1 autogene cevumeran** (Nature 2023, foundational) — first PDAC personalized mRNA neoantigen vaccine trial; 8/16 immune responders. → No issue (foundational INTRODUCTION + DISCUSSION reference). *Scientist. clinical-validation.*
+- **Nature 2025 follow-up — long-lived CD8+ T cells from autogene cevumeran** — 7.7-year mean estimated T-cell clone lifespan; RFS not reached for responders vs 13.4-mo non-responders. → No issue (DISCUSSION reference for vaccine durability mechanism). *Scientist. clinical-validation.*
+- **Personalized Cancer Vaccines clinical trial pipeline review** (APJCO 2026) — field-wide landscape including TG4050 head/neck (no relapses at 16.2-mo median, Arm A). → No issue (field-landscape DISCUSSION reference). *Scientist. methodology-signal.*
+
 ## 2026-05-02
 
 ### 10:04 UTC — Editor: Scientist


### PR DESCRIPTION
## Summary

Four items from this morning's lit search around personalized cancer neoantigen vaccines — all clinical-translation references for the manuscript DISCUSSION arc.

- **Autogene cevumeran 6-year follow-up** (AACR 2026 abstract, Balachandran/MSK) — ~90% of immune-responders alive at ~6 years post-vaccination in Phase 1 PDAC trial; durable CD8+ T-cell repertoire
- **Rojas et al. — original Phase 1** (Nature 2023, foundational) — first PDAC personalized mRNA neoantigen vaccine trial; 8/16 immune responders. Zotero `UIN9DIUP`
- **Nature 2025 follow-up** — long-lived CD8+ T cells; 7.7-yr mean estimated T-cell clone lifespan; RFS not reached for responders. Zotero `N2QF8MC6`
- **APJCO 2026 pipeline review** — field-wide landscape including TG4050 head/neck (no relapses at 16.2-mo median, Arm A). Zotero `II24UIUZ`

No issue link — log = journal per the convention.

## Test plan

- [ ] Diff renders cleanly in GitHub UI (new 2026-05-03 section + sub-heading at top, historical entries unchanged below)
- [ ] CI green (`pipeline-snakemake-dry-run`, `pipeline-pytest`)