### PR TITLE
docs(manuscript): INTRODUCTION — Rojas 2023 foundational personalized neoantigen vaccine (#268)

### DIFF
--- a/research/lab_notebook/scientist.md
+++ b/research/lab_notebook/scientist.md
@@ -5,3 +5,19 @@ Per-role lab notebook for Scientist sessions. Started 2026-05-06 as part of the 
 Format and rules unchanged from the unified notebook — see `shared/feedback_lab_notebook.md`. New date sections at the TOP; new time sections at the TOP of the date block; entries are immutable once committed.
 
 ---
+
+## 2026-05-06
+
+### 13:30 UTC — Editor: Scientist
+
+#### [Sub-Issue #268](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/268) INTRODUCTION — Rojas 2023 foundational personalized neoantigen vaccine reference
+
+**Placement.** Single sentence appended to the existing clinical-translation context block in section `## Cancer Neoepitopes` of [INTRODUCTION.md](research/manuscript/INTRODUCTION.md), inserted after the line "...personalized cancer vaccines and adoptive T-cell therapies." That line was the natural anchor — the sole pre-existing clinical-translation statement in INTRODUCTION, previously uncited. Considered Section 4 (HLA Genotype) where Sahin et al. 2017 + Ott et al. 2017 already cluster, and rejected — those are cited there for the *vaccine slot count* argument (10–20 candidates per formulation), a different rhetorical use; piling Rojas in would muddle the load-bearing function of the Section 4 citation. Considered a new paragraph and rejected — one foundational reference doesn't justify its own paragraph; INTRODUCTION should anchor and DISCUSSION should develop.
+
+**Framing.** Rojas et al., *Nature* 2023, 618:144-150 (Zotero `UIN9DIUP`) — Phase 1 autogene cevumeran trial in PDAC, 8/16 vaccine-induced T-cell responders, mRNA-LNP synthesis with up to 20 patient-specific neoantigens. The cited fact ("8 of 16 patients developed vaccine-induced T-cell responses") is the single cleanest summary of the trial's primary endpoint; no need to also cite the recurrence-free survival trend (covered in DISCUSSION via [PR #260](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/260)) or the 6-year follow-up (AACR 2026, surfaced [2026-05-03 14:07 UTC] in news_log; deferred to a future DISCUSSION update if/when published as a full paper).
+
+**Cross-section consistency.** INTRODUCTION now cites Rojas 2023 as foundational; DISCUSSION already develops the autogene cevumeran clinical context and adds the 6-year/long-lived T-cell durability follow-ups. Sahin et al. 2017 + Ott et al. 2017 remain in Section 4 only, doing different work (vaccine slot count). No duplication.
+
+**Citation style.** Author-year inline `(Rojas et al., *Nature* 2023)` matches the existing INTRODUCTION convention used by Yewdell & Bennink 1999, Sahin et al. 2017, Ott et al. 2017, Cai et al. 2026 (added in [PR #282](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/282)), Alam et al. 2023. Reference-list finalisation deferred to [Sub-Issue #272](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/272).
+
+---

--- a/research/manuscript/INTRODUCTION.md
+++ b/research/manuscript/INTRODUCTION.md
@@ -14,6 +14,9 @@ immune tolerance.
 
 Neoepitope-based immunotherapy has emerged as a promising approach in cancer treatment,
 underpinning the development of personalized cancer vaccines and adoptive T-cell therapies.
+Phase 1 trials of personalised mRNA neoantigen vaccines have established clinical
+feasibility — most notably autogene cevumeran in pancreatic ductal adenocarcinoma, where
+8 of 16 patients developed vaccine-induced T-cell responses (Rojas et al., *Nature* 2023).
 Most neoepitope discovery pipelines focus on single-nucleotide variants (SNVs) and small
 insertions/deletions (indels) as the source of altered peptide sequences. However, a
 broader class of tumor-specific alterations — aberrant splicing — has received comparatively

--- a/research/manuscript/INTRODUCTION.md
+++ b/research/manuscript/INTRODUCTION.md
@@ -14,7 +14,7 @@ immune tolerance.
 
 Neoepitope-based immunotherapy has emerged as a promising approach in cancer treatment,
 underpinning the development of personalized cancer vaccines and adoptive T-cell therapies.
-Phase 1 trials of personalised mRNA neoantigen vaccines have established clinical
+Phase 1 trials of personalized mRNA neoantigen vaccines have established clinical
 feasibility — most notably autogene cevumeran in pancreatic ductal adenocarcinoma, where
 8 of 16 patients developed vaccine-induced T-cell responses (Rojas et al., *Nature* 2023).
 Most neoepitope discovery pipelines focus on single-nucleotide variants (SNVs) and small
@@ -124,10 +124,10 @@ biologically cleaner winner than one with one strong and five near-zero predicti
 A complementary but distinct biological force is **immunodominance** — the well-documented
 hierarchy in which the strongest-binding epitope for the dominant allele tends to drive the
 T cell response while weaker epitopes become subdominant or cryptic (Yewdell & Bennink,
-*Annu Rev Immunol* 1999). In natural anti-tumour immunity, a peptide with one exceptionally
+*Annu Rev Immunol* 1999). In natural anti-tumor immunity, a peptide with one exceptionally
 strong allele can elicit a more potent focused T cell response than a peptide with moderate
 breadth, through intramolecular competition of peptides for the available MHC grooves of
-that allele and through immunodomination — dominant T cell clones monopolising
+that allele and through immunodomination — dominant T cell clones monopolizing
 antigen-presenting cells and suppressing priming of clones restricted to weaker alleles
 (Chen & McCluskey, *Adv Cancer Res* 2006). GPS alone does not capture this.
 
@@ -139,13 +139,13 @@ competing directly with the endogenous peptidome for empty MHC grooves achieve a
 complete bypass than mRNA vaccines, which re-enter intracellular antigen processing inside
 the APC — but the suppression of subdominant T cell clones through APC killing is
 alleviated in either case. Combined with the threat of HLA loss of heterozygosity under
-immune pressure and the limited number of peptide slots in a personalised vaccine
+immune pressure and the limited number of peptide slots in a personalized vaccine
 formulation (typically 10–20 candidates in current clinical trials; Sahin et al.,
 *Nature* 2017; Ott et al., *Nature* 2017), GPS becomes the committed primary
 ranking criterion for our application. `best_presentation_percentile` is retained not as a
 competing ranking dimension but as a minimum quality gate — at least one allele must reach
 strong or weak binder threshold to ensure sufficient pMHC density for vaccine-primed T
-cells to recognise the tumour at the site of disease.
+cells to recognize the tumor at the site of disease.
 
 ### Differential surface expression across HLA loci
 


### PR DESCRIPTION
## Summary

Adds Rojas et al. (*Nature* 2023) — Phase 1 autogene cevumeran PDAC trial — as the foundational clinical-translation reference in INTRODUCTION Section 1 (Cancer Neoepitopes).

- Single sentence appended to the existing "personalized cancer vaccines" line, previously uncited
- Author-year inline `(Rojas et al., *Nature* 2023)` matches existing convention (Yewdell & Bennink 1999, Sahin/Ott 2017, Cai 2026, Alam 2023)
- Light touch — INTRODUCTION anchors, DISCUSSION ([PR #260](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/260)) develops
- Lab notebook entry on the new per-role file `research/lab_notebook/scientist.md` (first entry post-split)

Closes [Issue #268](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/268).

## Test plan

- [ ] INTRODUCTION reads cleanly through the new sentence
- [ ] Citation style matches existing Section 1 convention
- [ ] Lab notebook entry on per-role file (not legacy `lab_notebook.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)