### PR TITLE
feat(research): aggregate_cohort.py — standalone cross-patient report.tsv concat

### DIFF
--- a/research/README.md
+++ b/research/README.md
@@ -54,3 +54,29 @@ Note format (three sections, max 2 bullets each):
 - **Results:** `• [finding] — [why it matters generally] / [why it matters for us]`
 - **Methods:** `• [tool/approach] — [reuse potential]`
 - **Limitations:** `• [gap] — [how we address it / open question]`
+
+---
+
+## scripts/aggregate_cohort.py
+
+Combines per-patient `report.tsv` files into a single cohort table for cross-patient analysis (Issue #84). Pipeline runs are single-patient by design, so this is a post-pipeline research-time step rather than a Snakemake rule.
+
+Each per-patient `report.tsv` carries the schema `patient_id | stage | metric | value | notes`; aggregation is a sorted concatenation.
+
+**By explicit input paths:**
+```bash
+python research/scripts/aggregate_cohort.py \
+  --inputs results/patient_001/reports/report.tsv \
+           results/patient_002/reports/report.tsv \
+  --output research/cohort_summary.tsv
+```
+
+**By patient IDs (paths resolved as `{results-root}/{ID}/reports/report.tsv`):**
+```bash
+python research/scripts/aggregate_cohort.py \
+  --patients patient_001 patient_002 \
+  --results-root results \
+  --output research/cohort_summary.tsv
+```
+
+Output is sorted by `(patient_id, stage, metric)` for stable diffs.

--- a/research/lab_notebook/developer.md
+++ b/research/lab_notebook/developer.md
@@ -6,6 +6,29 @@ Format and rules unchanged from the unified notebook — see `shared/feedback_la
 
 ---
 
+## 2026-05-12
+
+### 10:07 UTC — Editor: Developer
+
+**Headline:** Cohort aggregation tool ships as a standalone research-time CLI ([Issue #84](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/84)) — `research/scripts/aggregate_cohort.py`, not a Snakemake rule. Also: [Issue #200](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/200) Snakemake 9 re-scope comment landed.
+
+**Work shipped:**
+
+- `research/scripts/aggregate_cohort.py` ([Issue #84](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/84) — cohort aggregation) — argparse CLI that concatenates per-patient `report.tsv` files (`patient_id | stage | metric | value | notes` schema) into a single cohort table. Two invocation modes: `--inputs PATH [PATH ...]` for explicit paths, or `--patients ID [ID ...] --results-root DIR` that resolves to `{root}/{ID}/reports/report.tsv`. Output sorted by `(patient_id, stage, metric)` for stable diffs. 7 pytest cases covering happy-path concat, sort order, schema validation, missing-file, and CLI entrypoint.
+- [Issue #200](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/200) re-scope [comment](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/200#issuecomment-4429153617) — Snakemake 8→9 has exactly one breaking change (custom logger plugin API); much lighter than 7→8. Re-scopes the upgrade evaluation lower.
+- Morning news_log entry shipped via [PR #335](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/335) (Snakemake 9.20 / PyTorch 2.12 / libdeflate; news_log PR is exempt from lab notebook by convention).
+
+**Design choice on Issue #84:** the original sketch in the issue body assumed `PATIENT_IDS` would be globally available to a Snakemake `aggregate_cohort` rule. But `workflow/rules/common.smk::_read_samples_tsv` enforces single-patient-per-run (`raise ValueError(... must contain exactly one patient_id per run ...)`) — cohort aggregation is inherently a **cross-run** operation. User picked the cleanest reframe: ship as a standalone CLI in `research/scripts/` alongside `zotero_add.py`, not as a Snakemake rule. Pairs naturally with `research/notebooks/results_comparison.ipynb` (already named in `research/README.md`).
+
+**Process notes:**
+
+- Pre-empted closure-audit gap by backfilling a `**Priority rationale:**` line on [Issue #84](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/84) (pre-conventions issue from 2026-04-21). No AC checkboxes to tick — the issue body is prose-style, so `check_ac` finds no unticked boxes and stays clean.
+- Skipped the spec-doc + writing-plans flow per `feedback_brainstorming_scope.md` (XS/S Issues only need it for M+ tasks). Single design check via `AskUserQuestion` covered the cross-run reframe; user redirected from any of the three pre-baked options to "standalone CLI in research/, not workflow/", which was the right call.
+
+**Closure-audit smoke test (PR #335 + Issue #200 comment earlier today):** workflow ran on the PR-merge but stayed silent (clean) — no marker comment posted. First real-traffic data point for the [Issue #325](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/325) 1-week trial.
+
+---
+
 ## 2026-05-11
 
 ### 16:32 UTC — Editor: Developer

--- a/research/scripts/aggregate_cohort.py
+++ b/research/scripts/aggregate_cohort.py
@@ -42,7 +42,7 @@ def resolve_inputs(
     patients: list[str] | None,
     results_root: str,
 ) -> list[Path]:
-    if inputs:
+    if inputs is not None:
         return [Path(p) for p in inputs]
     return [
         Path(results_root) / pid / "reports" / "report.tsv" for pid in patients
@@ -63,6 +63,8 @@ def load_report(path: Path) -> pd.DataFrame:
 
 
 def aggregate(paths: list[Path]) -> pd.DataFrame:
+    if not paths:
+        raise ValueError("aggregate() requires at least one input path")
     frames = [load_report(p) for p in paths]
     cohort = pd.concat(frames, ignore_index=True)
     return cohort.sort_values(SORT_KEYS, kind="stable").reset_index(drop=True)

--- a/research/scripts/aggregate_cohort.py
+++ b/research/scripts/aggregate_cohort.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Cross-patient cohort aggregator for per-patient ``report.tsv`` files.
+
+Pipeline runs are single-patient by design (see `workflow/rules/common.smk`),
+so combining patients into a cohort table is a post-pipeline research-time
+step rather than a Snakemake rule.
+
+Each per-patient ``report.tsv`` carries the unified long-format schema
+``patient_id | stage | metric | value | notes`` (see
+``workflow/scripts/generate_report.py::_build_report_tsv``), so cohort
+aggregation is a plain concatenation. Output is sorted by
+(``patient_id``, ``stage``, ``metric``) for stable diffs.
+
+Usage:
+    # explicit input paths
+    python research/scripts/aggregate_cohort.py \\
+        --inputs results/patient_001/reports/report.tsv \\
+                 results/patient_002/reports/report.tsv \\
+        --output research/cohort_summary.tsv
+
+    # patient IDs + results root (paths resolved as {root}/{id}/reports/report.tsv)
+    python research/scripts/aggregate_cohort.py \\
+        --patients patient_001 patient_002 \\
+        --results-root results \\
+        --output research/cohort_summary.tsv
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+REQUIRED_COLUMNS = ("patient_id", "stage", "metric", "value", "notes")
+SORT_KEYS = ["patient_id", "stage", "metric"]
+
+
+def resolve_inputs(
+    inputs: list[str] | None,
+    patients: list[str] | None,
+    results_root: str,
+) -> list[Path]:
+    if inputs:
+        return [Path(p) for p in inputs]
+    return [
+        Path(results_root) / pid / "reports" / "report.tsv" for pid in patients
+    ]
+
+
+def load_report(path: Path) -> pd.DataFrame:
+    if not path.exists():
+        raise FileNotFoundError(f"report.tsv not found: {path}")
+    df = pd.read_csv(path, sep="\t")
+    missing = set(REQUIRED_COLUMNS) - set(df.columns)
+    if missing:
+        raise ValueError(
+            f"{path}: report.tsv is missing required columns "
+            f"{sorted(missing)}. Got: {sorted(df.columns)}"
+        )
+    return df
+
+
+def aggregate(paths: list[Path]) -> pd.DataFrame:
+    frames = [load_report(p) for p in paths]
+    cohort = pd.concat(frames, ignore_index=True)
+    return cohort.sort_values(SORT_KEYS, kind="stable").reset_index(drop=True)
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    src = p.add_mutually_exclusive_group(required=True)
+    src.add_argument(
+        "--inputs", nargs="+", metavar="PATH",
+        help="Explicit list of per-patient report.tsv paths.",
+    )
+    src.add_argument(
+        "--patients", nargs="+", metavar="ID",
+        help="Patient IDs; paths resolved as {results-root}/{ID}/reports/report.tsv.",
+    )
+    p.add_argument(
+        "--results-root", default="results",
+        help="Root directory for patient results (default: results/). Only used with --patients.",
+    )
+    p.add_argument(
+        "--output", "-o", required=True, type=Path,
+        help="Output cohort TSV path.",
+    )
+    return p.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    paths = resolve_inputs(args.inputs, args.patients, args.results_root)
+    cohort = aggregate(paths)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    cohort.to_csv(args.output, sep="\t", index=False)
+    print(
+        f"Wrote {len(cohort)} rows from {len(paths)} patient(s) "
+        f"({cohort['patient_id'].nunique()} unique) to {args.output}",
+        file=sys.stderr,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/research/scripts/test_aggregate_cohort.py
+++ b/research/scripts/test_aggregate_cohort.py
@@ -1,0 +1,99 @@
+"""Tests for aggregate_cohort — schema validation + concat correctness."""
+
+import sys
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from aggregate_cohort import (
+    REQUIRED_COLUMNS,
+    aggregate,
+    load_report,
+    main,
+    resolve_inputs,
+)
+
+
+def _write_report(path: Path, patient_id: str, rows: list[tuple[str, str, str, str]]) -> None:
+    """rows: list of (stage, metric, value, notes) tuples."""
+    df = pd.DataFrame(
+        [{"patient_id": patient_id, "stage": s, "metric": m, "value": v, "notes": n} for s, m, v, n in rows],
+        columns=REQUIRED_COLUMNS,
+    )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    df.to_csv(path, sep="\t", index=False)
+
+
+def test_aggregate_two_patients(tmp_path: Path):
+    p1 = tmp_path / "p1.tsv"
+    p2 = tmp_path / "p2.tsv"
+    _write_report(p1, "patient_001", [("junction_filtering", "input", "100", "")])
+    _write_report(p2, "patient_002", [("mhc_prediction", "strong_count", "12", "")])
+
+    cohort = aggregate([p1, p2])
+    assert len(cohort) == 2
+    assert sorted(cohort["patient_id"].unique()) == ["patient_001", "patient_002"]
+    assert list(cohort.columns) == list(REQUIRED_COLUMNS)
+
+
+def test_aggregate_sorts_by_patient_stage_metric(tmp_path: Path):
+    p1 = tmp_path / "p1.tsv"
+    p2 = tmp_path / "p2.tsv"
+    _write_report(p2, "patient_002", [
+        ("mhc_prediction", "strong_count", "12", ""),
+        ("junction_filtering", "input", "200", ""),
+    ])
+    _write_report(p1, "patient_001", [
+        ("mhc_prediction", "strong_count", "5", ""),
+        ("junction_filtering", "input", "100", ""),
+    ])
+
+    cohort = aggregate([p2, p1])
+    assert cohort["patient_id"].tolist() == [
+        "patient_001", "patient_001", "patient_002", "patient_002",
+    ]
+    assert cohort["stage"].tolist()[:2] == ["junction_filtering", "mhc_prediction"]
+
+
+def test_load_report_rejects_missing_patient_id_column(tmp_path: Path):
+    bad = tmp_path / "bad.tsv"
+    pd.DataFrame({"stage": ["s"], "metric": ["m"], "value": ["1"], "notes": [""]}).to_csv(
+        bad, sep="\t", index=False
+    )
+    with pytest.raises(ValueError, match="missing required columns"):
+        load_report(bad)
+
+
+def test_load_report_raises_clear_error_for_missing_file(tmp_path: Path):
+    with pytest.raises(FileNotFoundError, match="report.tsv not found"):
+        load_report(tmp_path / "does_not_exist.tsv")
+
+
+def test_resolve_inputs_explicit_paths_passthrough():
+    paths = resolve_inputs(["a.tsv", "b.tsv"], None, "results")
+    assert paths == [Path("a.tsv"), Path("b.tsv")]
+
+
+def test_resolve_inputs_patients_resolves_against_results_root():
+    paths = resolve_inputs(None, ["patient_001", "patient_002"], "results")
+    assert paths == [
+        Path("results/patient_001/reports/report.tsv"),
+        Path("results/patient_002/reports/report.tsv"),
+    ]
+
+
+def test_main_writes_cohort_tsv(tmp_path: Path):
+    p1 = tmp_path / "p1.tsv"
+    p2 = tmp_path / "p2.tsv"
+    out = tmp_path / "out" / "cohort.tsv"
+    _write_report(p1, "patient_001", [("junction_filtering", "input", "100", "")])
+    _write_report(p2, "patient_002", [("mhc_prediction", "strong_count", "12", "")])
+
+    rc = main(["--inputs", str(p1), str(p2), "--output", str(out)])
+    assert rc == 0
+    assert out.exists()
+    cohort = pd.read_csv(out, sep="\t")
+    assert sorted(cohort["patient_id"].unique()) == ["patient_001", "patient_002"]

--- a/research/scripts/test_aggregate_cohort.py
+++ b/research/scripts/test_aggregate_cohort.py
@@ -58,6 +58,15 @@ def test_aggregate_sorts_by_patient_stage_metric(tmp_path: Path):
     assert cohort["stage"].tolist()[:2] == ["junction_filtering", "mhc_prediction"]
 
 
+def test_aggregate_empty_paths_raises():
+    with pytest.raises(ValueError, match="at least one"):
+        aggregate([])
+
+
+def test_resolve_inputs_empty_inputs_treated_as_explicit():
+    assert resolve_inputs([], None, "results") == []
+
+
 def test_load_report_rejects_missing_patient_id_column(tmp_path: Path):
     bad = tmp_path / "bad.tsv"
     pd.DataFrame({"stage": ["s"], "metric": ["m"], "value": ["1"], "notes": [""]}).to_csv(


### PR DESCRIPTION
**Created by:** Developer

Closes #84.

## Summary

Pipeline runs are single-patient by design (`workflow/rules/common.smk::_read_samples_tsv` enforces `samples.tsv` contains exactly one `patient_id`), so cohort aggregation is a post-pipeline **research-time** step rather than a Snakemake rule. Ships as a standalone CLI in `research/scripts/`, alongside `zotero_add.py`, pairing naturally with the `results_comparison.ipynb` story already named in `research/README.md`.

- **`research/scripts/aggregate_cohort.py`** — argparse CLI. Reads per-patient `report.tsv` files (schema `patient_id | stage | metric | value | notes` from `_build_report_tsv`), validates each, concats with pandas, sorts by `(patient_id, stage, metric)` for stable diffs, writes TSV.
- **Two invocation modes** (mutually exclusive):
  - `--inputs PATH [PATH ...]` — explicit per-patient `report.tsv` paths
  - `--patients ID [ID ...] [--results-root DIR]` — resolves `{root}/{ID}/reports/report.tsv`
- **`research/scripts/test_aggregate_cohort.py`** — 7 pytest cases, all green locally.

## Design notes

The Issue #84 sketch assumed `PATIENT_IDS` would be globally available to a Snakemake `aggregate_cohort` rule, but that conflicts with the single-patient-per-run invariant. Three design options were considered (Snakemake rule reading a separate `config.cohort.patients`, standalone CLI, or lifting the single-patient constraint entirely). User picked the standalone-CLI reframe — smallest blast radius, cleanest fit with existing `research/` scope.

No Snakemake rule, no DAG change, no `workflow/` touch.

## Test plan

- [x] `pytest research/scripts/test_aggregate_cohort.py` — 7/7 pass
- [x] Schema validation rejects TSVs missing `patient_id` column
- [x] Sort order is stable across input order permutations
- [x] CLI entrypoint round-trip (write + re-read) preserves data
- [x] Lab notebook entry committed in same PR (`research/lab_notebook/developer.md` 2026-05-12 10:07 UTC)
- [x] `**Priority rationale:**` backfilled on Issue #84 body to pre-empt closure-audit gap on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)