### PR TITLE
docs(manuscript): DISCUSSION — SpliceMutr + ENEO comparison subsection (#270)

### DIFF
--- a/research/lab_notebook.md
+++ b/research/lab_notebook.md
@@ -4,6 +4,20 @@
 
 ## 2026-05-05
 
+### 20:49 UTC — Editor: Scientist
+
+#### [Sub-Issue #270](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/270) DISCUSSION — SpliceMutr + ENEO
+
+**Subsection placement.** New `## Comparison to related neoantigen-prediction tools` inserted before `Structural validation` in [DISCUSSIONS.md](research/manuscript/DISCUSSIONS.md) — broader-context positioning belongs near the end of the discussion, parallel to the METHODS comparison subsection landed via [PR #274](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/274) (which closed [Sub-Issue #269](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/269)).
+
+**SpliceMutr (Palmer et al., *Cancer Research Communications* 2024)** — framed around *causal mutation–splice linkage as cohort-scale tumor-exclusivity proof*. The original draft positioned this as "mutation-driven scope vs. junction-driven scope," but user pushed for the deeper rationale: anchoring each splice event to a predicted-causal somatic SNV (splice-site, branch-point, splice-regulatory-element mutations via SpliceAI/MaxEntScan) gives the splice consequence its tumor-exclusivity proof at the DNA level — no RNA-level normal comparison needed. Two cohort-scale wins: causal interpretability per event + false-positive control across thousands of TCGA samples. Trade-off explicit: misses non-mutation-driven aberrant splicing (SF3B1/U2AF1 *trans* effects, epigenetic dysregulation, transformed-cell spliceosomal noise) — a serious gap for vaccine candidate prioritisation where pool size matters.
+
+**ENEO (Tatoni et al., *NAR Genomics and Bioinformatics* 2025)** — sharpened framing thanks to user's question. Initial draft called it "Bayesian neoantigen calling" without articulating *what the Bayesian classifier actually does*. The user pushed: "is ENEO's Bayesian approach also basically comparing tumor signal against some a priori population knowledge?" — yes, exactly. ENEO replaces the matched-normal sample with **population-level priors at the variant level** (gnomAD-class germline AF + sequencing-error models + somatic prior). This is *the same conceptual move* as our GTEx pan-tissue filter at the junction level. The boundary conditions distinguishing the approaches: (i) antigen source (SNV vs. junction) + (ii) probabilistic-vs-binary thresholding. Probabilistic framing transferable to our pipeline as future work — population-frequency prior over GTEx junction read counts → posterior tumor-specificity score, recovering candidates excluded by single-read GTEx artefacts and downweighting low-coverage tumor candidates appropriately.
+
+**Pedagogical detour.** User asked for the binary-vs-Bayesian distinction explicitly ("never understood the difference") — concrete walk-through with junction-read-count examples (50 tumor reads / 0 GTEx → posterior ≈ 0.99; 50 tumor / 1 in 1 of 900 GTEx → 0.92; 2 tumor / 0 GTEx → 0.55) clarified the uncertainty-handling axis. Worth keeping the explanation pattern in mind for similar future asks: edge cases first, then the gain (rank-ordering, tunable thresholds), then the cost (priors specification, computational weight, communication overhead).
+
+---
+
 ### 15:29 UTC — Editor: Developer
 
 #### [Issue #229](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/229) — `zotero_add.py` preprint-DOI crash fixed ([PR #275](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/275))

--- a/research/manuscript/DISCUSSIONS.md
+++ b/research/manuscript/DISCUSSIONS.md
@@ -547,6 +547,86 @@ The pipeline's GPS prioritisation surfaces splice neoepitopes from immune-pathwa
 
 ---
 
+## Comparison to related neoantigen-prediction tools
+
+Two recently published tools span the same problem space from complementary angles —
+pan-cancer splice-neoantigen burden estimation (SpliceMutr) and tumor-only neoantigen
+calling without matched normal (ENEO). Comparing this pipeline to each clarifies the
+design choices made here and the gaps each leaves uncovered.
+
+### SpliceMutr: causal mutation–splice linkage as cohort-scale tumor-exclusivity proof
+
+SpliceMutr (Palmer et al., *Cancer Research Communications* 2024) quantifies
+splicing-derived neoantigen burden across TCGA tumour types. Each candidate splice
+event is anchored to a somatic mutation predicted to cause it — splice-site mutations
+at the canonical donor/acceptor dinucleotides or splice-regulatory-element mutations
+that disrupt spliceosome recognition. The somatic mutation, called from tumor-vs-normal
+DNA pairs, supplies the tumor-exclusivity proof at the DNA level; the splice consequence
+inherits that proof without an additional RNA-level normal-vs-tumor comparison. This
+mutation-anchored framing serves two cohort-scale needs: causal interpretability (each
+event has a mechanistic explanation) and false-positive control across thousands of
+samples that cannot be manually validated.
+
+This pipeline takes the broader scope: any unannotated junction absent from a matched
+(or pan-tissue GTEx) normal is a candidate, irrespective of an identified somatic
+driver. This captures non-mutation-driven aberrant splicing — splicing-factor mutations
+(e.g. SF3B1, U2AF1) acting in *trans* across many genes, epigenetic dysregulation, and
+stochastic spliceosomal noise in transformed cells — that mutation-anchored approaches
+miss by construction. The cost is reduced mechanistic interpretability per candidate:
+the somatic origin of a junction may be unknown, and tumor-exclusivity must be
+established at the RNA level rather than inherited from DNA.
+
+The two scopes are complementary. SpliceMutr is the appropriate framing for cohort-level
+burden estimation, where causal anchoring controls false positives at scale; this
+pipeline is the appropriate framing for patient-level vaccine candidate prioritisation,
+where the objective is to maximise the candidate pool subject to safety filters and the
+mutation-driven subset alone is too narrow.
+
+### ENEO: population-reference substitution for matched normal at the variant level
+
+ENEO (Tatoni et al., *NAR Genomics and Bioinformatics* 2025) addresses the
+unmatched-normal problem with a Bayesian classifier that separates somatic from
+germline and sequencing-error variants from tumor RNA-seq alone. The classifier's
+priors are drawn from population genomic resources — germline allele frequencies from
+population databases (gnomAD-class), calibrated sequencing error models, and somatic
+prior distributions — converting the matched-normal sample into a population-derived
+reference computed once for any patient. The Bayesian framing is conceptually parallel
+to this pipeline's GTEx pan-tissue filter (see *GTEx pan-tissue filter* above): both
+substitute *population-level reference knowledge* for an individual matched normal,
+just at different antigen-source levels.
+
+Two boundary conditions distinguish the approaches:
+
+- **Antigen source.** ENEO is SNV-driven: candidates are MHC-presented peptides
+  produced by tumor-specific point mutations or short indels in coding sequence. The
+  Bayesian classifier solves the variant identifiability problem under tumor-only
+  conditions but does not address the splice-derived antigen axis, where the
+  tumour-exclusivity signal is at the junction level rather than the variant level.
+  The corresponding tumor-only problem for splice junctions — distinguishing
+  tumour-specific junctions from the patient's unobserved normal splicing repertoire —
+  requires population-level junction reference filtering (GTEx pan-tissue), not
+  variant-level Bayesian classification.
+- **Probabilistic vs. binary thresholding.** ENEO's posterior outputs a continuous
+  probability of somatic origin per variant, allowing rank-ordered candidate lists and
+  context-dependent thresholds. The current GTEx pan-tissue filter is binary: a junction
+  is excluded if observed in any GTEx tissue. The binary filter is robust at scale and
+  trivial to communicate, but loses information at noisy edges — single-read presence
+  in one of ~900 donors triggers exclusion equivalently to consistent presence across
+  all donors, and low-coverage tumor candidates are kept with the same confidence as
+  high-coverage ones.
+
+ENEO's Bayesian framing is conceptually transferable to this pipeline. A
+population-frequency prior over GTEx junction read counts could replace the binary
+inclusion/exclusion criterion with a posterior probability of tumor-specificity per
+junction, which would (i) recover candidates excluded only by single-read GTEx
+artefacts, (ii) downweight low-coverage tumor junctions whose evidence does not warrant
+high confidence, and (iii) yield a continuous tumour-exclusivity score that ranks
+candidates rather than only filtering them. This remains an open avenue for future
+work, particularly for the patient_002-class scenario where matched-normal RNA is
+absent and the binary filter's loss of edge information matters most.
+
+---
+
 ## Structural validation: TCR-pMHC docking and TCR panel design
 
 MHC binding prediction identifies peptides with the thermodynamic potential to occupy the

--- a/research/manuscript/DISCUSSIONS.md
+++ b/research/manuscript/DISCUSSIONS.md
@@ -557,7 +557,7 @@ design choices made here and the gaps each leaves uncovered.
 ### SpliceMutr: causal mutation–splice linkage as cohort-scale tumor-exclusivity proof
 
 SpliceMutr (Palmer et al., *Cancer Research Communications* 2024) quantifies
-splicing-derived neoantigen burden across TCGA tumour types. Each candidate splice
+splicing-derived neoantigen burden across TCGA tumor types. Each candidate splice
 event is anchored to a somatic mutation predicted to cause it — splice-site mutations
 at the canonical donor/acceptor dinucleotides or splice-regulatory-element mutations
 that disrupt spliceosome recognition. The somatic mutation, called from tumor-vs-normal
@@ -578,8 +578,8 @@ established at the RNA level rather than inherited from DNA.
 
 The two scopes are complementary. SpliceMutr is the appropriate framing for cohort-level
 burden estimation, where causal anchoring controls false positives at scale; this
-pipeline is the appropriate framing for patient-level vaccine candidate prioritisation,
-where the objective is to maximise the candidate pool subject to safety filters and the
+pipeline is the appropriate framing for patient-level vaccine candidate prioritization,
+where the objective is to maximize the candidate pool subject to safety filters and the
 mutation-driven subset alone is too narrow.
 
 ### ENEO: population-reference substitution for matched normal at the variant level
@@ -589,11 +589,11 @@ unmatched-normal problem with a Bayesian classifier that separates somatic from
 germline and sequencing-error variants from tumor RNA-seq alone. The classifier's
 priors are drawn from population genomic resources — germline allele frequencies from
 population databases (gnomAD-class), calibrated sequencing error models, and somatic
-prior distributions — converting the matched-normal sample into a population-derived
-reference computed once for any patient. The Bayesian framing is conceptually parallel
-to this pipeline's GTEx pan-tissue filter (see *GTEx pan-tissue filter* above): both
-substitute *population-level reference knowledge* for an individual matched normal,
-just at different antigen-source levels.
+prior distributions — eliminating the matched-normal requirement entirely. The
+Bayesian framing is conceptually parallel to this pipeline's GTEx pan-tissue filter
+(see *GTEx pan-tissue filter* above): both substitute *population-level reference
+knowledge* for an individual matched normal — ENEO at the variant level (somatic
+SNVs/indels), this pipeline at the junction level (splice events).
 
 Two boundary conditions distinguish the approaches:
 
@@ -601,9 +601,9 @@ Two boundary conditions distinguish the approaches:
   produced by tumor-specific point mutations or short indels in coding sequence. The
   Bayesian classifier solves the variant identifiability problem under tumor-only
   conditions but does not address the splice-derived antigen axis, where the
-  tumour-exclusivity signal is at the junction level rather than the variant level.
+  tumor-exclusivity signal is at the junction level rather than the variant level.
   The corresponding tumor-only problem for splice junctions — distinguishing
-  tumour-specific junctions from the patient's unobserved normal splicing repertoire —
+  tumor-specific junctions from the patient's unobserved normal splicing repertoire —
   requires population-level junction reference filtering (GTEx pan-tissue), not
   variant-level Bayesian classification.
 - **Probabilistic vs. binary thresholding.** ENEO's posterior outputs a continuous
@@ -619,8 +619,8 @@ ENEO's Bayesian framing is conceptually transferable to this pipeline. A
 population-frequency prior over GTEx junction read counts could replace the binary
 inclusion/exclusion criterion with a posterior probability of tumor-specificity per
 junction, which would (i) recover candidates excluded only by single-read GTEx
-artefacts, (ii) downweight low-coverage tumor junctions whose evidence does not warrant
-high confidence, and (iii) yield a continuous tumour-exclusivity score that ranks
+artifacts, (ii) downweight low-coverage tumor junctions whose evidence does not warrant
+high confidence, and (iii) yield a continuous tumor-exclusivity score that ranks
 candidates rather than only filtering them. This remains an open avenue for future
 work, particularly for the patient_002-class scenario where matched-normal RNA is
 absent and the binary filter's loss of edge information matters most.


### PR DESCRIPTION
**Created by:** Scientist

Closes [Sub-Issue #270](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/270) (DISCUSSION SpliceMutr + ENEO).

## Summary

- New `## Comparison to related neoantigen-prediction tools` subsection in [DISCUSSIONS.md](research/manuscript/DISCUSSIONS.md), inserted before the *Structural validation* section so broader-context positioning lives near the end of the discussion (parallel to the METHODS comparison subsection landed in [PR #274](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/274)).
- **SpliceMutr** (Palmer et al., *Cancer Research Communications* 2024) framed around *causal mutation–splice linkage as cohort-scale tumor-exclusivity proof*. Anchoring each splice event to a predicted-causal somatic SNV (splice-site, branch-point, splice-regulatory-element mutations via SpliceAI/MaxEntScan) supplies tumor-exclusivity at the DNA level — no RNA-level normal comparison required. Trade-off: misses non-mutation-driven aberrant splicing (SF3B1/U2AF1 *trans*-effects, epigenetic dysregulation, transformed-cell spliceosomal noise).
- **ENEO** (Tatoni et al., *NAR Genomics and Bioinformatics* 2025) framed as *population-reference substitution for matched normal at the variant level*. The Bayesian classifier replaces the matched-normal sample with population-level priors (gnomAD-class germline AF, sequencing-error models, somatic priors) — *the same conceptual move* as this pipeline's GTEx pan-tissue filter at the junction level, just probabilistic instead of binary. Boundary conditions: antigen source (SNV vs. junction) + thresholding (probabilistic vs. binary).
- Probabilistic framing flagged as transferable future work: a population-frequency prior over GTEx junction read counts could replace the binary inclusion criterion with a posterior tumor-specificity score, recovering candidates currently excluded by single-read GTEx artefacts.

## Test plan

- [ ] DISCUSSIONS.md renders cleanly (markdown headings + bullets) — visual inspection on the GitHub diff
- [ ] No prose duplication with the METHODS comparison subsection ([PR #274](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/274), splice2neo + AlphaGenome) — verified: METHODS covers variant-driven contrast + computational normal filter; this DISCUSSION covers cohort-scale burden estimation + tumor-only neoantigen calling
- [ ] Lab notebook entry exists (per shared rule) — see [lab_notebook.md](research/lab_notebook.md) §20:49 UTC

🤖 Generated with [Claude Code](https://claude.com/claude-code)