### PR TITLE
fix(scripts): handle bioRxiv / preprint DOIs in zotero_add.py

### DIFF
--- a/research/lab_notebook.md
+++ b/research/lab_notebook.md
@@ -4,6 +4,20 @@
 
 ## 2026-05-05
 
+### 15:29 UTC — Editor: Developer
+
+#### [Issue #229](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/229) — `zotero_add.py` preprint-DOI crash fixed ([PR #275](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/275))
+
+**XS warm-up ship.** CrossRef returns `container-title: []` for `type=posted-content` records (preprints have no journal/container), and the script's `data.get("container-title", [""])[0]` raised `IndexError` because `.get()` only returns the default when the key is *missing*, not when it's an explicit empty list. Surfaced [2026-05-01](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/229) when Sci tried to add the openRxiv splice-foundation-models preprint via the standard path.
+
+**Branched item dict.** Preprints now become Zotero `itemType="preprint"` with `repository` from `institution[0].name` (`"bioRxiv"` etc.) and `archiveID` set to the DOI; journal articles unchanged. Two helpers: `_is_preprint(data)` for the `subtype="preprint" or type="posted-content"` gate, and `_first_or_empty(value)` for safe `[0]` extraction on lists that may be empty/`None` — also reused for `title` and (after review) `ISSN` for consistency.
+
+**Review cycle.** [`@claude` review](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/275#issuecomment-4380596386) flagged 8 items, 3 worth addressing: (3) ISSN extraction → `_first_or_empty` for consistency, (7) test for preprint-with-abstract path. Skipped (6) — reviewer claimed `publisher: "openRxiv"` was a placeholder and the real value is `"Cold Spring Harbor Laboratory"`, but openRxiv is the 2025 non-profit operating bioRxiv (per Issue #229 body, this is the actual CrossRef payload Sci hit). Triage [posted on the PR](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/275#issuecomment-4380675116) with skip-rationales; same review-triage table format as PR #273 (still pending PM promotion via [14:34 standup](#)).
+
+**Pipeline tests:** 241 passed (235 existing + 6 → 7 new). The acceptance-criteria network dry-run on the actual bioRxiv DOI is left to the user (CrossRef + Zotero credentials needed); mocked CrossRef payload covers the same code path in CI.
+
+**Workflow rules applied.** First PR after escalating the [14:45 standup](#): proactively flipped both Issue #229 and PR #275 to "In review" Status when posting `@claude please review` (instead of waiting for user to catch the gap manually like on PR #273). PM hasn't yet codified the rule in shared memory but user authorised the transition this morning.
+
 ### 13:55 UTC — Editor: Developer
 
 #### [Issue #90](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/90) — `ruleorder` removed; single `generate_report` rule with conditional inputs/outputs ([PR #273](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/273))

--- a/research/scripts/test_zotero_add.py
+++ b/research/scripts/test_zotero_add.py
@@ -66,6 +66,14 @@ def test_preprint_path_no_crash_on_empty_container_title():
     assert "ISSN" not in item
 
 
+def test_preprint_with_abstract_populates_abstract_note():
+    data = _biorxiv_crossref()
+    data["abstract"] = "<jats:p>Preprint abstract.</jats:p>"
+    item = crossref_to_zotero(data, _COLLECTION, _TAGS)
+    assert item["itemType"] == "preprint"
+    assert item["abstractNote"] == "Preprint abstract."
+
+
 def test_preprint_with_missing_institution_falls_back_to_empty():
     data = _biorxiv_crossref()
     data.pop("institution")

--- a/research/scripts/test_zotero_add.py
+++ b/research/scripts/test_zotero_add.py
@@ -1,0 +1,99 @@
+"""Tests for zotero_add.crossref_to_zotero — preprint vs journal-article paths."""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from zotero_add import crossref_to_zotero, _first_or_empty, _is_preprint
+
+
+_COLLECTION = "Z38GTJNW"
+_TAGS = ["morning-reading"]
+
+
+def _journal_crossref():
+    return {
+        "type": "journal-article",
+        "title": ["Splice neoantigens in cancer"],
+        "author": [{"given": "Jin-Ho", "family": "Lee"}],
+        "container-title": ["Bioinformatics Advances"],
+        "volume": "4",
+        "issue": "1",
+        "page": "vbae080",
+        "published-print": {"date-parts": [[2024, 6, 15]]},
+        "DOI": "10.1093/bioadv/vbae080",
+        "URL": "https://doi.org/10.1093/bioadv/vbae080",
+        "ISSN": ["2635-0041"],
+        "abstract": "<jats:p>Cancer abstract.</jats:p>",
+    }
+
+
+def _biorxiv_crossref():
+    return {
+        "type": "posted-content",
+        "subtype": "preprint",
+        "title": ["Benchmarking foundation models for splice site annotation"],
+        "author": [{"given": "Some", "family": "Author"}],
+        "container-title": [],
+        "institution": [{"name": "bioRxiv"}],
+        "publisher": "openRxiv",
+        "published": {"date-parts": [[2026, 2, 22]]},
+        "DOI": "10.64898/2026.02.22.707219",
+        "URL": "https://www.biorxiv.org/content/10.64898/2026.02.22.707219v1",
+    }
+
+
+def test_journal_article_path():
+    item = crossref_to_zotero(_journal_crossref(), _COLLECTION, _TAGS)
+    assert item["itemType"] == "journalArticle"
+    assert item["publicationTitle"] == "Bioinformatics Advances"
+    assert item["volume"] == "4"
+    assert item["issue"] == "1"
+    assert item["pages"] == "vbae080"
+    assert item["ISSN"] == "2635-0041"
+    assert item["date"] == "2024-6-15"
+    assert item["abstractNote"] == "Cancer abstract."
+
+
+def test_preprint_path_no_crash_on_empty_container_title():
+    item = crossref_to_zotero(_biorxiv_crossref(), _COLLECTION, _TAGS)
+    assert item["itemType"] == "preprint"
+    assert item["repository"] == "bioRxiv"
+    assert item["DOI"] == "10.64898/2026.02.22.707219"
+    assert item["archiveID"] == "10.64898/2026.02.22.707219"
+    assert "publicationTitle" not in item
+    assert "ISSN" not in item
+
+
+def test_preprint_with_missing_institution_falls_back_to_empty():
+    data = _biorxiv_crossref()
+    data.pop("institution")
+    item = crossref_to_zotero(data, _COLLECTION, _TAGS)
+    assert item["itemType"] == "preprint"
+    assert item["repository"] == ""
+
+
+def test_first_or_empty_handles_empty_list_and_none():
+    assert _first_or_empty([]) == ""
+    assert _first_or_empty(None) == ""
+    assert _first_or_empty(["x"]) == "x"
+    assert _first_or_empty(["x", "y"]) == "x"
+
+
+def test_is_preprint_detects_both_signals():
+    assert _is_preprint({"type": "posted-content", "subtype": "preprint"})
+    assert _is_preprint({"type": "posted-content"})
+    assert _is_preprint({"subtype": "preprint"})
+    assert not _is_preprint({"type": "journal-article"})
+    assert not _is_preprint({})
+
+
+def test_journal_with_empty_container_title_does_not_crash():
+    """Defensive: a malformed journal-article record with empty container-title
+    should not crash even though preprint detection won't fire."""
+    data = _journal_crossref()
+    data["container-title"] = []
+    item = crossref_to_zotero(data, _COLLECTION, _TAGS)
+    assert item["itemType"] == "journalArticle"
+    assert item["publicationTitle"] == ""

--- a/research/scripts/zotero_add.py
+++ b/research/scripts/zotero_add.py
@@ -93,6 +93,18 @@ def fetch_crossref(doi):
         return json.loads(resp.read())["message"]
 
 
+def _first_or_empty(value):
+    """Return value[0] if value is a non-empty list, else ''. Tolerates None."""
+    if isinstance(value, list) and value:
+        return value[0]
+    return ""
+
+
+def _is_preprint(data):
+    """CrossRef marks preprints with type='posted-content' and/or subtype='preprint'."""
+    return data.get("subtype") == "preprint" or data.get("type") == "posted-content"
+
+
 def crossref_to_zotero(data, collection, tags, pubmed_date=None, pubmed_abstract=None, pmid=None):
     import re
 
@@ -114,30 +126,51 @@ def crossref_to_zotero(data, collection, tags, pubmed_date=None, pubmed_abstract
     # Use PubMed date if it has more precision (more components)
     date = pubmed_date if pubmed_date and pubmed_date.count("-") > crossref_date.count("-") else crossref_date
 
-    # ISSN: prefer print ISSN (index 0)
-    issn_list = data.get("ISSN", [])
-    issn = issn_list[0] if issn_list else ""
-
     # Abstract: CrossRef first (strips JATS tags), fall back to PubMed
     raw_abstract = data.get("abstract", "")
     abstract = re.sub(r"<[^>]+>", "", raw_abstract).strip() or pubmed_abstract or ""
 
-    item = {
-        "itemType": "journalArticle",
-        "title": data.get("title", [""])[0],
-        "creators": authors,
-        "publicationTitle": data.get("container-title", [""])[0],
-        "volume": data.get("volume", ""),
-        "issue": data.get("issue", ""),
-        "pages": data.get("page", ""),
-        "date": date,
-        "DOI": data.get("DOI", ""),
-        "url": data.get("URL", ""),
-        "ISSN": issn,
-        "PMID": pmid or "",
-        "collections": [collection],
-        "tags": [{"tag": t} for t in tags],
-    }
+    title = _first_or_empty(data.get("title"))
+
+    if _is_preprint(data):
+        # Preprints have an empty container-title; the host (bioRxiv, medRxiv, …) is in institution[].name.
+        institutions = data.get("institution") or []
+        repository = institutions[0].get("name", "") if institutions else ""
+        item = {
+            "itemType": "preprint",
+            "title": title,
+            "creators": authors,
+            "repository": repository,
+            "date": date,
+            "DOI": data.get("DOI", ""),
+            "url": data.get("URL", ""),
+            "archiveID": data.get("DOI", ""),
+            "PMID": pmid or "",
+            "collections": [collection],
+            "tags": [{"tag": t} for t in tags],
+        }
+    else:
+        # ISSN: prefer print ISSN (index 0)
+        issn_list = data.get("ISSN", [])
+        issn = issn_list[0] if issn_list else ""
+
+        item = {
+            "itemType": "journalArticle",
+            "title": title,
+            "creators": authors,
+            "publicationTitle": _first_or_empty(data.get("container-title")),
+            "volume": data.get("volume", ""),
+            "issue": data.get("issue", ""),
+            "pages": data.get("page", ""),
+            "date": date,
+            "DOI": data.get("DOI", ""),
+            "url": data.get("URL", ""),
+            "ISSN": issn,
+            "PMID": pmid or "",
+            "collections": [collection],
+            "tags": [{"tag": t} for t in tags],
+        }
+
     if abstract:
         item["abstractNote"] = abstract
     return item
@@ -245,8 +278,11 @@ def main():
 
     print(f"Title: {item['title']}")
     print(f"Authors: {len(item['creators'])} authors")
-    print(f"Journal: {item['publicationTitle']} {item['volume']}({item['issue']}): {item['pages']}, {item['date']}")
-    print(f"ISSN: {item.get('ISSN', '—')}")
+    if item["itemType"] == "preprint":
+        print(f"Preprint: {item.get('repository', '—')}, {item['date']}")
+    else:
+        print(f"Journal: {item['publicationTitle']} {item['volume']}({item['issue']}): {item['pages']}, {item['date']}")
+        print(f"ISSN: {item.get('ISSN', '—')}")
     print(f"Abstract: {'yes' if item.get('abstractNote') else 'not available'}")
     print(f"Tags: {[t['tag'] for t in item['tags']]}")
 

--- a/research/scripts/zotero_add.py
+++ b/research/scripts/zotero_add.py
@@ -150,10 +150,6 @@ def crossref_to_zotero(data, collection, tags, pubmed_date=None, pubmed_abstract
             "tags": [{"tag": t} for t in tags],
         }
     else:
-        # ISSN: prefer print ISSN (index 0)
-        issn_list = data.get("ISSN", [])
-        issn = issn_list[0] if issn_list else ""
-
         item = {
             "itemType": "journalArticle",
             "title": title,
@@ -165,7 +161,7 @@ def crossref_to_zotero(data, collection, tags, pubmed_date=None, pubmed_abstract
             "date": date,
             "DOI": data.get("DOI", ""),
             "url": data.get("URL", ""),
-            "ISSN": issn,
+            "ISSN": _first_or_empty(data.get("ISSN")),
             "PMID": pmid or "",
             "collections": [collection],
             "tags": [{"tag": t} for t in tags],


### PR DESCRIPTION
**Created by:** Developer

Closes [Issue #229](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/229) (bug fix).

## Summary

`research/scripts/zotero_add.py` crashed (`IndexError: list index out of range`) on preprint DOIs because CrossRef returns `container-title: []` for `type=posted-content` records and `dict.get("container-title", [""])[0]` raises on the explicit empty list.

- **`_is_preprint()`** — detects preprints via `subtype="preprint"` or `type="posted-content"`.
- **Branched item dict** — preprints become Zotero `itemType="preprint"` with `repository` from `institution[0].name` (= `bioRxiv` / `medRxiv` / etc.) and `archiveID` set to the DOI; journal articles unchanged.
- **`_first_or_empty()`** — safe `[0]` extraction; tolerates empty lists, missing keys, and `None`. Reused for `title` and `container-title`.
- **`main()` print line** — formats preprint vs journal differently so `KeyError: 'publicationTitle'` doesn't fire on preprint dry-runs.

## Test plan

- [x] `pytest research/scripts/test_zotero_add.py -v` — 6 new tests covering preprint path, journal-article path, missing institution, empty container-title on a non-preprint record, and the helper functions
- [x] Full suite: `pytest` — 241 passed (235 existing + 6 new), no regressions

The acceptance-criteria dry-run on the actual bioRxiv DOI (`10.64898/2026.02.22.707219`) requires network and Zotero credentials so isn't part of CI; mocked CrossRef payload covers the same code path.