### PR TITLE
docs(manuscript): cite Onkar/Bhardwaj 2026 in DISCUSSIONS clinical-translation section

### DIFF
--- a/research/lab_notebook/scientist.md
+++ b/research/lab_notebook/scientist.md
@@ -8,6 +8,18 @@ Format and rules unchanged from the unified notebook — see `shared/feedback_la
 
 ## 2026-05-12
 
+### 10:16 UTC — Editor: Scientist
+
+#### [Issue #334](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/334) — Onkar/Bhardwaj 2026 DISCUSSION citation
+
+Picked up [Issue #334](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/334) from Backlog as a short ship before lunch. Work is the natural follow-on to the morning news_log entry; Zotero entry was already attached this morning (key `P6K7QWR4`) so this PR is purely manuscript-side.
+
+**DISCUSSIONS.md edit.** Added a new opening paragraph to the *Clinical translation: durability of personalized neoantigen vaccines in low-mutation tumors* section (before the existing "Among multiple active personalized neoantigen vaccine trials..." paragraph). The opener uses Onkar et al. as the analytical-synthesis framing — neoantigen + ICI convergence + off-the-shelf shared-NA vaccines as the emerging strategy + manufacturing-time / biomarker as unsolved field-wide problems. Naturally bookends with the existing trial-pipeline reference (Iamukova & Alferova 2026) and sets up the Kwok subsection downstream where the personalized-vs-shared axis is concretely treated for splice neoantigens.
+
+**REFERENCES.md.** Added Onkar et al. entry under `## O` (alphabetically between O'Donnell and Ott), with full DOI metadata (`10.1016/j.xcrm.2025.102575`) and `→ Cited in DISCUSSIONS.md (clinical translation section; field synthesis)` annotation. Added matching row to the *All current in-text citations* cross-reference table. Not marked with ★ since Onkar/Bhardwaj is not in the original 8-paper inventory of [parent Issue #232](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/232) / [Issue #272](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/272); it's a discretionary morning-news addition.
+
+**Issue body typo.** AC 1 references `DISCUSSION.md` (singular) but the actual file is `DISCUSSIONS.md` (plural) — corrected in the Issue body when ticking the AC. Pre-merge body edit; not a hidden change.
+
 ### 09:06 UTC — Editor: Scientist
 
 #### Morning routine — news_log + Zotero + [Issue #334](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/334) (Onkar et al. 2026 cancer-vaccine field synthesis)

--- a/research/lab_notebook/scientist.md
+++ b/research/lab_notebook/scientist.md
@@ -8,6 +8,16 @@ Format and rules unchanged from the unified notebook — see `shared/feedback_la
 
 ## 2026-05-12
 
+### 12:10 UTC — Editor: Scientist
+
+#### [PR #340](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/340) review pass — citation-form fix on [Issue #334](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/334)
+
+Back from lunch. [@claude review](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/340#issuecomment-4429566946) flagged one substantive item on [PR #340](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/340): the in-text citation `(Onkar et al., *Cell Rep Med* 2026; Bhardwaj lab)` reads as a two-work citation because a semicolon inside `()` is the standard separator for multiple sources (e.g. `(Smith 2020; Jones 2021)`). The bot's catch is correct — lab attributions belong in prose, not citation brackets.
+
+**Fix.** Moved Bhardwaj lab attribution into prose: `a recent field synthesis from the Bhardwaj lab (Onkar et al., *Cell Rep Med* 2026) identifies…`. Re-wrapped the paragraph to the file's ~78-char convention (line 438 had drifted to 97 chars post-edit). Diff scope: 7 lines changed in [`research/manuscript/DISCUSSIONS.md`](research/manuscript/DISCUSSIONS.md), no other files.
+
+All other review items (alphabetical placement, cross-reference table, lab notebook ordering, no-★ marking, DOI/volume year discrepancy) cleared as correct — no further action needed.
+
 ### 10:16 UTC — Editor: Scientist
 
 #### [Issue #334](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/334) — Onkar/Bhardwaj 2026 DISCUSSION citation

--- a/research/manuscript/DISCUSSIONS.md
+++ b/research/manuscript/DISCUSSIONS.md
@@ -433,13 +433,13 @@ scoring throughout.
 ## Clinical translation: durability of personalized neoantigen vaccines in low-mutation tumors
 
 The personalized neoantigen vaccine paradigm has consolidated into a
-recognisable trajectory: a recent field synthesis (Onkar et al., *Cell Rep Med*
-2026; Bhardwaj lab) identifies neoantigen-based vaccines in combination with
-immune checkpoint inhibitors as the convergent direction of cancer vaccinology,
-and highlights "off-the-shelf" shared-neoantigen vaccines as the emerging
-strategy to bypass the manufacturing time and cost of fully personalized
-formulations. Manufacturing turnaround and biomarker discovery for response
-prediction remain field-wide unsolved problems.
+recognisable trajectory: a recent field synthesis from the Bhardwaj lab (Onkar
+et al., *Cell Rep Med* 2026) identifies neoantigen-based vaccines in combination
+with immune checkpoint inhibitors as the convergent direction of cancer
+vaccinology, and highlights "off-the-shelf" shared-neoantigen vaccines as the
+emerging strategy to bypass the manufacturing time and cost of fully
+personalized formulations. Manufacturing turnaround and biomarker discovery for
+response prediction remain field-wide unsolved problems.
 
 Among multiple active personalized neoantigen vaccine trials spanning
 head-and-neck (TG4050), melanoma (mRNA-4157/V940), pancreatic (autogene

--- a/research/manuscript/DISCUSSIONS.md
+++ b/research/manuscript/DISCUSSIONS.md
@@ -432,6 +432,15 @@ scoring throughout.
 
 ## Clinical translation: durability of personalized neoantigen vaccines in low-mutation tumors
 
+The personalized neoantigen vaccine paradigm has consolidated into a
+recognisable trajectory: a recent field synthesis (Onkar et al., *Cell Rep Med*
+2026; Bhardwaj lab) identifies neoantigen-based vaccines in combination with
+immune checkpoint inhibitors as the convergent direction of cancer vaccinology,
+and highlights "off-the-shelf" shared-neoantigen vaccines as the emerging
+strategy to bypass the manufacturing time and cost of fully personalized
+formulations. Manufacturing turnaround and biomarker discovery for response
+prediction remain field-wide unsolved problems.
+
 Among multiple active personalized neoantigen vaccine trials spanning
 head-and-neck (TG4050), melanoma (mRNA-4157/V940), pancreatic (autogene
 cevumeran), and other indications (Iamukova & Alferova, *Asia-Pacific Journal

--- a/research/manuscript/REFERENCES.md
+++ b/research/manuscript/REFERENCES.md
@@ -87,6 +87,9 @@
 **O'Donnell et al., *Cell Syst* 2020** — MHCflurry 2.0: Improved pan-allele prediction of MHC class I-presented peptides by incorporating antigen processing. *Cell Syst* 2020;11(1):42–48.
 → Cited in DISCUSSIONS.md (MHC binding prediction section; composite presentation score)
 
+**Onkar et al., *Cell Rep Med* 2026** — Pipe dream to pipeline: Journey of cancer vaccines and the road ahead. *Cell Rep Med* 2026;7(2):102575. doi:10.1016/j.xcrm.2025.102575
+→ Cited in DISCUSSIONS.md (clinical translation section; field synthesis — neoantigen + ICI convergence, off-the-shelf shared-NA vaccines)
+
 **Ott et al., *Nature* 2017** — An immunogenic personal neoantigen vaccine for patients with melanoma. *Nature* 2017;547(7662):217–221. doi:10.1038/nature22991
 → Cited in INTRODUCTION.md, DISCUSSIONS.md (vaccine slot efficiency; 10–20 candidates per trial)
 
@@ -200,6 +203,7 @@ The original 8-paper inventory plus Kwok 2025 and Kim 2025 (both added after the
 | Lang et al., *Bioinform Adv* 2024 | ✅ | |
 | McKeithan, *PNAS* 1995 | ✅ | |
 | O'Donnell et al., *Cell Syst* 2020 | ✅ | Manuscript uses full form ("Cell Systems"); also year-before-journal ordering |
+| Onkar et al., *Cell Rep Med* 2026 | ✅ | |
 | Ott et al., *Nature* 2017 | ✅ | |
 | Palmer et al., *Cancer Res Commun* 2024 | ✅ | Manuscript uses full form ("Cancer Research Communications") |
 | Peacock et al., *Bioinformatics* 2023 | ✅ | |


### PR DESCRIPTION
## Summary

- Adds Onkar et al. (*Cell Rep Med* 2026; Bhardwaj lab) as the field-synthesis opener of the *Clinical translation* section in DISCUSSIONS.md. Frames the personalized-vs-shared neoantigen axis at field level, setting up the existing trial-pipeline reference (Iamukova & Alferova 2026) and the downstream Kwok subsection.
- New REFERENCES.md entry under O (between O'Donnell and Ott) with full DOI metadata; cross-reference table row added. Not ★-marked — outside the original 8-paper inventory of [Issue #232](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/232) / [Issue #272](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/272).
- Lab notebook entry on the manuscript edit.
- Post-review fix (`5577f5e`): moved Bhardwaj lab attribution into prose to remove citation-form ambiguity (semicolon inside `()` reads as a multi-source separator); paragraph re-wrapped to file convention. Per [@claude review](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/340#issuecomment-4429566946).

Closes #334.

## Test plan

- [x] Visual review of DISCUSSIONS.md edit rendering (new paragraph at start of clinical translation section, before existing "Among multiple active..." paragraph)
- [x] REFERENCES.md: alphabetical placement (O'Donnell → Onkar → Ott) + cross-reference table row visible
- [x] Lab notebook entry order (newest at top within 2026-05-12 — 12:10 UTC above 10:16 UTC above the existing 09:06 UTC)
- [x] Citation form consistent: "Onkar et al., *Cell Rep Med* 2026" everywhere — zero instances of "Bhardwaj et al." in DISCUSSIONS.md / REFERENCES.md (per the author-form correction)
- [x] [Issue #334](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/334) body shows the pre-merge corrections (Bhardwaj → Onkar + DISCUSSION → DISCUSSIONS) + 4/4 ACs ticked

**Created by:** Scientist