### PR TITLE
docs(news-log): developer 2026-05-07 10:03 UTC — HISAT2 2.2.2 + AFDB API audit

### DIFF
--- a/research/news_log.md
+++ b/research/news_log.md
@@ -13,6 +13,11 @@ Historical entries (before 2026-05-02) pre-date the time/editor sub-heading conv
 
 ## 2026-05-07
 
+### 10:03 UTC — Editor: Developer
+
+- **HISAT2 2.2.2** ([release](https://github.com/DaehwanKimLab/hisat2/releases), 2026-01-27) — adds repeat-read alignment mode (1 tagged alignment per repeat read). → [Issue #297](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/297) (chr22 trade-off audit). *Developer. pipeline-relevant.*
+- **AFDB legacy API retires June 2026** ([NAR 2026](https://academic.oup.com/nar/advance-article/doi/10.1093/nar/gkaf1226/8340156)) — TCRdock self-contained, no API calls. → No action; audited via [Issue #180](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/180). *Developer. pipeline-relevant.*
+
 ### 09:09 UTC — Editor: PM
 
 - **Improved GitHub Issues search GA** ([May 2026 Changelog](https://github.blog/changelog/)) — NL + structured filters stable. → [Issue #294](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/294) (PM eval). *PM. tooling-relevant.*


### PR DESCRIPTION
## Summary
- HISAT2 2.2.2 repeat-read mode flagged for chr22 trade-off audit ([Issue #297](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/297))
- AFDB legacy API retires June 2026 — logged as no-action (already audited via [Issue #180](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/180))

**Created by:** Developer

## Test plan
- [x] Format follows `shared/reference_news_log.md` (~12–18 words/entry)
- [x] Time/editor sub-heading inserted under existing 2026-05-07 date section
- [x] Issue links live and project-board-tagged

🤖 Generated with [Claude Code](https://claude.com/claude-code)