### PR TITLE
docs(manuscript): clarify duplicate-peptide dedup in RESULTS.md patient_001 section

### DIFF
--- a/research/lab_notebook/scientist.md
+++ b/research/lab_notebook/scientist.md
@@ -8,6 +8,16 @@ Format and rules unchanged from the unified notebook — see `shared/feedback_la
 
 ## 2026-05-12
 
+### 12:30 UTC — Editor: Scientist
+
+#### [Issue #342](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/342) — RESULTS.md prose: duplicate-peptide dedup misrepresentation
+
+User scrutiny pass on the patient_001 RESULTS.md tables surfaced a count discrepancy: *Peptide Translation* reports `Total = 1,286,492` / `Unique sequences = 1,260,074`, while *MHC Presentation Predictions* reports `Total predictions = 1,286,492` — suggesting MHCflurry is called on non-deduped peptides (~26k wasted predictions). Traced [`run_mhcflurry.py`](workflow/scripts/run_mhcflurry.py): dedup happens at [line 427](workflow/scripts/run_mhcflurry.py#L427) (`peptides_df["peptide"].unique()`), prediction runs on the 1,260,074 unique sequences only, then the predictions are merge-joined back to all 1,286,492 source rows at [line 475](workflow/scripts/run_mhcflurry.py#L475) to preserve `contig_key`/`start_nt` traceability.
+
+**Verdict:** compute is already efficient; the prose just misrepresents the design. Current wording *"one prediction per input peptide; duplicate sequences from different junctions or reading frames are each predicted separately"* is factually wrong — duplicates are predicted **once** and **replicated across source rows**, not predicted independently.
+
+**Fix.** Rewrote `RESULTS.md` lines 72–76 to explicitly state: (a) one row per input peptide position in the output; (b) MHCflurry runs only on the 1,260,074 unique sequences internally; (c) predictions are joined back per source row for `contig_key`/`start_nt` traceability. Added inline code links to `run_mhcflurry.py:427` + `:475` so a future reader can verify directly. Patient_002 section grepped clean — no equivalent misleading prose to fix.
+
 ### 12:10 UTC — Editor: Scientist
 
 #### [PR #340](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/340) review pass — citation-form fix on [Issue #334](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/334)

--- a/research/manuscript/RESULTS.md
+++ b/research/manuscript/RESULTS.md
@@ -72,7 +72,7 @@ complete-codon junction-spanning filter applied. `peptide_lengths: [8, 9, 10]`
 97.9% of peptides are unique sequences. Peptide totals are computed in
 `research/notebooks/patient_001_results.ipynb` §3 from `peptides_novel.tsv`;
 the total matches `report.tsv` `mhc_prediction.total_predictions` because the
-prediction output preserves one row per input peptide position. Internally,
+output TSV preserves one row per input peptide position. Internally,
 MHCflurry is run only on the 1,260,074 unique sequences (see
 [`run_mhcflurry.py:427`](workflow/scripts/run_mhcflurry.py#L427)) and the
 predictions are joined back to each source row

--- a/research/manuscript/RESULTS.md
+++ b/research/manuscript/RESULTS.md
@@ -71,9 +71,13 @@ complete-codon junction-spanning filter applied. `peptide_lengths: [8, 9, 10]`
 
 97.9% of peptides are unique sequences. Peptide totals are computed in
 `research/notebooks/patient_001_results.ipynb` §3 from `peptides_novel.tsv`;
-the total matches `report.tsv` `mhc_prediction.total_predictions` (one prediction
-per input peptide; duplicate sequences from different junctions or reading frames
-are each predicted separately).
+the total matches `report.tsv` `mhc_prediction.total_predictions` because the
+prediction output preserves one row per input peptide position. Internally,
+MHCflurry is run only on the 1,260,074 unique sequences (see
+[`run_mhcflurry.py:427`](workflow/scripts/run_mhcflurry.py#L427)) and the
+predictions are joined back to each source row
+([`run_mhcflurry.py:475`](workflow/scripts/run_mhcflurry.py#L475)) to retain
+the `contig_key`/`start_nt` mapping.
 
 ### MHC Presentation Predictions
 


### PR DESCRIPTION
## Summary

- Rewrites the *Peptide Translation* paragraph in [`RESULTS.md:72-79`](research/manuscript/RESULTS.md#L72-L79) (patient_001 section) to correctly describe duplicate-peptide handling.
- Previous prose claimed *"duplicate sequences from different junctions or reading frames are each predicted separately"* — this is wrong. MHCflurry runs only on the 1,260,074 unique sequences ([`run_mhcflurry.py:427`](workflow/scripts/run_mhcflurry.py#L427)); the 1,286,492 output rows come from joining predictions back to all source positions ([`run_mhcflurry.py:475`](workflow/scripts/run_mhcflurry.py#L475)) to preserve `contig_key`/`start_nt` traceability.
- Patient_002 mirror section has no equivalent misleading prose (grepped clean).
- Lab notebook entry.
- Post-review polish (`ff5ad5a`): `"prediction output"` → `"output TSV"` for precision (intermediate `pred_df` vs final TSV). Per [@claude review](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/343#issuecomment-4430609135) non-blocking nit.

Closes #342.

## Test plan

- [x] `RESULTS.md:72-79` reads as: one row per input peptide position; MHCflurry runs on unique sequences only; predictions joined back to source rows for traceability
- [x] Inline `run_mhcflurry.py:427` + `:475` links render correctly on GitHub
- [x] Patient_002 section (lines ~210–227) untouched
- [x] Lab notebook 2026-05-12 entry order: 12:30 UTC above 12:10 UTC above 10:16 UTC above 09:06 UTC
- [x] No factual claims beyond what the code actually does (cross-check against `run_mhcflurry.py` lines 427/443-444/475)

**Created by:** Scientist