### PR TITLE
docs: morning news entry + CLAUDE.md torch P100 pin clarification

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,6 +106,7 @@ The old `config.yaml` had an `assembly:` block (`upstream_nt`, `downstream_nt`, 
 ### `python.yaml` — PyTorch SM 6.0 / P100 compatibility
 PyTorch 2.5+ dropped SM 6.0 (Pascal) support. On a P100, `torch.cuda.is_available()` still returns `True` but kernel dispatch fails silently or with a cryptic error.
 **Fix:** pin `torch>=2.0,<2.5` in `python.yaml` (installs 2.4.1 which includes SM 6.0 kernels).
+**This pin is permanent on this hardware — not a temporary workaround.** PyTorch 2.8 confirmed Pascal kernel support is gone in cu128/cu129 builds; the [PyTorch dev-discuss thread](https://dev-discuss.pytorch.org/t/cuda-toolkit-version-and-architecture-support-update-maxwell-and-pascal-architecture-support-removed-in-cuda-12-8-and-12-9-builds/3128) describes Maxwell/Pascal/Volta as "feature-complete with no further enhancements planned." Last supporting combo is PyTorch 2.7 + CUDA ≤12.6. Do not bump the pin without first migrating off P100 hardware.
 `_has_gpu()` in `run_mhcflurry.py` uses a PyTorch smoke-test kernel (not TensorFlow) to catch this case: `torch.nn.functional.relu(torch.zeros(2, device="cuda"))`. TF reported GPU available even when PyTorch kernels would fail — both must work because MHCflurry 2.2.x uses PyTorch for inference.
 
 ### `run_mhcflurry.py` — no ProcessPoolExecutor with GPU

--- a/research/lab_notebook.md
+++ b/research/lab_notebook.md
@@ -2,6 +2,24 @@
 
 ---
 
+## 2026-05-03
+
+### 14:05 UTC — Editor: Developer
+
+#### Morning routine — standup cleanup + news briefing
+
+Standup cleanup: deleted 4 own Done messages from 2026-04-29 (>3 days, per the standup file rule). One Issue #79 scope-expansion notification + three follow-ups to PM. The durable record stays in commits / lab notebook / project board; standup is for active conversation only.
+
+News briefing surfaced three pipeline-relevant items, all logged in [`research/news_log.md`](news_log.md) so they don't re-surface in future morning briefings (gap caught when I re-surfaced the `googlebatch` executor today even though it was already tracked in [Issue #66](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/66)):
+
+1. **PyTorch 2.7 + CUDA 12.6 = last P100-supporting combo.** PyTorch's [dev-discuss thread](https://dev-discuss.pytorch.org/t/cuda-toolkit-version-and-architecture-support-update-maxwell-and-pascal-architecture-support-removed-in-cuda-12-8-and-12-9-builds/3128) describes Maxwell/Pascal/Volta as "feature-complete with no further enhancements planned" — 2.8 dropped Pascal kernels in cu128/cu129 builds. We already pin `torch>=2.0,<2.5` in `python.yaml`; this confirms the pin is **permanent on this hardware**, not a temporary workaround. Updated CLAUDE.md's `python.yaml — PyTorch SM 6.0 / P100 compatibility` section with this detail (this PR).
+2. **Snakemake `googlebatch` executor plugin** — already covered by [Issue #66](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/66) (the issue body literally links the plugin catalog page). User correctly flagged the re-surface; logged it in `news_log.md` so we don't trip on it again.
+3. **Snakemake 9.x deprecates `--use-conda`** in favour of `--software-deployment-method conda`. Affects every snakemake call site in CLAUDE.md, `run_cloud_gpu.sh`, `setup_local.sh`, and possibly internal docs. Posted a [comment on Issue #200](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/200#issuecomment-4366348544) listing affected files — bundle into the 9.x migration PR rather than fixing separately, since 8.x still accepts both forms.
+
+Memory rule reinforced (didn't have to add): morning-routine news scan must check `news_log.md` first — items already logged shouldn't re-surface unless there's a meaningful update. The googlebatch slip happened because the original Issue #66 was opened before `news_log.md` existed (introduced 2026-05-01); now-logged → won't repeat.
+
+---
+
 ## 2026-05-02
 
 ### 19:53 UTC — Editor: PM

--- a/research/news_log.md
+++ b/research/news_log.md
@@ -11,6 +11,14 @@ Historical entries (before 2026-05-02) pre-date the time/editor sub-heading conv
 
 ---
 
+## 2026-05-03
+
+### 10:49 UTC — Editor: Developer
+
+- **PyTorch 2.7 + CUDA 12.6 = last P100-supporting combo** (2026, dev-discuss) — Maxwell/Pascal/Volta described as "feature-complete with no further enhancements planned"; PyTorch 2.8 dropped Pascal kernels in cu128/cu129 builds. → CLAUDE.md note clarifying the `torch<2.5` pin is permanent on this hardware. *Developer. pipeline-relevant.*
+- **Snakemake `googlebatch` executor plugin** — official replacement for the deprecated Google Life Sciences executor. → Already tracked in [Issue #66](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/66) (logged here so it doesn't re-surface in future briefings). *Developer. pipeline-relevant.*
+- **Snakemake 9.x deprecates `--use-conda`** in favour of `--software-deployment-method conda` — affects every snakemake call site in CLAUDE.md, `run_cloud_gpu.sh`, `setup_local.sh`. → Comment on [Issue #200](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/200) — bundle into the 9.x migration. *Developer. pipeline-relevant.*
+
 ## 2026-05-02
 
 ### 10:04 UTC — Editor: Scientist


### PR DESCRIPTION
## Summary

Three small docs updates from this morning's session:

- **`CLAUDE.md`** — clarify that the \`torch>=2.0,<2.5\` pin in [\`python.yaml\`](workflow/envs/python.yaml) is **permanent on P100 hardware**, not a temporary workaround. PyTorch's [dev-discuss thread](https://dev-discuss.pytorch.org/t/cuda-toolkit-version-and-architecture-support-update-maxwell-and-pascal-architecture-support-removed-in-cuda-12-8-and-12-9-builds/3128) describes Maxwell/Pascal/Volta as "feature-complete with no further enhancements planned"; 2.8 dropped Pascal kernels in cu128/cu129 builds.
- **`research/news_log.md`** — 2026-05-03 entry logging today's three surfaced items: PyTorch P100, the Snakemake \`googlebatch\` executor (already tracked in [Issue #66](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/66) — logged here so it doesn't re-surface again), and \`--use-conda\` deprecation (commented on [Issue #200](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/200#issuecomment-4366348544)).
- **`research/lab_notebook.md`** — 2026-05-03 14:05 UTC entry covering the morning standup cleanup + news briefing.

## Test plan

- [x] Doc-only changes; no pipeline-rule modifications.
- [x] Lab notebook entry on this branch per the "before merge" rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)