### PR TITLE
chore(gitignore): ignore Claude Code per-worktree local files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -225,3 +225,4 @@ pipeline.log
 
 # Claude Code — per-machine, per-worktree notes (e.g. role binding, local paths)
 CLAUDE.local.md
+.claude/commands/

--- a/.gitignore
+++ b/.gitignore
@@ -222,3 +222,6 @@ pipeline.log
 
 # macOS metadata
 .DS_Store
+
+# Claude Code — per-machine, per-worktree notes (e.g. role binding, local paths)
+CLAUDE.local.md


### PR DESCRIPTION
## Summary

- Ignore `CLAUDE.local.md` (per-worktree role binding for the v1 claude-personas setup)
- Ignore `.claude/commands/` (per-project slash command overrides — needed for v2-style claude-personas where some projects use the new symlink-based wiring while splice still uses the v1 autoMemoryDirectory setup)

Both files are local Claude Code configuration that varies per machine/worktree and shouldn't be tracked. Same pattern as the existing `chore(gitignore): ignore Claude Code transient scheduler state (#293)`.

## Test plan

- [ ] Confirm `.claude/commands/` shows as ignored after merge (`git status --ignored`)
- [ ] Confirm `CLAUDE.local.md` continues to be ignored
- [ ] No tracked Claude Code files affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)