### PR TITLE
refactor(report): replace ruleorder with conditional inputs in generate_report

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -47,10 +47,6 @@ include: "workflow/rules/mhc_affinity.smk"
 include: "workflow/rules/analysis.smk"
 include: "workflow/rules/structure.smk"
 
-# When TCRdock is enabled, prefer the structure report over the plain report.
-if config.get("tcrdock", {}).get("enabled", False):
-    ruleorder: generate_report_with_structure > generate_report
-
 # ── final target ─────────────────────────────────────────────────────────────
 # _read_samples_tsv (common.smk) validates exactly one patient per run.
 PATIENT_ID = _read_samples_tsv(config["samples_tsv"])[0]["patient_id"]

--- a/research/lab_notebook.md
+++ b/research/lab_notebook.md
@@ -4,6 +4,16 @@
 
 ## 2026-05-05
 
+### 13:55 UTC — Editor: Developer
+
+#### [Issue #90](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/90) — `ruleorder` removed; single `generate_report` rule with conditional inputs/outputs ([PR #273](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/273))
+
+**Code-smell cleanup that's been queued for a while.** Two rules (`generate_report` and `generate_report_with_structure`) both produced `report.html`, disambiguated only at parse time by a `ruleorder` directive in [Snakefile](Snakefile). Replaced with a single `generate_report` rule whose input dict and output dict are built at parse time from `_TCRDOCK_ENABLED = config.get("tcrdock", {}).get("enabled", False)`. TCRdock-OFF path: 4–5 inputs, 3 outputs (no `pdb`/`scores_tsv`/`report_3d_structure_tsv`). TCRdock-ON path: 6–7 inputs, 4 outputs.
+
+**No script change needed.** [generate_report.py:1393-1397](workflow/scripts/generate_report.py#L1393-L1397) already pulls `pdb`, `scores_tsv`, and `report_3d_structure_tsv` via `getattr(snakemake.input/output, ..., None)` — the script was already shape-tolerant; the wrapper rules were the rigid bit.
+
+**Verification.** `pytest` 235 passed in 1.94s. Snakemake dry-runs clean for both modes: TCRdock-OFF schedules 7 jobs with `generate_report` as the sole report rule; TCRdock-ON schedules 8 jobs with `generate_report` carrying the full 7-input / 4-output shape (incl. `report_3d_structure_tsv`) and `run_tcrdock` upstream. No ambiguity warnings either way. Skipped a local chr22 pipeline run — test config has TCRdock OFF (so only re-exercises the integration-pytest path), and the ON path is GPU+Docker so unreachable locally regardless.
+
 ### 10:39 UTC — Editor: Developer
 
 #### Morning routine — TCR-pMHC structure prediction news + glossary batch

--- a/workflow/rules/analysis.smk
+++ b/workflow/rules/analysis.smk
@@ -3,6 +3,7 @@
 # =============================================================================
 
 _HLA_QC_ENABLED = config.get("hla", {}).get("enabled", False)
+_TCRDOCK_ENABLED = config.get("tcrdock", {}).get("enabled", False)
 
 
 def _generate_report_input(wildcards):
@@ -24,7 +25,27 @@ def _generate_report_input(wildcards):
         d["hla_qc"] = os.path.join(
             _RES, wildcards.patient_id, "hla_typing", "hla_qc.tsv",
         )
+    if _TCRDOCK_ENABLED:
+        d["pdb"] = os.path.join(
+            _RES, wildcards.patient_id, "predictions", "tcrdock", "top_candidate.pdb",
+        )
+        d["scores_tsv"] = os.path.join(
+            _RES, wildcards.patient_id, "predictions", "tcrdock", "docking_scores.tsv",
+        )
     return d
+
+
+_generate_report_output = {
+    "report_html": os.path.join(_RES, "{patient_id}", "reports", "report.html"),
+    "report_tsv": os.path.join(_RES, "{patient_id}", "reports", "report.tsv"),
+    "report_top_candidates_tsv": os.path.join(
+        _RES, "{patient_id}", "reports", "report_top_candidates.tsv"
+    ),
+}
+if _TCRDOCK_ENABLED:
+    _generate_report_output["report_3d_structure_tsv"] = os.path.join(
+        _RES, "{patient_id}", "reports", "report_3d_structure.tsv"
+    )
 
 
 rule generate_report:
@@ -32,19 +53,12 @@ rule generate_report:
     - Junction origin counts (tumor_exclusive vs normal_shared per sample)
     - HLA typing results with source and normal/tumor concordance (when enabled)
     - Neoepitope prediction summary (strong / weak / non binder counts)
-    - Top strong binders table (presentation_percentile ≤ strong threshold)"""
+    - Top strong binders table (presentation_percentile ≤ strong threshold)
+    - Embedded Mol* 3D viewer for the top TCR-pMHC candidate (when TCRdock enabled)"""
     input:
         unpack(_generate_report_input),
     output:
-        report_html=os.path.join(
-            _RES, "{patient_id}", "reports", "report.html"
-        ),
-        report_tsv=os.path.join(
-            _RES, "{patient_id}", "reports", "report.tsv"
-        ),
-        report_top_candidates_tsv=os.path.join(
-            _RES, "{patient_id}", "reports", "report_top_candidates.tsv"
-        ),
+        **_generate_report_output,
     log:
         os.path.join(_LOGS, "{patient_id}", "analysis", "report.log"),
     params:

--- a/workflow/rules/analysis.smk
+++ b/workflow/rules/analysis.smk
@@ -26,11 +26,9 @@ def _generate_report_input(wildcards):
             _RES, wildcards.patient_id, "hla_typing", "hla_qc.tsv",
         )
     if _TCRDOCK_ENABLED:
-        d["pdb"] = os.path.join(
-            _RES, wildcards.patient_id, "predictions", "tcrdock", "top_candidate.pdb",
-        )
-        d["scores_tsv"] = os.path.join(
-            _RES, wildcards.patient_id, "predictions", "tcrdock", "docking_scores.tsv",
+        d["pdb"] = rules.run_tcrdock.output.pdb.format(patient_id=wildcards.patient_id)
+        d["scores_tsv"] = rules.run_tcrdock.output.scores_tsv.format(
+            patient_id=wildcards.patient_id
         )
     return d
 

--- a/workflow/rules/structure.smk
+++ b/workflow/rules/structure.smk
@@ -54,37 +54,3 @@ if _TCRDOCK_ENABLED:
             "../envs/python.yaml"
         script:
             "../scripts/run_tcrdock.py"
-
-    rule generate_report_with_structure:
-        """Generate HTML report including embedded Mol* 3D structure viewer.
-
-        Extends the standard report with an interactive TCR-peptide-MHC
-        structure for the top candidate, with the PDB inlined as text so
-        the report remains fully self-contained.
-        """
-        input:
-            unpack(_generate_report_input),
-            pdb=rules.run_tcrdock.output.pdb,
-            scores_tsv=rules.run_tcrdock.output.scores_tsv,
-        output:
-            report_html=os.path.join(
-                _RES, "{patient_id}", "reports", "report.html"
-            ),
-            report_tsv=os.path.join(
-                _RES, "{patient_id}", "reports", "report.tsv"
-            ),
-            report_top_candidates_tsv=os.path.join(
-                _RES, "{patient_id}", "reports", "report_top_candidates.tsv"
-            ),
-            report_3d_structure_tsv=os.path.join(
-                _RES, "{patient_id}", "reports", "report_3d_structure.tsv"
-            ),
-        log:
-            os.path.join(_LOGS, "{patient_id}", "structure", "report.log"),
-        params:
-            presentation_percentile_strong=config["mhcflurry"]["presentation_percentile_strong"],
-            presentation_percentile_weak=config["mhcflurry"]["presentation_percentile_weak"],
-        conda:
-            "../envs/python.yaml"
-        script:
-            "../scripts/generate_report.py"


### PR DESCRIPTION
**Created by:** Developer

Closes [Issue #90](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/90) (refactor).

## Summary

- Merge `generate_report_with_structure` into `generate_report` via parse-time conditional input/output dicts (`_TCRDOCK_ENABLED`).
- Drop the `ruleorder: generate_report_with_structure > generate_report` directive in [Snakefile](Snakefile).
- TCRdock-OFF: 3 outputs, 4–5 inputs (no `pdb` / `scores_tsv`).
- TCRdock-ON: 4 outputs (adds `report_3d_structure_tsv`), 6–7 inputs (adds `pdb` + `scores_tsv`).
- No script change needed — `generate_report.py` already reads `pdb`, `scores_tsv`, and `report_3d_structure_tsv` via `getattr(snakemake.input/output, ..., None)`.

## Why

`ruleorder` is a code smell: two rules producing the same output (`report.html`) is inherently ambiguous, and the directive disambiguates only at parse time, not at the DAG level. A single rule with conditional inputs/outputs is clearer and removes the need for the directive entirely.

## Test plan

- [x] `pytest` — 235 passed in 1.94s
- [x] `snakemake -n --configfile config/test_config.yaml` (TCRdock OFF) — clean: `generate_report` is the sole report rule; 7 jobs total
- [x] `snakemake -n --configfile config/test_config.yaml config/gpu_config.yaml` (TCRdock ON) — clean: `generate_report` has 7 inputs (incl. `pdb`/`scores_tsv`) and 4 outputs (incl. `report_3d_structure_tsv`); `run_tcrdock` scheduled; 8 jobs total; no ambiguity warnings.