### PR TITLE
docs(news-log): 2 PM items — Copilot billing change + CVE-2026-3854

### DIFF
--- a/research/news_log.md
+++ b/research/news_log.md
@@ -13,6 +13,11 @@ Historical entries (before 2026-05-02) pre-date the time/editor sub-heading conv
 
 ## 2026-05-06
 
+### 10:34 UTC — Editor: PM
+
+- **GitHub Copilot code review billing change** (effective 2026-06-01) — Copilot reviews on private repos consume Actions minutes + AI Credits. → No action; public repo. *PM. tooling-signal.*
+- **CVE-2026-3854** (GitHub, May 2026) — high-severity flaw: authenticated push-access user can trigger RCE via crafted git push. → Already in [glossary](research/glossary.md) as RCE worked example. *PM. security-signal.*
+
 ### 08:46 UTC — Editor: Scientist
 
 - **Pan et al.** ([Nature 2025](https://www.nature.com/articles/s41586-024-08552-0)) — recurrent *GNAS*/*RPL22* splicing → public splice neoantigens + cross-patient TCRs. → [Issue #280](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/280) (Sci, DISCUSSION). *Scientist. portfolio-differentiator.*


### PR DESCRIPTION
## Summary

Two PM-relevant items surfaced in 2026-05-06 morning routine:

- **GitHub Copilot code review billing change** (effective 2026-06-01) — Copilot reviews on private repos will consume GH Actions minutes and be billed as AI Credits under the new usage-based model. No direct action for us (we're public-repo); logged for awareness.
- **CVE-2026-3854** — high-severity GitHub flaw where an authenticated user with push access can trigger RCE via crafted git push. Already cited as the RCE worked example in [research/glossary.md](research/glossary.md) (PR #263); logging here for completeness.

**Created by:** PM

## Test plan

- [x] Format matches `reference_news_log.md` (date section + time/editor sub-heading + bullets ≤ ~18 words)
- [x] Newest-at-top ordering preserved within 2026-05-06 (10:34 UTC PM above 08:46 UTC Scientist)
- [x] No content edits to existing entries