### PR TITLE
docs(news-log): pm 2026-05-12 09:31 UTC — Hierarchy view GA + Code Agent Orchestra

### DIFF
--- a/research/news_log.md
+++ b/research/news_log.md
@@ -13,6 +13,11 @@ Historical entries (before 2026-05-02) pre-date the time/editor sub-heading conv
 
 ## 2026-05-12
 
+### 09:31 UTC — Editor: PM
+
+- **GitHub Projects "Hierarchy view" GA** (2026-03-19, [changelog](https://github.blog/changelog/2026-03-19-hierarchy-view-in-github-projects-is-now-generally-available/)) — nested sub-issues now render on the board (8 levels), inline create + drag-to-reparent. → User-facing only; agent-side `gh api .../sub_issues` unchanged (new rule `feedback_ui_vs_agent.md`). *PM. tooling-signal.*
+- **AddyOsmani — "The Code Agent Orchestra"** ([blog post](https://addyosmani.com/blog/code-agent-orchestra/)) — essay on what makes multi-agent coding work; convergent with PM/Sci/Dev orchestrator pattern. → [Issue #337](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/337) (PM, landscape doc + backfill). *PM. methodology-signal.*
+
 ### 09:06 UTC — Editor: Scientist
 
 - **Onkar et al. — Bhardwaj-lab cancer vaccine field synthesis** ([Cell Rep Med 2026](https://www.cell.com/cell-reports-medicine/fulltext/S2666-3791(25)00648-2)) — neoantigen + ICI convergence; off-the-shelf shared-NA vaccines named as emerging strategy. → [Issue #334](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/334) (Sci, DISCUSSION clinical-translation framing). *Scientist. portfolio-differentiator.*


### PR DESCRIPTION
## Summary

Two PM news items appended to `research/news_log.md`:

- **GitHub Projects "Hierarchy view" GA** (2026-03-19) — sub-issues now render nested on the board with 8 levels of depth, drag-to-reparent, sub-issue-aware filters. User-facing UI only; `gh api .../sub_issues` calls unchanged for the agent (per new `feedback_ui_vs_agent.md` rule captured this morning).
- **AddyOsmani — "The Code Agent Orchestra"** — methodology essay on what makes multi-agent coding work; convergent with our PM/Sci/Dev orchestrator pattern. → [Issue #337](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/337) (landscape doc scaffold + backfill).

## Test plan

- [ ] News log renders with two new bullets under `### 09:31 UTC — Editor: PM` above the existing Developer 08:57 UTC entry (newest editor session at top)
- [ ] Bullets follow the `~25-word keyword clause` length convention (`feedback_news_log_length.md`)
- [ ] Issue references use the link + prefix + keyword convention (`#337` → `[Issue #337](url) (landscape doc)`)
- [ ] No regression on prior entries — only insertion, no edits

**Created by:** PM

🤖 Generated with [Claude Code](https://claude.com/claude-code)