### PR TITLE
chore(gitignore): ignore Claude Code transient scheduler state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -225,3 +225,7 @@ pipeline.log
 
 # Claude Code — per-machine, per-worktree notes (e.g. role binding, local paths)
 CLAUDE.local.md
+
+# Claude Code — transient scheduler state (per-session lock + durable cron jobs)
+.claude/scheduled_tasks.lock
+.claude/scheduled_tasks.json

--- a/research/lab_notebook/pm.md
+++ b/research/lab_notebook/pm.md
@@ -8,6 +8,16 @@ Format and rules unchanged from the unified notebook — see `shared/feedback_la
 
 ## 2026-05-06
 
+### 21:30 UTC — Editor: PM
+
+#### [PR #293](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/293) — gitignore Claude Code transient scheduler state
+
+**Trigger.** User opened `.claude/scheduled_tasks.lock` in the IDE this evening and asked what it was. Inspection: per-session ownership lock for Claude Code's in-process cron scheduler — single-line JSON with `sessionId`, `pid`, `procStart`, `acquiredAt`. Created any time a session arms a cron in this project (today: via `/pong` for the 30-min cache-keepalive). Showed up as untracked noise in `git status`.
+
+**Decision.** Surgical ignore for the two transient files (`.claude/scheduled_tasks.lock` + `.claude/scheduled_tasks.json` for `durable: true` jobs) rather than blanket-ignoring `.claude/` — leaves room to check in `.claude/settings.json` later if shared project-level Claude config ever becomes useful. `.claude/settings.local.json` is already covered by global `~/.config/git/ignore`.
+
+**Mechanics.** Branch `chore/pm/gitignore-claude-scheduler-2026-05-06` off `workspace/pm`; commit, then push as separate steps (per the commit-push-merge three-step rule promoted this morning); PR opened with project board attached + Status flipped to `Ready for review` via single `updateProjectV2ItemFieldValue` GraphQL call. Branch was behind main; user updated via the GitHub UI which created a merge commit (initially read as a bot/auto-update mystery; resolved on clarification).
+
 ### 12:11 UTC — Editor: PM
 
 #### [Issue #286](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/286) — lab-notebook split into per-role files (this PR)


### PR DESCRIPTION
## Summary

- Adds `.claude/scheduled_tasks.lock` and `.claude/scheduled_tasks.json` to `.gitignore`.
- Both files are per-machine, per-session state used by Claude Code's in-process cron scheduler — not project state.
  - `.lock` records the owning sessionId + PID + acquired-at timestamp; prevents two Claude sessions in the same project from firing scheduled tasks concurrently. Created any time a session arms a cron (e.g. via `/pong`).
  - `.json` (created only when a `durable: true` cron is scheduled) persists user-specific durable jobs across restarts.
- Without this, the lock shows up as untracked noise in `git status` whenever any Claude session is active in this repo.

## Why surgical (not `.claude/`)

Leaves room to check in `.claude/settings.json` later if we ever want shared project-level Claude config. Per-user `.claude/settings.local.json` is already ignored via global `~/.config/git/ignore`.

## Test plan

- [x] `git check-ignore -v .claude/scheduled_tasks.lock` matches `.gitignore:230`
- [x] `git check-ignore -v .claude/scheduled_tasks.json` matches `.gitignore:231`
- [x] `git status` no longer surfaces the lock file

**Created by:** PM

🤖 Generated with [Claude Code](https://claude.com/claude-code)