### PR TITLE
chore(deps): update libdeflate-cap TODO refs from #107 to #237

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,7 +97,7 @@ The old `config.yaml` had an `assembly:` block (`upstream_nt`, `downstream_nt`, 
 **Workarounds that were tried and rejected:**
 - `samtools >= 1.20` pin — made things worse; solver produced an env without samtools (exit 127 on linux-64)
 - Fully unpinned samtools — solver falls back to samtools 1.3.1 (2016, 10 versions behind); not acceptable long-term
-**TODO(#107):** revisit once bioconda ships an htslib/samtools build against libdeflate >= 1.26.
+**TODO(#237):** revisit once bioconda ships an htslib/samtools build against libdeflate >= 1.26. Re-tested 2026-05-06: bioconda's 2026-03 samtools/htslib refactor (samtools 1.23.1) did NOT lift the cap — solver still reports `libdeflate >=1.20,<1.26.0a0` for modern htslib builds, conflicting with regtools 1.0.0's `libdeflate >=1.26`. Workaround remains in place.
 
 ### `run_mhcflurry.py` — Class1PresentationPredictor genotype API
 `Class1PresentationPredictor.predict()` is a genotype-level call: pass all patient HLA alleles at once (≤6 as a list), get one best-allele prediction per peptide back. Do NOT repeat a single allele N times (that was the `Class1AffinityPredictor` convention and raises `ValueError`).

--- a/workflow/envs/hisat2.yaml
+++ b/workflow/envs/hisat2.yaml
@@ -11,4 +11,6 @@ dependencies:
   # samtools intentionally omitted: regtools >=1.0.0 requires libdeflate >=1.26,
   # but no bioconda linux-64 samtools/htslib build is compatible with libdeflate >=1.26.
   # Using system samtools (apt-get, currently 1.13) instead.
-  # TODO(#107): revisit once bioconda ships an htslib build against libdeflate >=1.26.
+  # TODO(#237): revisit once bioconda ships an htslib build against libdeflate >=1.26.
+  # Re-tested 2026-05-06 (Issue #237): bioconda 2026-03 recipe refactor (samtools 1.23.1)
+  # did NOT lift the cap — modern htslib still pins libdeflate <1.26.0a0. Workaround stays.


### PR DESCRIPTION
**Created by:** Developer

Closes [Issue #237](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/237) (libdeflate cap re-test).

## Summary

- Stale `TODO(#107)` reference in `workflow/envs/hisat2.yaml` and `CLAUDE.md` "Known Dependency Issues" section pointed at the wrong issue ([Issue #107](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/107) was VM consolidation, unrelated). Updated to [Issue #237](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/237).
- Re-tested 2026-05-06: bioconda's 2026-03 recipe refactor (samtools 1.23.1) did NOT lift the libdeflate cap on linux-64. Solver still reports `libdeflate >=1.20,<1.26.0a0` for modern htslib builds, conflicting with `regtools 1.0.0`'s `libdeflate >=1.26`. Comment annotated with the test date and finding so future maintainers don't re-deliberate.
- The system-samtools workaround stays in place.

## Test plan

- [ ] `pytest` (235 tests) passes — confirmed locally
- [ ] No code-path changes; comment-only update + CLAUDE.md narrative

🤖 Generated with [Claude Code](https://claude.com/claude-code)