### PR TITLE
docs(claude-md): note 'up-to-date' branch protection rule removed 2026-05-09

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,7 @@ Modernised reimplementation of a 2015 cancer neoepitope prediction pipeline (Jin
 - **NVIDIA driver pinned to `nvidia-headless-570-server` (DKMS)** — do not upgrade. Driver ≥575 dropped P100 Pascal (SM 6.0) support. Image family `common-cu129-ubuntu-2204-nvidia-580` is used but the driver is overridden to 570 in the setup script.
 - Pipeline is run with `snakemake --cores $(nproc) --use-conda --rerun-triggers mtime` inside a `tmux` session
 - GitHub project board: user project #9 ("JH M Lee Lab") under user `Jin-HoMLee` — query via `gh api graphql` with `user(login: "Jin-HoMLee") { projectV2(number: 9) { ... } }` (it's a user project, not org)
+- `main` branch protection: required CI checks (`pipeline-pytest`, `pipeline-snakemake-dry-run`) + squash-merge default. The "Require branches to be up to date before merging" rule was **removed 2026-05-09** — it fired on every PR cut from a worktree branch lagging `main`, even without real conflicts. Don't suggest `gh pr update-branch` or `--admin` workarounds for "branch is behind main" anymore (the rule is gone). Real file-level conflicts still need manual resolution.
 
 ## Pipeline Design Decisions
 


### PR DESCRIPTION
## Summary
- Document that the **"Require branches to be up to date before merging"** branch protection rule on `main` was removed 2026-05-09 (by user, manually in repo settings).
- Saves future Claude sessions from suggesting stale `gh pr update-branch` / `--admin` workarounds for "branch is behind main" errors that no longer fire.

## Test plan
- [x] One-line addition under `## Infrastructure` section — between project board bullet and Pipeline Design Decisions header
- [x] Notes which protections remain (CI checks + squash-merge default)
- [x] No code change

🤖 Generated with [Claude Code](https://claude.com/claude-code)