### PR TITLE
refactor(lab-notebook): split into per-role files (closes #286)

### DIFF
--- a/research/lab_notebook.md
+++ b/research/lab_notebook.md
@@ -1,5 +1,7 @@
 # Lab Notebook
 
+> **Frozen 2026-05-06 12:05 UTC.** New lab-notebook entries from this commit onward go to per-role files under [`research/lab_notebook/`](lab_notebook/) (`pm.md`, `scientist.md`, `developer.md`). Pre-existing 2026-05-06 entries in this file (e.g. Scientist's 10:03 UTC entry below) remain valid historical entries — they are immutable per `shared/feedback_lab_notebook.md` and not migrated. Rationale: 3 merge conflicts on this file in 3 days (2026-05-03 → 2026-05-05) drove a structural fix; per-role files eliminate cross-role same-file collisions. Full proposal in standup [2026-05-05 15:13 UTC] post.
+
 ---
 
 ## 2026-05-06

--- a/research/lab_notebook/developer.md
+++ b/research/lab_notebook/developer.md
@@ -1,0 +1,7 @@
+# Lab Notebook — Developer
+
+Per-role lab notebook for Developer sessions. Started 2026-05-06 as part of the lab-notebook split (see `lab_notebook.md` freeze note for rationale).
+
+Format and rules unchanged from the unified notebook — see `shared/feedback_lab_notebook.md`. New date sections at the TOP; new time sections at the TOP of the date block; entries are immutable once committed.
+
+---

--- a/research/lab_notebook/pm.md
+++ b/research/lab_notebook/pm.md
@@ -1,0 +1,21 @@
+# Lab Notebook — PM
+
+Per-role lab notebook for PM sessions. Started 2026-05-06 as part of the lab-notebook split (see `lab_notebook.md` freeze note for rationale).
+
+Format and rules unchanged from the unified notebook — see `shared/feedback_lab_notebook.md`. New date sections at the TOP; new time sections at the TOP of the date block; entries are immutable once committed.
+
+---
+
+## 2026-05-06
+
+### 12:11 UTC — Editor: PM
+
+#### [Issue #286](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/286) — lab-notebook split into per-role files (this PR)
+
+**Why now.** 3 merge conflicts on `research/lab_notebook.md` between 2026-05-03 and 2026-05-05, all same root cause: high-traffic shared file + sync-before-branch slip. Dev escalated "sync main before branching" to role MEMORY.md Always-in-effect 2026-05-05 morning; Sci slipped on the same rule 4 hours later — discipline rule alone wasn't internalising fast enough. Sci proposed per-role files in standup [2026-05-05 15:13 UTC]; PM agreed today with one tweak (subdirectory rather than 3 top-level files for tidier `research/`).
+
+**This PR.** Creates `research/lab_notebook/{pm,scientist,developer}.md` with minimal headers. Freezes `research/lab_notebook.md` via top-of-file banner; pre-2026-05-06 entries (and any 2026-05-06 entries already written before freeze) are immutable per `shared/feedback_lab_notebook.md` and not migrated. Forward-only change; no rewrite of historical content. This PM entry is the first one written under the new structure.
+
+**Cerebrum memory updates ship separately.** Direct memory writes (no PR) follow this PR's merge: `shared/MEMORY.md` Always-in-effect rule pointer update, each role's morning-routine memory file pointer, `shared/feedback_lab_notebook.md` structure section, /CEREBRUM ALL broadcast, and a follow-up to Sci's [2026-05-05 15:13 UTC] proposal post on standup. Sequencing: project PR merges first so role pointers don't reference not-yet-merged paths.
+
+**Workflow rule promoted earlier today (related).** Sci's [2026-05-06 10:16 UTC] standup post proposed extending the existing "push and merge are two separate steps" rule to also cover `git commit && git push`; promoted to shared/MEMORY.md Always-in-effect at 11:41 UTC. User caught Sci chaining commit+push for [PR #267](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/267)'s docs branch this morning, and PM had also slipped on the same chain earlier in the same session ([PR #283](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/283) news_log) — two slips in one morning across two roles drove the promotion.

--- a/research/lab_notebook/scientist.md
+++ b/research/lab_notebook/scientist.md
@@ -1,0 +1,7 @@
+# Lab Notebook — Scientist
+
+Per-role lab notebook for Scientist sessions. Started 2026-05-06 as part of the lab-notebook split (see `lab_notebook.md` freeze note for rationale).
+
+Format and rules unchanged from the unified notebook — see `shared/feedback_lab_notebook.md`. New date sections at the TOP; new time sections at the TOP of the date block; entries are immutable once committed.
+
+---


### PR DESCRIPTION
## Summary

Closes [Issue #286](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/286).

Splits `research/lab_notebook.md` into per-role files under `research/lab_notebook/{pm,scientist,developer}.md`. Driven by 3 merge conflicts on the unified file in 3 days (2026-05-03 → 2026-05-05), all traced to the same sync-before-branch failure mode that a discipline rule alone wasn't fixing.

- Adds `research/lab_notebook/{pm,scientist,developer}.md` with minimal headers
- Freezes `research/lab_notebook.md` via top-of-file banner; pre-existing entries are immutable per `shared/feedback_lab_notebook.md` and not migrated
- First PM lab notebook entry written under the new structure (in `pm.md`)

**Originating proposal:** Sci's standup post [2026-05-05 15:13 UTC]; PM agreed today with one tweak (subdirectory rather than 3 top-level files).

**Cerebrum memory updates ship separately** (direct memory writes, no PR) after this merges — sequencing avoids role pointers referencing not-yet-merged paths. Scope listed in [Issue #286](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/286)'s acceptance criteria.

**Created by:** PM

## Test plan

- [x] `research/lab_notebook/{pm,scientist,developer}.md` created with minimal headers
- [x] Freeze banner added to `research/lab_notebook.md` (no edits to pre-existing entries)
- [x] First PM entry written under the new path
- [ ] CI (markdown lint + workflow tests) green
- [ ] Cerebrum memory updates land after merge (tracked in [Issue #286](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/286) ACs)