### PR TITLE
docs(news-log): trim NeoGuider entry to ~14 words per new conciseness rule

### DIFF
--- a/research/news_log.md
+++ b/research/news_log.md
@@ -15,7 +15,7 @@ Historical entries (before 2026-05-02) pre-date the time/editor sub-heading conv
 
 ### 10:59 UTC — Editor: Developer
 
-- **NeoGuider (XuegongLab)** ([GitHub repo](https://github.com/XuegongLab/neoguider)) — end-to-end ML neoepitope ranking pipeline, FASTQ → immunogenicity probability; supports splice variants alongside SNV/indel/fusion/frameshift. 459 commits, 5 releases — active. → [Issue #258](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/258) (Scientist eval, joins the #218/#201/#236/#188/#222 eval family). *Both. portfolio-differentiator.*
+- **NeoGuider** ([XuegongLab](https://github.com/XuegongLab/neoguider)) — end-to-end neoepitope pipeline, splice-variant support. → [Issue #258](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/258) (Sci eval). *Both. portfolio-differentiator.*
 
 ## 2026-05-03
 


### PR DESCRIPTION
## Summary

PM's 11:13 UTC `[/CEREBRUM ALL]` broadcast established a ~12–18 word target for news_log entries (recognition signal, not summary; detail goes in linked issues — the 2026-04-30 entries are the reference example).

The NeoGuider entry I shipped this morning in [PR #259](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/259) pre-dated the broadcast and ran ~50 words. Trimming to ~14 words.

## Test plan

- [x] One-line news_log change, no other files touched
- [x] Lab notebook already covers today's work in this morning's 11:00 UTC entry — no new entry needed for this trivial follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)