### PR TITLE
docs(glossary): add 5 abbreviations — AC, CVE, MCP, OKR, RCE

### DIFF
--- a/research/glossary.md
+++ b/research/glossary.md
@@ -42,6 +42,8 @@ Project-relevant abbreviations and acronyms. The pipeline mixes biology, ML, bio
 
 ## M
 
+**MCP** — Model Context Protocol. Anthropic's open spec (late 2024) for AI agents to discover and invoke external tools / data sources via per-purpose MCP servers; the standardized way to expose resources to LLMs without bespoke per-tool integration. *"USB-C for AI agents."* Used by Claude Code, the GitHub MCP server, filesystem servers, etc. *Domain: ml.*
+
 **MHC** — Major Histocompatibility Complex. Cell-surface proteins that present peptides to T cells; class I (all nucleated cells, presents endogenous peptides) drives this pipeline. Human MHC = HLA. *Domain: bio.*
 
 ## O

--- a/research/glossary.md
+++ b/research/glossary.md
@@ -10,7 +10,13 @@ Project-relevant abbreviations and acronyms. The pipeline mixes biology, ML, bio
 
 ## A
 
+**AC** — Acceptance Criteria. The checklist in an issue body defining what "done" means for that issue. Per the closure ritual, all AC boxes must be ticked (`- [x]`) or comment-deferred before closing. *Domain: project.*
+
 **AFDB** — AlphaFold Database (alphafold.ebi.ac.uk). DeepMind/EBI's public repo of ~200M predicted protein structures. *Domain: bio.*
+
+## C
+
+**CVE** — Common Vulnerabilities and Exposures. Standardised identifier system for publicly disclosed security flaws (CVE-YYYY-NNNN format); maintained by MITRE, used industry-wide for tracking known vulns. *Domain: security.*
 
 ## E
 
@@ -38,6 +44,10 @@ Project-relevant abbreviations and acronyms. The pipeline mixes biology, ML, bio
 
 **MHC** — Major Histocompatibility Complex. Cell-surface proteins that present peptides to T cells; class I (all nucleated cells, presents endogenous peptides) drives this pipeline. Human MHC = HLA. *Domain: bio.*
 
+## O
+
+**OKR** — Objectives and Key Results. Goal-setting framework popularised by Intel/Google: one qualitative *Objective* + 3–5 quantitative *Key Results*, usually quarterly. Common in software shops; we use S1–S7 lifecycle stages + iteration capacity instead. *Domain: project.*
+
 ## P
 
 **PAE** — Predicted Aligned Error. AlphaFold/TCRdock per-residue-pair error estimate (in Å); summarised globally to gauge inter-domain confidence (e.g. relative MHC↔TCR docking confidence). *Domain: bio.*
@@ -49,6 +59,10 @@ Project-relevant abbreviations and acronyms. The pipeline mixes biology, ML, bio
 **PoN** — Panel of Normals. Aggregated reference set of normal samples (originally GATK's somatic variant calling concept); used to filter recurrent germline variation / artefacts that single matched normals miss. *Domain: bio.*
 
 **PSI** — Percent Spliced In. Fraction of transcripts that include a given alternative exon/junction (vs skip); the standard quantitative readout of splicing in RNA-seq analyses. *Domain: bio.*
+
+## R
+
+**RCE** — Remote Code Execution. Vulnerability class where an attacker runs arbitrary code on a remote system, typically via input-validation or memory-safety bugs (e.g. CVE-2026-3854's crafted git push trigger). *Domain: security.*
 
 ## S
 


### PR DESCRIPTION
## Summary

Adds five abbreviations to `research/glossary.md`, all surfaced during today's PM session:

- **AC** (Acceptance Criteria) — used throughout the closure ritual + audit work
- **CVE** (Common Vulnerabilities and Exposures) — surfaced from CVE-2026-3854 news item
- **MCP** (Model Context Protocol) — discussed as the natural agent-to-agent communication primitive
- **OKR** (Objectives and Key Results) — goal-setting framework discussed in the Korey comparison; we don't use it (stage-based milestones instead)
- **RCE** (Remote Code Execution) — vulnerability class

## Test plan

- [x] All 5 entries placed in alphabetical position with proper section headers (created C, O, R sections that didn't exist)
- [x] Format matches existing entries: `**ABBREV** — Expansion. One-line context. *Domain: X.*`
- [x] Branch from latest main (no merge conflicts expected)