### PR TITLE
docs(news_log): am 2026-05-12 — Snakemake 9.20 + PyTorch 2.12 + libdeflate

### DIFF
--- a/research/news_log.md
+++ b/research/news_log.md
@@ -11,6 +11,14 @@ Historical entries (before 2026-05-02) pre-date the time/editor sub-heading conv
 
 ---
 
+## 2026-05-12
+
+### 08:57 UTC — Editor: Developer
+
+- **Snakemake 9.20.0 + 8→9 migration is small** ([changelog](https://snakemake.readthedocs.io/en/stable/project_info/history.html), [migration guide](https://snakemake.readthedocs.io/en/stable/getting_started/migration.html)) — only 1 breaking change (custom logger API via `--logger` / `OutputSettings.log_handler_settings`); much lighter than 7→8. → Re-scope [Issue #200](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/200) (Snakemake 9.x migration) lower. *Developer. pipeline-relevant.*
+- **PyTorch 2.12 ships 2026-05-13** ([release key dates](https://dev-discuss.pytorch.org/t/pytorch-release-2-12-key-dates/3329)) — CUDA 13.2 experimental + Blackwell expansion; no Pascal revival. → No action; `torch<2.5` pin stays permanent on P100. *Developer. pipeline-relevant.*
+- **libdeflate 1.26 still missing from bioconda samtools** (deps still pinned `<1.26.0a0`) — `hisat2.yaml` system-samtools workaround remains permanent. → No action; revisit [Issue #237](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/237) when bioconda lifts the cap. *Developer. pipeline-relevant.*
+
 ## 2026-05-11
 
 ### 10:04 UTC — Editor: Developer


### PR DESCRIPTION
**Created by:** Developer

## Summary

Three pipeline-relevant items from this morning's Developer briefing:

- **Snakemake 9.20.0 + 8→9 migration is small** — only 1 breaking change (custom logger API via `--logger` / `OutputSettings.log_handler_settings`), much lighter than 7→8. Re-scopes [Issue #200](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/200) (Snakemake 9.x migration) lower; follow-up comment to land there.
- **PyTorch 2.12 ships 2026-05-13** — CUDA 13.2 experimental + Blackwell expansion; no Pascal revival → `torch<2.5` pin stays permanent on P100.
- **libdeflate 1.26 still missing from bioconda samtools** — `hisat2.yaml` system-samtools workaround remains permanent ([Issue #237](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/237) still unblocked).

## Test plan

- [x] Markdown renders cleanly (links + bullet hierarchy)
- [x] New `## 2026-05-12` section inserted at the top of `news_log.md`
- [x] No lab notebook entry required (news_log PRs are exempt per `shared/reference_news_log.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)