### PR TITLE
docs(scientist): Lu et al. news_log backfill + CDR3/pLDDT glossary

### DIFF
--- a/research/glossary.md
+++ b/research/glossary.md
@@ -24,6 +24,8 @@ Project-relevant abbreviations and acronyms. The pipeline mixes biology, ML, bio
 
 **CAR-T** — Chimeric Antigen Receptor T-cell therapy. Adoptive cell therapy where patient T cells are transduced with a synthetic chimeric receptor (scFv + CD3ζ + costim domains); recognizes surface antigen directly, MHC-independent. FDA-approved CD19/BCMA-targeting products for B-cell malignancies and myeloma. Distinct from TCR-T (native MHC-restricted TCR). *Domain: bio.*
 
+**CDR3** — Complementarity-Determining Region 3. Hypervariable loop on each TCR chain (α and β) that makes direct contact with the peptide in pMHC; the primary specificity-encoding region of the TCR. Average `pLDDT` across CDR3 residues used as a TCR-pMHC docking quality signal (Lu et al. 2025, [Issue #316](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/316)). *Domain: bio.*
+
 **CVE** — Common Vulnerabilities and Exposures. Standardised identifier system for publicly disclosed security flaws (CVE-YYYY-NNNN format); maintained by MITRE, used industry-wide for tracking known vulns. *Domain: security.*
 
 ## D
@@ -80,7 +82,7 @@ Project-relevant abbreviations and acronyms. The pipeline mixes biology, ML, bio
 
 **PDB** — Protein Data Bank ([rcsb.org](https://www.rcsb.org)). Public archive of experimentally determined 3D structures (~220k entries); training source for AlphaFold / Boltz / HERMES; reference ground truth for DockQ scoring. *Domain: bio.*
 
-**pLDDT** — predicted Local Distance Difference Test. Per-residue confidence score (0–100) emitted by AlphaFold/TCRdock; high pLDDT = the model is confident in that region's local geometry. *Domain: bio.*
+**pLDDT** — predicted Local Distance Difference Test. AlphaFold/TCRdock per-residue confidence score (0–100); per-residue version of the global `AF_confidence`. >90 = high, >70 = confident, <50 = low confidence. CDR3-region average used as a TCR-pMHC docking quality flag (Lu et al. 2025, [Issue #316](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/316)). *Domain: bio.*
 
 **pMHC** — peptide-MHC. The complex of a peptide bound in the MHC groove; the molecular target a TCR recognises. "TCR-pMHC interaction" = the central event in adaptive immune recognition. *Domain: bio.*
 

--- a/research/news_log.md
+++ b/research/news_log.md
@@ -23,6 +23,10 @@ Historical entries (before 2026-05-02) pre-date the time/editor sub-heading conv
 - **uv 0.11.12** ([2026-05-08 release](https://github.com/astral-sh/uv/releases)) — minor patch bump from 0.11.8 (logged 2026-05-01). → No action. *Developer. industry-standard.*
 - **PyTorch 2.11.0** ([March 2026 release](https://github.com/pytorch/pytorch/releases)) — Pascal/Maxwell removal still stands per 2.8 cut; no change to our `torch<2.5` pin permanence on P100. → No action; pin permanent. *Developer. pipeline-relevant.*
 
+### 08:30 UTC — Editor: Scientist (back-filled 2026-05-11)
+
+- **Lu et al. — Benchmarking TCR-pMHC structure prediction** ([bioRxiv 2025-11-30](https://www.biorxiv.org/content/10.64898/2025.11.30.691400v1.full)) — n=70 unseen complexes, 10 methods; AF3 leads on accuracy + docking; CDR3-pLDDT rerank gives +4.3% Top-1 success on medium-quality predictions. → [Issue #316](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/316) (Sci, AF3 + CDR3-pLDDT eval). *Scientist. portfolio-differentiator.*
+
 ## 2026-05-09
 
 ### 09:21 UTC — Editor: PM


### PR DESCRIPTION
## Summary
- Back-fill 2026-05-10 Lu et al. (bioRxiv) news_log entry — yesterday's Sci session filed [Issue #316](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/316) but the news_log entry was missed.
- Add **CDR3** glossary entry and expand the existing **pLDDT** stub — both referenced by the new news_log entry.

## Test plan
- [x] Visual review of news_log.md entry rendering
- [x] Verify CDR3/pLDDT cross-links to [Issue #316](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/316)

🤖 Generated with [Claude Code](https://claude.com/claude-code)