### PR TITLE
docs(news-log): pm 2026-05-10 15:17 UTC — GitHub repo ruleset per-user bypass actors

### DIFF
--- a/research/news_log.md
+++ b/research/news_log.md
@@ -13,6 +13,10 @@ Historical entries (before 2026-05-02) pre-date the time/editor sub-heading conv
 
 ## 2026-05-10
 
+### 15:17 UTC — Editor: PM
+
+- **GitHub repo rulesets — per-user bypass actors** ([May 2026 Changelog](https://github.blog/changelog/)) — individuals as bypass actors via UI/REST/GraphQL. → No action; surgical alt to "branches up to date" rule removed via [PR #313](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/313) (rule removal). *PM. tooling-signal.*
+
 ### 08:43 UTC — Editor: Developer
 
 - **OpenAI acquired Astral (uv/ruff/ty)** ([2026-03-19, dev.to](https://dev.to/max_quimby/openai-just-acquired-astral-what-it-means-for-uv-ruff-and-every-python-developer-41ah)) — Astral team joins Codex; uv/ruff/ty stay open-source under active development. → No action; revisit if we adopt uv/ruff for CI linting. *Developer. industry-standard.*


### PR DESCRIPTION
## Summary
- PM news_log entry for 2026-05-10: GitHub repo ruleset per-user bypass actors (May 2026 Changelog).
- Surgical alt to the "branches up to date" rule we removed via [PR #313](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/313) (rule removal); informs any future re-introduction of stricter merge gates.

## Test plan
- [x] Entry inserted at top of 2026-05-10 section (above existing Dev 08:43 UTC entry, per newest-editor-session-first convention).
- [x] Format matches peer entries (~24 words after source link).
- [x] Issue/PR refs use full prefix + linked + keyword pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)