### PR TITLE
feat(scripts): adopt snakevision for interactive DAG visualization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -220,6 +220,11 @@ resources/mhcflurry_models.done
 # Logs
 pipeline.log
 
+# DAG visualization output (scripts/visualize_dag.sh / snakevision)
+dag.svg
+dag.png
+dag.pdf
+
 # macOS metadata
 .DS_Store
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -92,3 +92,38 @@ snakemake --cores 1 --use-conda -n \
 
 You should see a list of planned jobs (or "Nothing to be done" if outputs already
 exist). A Python traceback indicates a missing config file or inactive conda env.
+
+---
+
+## 6. DAG Visualization (dev tool)
+
+After editing Snakemake rules, render the rule graph to confirm the DAG matches
+intent — `scripts/setup_local.sh` installs [snakevision](https://pypi.org/project/snakevision/)
+into the `snakemake` env automatically. Wrapper:
+
+```bash
+conda activate snakemake
+bash scripts/visualize_dag.sh                                                       # default: config/test_config.yaml
+bash scripts/visualize_dag.sh config/config.yaml --config samples_tsv=config/samples/patient_002.tsv
+```
+
+The wrapper runs `snakemake --rulegraph --forceall`, pipes the `.dot` to
+`snakevision`, writes `dag.svg`, and (on macOS) opens it. Override the output
+path with `OUTPUT=foo.svg bash scripts/visualize_dag.sh`.
+
+**`--clean` flag — full per-sample DAG.** Snakemake's `--rulegraph` prunes
+rules whose outputs already exist, even with `--forceall`. Once the test
+pipeline has run once, per-sample rules (`run_optitype`, `hisat2_align`,
+`extract_junctions`, `download_fastq`, …) drop off the rendered DAG. To see
+the complete pipeline architecture, use `--clean`:
+
+```bash
+bash scripts/visualize_dag.sh --clean
+```
+
+This renders against a symlink-only temp workspace (no `results/`), so snakemake
+sees a "no outputs yet" state and emits every rule. Real `results/` are untouched.
+
+Recommended workflow when changing rules: edit → dry-run → `bash scripts/visualize_dag.sh`
+→ open the SVG → confirm intent before opening the PR. Use `--clean` when adding
+or restructuring per-sample rules.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -124,6 +124,12 @@ bash scripts/visualize_dag.sh --clean
 This renders against a symlink-only temp workspace (no `results/`), so snakemake
 sees a "no outputs yet" state and emits every rule. Real `results/` are untouched.
 
+> **Caveat:** `--clean` reads `samples_tsv` from the configfile only. Overrides
+> via `--config samples_tsv=…` extra args are passed through to snakemake but
+> NOT applied to placeholder FASTQ generation, so the DAG can come out pruned or
+> fail. Use a configfile that already points to the desired samples TSV (the
+> wrapper warns at runtime if it detects `--config samples_tsv=…`).
+
 Recommended workflow when changing rules: edit → dry-run → `bash scripts/visualize_dag.sh`
 → open the SVG → confirm intent before opening the PR. Use `--clean` when adding
 or restructuring per-sample rules.

--- a/scripts/setup_local.sh
+++ b/scripts/setup_local.sh
@@ -81,9 +81,13 @@ fi
 # 3. Install dev-tooling (snakevision) into the snakemake env
 # ---------------------------------------------------------------------------
 echo ""
-echo "[3/3] Installing dev-tooling (snakevision) into 'snakemake' env..."
-conda run -n snakemake pip install --quiet snakevision
-echo "    snakevision installed (use scripts/visualize_dag.sh to render DAGs)."
+if conda run -n snakemake python -c "import snakevision" 2>/dev/null; then
+    echo "[3/3] snakevision already installed — skipping."
+else
+    echo "[3/3] Installing dev-tooling (snakevision) into 'snakemake' env..."
+    conda run -n snakemake pip install --quiet "snakevision==1.1.0"
+    echo "    snakevision installed (use scripts/visualize_dag.sh to render DAGs)."
+fi
 
 # ---------------------------------------------------------------------------
 # Done

--- a/scripts/setup_local.sh
+++ b/scripts/setup_local.sh
@@ -6,7 +6,8 @@
 # What this does:
 #   1. Installs Miniforge3 (conda) if not already present
 #   2. Creates a 'snakemake' conda environment with Snakemake
-#   3. Prints next steps
+#   3. Installs dev-tooling (snakevision for DAG visualization) into that env
+#   4. Prints next steps
 #
 # Usage:
 #   bash scripts/setup_local.sh
@@ -24,10 +25,10 @@ echo ""
 # 1. Check / install conda (Miniforge3)
 # ---------------------------------------------------------------------------
 if command -v conda &>/dev/null; then
-    echo "[1/2] conda already installed at: $(conda info --base)"
+    echo "[1/3] conda already installed at: $(conda info --base)"
     echo "      Skipping Miniforge3 installation."
 else
-    echo "[1/2] Installing Miniforge3..."
+    echo "[1/3] Installing Miniforge3..."
     # Miniforge uses "MacOSX" where uname returns "Darwin"
     _OS=$(uname)
     _ARCH=$(uname -m)
@@ -68,13 +69,21 @@ fi
 # ---------------------------------------------------------------------------
 echo ""
 if conda env list | grep -q "^snakemake "; then
-    echo "[2/2] 'snakemake' environment already exists — skipping creation."
+    echo "[2/3] 'snakemake' environment already exists — skipping creation."
 else
-    echo "[2/2] Creating 'snakemake' conda environment..."
+    echo "[2/3] Creating 'snakemake' conda environment..."
     conda create -n snakemake -c conda-forge -c bioconda \
         "snakemake>=8.0,<9" python=3.11 -y
     echo "    Created 'snakemake' environment."
 fi
+
+# ---------------------------------------------------------------------------
+# 3. Install dev-tooling (snakevision) into the snakemake env
+# ---------------------------------------------------------------------------
+echo ""
+echo "[3/3] Installing dev-tooling (snakevision) into 'snakemake' env..."
+conda run -n snakemake pip install --quiet snakevision
+echo "    snakevision installed (use scripts/visualize_dag.sh to render DAGs)."
 
 # ---------------------------------------------------------------------------
 # Done

--- a/scripts/visualize_dag.sh
+++ b/scripts/visualize_dag.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# scripts/visualize_dag.sh
+#
+# Render a Snakemake rule-graph SVG via snakevision and open it.
+# Workflow: snakemake --rulegraph → .dot file → snakevision → SVG → open.
+#
+# snakevision uses dagviz's "metro map" style: top-to-bottom data flow with
+# horizontal lane branching (subway-diagram metaphor). The defaults below
+# (scale, node_radius, edge_stroke_width) are tuned for readability on
+# multi-rule pipelines — override via STYLE_ARGS env if needed.
+#
+# Usage:
+#   bash scripts/visualize_dag.sh [--clean] [configfile] [extra snakemake args...]
+#
+# Examples:
+#   bash scripts/visualize_dag.sh                                                          # default: config/test_config.yaml
+#   bash scripts/visualize_dag.sh --clean                                                  # full DAG (per-sample rules included)
+#   bash scripts/visualize_dag.sh config/test_config.yaml
+#   bash scripts/visualize_dag.sh config/config.yaml --config samples_tsv=config/samples/patient_002.tsv
+#
+# --clean flag: snakemake's --rulegraph prunes rules whose outputs already exist,
+# even with --forceall. Per-sample rules (run_optitype, hisat2_align, etc.) drop
+# off the DAG once the test pipeline has been run. --clean renders against a
+# symlink-only temp workspace (all dirs except results/ are symlinked from $PWD)
+# so snakemake sees a "no outputs yet" state and emits the full per-sample DAG.
+#
+# Override styling (full list: dagviz.style.metro.StyleConfig fields):
+#   STYLE_ARGS="--style scale=20 --style node_radius=12" bash scripts/visualize_dag.sh
+#
+# Prerequisite: snakevision installed in the active conda env. setup_local.sh installs
+# it into the 'snakemake' env; manually: `conda activate snakemake && pip install snakevision`.
+#
+set -euo pipefail
+
+CLEAN_MODE=false
+if [[ "${1:-}" == "--clean" ]]; then
+    CLEAN_MODE=true
+    shift
+fi
+
+CONFIGFILE="${1:-config/test_config.yaml}"
+shift || true
+OUTPUT="${OUTPUT:-dag.svg}"
+STYLE_ARGS="${STYLE_ARGS:---style scale=15 --style node_radius=10 --style edge_stroke_width=3}"
+
+DOT_FILE=$(mktemp)
+TMPWORK=""
+
+cleanup() {
+    rm -f "$DOT_FILE"
+    [[ -n "$TMPWORK" && -d "$TMPWORK" ]] && rm -rf "$TMPWORK"
+}
+trap cleanup EXIT
+
+if ! command -v snakevision &>/dev/null; then
+    echo "Error: snakevision not found on PATH." >&2
+    echo "Activate the snakemake env and install: conda activate snakemake && pip install snakevision" >&2
+    exit 1
+fi
+
+if [[ ! -f "$CONFIGFILE" ]]; then
+    echo "Error: configfile '$CONFIGFILE' not found." >&2
+    exit 1
+fi
+
+if [[ "$CLEAN_MODE" == true ]]; then
+    echo "Generating rule graph in clean workspace (full DAG, all per-sample rules)..."
+    TMPWORK=$(mktemp -d)
+    # Symlink read-only project files; omit results/ + data/ so snakemake sees a
+    # fresh state. data/ is populated below with empty placeholders for source
+    # FASTQs so input-existence checks pass without requiring real test data.
+    for f in Snakefile workflow config scripts resources .snakemake; do
+        [[ -e "$f" ]] && ln -s "$PWD/$f" "$TMPWORK/$f"
+    done
+
+    # Resolve samples_tsv from the configfile (override via --config samples_tsv=...
+    # passed in "$@" is intentionally ignored here for simplicity — pass the right
+    # configfile explicitly if you need a different samples list).
+    SAMPLES_TSV=$(awk -F'[: ]+' '/^samples_tsv:/ {gsub(/"/, "", $2); print $2; exit}' "$CONFIGFILE")
+    if [[ -n "$SAMPLES_TSV" && -f "$SAMPLES_TSV" ]]; then
+        # For each non-URL FASTQ path in the samples TSV, create an empty placeholder
+        # at the same relative path inside TMPWORK. URLs (gs://, https://) are produced
+        # by the download_fastq rule and don't need placeholders.
+        awk -F'\t' 'NR>1 && $1 !~ /^#/ {
+            for (i=4; i<=5; i++) {
+                if ($i != "" && $i !~ /^(https?|gs):\/\//) print $i
+            }
+        }' "$SAMPLES_TSV" | while IFS= read -r fq; do
+            [[ -z "$fq" ]] && continue
+            mkdir -p "$TMPWORK/$(dirname "$fq")"
+            : > "$TMPWORK/$fq"
+        done
+    fi
+
+    (cd "$TMPWORK" && snakemake --configfile "$CONFIGFILE" "$@" --rulegraph --forceall) > "$DOT_FILE"
+else
+    echo "Generating rule graph (configfile: $CONFIGFILE; pass --clean for full per-sample DAG)..."
+    snakemake --configfile "$CONFIGFILE" "$@" --rulegraph --forceall > "$DOT_FILE"
+fi
+
+echo "Rendering with snakevision (metro style, top-to-bottom flow)..."
+# shellcheck disable=SC2086 # STYLE_ARGS is intentionally word-split
+snakevision $STYLE_ARGS -o "$OUTPUT" "$DOT_FILE"
+
+echo "Wrote $OUTPUT"
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    open "$OUTPUT"
+fi

--- a/scripts/visualize_dag.sh
+++ b/scripts/visualize_dag.sh
@@ -73,14 +73,26 @@ if [[ "$CLEAN_MODE" == true ]]; then
         [[ -e "$f" ]] && ln -s "$PWD/$f" "$TMPWORK/$f"
     done
 
-    # Resolve samples_tsv from the configfile (override via --config samples_tsv=...
-    # passed in "$@" is intentionally ignored here for simplicity — pass the right
-    # configfile explicitly if you need a different samples list).
+    # Warn if --config samples_tsv=... is in extra args — placeholder generation
+    # below reads samples_tsv from the configfile, NOT the override. Mismatch
+    # would produce placeholders for the wrong samples and a pruned/failing DAG.
+    for arg in "$@"; do
+        if [[ "$arg" == samples_tsv=* ]]; then
+            echo "Warning: --config $arg detected. --clean reads samples_tsv from the configfile" >&2
+            echo "         only — the override is NOT applied to placeholder FASTQ generation." >&2
+            echo "         Use a configfile that already points to the right samples_tsv." >&2
+            break
+        fi
+    done
+
+    # Resolve samples_tsv from the configfile.
     SAMPLES_TSV=$(awk -F'[: ]+' '/^samples_tsv:/ {gsub(/"/, "", $2); print $2; exit}' "$CONFIGFILE")
     if [[ -n "$SAMPLES_TSV" && -f "$SAMPLES_TSV" ]]; then
         # For each non-URL FASTQ path in the samples TSV, create an empty placeholder
         # at the same relative path inside TMPWORK. URLs (gs://, https://) are produced
         # by the download_fastq rule and don't need placeholders.
+        # NOTE: columns 4 and 5 are fastq1 and fastq2 per the samples TSV schema
+        # (see config/samples/patient_*.tsv header). Update if the schema changes.
         awk -F'\t' 'NR>1 && $1 !~ /^#/ {
             for (i=4; i<=5; i++) {
                 if ($i != "" && $i !~ /^(https?|gs):\/\//) print $i


### PR DESCRIPTION
**Created by:** Developer

Closes [Issue #284](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/284) (snakevision adoption)

## Summary

- `scripts/setup_local.sh` installs [snakevision 1.1.0](https://pypi.org/project/snakevision/) into the `snakemake` conda env (new step 3/3)
- New `scripts/visualize_dag.sh` wrapper: `snakemake --rulegraph` → snakevision → `dag.svg` → opens it. Tuned metro-style defaults (`scale=15 node_radius=10 edge_stroke_width=3`) for multi-rule pipeline readability
- `--clean` flag renders against a temp symlink workspace so all per-sample rules appear (works around snakemake's `--rulegraph` pruning of rules whose outputs already exist; placeholder source FASTQs auto-created so test data isn't required)
- `docs/installation.md` adds section 6 (DAG visualization) documenting the workflow and `--clean` caveat
- `dag.{svg,png,pdf}` added to `.gitignore`

## Test plan

- [x] `bash scripts/visualize_dag.sh` renders a clean DAG SVG showing aggregation/per-patient rules (test config, with `results/` already present)
- [x] `bash scripts/visualize_dag.sh --clean` renders the full DAG including per-sample rules (`run_optitype`, `hisat2_align`, `extract_junctions`, etc.)
- [x] Real `results/` directory is untouched after `--clean` runs
- [ ] `bash scripts/setup_local.sh` succeeds end-to-end (snakemake env created or detected, snakevision pip installed)
- [x] `pytest` (235 tests) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)