### PR TITLE
docs(news-log): pm 2026-05-08 — Anthropic Managed Agents + Claude Code May update

### DIFF
--- a/research/news_log.md
+++ b/research/news_log.md
@@ -11,6 +11,13 @@ Historical entries (before 2026-05-02) pre-date the time/editor sub-heading conv
 
 ---
 
+## 2026-05-08
+
+### 13:18 UTC — Editor: PM
+
+- **Anthropic Managed Agents — Dreaming + Multiagent Orchestration** ([2026-05-07, 9to5Mac](https://9to5mac.com/2026/05/07/anthropic-updates-claude-managed-agents-with-three-new-features/)) — agents review past sessions to self-improve; lead delegates to specialists. → [Issue #305](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/305) (PM eval, memory tightening). *PM. methodology-signal.*
+- **Claude Code May 2026 update** ([changelog](https://code.claude.com/docs/en/changelog)) — `claude project purge`, smarter /model picker, plugin URLs, OAuth fixes. → No action; Dev-tooling. *PM. tooling-signal.*
+
 ## 2026-05-07
 
 ### 09:09 UTC — Editor: PM


### PR DESCRIPTION
## Summary

PM news_log entry for 2026-05-08 13:18 UTC, two items:

- **Anthropic Managed Agents — Dreaming + Multiagent Orchestration** ([2026-05-07, 9to5Mac](https://9to5mac.com/2026/05/07/anthropic-updates-claude-managed-agents-with-three-new-features/)) — opened [Issue #305](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/305) to re-read `feedback_multi_role_not_multi_agent.md` against the article (Multiagent Orchestration mirrors our PM/Sci/Dev pattern but with autonomous-agent vs human orchestration).
- **Claude Code May 2026 update** ([changelog](https://code.claude.com/docs/en/changelog)) — `claude project purge`, smarter `/model` picker, plugin URLs, OAuth fixes. Tooling-signal, no action.

**Created by:** PM

## Test plan

- [x] Both entries within ~12-18 word body length per `shared/reference_news_log.md`
- [x] Time/editor sub-heading inserted at top (new date section per insertion-order rule)
- [x] [Issue #305](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/305) live and project-board-tagged before this PR opened

🤖 Generated with [Claude Code](https://claude.com/claude-code)