### PR TITLE
fix(scripts): zotero_add.py — emit bioRxiv preprints as journalArticle with publicationTitle

### DIFF
--- a/research/scripts/test_zotero_add.py
+++ b/research/scripts/test_zotero_add.py
@@ -86,6 +86,15 @@ def test_preprint_with_missing_institution_falls_back_to_empty():
     assert item["publicationTitle"] == ""
 
 
+def test_medrxiv_preprint_uses_medrxiv_as_publication_title():
+    """Same code path as bioRxiv — verify the institution label propagates verbatim."""
+    data = _biorxiv_crossref()
+    data["institution"] = [{"name": "medRxiv"}]
+    item = crossref_to_zotero(data, _COLLECTION, _TAGS)
+    assert item["itemType"] == "journalArticle"
+    assert item["publicationTitle"] == "medRxiv"
+
+
 def test_first_or_empty_handles_empty_list_and_none():
     assert _first_or_empty([]) == ""
     assert _first_or_empty(None) == ""

--- a/research/scripts/test_zotero_add.py
+++ b/research/scripts/test_zotero_add.py
@@ -56,13 +56,17 @@ def test_journal_article_path():
     assert item["abstractNote"] == "Cancer abstract."
 
 
-def test_preprint_path_no_crash_on_empty_container_title():
+def test_biorxiv_preprint_matches_native_ris_export():
+    """bioRxiv's own .ris export uses TY=JOUR + JF=bioRxiv. Verify our output
+    mirrors that convention: itemType=journalArticle, publicationTitle=<institution>."""
     item = crossref_to_zotero(_biorxiv_crossref(), _COLLECTION, _TAGS)
-    assert item["itemType"] == "preprint"
-    assert item["repository"] == "bioRxiv"
+    assert item["itemType"] == "journalArticle"
+    assert item["publicationTitle"] == "bioRxiv"
     assert item["DOI"] == "10.64898/2026.02.22.707219"
-    assert item["archiveID"] == "10.64898/2026.02.22.707219"
-    assert "publicationTitle" not in item
+    # Legacy preprint-itemType fields removed
+    assert "repository" not in item
+    assert "archiveID" not in item
+    # CrossRef preprints don't carry ISSN
     assert "ISSN" not in item
 
 
@@ -70,7 +74,7 @@ def test_preprint_with_abstract_populates_abstract_note():
     data = _biorxiv_crossref()
     data["abstract"] = "<jats:p>Preprint abstract.</jats:p>"
     item = crossref_to_zotero(data, _COLLECTION, _TAGS)
-    assert item["itemType"] == "preprint"
+    assert item["itemType"] == "journalArticle"
     assert item["abstractNote"] == "Preprint abstract."
 
 
@@ -78,8 +82,8 @@ def test_preprint_with_missing_institution_falls_back_to_empty():
     data = _biorxiv_crossref()
     data.pop("institution")
     item = crossref_to_zotero(data, _COLLECTION, _TAGS)
-    assert item["itemType"] == "preprint"
-    assert item["repository"] == ""
+    assert item["itemType"] == "journalArticle"
+    assert item["publicationTitle"] == ""
 
 
 def test_first_or_empty_handles_empty_list_and_none():

--- a/research/scripts/zotero_add.py
+++ b/research/scripts/zotero_add.py
@@ -133,18 +133,19 @@ def crossref_to_zotero(data, collection, tags, pubmed_date=None, pubmed_abstract
     title = _first_or_empty(data.get("title"))
 
     if _is_preprint(data):
-        # Preprints have an empty container-title; the host (bioRxiv, medRxiv, …) is in institution[].name.
+        # Mirror bioRxiv's own .ris export: TY=JOUR, JF=bioRxiv (publicationTitle).
+        # journalArticle renders correctly across CSL citation styles; the host
+        # (bioRxiv, medRxiv, …) is taken from CrossRef's institution[].name.
         institutions = data.get("institution") or []
-        repository = institutions[0].get("name", "") if institutions else ""
+        publication_title = institutions[0].get("name", "") if institutions else ""
         item = {
-            "itemType": "preprint",
+            "itemType": "journalArticle",
             "title": title,
             "creators": authors,
-            "repository": repository,
+            "publicationTitle": publication_title,
             "date": date,
             "DOI": data.get("DOI", ""),
             "url": data.get("URL", ""),
-            "archiveID": data.get("DOI", ""),
             "PMID": pmid or "",
             "collections": [collection],
             "tags": [{"tag": t} for t in tags],
@@ -274,8 +275,9 @@ def main():
 
     print(f"Title: {item['title']}")
     print(f"Authors: {len(item['creators'])} authors")
-    if item["itemType"] == "preprint":
-        print(f"Preprint: {item.get('repository', '—')}, {item['date']}")
+    if _is_preprint(data):
+        # Preprint emitted as journalArticle (matches bioRxiv .ris convention) — distinguish source by CrossRef classification.
+        print(f"Preprint ({item['publicationTitle'] or '—'}): {item['date']}")
     else:
         print(f"Journal: {item['publicationTitle']} {item['volume']}({item['issue']}): {item['pages']}, {item['date']}")
         print(f"ISSN: {item.get('ISSN', '—')}")

--- a/research/scripts/zotero_add.py
+++ b/research/scripts/zotero_add.py
@@ -276,7 +276,7 @@ def main():
     print(f"Title: {item['title']}")
     print(f"Authors: {len(item['creators'])} authors")
     if _is_preprint(data):
-        # Preprint emitted as journalArticle (matches bioRxiv .ris convention) — distinguish source by CrossRef classification.
+        # itemType is now journalArticle for both paths; use CrossRef classification to tell them apart.
         print(f"Preprint ({item['publicationTitle'] or '—'}): {item['date']}")
     else:
         print(f"Journal: {item['publicationTitle']} {item['volume']}({item['issue']}): {item['pages']}, {item['date']}")


### PR DESCRIPTION
**Created by:** Developer

Closes [Issue #307](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/307).

## Summary
- Switches the CrossRef preprint branch in `crossref_to_zotero` from `itemType=preprint` + `repository` to `itemType=journalArticle` + `publicationTitle`, matching bioRxiv's own `.ris` export convention (`TY=JOUR`, `JF=bioRxiv`).
- Drops the legacy `archiveID` field — was preprint-itemType-specific.
- The CLI status-line in `main()` now uses `_is_preprint(data)` to keep a dedicated "Preprint (<host>): <date>" output line since `itemType` alone no longer distinguishes the two sources.

## Path 1 — chosen (rationale)
Three paths surfaced in the issue body. **Path 1 wins** because bioRxiv's *own* `.ris` export is the empirical ground truth for "what does a correct bioRxiv citation look like in Zotero?" — and that export uses `TY=JOUR` + `JF=bioRxiv`, mapping cleanly to `itemType=journalArticle` + `publicationTitle=bioRxiv`. CSL processors render this consistently across styles, no Zotero-side schema gymnastics required, and existing manually-imported entries (which use the same `.ris`) become indistinguishable from auto-added ones.

The trade-off — losing Zotero's "preprint" UI filter — is mild: users can re-tag manually if classification matters, and the citation rendering wins outweigh it for the manuscript-citation use case Sci primarily uses this tool for.

## Acceptance criteria
- [x] Pick a solution path (1, 2, or 3) — Path 1
- [x] Implement in `research/scripts/zotero_add.py`; update `research/scripts/test_zotero_add.py`
- [ ] **Real bioRxiv smoke test**: actually post + verify a real bioRxiv DOI ends up with the expected `Publication` field rendering in Zotero — *user-gated, awaits real ZOTERO_API_KEY run*
- [ ] Cleanup: retire the `Zotero — bioRxiv unreliable` entry from `shared/MEMORY.md` once the fix lands — *follow-up after merge + smoke-test confirmation*

## Test plan
- [x] Unit tests pass (7/7) — verified via direct Python invocation; `test_biorxiv_preprint_matches_native_ris_export` anchored to the [user-supplied bioRxiv .ris export](https://www.biorxiv.org/content/10.64898/2025.11.30.691400v1) used as ground truth.
  - Note: local `pytest` hangs on collection (likely walking `.snakemake/conda/*/lib/python3.12/site-packages/{pandas,numpy,sklearn,...}/conftest.py`); CI will run `pytest` natively without that pollution. Worth a follow-up `pytest.ini` pinning `norecursedirs = .snakemake .venv`.
- [ ] **Real bioRxiv smoke test (user runs after CI green):** `.venv/bin/python research/scripts/zotero_add.py 10.64898/<some-real-bioRxiv-DOI> --dry-run` to inspect the JSON, then a non-`--dry-run` post + visual check in Zotero that the entry shows "Publication: bioRxiv" in the citation preview (and the resolved CSL render via Pandoc/whatever style we use). This is the verified version of [Issue #229](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/229)'s deferred AC 1.
- [ ] **Memory cleanup (post-merge):** delete `cerebrum/splice-neoepitope-pipeline/shared/feedback_zotero_biorxiv.md` and remove the index pointer from `shared/MEMORY.md` line 88.

## Out of scope
- Migrating existing Zotero entries from the old preprint format. The fix only changes new additions; existing entries remain untouched and can be edited manually if desired.
- Detecting the new `10.64898/` bioRxiv DOI prefix explicitly. The current `_is_preprint(data)` check uses CrossRef's `subtype=preprint` / `type=posted-content` classification, which works for both `10.1101/` (legacy) and `10.64898/` (new) prefixes as long as CrossRef classifies them correctly.