### PR TITLE
docs(manuscript): METHODS — splice2neo + AlphaGenome comparison subsection (#269)

### DIFF
--- a/research/lab_notebook.md
+++ b/research/lab_notebook.md
@@ -4,6 +4,26 @@
 
 ## 2026-05-05
 
+### 14:25 UTC — Editor: Scientist
+
+#### [Issue #232](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/232) decomposition + [Sub-Issue #269](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/269) METHODS landing
+
+**[#232](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/232) auto-closed by yesterday's [PR #260](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/260)** despite `Refs #232` in the body — root cause: `gh issue develop 232 --name <branch>` created a Development-link that auto-closes regardless of the body keyword (verified via `gh pr view 260 --json closingIssuesReferences` listing #232). The "Refs vs Closes" counter-pattern only works when the branch was created without `gh issue develop`, which collides with our Always-in-effect rule mandating `gh issue develop`. PM had reopened in the morning closure-audit; I extended `shared/feedback_github_auto_close.md` with the second auto-close path and broadcast via [/CEREBRUM ALL](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline) standup post.
+
+**Decomposed [#232](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/232) into 6 sibling sub-issues** ([#267](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/267)–[#272](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/272)) per the AC-checkbox heuristic — each remaining acceptance criterion now has a dedicated focused branch target, parent stays open as the umbrella, no more `gh issue develop` collision risk. PM applied Priority + Size + Target on the board: P1 METHODS gates → P1 main DISCUSSION → P2 INTRODUCTION fillers → deferred + reference closer.
+
+**[Sub-Issue #269](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/269) METHODS splice2neo + AlphaGenome.** New `### Comparison to related approaches` subsection at end of Section 3 (Junction Classification) — placement chosen because that's where our junction-origin classification is described, so the splice2neo contrast (variant-driven vs junction-driven) lands naturally. **splice2neo** (Lang et al., 2024, *Bioinform Adv*) starts from somatic SNVs/indels → predicts altered splicing via SpliceAI-style models → derives neoantigens; ours starts from observed junctions → classifies by origin. Variant-driven captures splicing changes attributable to specific variants; junction-driven captures any tumor-exclusive junction regardless of underlying cause. **AlphaGenome** (Avsec et al., 2026, *Nature*) introduced as a candidate computational normal filter under evaluation (Issue [#203](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/203)); METHODS-section coverage of inputs/outputs only — validation outcome deferred to DISCUSSION via [Sub-Issue #271](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/271) once #203 closes. Author/year verified against Zotero (`Z4FAE6QM`, `UZWZ5QEB`).
+
+#### Created-by attribution slip + retro-fix on 8 artifacts
+
+**Slip discovered after morning's GitHub work**: the shared workflow rule `**Created by:** <Role>` on every issue + PR body (documented at `shared/feedback_github_workflow.md:151`) was not promoted to `shared/MEMORY.md` Always-in-effect — only Developer had it inline at their role MEMORY.md. I missed it on today's 6 sub-issues + the [#232](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/232) body update + yesterday's [PR #260](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/260)/[PR #261](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/261). User flagged.
+
+**Resolution path** — same temporary-stopgap pattern we used today: I added the rule to my role `MEMORY.md` Always-in-effect as a temporary entry to protect the immediate session, pinged PM via standup to request shared-memory promotion + comments-scope clarification, retro-fixed all 8 artifacts via `gh issue edit` / `gh pr edit`. PM landed shared promotion at 14:04 UTC + answered comments-scope (body-only, comments excluded). I removed the Sci-local stopgap to avoid role+shared duplication.
+
+**Tooling note — project item ID lookup.** Burned 3 tool calls paginating `projectV2.items` to find #269's item ID for the Status flip before realising the direct path is `repository → issue → projectItems` — a single GraphQL call regardless of project size. Saved snippet locally as `scientist/reference_project_item_lookup.md` (TEMPORARY) + pinged PM to fold into `shared/feedback_project_board.md` (which already has the field/option IDs, so it's the natural home).
+
+---
+
 ### 10:39 UTC — Editor: Developer
 
 #### Morning routine — TCR-pMHC structure prediction news + glossary batch

--- a/research/manuscript/METHODS.md
+++ b/research/manuscript/METHODS.md
@@ -61,6 +61,28 @@ carried forward to neoepitope prediction.
 When no matched normal sample is available, all unannotated junctions are labeled
 `tumor_exclusive` with a warning.
 
+### Comparison to related approaches
+
+Two recently published tools approach splice-derived neoantigen identification differently:
+
+- **splice2neo** (Lang et al., 2024, *Bioinform Adv*) is **variant-driven**: it starts from
+  somatic SNVs/indels, predicts altered splicing as a downstream consequence using
+  SpliceAI-style models, and derives candidate neoantigens from the predicted altered
+  transcripts. The pipeline described here is **junction-driven**: it starts from observed
+  RNA-seq junctions and classifies them by origin (annotated, normal-shared,
+  tumor-exclusive). The variant-driven approach captures splicing changes attributable to
+  specific somatic variants; the junction-driven approach captures any tumor-exclusive
+  junction regardless of underlying cause (somatic variant, intronic mis-splicing, intron
+  retention, or splicing-factor dysregulation).
+- **AlphaGenome** (Avsec et al., 2026, *Nature*) is a deep-learning model that predicts
+  regulatory and splicing outcomes from sequence context, with a dedicated splice-junction
+  output that returns donor–acceptor pair probabilities. We are evaluating AlphaGenome as
+  a candidate **computational normal filter** — an alternative or complement to the
+  matched-normal RNA-seq filter described above, that does not require a per-patient
+  normal sample. Inputs are junction coordinates and the GRCh38 reference; outputs are
+  per-junction tissue-specific splicing probabilities. The validation outcome is reported
+  in the Discussion.
+
 ---
 
 ## 4. HLA Typing

--- a/research/manuscript/METHODS.md
+++ b/research/manuscript/METHODS.md
@@ -63,17 +63,16 @@ When no matched normal sample is available, all unannotated junctions are labele
 
 ### Comparison to related approaches
 
-Two recently published tools approach splice-derived neoantigen identification differently:
+Two recently published resources are relevant to this pipeline's junction classification approach:
 
 - **splice2neo** (Lang et al., 2024, *Bioinform Adv*) is **variant-driven**: it starts from
-  somatic SNVs/indels, predicts altered splicing as a downstream consequence using
-  SpliceAI-style models, and derives candidate neoantigens from the predicted altered
-  transcripts. The pipeline described here is **junction-driven**: it starts from observed
-  RNA-seq junctions and classifies them by origin (annotated, normal-shared,
-  tumor-exclusive). The variant-driven approach captures splicing changes attributable to
-  specific somatic variants; the junction-driven approach captures any tumor-exclusive
-  junction regardless of underlying cause (somatic variant, intronic mis-splicing, intron
-  retention, or splicing-factor dysregulation).
+  somatic SNVs/indels, predicts altered splicing as a downstream consequence, and derives
+  candidate neoantigens from the predicted altered transcripts. The pipeline described
+  here is **junction-driven**: it starts from observed RNA-seq junctions and classifies
+  them by origin (annotated, normal-shared, tumor-exclusive). The variant-driven approach
+  captures splicing changes attributable to specific somatic variants; the junction-driven
+  approach captures any tumor-exclusive junction regardless of underlying cause (somatic
+  variant, intronic mis-splicing, intron retention, or splicing-factor dysregulation).
 - **AlphaGenome** (Avsec et al., 2026, *Nature*) is a deep-learning model that predicts
   regulatory and splicing outcomes from sequence context, with a dedicated splice-junction
   output that returns donor–acceptor pair probabilities. We are evaluating AlphaGenome as


### PR DESCRIPTION
**Created by:** Scientist

## Summary

Adds a `### Comparison to related approaches` subsection at the end of Section 3 (Junction Classification) in `research/manuscript/METHODS.md`. Two short entries:

- **splice2neo** (Lang et al., 2024, *Bioinform Adv*) — frames the variant-driven approach (somatic SNVs/indels → predicted altered splicing → neoantigens) as a contrast to our junction-driven approach (observed junctions → classify by origin). Coverage rationale: variant-driven captures splicing changes attributable to specific variants; junction-driven captures any tumor-exclusive junction regardless of underlying cause.
- **AlphaGenome** (Avsec et al., 2026, *Nature*) — introduced as a candidate computational normal filter under evaluation in [Issue #203](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/203). METHODS-section coverage of inputs/outputs only — the validation outcome is deferred to DISCUSSION via [Sub-Issue #271](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/271) once #203 closes.

**Placement rationale:** Section 3 is where our junction-origin classification + matched-normal filter are described. splice2neo's variant-driven contrast and AlphaGenome's candidate-normal-filter framing both attach naturally there; no new top-level section needed.

**Author/year verification:** Both citations checked against Zotero (`Z4FAE6QM` for splice2neo; `UZWZ5QEB` for AlphaGenome). AlphaGenome's date is January 2026 (not 2025).

## Scope

Closes [Sub-Issue #269](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/269), one of the 6 sibling sub-issues spawned from the [parent Issue #232](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/232) decomposition this morning. Citation finalization (consistent house style + reference-list integration for all 8 papers) is tracked separately in [Sub-Issue #272](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/272) — not in scope here.

## Test plan

- [ ] Diff renders cleanly in GitHub UI (one new subsection mid-Section 3, no other files touched besides the lab notebook)
- [ ] Citations resolve (both Zotero keys correspond to existing collection entries)
- [ ] Lab notebook entry exists for today's session (this PR; lands together)
- [ ] CI green (`pipeline-snakemake-dry-run`, `pipeline-pytest`)

Closes #269