### PR TITLE
feat(research): scaffold multi-agent landscape doc + backfill 6 items (closes #337)

### DIFF
--- a/research/lab_notebook/pm.md
+++ b/research/lab_notebook/pm.md
@@ -8,6 +8,29 @@ Format and rules unchanged from the unified notebook — see `shared/feedback_la
 
 ## 2026-05-12
 
+### 14:32 UTC — Editor: PM
+
+#### [Issue #337](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/337) scaffold — multi-agent orchestration landscape doc + PR-body minimalism rule
+
+**Doc scaffold.** Created `research/multi_agent_landscape.md` with three sections: Frameworks (Symphony, Managed Agents, Fugu), Methodology / framing (Trends Report, Mason, Code Agent Orchestra), Our position. Each backfilled entry has source link, one-line summary, rationale tagged **Observe / Pattern-confirmation / Counter-position / Pattern borrow + roster reject / Direct reinforcement / Convergent vocabulary** — six distinct stances surfacing the asymmetry between borrowing the *pattern* (one orchestrator + N specialists) and the *roster* (PM/Sci/Dev) on a per-item basis. "Our position" reproduces the 3 framing rules inline (since the cerebrum repo is gitignored and not portfolio-readable) plus the 3-layer orchestration shape (human → PM → Sci/Dev).
+
+**Cross-link side of the work.** Updated all 3 framing memories (`feedback_multi_role_not_multi_agent`, `feedback_domain_bespoke_roles`, `feedback_cerebrum_vs_project`) with a closing `**Cross-reference:**` block pointing at the landscape doc. Goal: when a future role re-reads a framing memory in isolation, they discover the landscape doc as the curated synthesis — and when they read the landscape doc, the inline rationales bottom out at the framing memories. Reciprocal pointers, no duplicated content.
+
+**Reference + workflow hook.** Registered the landscape doc in `shared/reference_docs_inventory.md` as a stale-watch artifact. Maintenance hook lives in PM's `feedback_morning_routine.md` Step 0 ("How to apply"): when news_log gets a `methodology-signal` entry, scan against the landscape doc and pick (a) backfill, (b) update existing rationale, or (c) skip. No new reference memory file created — keeping rule-proliferation in check (same discipline as yesterday's [16:31 UTC] entry where I folded the news-cap into existing morning-routine files instead of spawning `feedback_news_issue_cap.md`).
+
+**PR-body minimalism rule (mid-session capture).** User asked, *"do you feel the PR body is redundant?"* — looking at [PR #341](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/341)'s Summary section (5 bullets that mirrored the lab-notebook entry's `####` topic headings), yes. The lab notebook IS the artifact; markdown renders in the diff view; the Summary section was content re-serialization. User caught me drafting it as a new file (`feedback_lab_notebook_pr_body.md`) — same rule-proliferation slip I just praised yesterday's entry for avoiding. Reverted to extending `shared/feedback_lab_notebook.md` with a new "PR body — minimal, no content re-serialization" section + template + Why + How to apply. Today's [PR #341](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/341) became the "before" example (immutable; merged). This PR is the first one using the new template.
+
+**Design rationale — why "living .md" over parent-issue-with-sub-issues.** This decision was made earlier today during the morning routine; recording the full reasoning here. Three framings were on the table:
+- Parent-issue-with-sub-issues (one Issue per framework) — high signal/board churn for items that may never become work; many would just sit as `methodology-signal: observe` with no action.
+- Living .md with portfolio framing (chosen) — low-ceremony append; reviewer can read all six items + our rationale in one place; doubles as portfolio artifact.
+- Lightweight notes append (just keep extending news_log) — chronological order obscures by-framework comparison; no synthesis surface.
+
+The first option is rejected by the "Issue cap from news" rule (1/day, concrete-hook gate); the third option fails the synthesis test. Living .md is the only framing that survives both constraints.
+
+**Process meta — `gh issue develop` flag name slip.** Used `--branch` then got an error showing the correct flag is `--name`. Minor; not memory-worthy. Worth noting only because the per-role branch-creation rule (`feedback_branch_creation.md`) emphasizes `gh issue develop`, but doesn't pin the flag name — and the gh help output is the source of truth, not memory.
+
+**Side-thread: stray reflog cleanup.** During the rebase-before-write step, `git fetch` failed with `fatal: bad object refs/heads/docs/scientist/issue-334-bhardwaj-discussion 2`. Diagnosis: a stray reflog file with literal " 2" suffix in `.git/logs/refs/heads/docs/scientist/` (macOS Finder copy artifact from 11:00 today). Confirmed it was a reflog (history), not a ref (branch state); the actual branch lives in the scientist worktree. User approved deletion; fetch restored. Logged here because it's the kind of incident future-grep might want to find — search "fatal: bad object refs/heads/" + "Finder copy" lands here.
+
 ### 12:02 UTC — Editor: PM
 
 #### Morning routine: UI-vs-agent rule capture + [Issue #337](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/337) creation + closure-audit retro-backfill realization

--- a/research/multi_agent_landscape.md
+++ b/research/multi_agent_landscape.md
@@ -54,6 +54,12 @@ Essays and reports that shape how the field talks about itself. Distinct from fr
 - **Summary:** Essay on what makes multi-agent coding work — section roles, conductor metaphor.
 - **Our rationale:** **Convergent vocabulary.** Maps cleanly onto our 3-layer orchestration: human (conductor) → PM (section leader) → Sci/Dev (instrumentalists). No new action items — this landscape doc itself ([Issue #337](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/337)) is the response to the essay.
 
+### digitalapplied — "Pattern Language 2026"
+
+- **Source:** [digitalapplied, 2026-05](https://www.digitalapplied.com/blog/multi-agent-orchestration-patterns-producer-consumer)
+- **Summary:** Formal taxonomy reducing every reliable multi-agent system to 5 archetypes — producer (decomposes ambiguity into work items), consumer (executes them), coordinator (routes + bounded fan-out), critic (suggestions, no gate authority), judge (binary go/no-go). 12 composition rules (acyclicity, idempotent consumers, bounded fan-out, etc.); 8 predictable failure modes (cycle formation, critic-judge deadlock, coordinator overload, silent drift, others). Maps cleanly to LangGraph, CrewAI, OpenAI Agents SDK, Claude Agent SDK without changing the underlying shape.
+- **Our rationale:** **Vocabulary candidate — open question.** Distinct from AddyOsmani above (essay vs. taxonomy) and from the Trends Report (coding-scoped vs. domain-agnostic). Possible re-description of our shape: `human = meta-coordinator → PM = coordinator + judge → Scientist = producer + critic + Developer = consumer + producer (infra) + critic`. The 8-failure-mode list doubles as a portfolio audit lens (have we hit critic-judge deadlock? silent drift?). Decision tracked via [Issue #353](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/353) (PM vocabulary adoption).
+
 ---
 
 ## Our position

--- a/research/multi_agent_landscape.md
+++ b/research/multi_agent_landscape.md
@@ -14,7 +14,7 @@ Concrete products / tooling that could plausibly displace, augment, or be borrow
 
 ### Anthropic Managed Agents — Dreaming + Multiagent Orchestration
 
-- **Source:** [9to5Mac coverage, 2026-05-07](https://9to5mac.com/2026/05/07/anthropic-updates-claude-managed-agents-with-three-new-features/)
+- **Source:** [Anthropic blog, 2026-05-06](https://claude.com/blog/new-in-claude-managed-agents)
 - **Summary:** Agents review past sessions to self-improve ("dreaming"); a lead agent delegates to specialists rather than the human dispatching each role.
 - **Our rationale:** **Observe.** Dreaming is the closest production analog to our `/cerebrum` memory-rehydration pattern. Orchestrator-delegation is what PM does for Sci/Dev today, *but in our setup the human opens the next session* — we don't have agent-to-agent triggers (per [multi-role, not multi-agent](#our-position)). Tracking via [Issue #305](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/305) (PM eval + memory tightening borrow).
 

--- a/research/multi_agent_landscape.md
+++ b/research/multi_agent_landscape.md
@@ -1,0 +1,91 @@
+# Multi-agent / agentic-coding orchestration — landscape
+
+Curated reference of the multi-agent / agentic-coding field with one-line summaries, our rationale per item, and links to internal Issues and framing memories. Doubles as a portfolio artifact (we surveyed the field; we're not cargo-culting) and a project memory aid (where prior reasoning on Symphony, Fugu, Managed Agents, etc. lives without re-grepping `news_log.md`).
+
+Maintained by PM. Updated when `news_log.md` entries get tagged `methodology-signal` — see [Maintenance](#maintenance) at the bottom.
+
+For our position relative to this landscape — why PM/Sci/Dev, why "multi-role" instead of "multi-agent" — see [Our position](#our-position).
+
+---
+
+## Frameworks
+
+Concrete products / tooling that could plausibly displace, augment, or be borrowed from for our PM/Sci/Dev workflow.
+
+### Anthropic Managed Agents — Dreaming + Multiagent Orchestration
+
+- **Source:** [9to5Mac coverage, 2026-05-07](https://9to5mac.com/2026/05/07/anthropic-updates-claude-managed-agents-with-three-new-features/)
+- **Summary:** Agents review past sessions to self-improve ("dreaming"); a lead agent delegates to specialists rather than the human dispatching each role.
+- **Our rationale:** **Observe.** Dreaming is the closest production analog to our `/cerebrum` memory-rehydration pattern. Orchestrator-delegation is what PM does for Sci/Dev today, *but in our setup the human opens the next session* — we don't have agent-to-agent triggers (per [multi-role, not multi-agent](#our-position)). Tracking via [Issue #305](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/305) (PM eval + memory tightening borrow).
+
+### OpenAI Symphony
+
+- **Source:** Reported late April 2026 (no public docs yet — pattern-only)
+- **Summary:** Enterprise multi-agent orchestration; uses PM-style project boards as the control plane for coding agents.
+- **Our rationale:** **Pattern-confirmation, no action.** The "boards-as-control-plane" framing matches what we do — GitHub Projects v2 IS our PM/Sci/Dev coordination surface (Status / Priority / Size / Target Date fields drive triage). Product itself targets corporate teams (not solo/research), so no adoption path. Confirms the convergent pattern.
+
+### Sakana Fugu
+
+- **Source:** [Sakana 2026 (beta)](https://sakana.ai/fugu-beta/)
+- **Summary:** Multi-agent orchestration as a foundation model — dynamically assembles agent teams from a pool, no fixed roles.
+- **Our rationale:** **Explicit counter-position.** Opposite of our fixed PM/Sci/Dev split — per [Role decomposition is domain-bespoke](#our-position), our roster is intentionally bespoke to bioinformatics research (Scientist exists because literature/biology reasoning has no analog in pure coding). Fugu optimises for generality; we optimise for domain fit. Still borrowed three secondary mechanics: [Issue #324](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/324) (model routing per task type), [Issue #325](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/325) (post-merge critic), [Issue #326](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/326) (memory consolidation).
+
+---
+
+## Methodology / framing
+
+Essays and reports that shape how the field talks about itself. Distinct from frameworks above — these change vocabulary and mental model, not tooling.
+
+### Anthropic 2026 Agentic Coding Trends Report
+
+- **Source:** Anthropic 2026 (PDF; tracked via [Issue #235](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/235))
+- **Summary:** Industry data on multi-agent coding workflows. Proposes canonical 4-specialist split: Architecture & Design / Implementation & Coding / Testing & Validation / Review & Docs.
+- **Our rationale:** **Pattern borrow + roster reject.** Convergent pattern (one orchestrator + multiple specialists, each with own context) applies. Roster doesn't — that report is scoped to *coding*; we're scoped to bioinformatics research, where literature integration and biological interpretation have no analog in pure coding (so Scientist instead of Designer). Primary source for both [Role decomposition is domain-bespoke](#our-position) and [multi-role, not multi-agent](#our-position). Skim + 5 PM-practices cross-checks in [Issue #235](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/235).
+
+### Mason — "Coherence Through Orchestration, Not Autonomy"
+
+- **Source:** [Mike Mason, Jan 2026](https://mikemason.ca/writing/ai-coding-agents-jan-2026/)
+- **Summary:** Argues "multi-agent" coding works because of orchestration discipline, not agent autonomy.
+- **Our rationale:** **Direct reinforcement.** Primary external source for [multi-role, not multi-agent](#our-position) — we don't claim autonomy, we claim disciplined orchestration. The user is the message bus; agents communicate via human-readable artifacts (standup, sub-issues). No action — already internalised.
+
+### AddyOsmani — "The Code Agent Orchestra"
+
+- **Source:** [AddyOsmani blog, 2026-05-12](https://addyosmani.com/blog/code-agent-orchestra/)
+- **Summary:** Essay on what makes multi-agent coding work — section roles, conductor metaphor.
+- **Our rationale:** **Convergent vocabulary.** Maps cleanly onto our 3-layer orchestration: human (conductor) → PM (section leader) → Sci/Dev (instrumentalists). No new action items — this landscape doc itself ([Issue #337](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/337)) is the response to the essay.
+
+---
+
+## Our position
+
+We describe this project as a **human-orchestrated multi-role workflow**, not a "multi-agent system." Three internal framing notes (PM-shared memory files; reproduced inline here so this doc is self-contained) pin this down:
+
+1. **"multi-role, not multi-agent."** Industry "multi-agent" usage implies agent-to-agent autonomy — fire-and-forget orchestration, self-organising task assignment. What we have is role-bound Claude Code sessions (PM / Sci / Dev) where *the human is the message bus*: when one role flags work for another, the human opens the other session and surfaces the flag. Agents never trigger each other. Calling this "multi-agent" overclaims; "multi-role workflow" is honest.
+
+2. **Role decomposition is domain-bespoke.** The *pattern* (one orchestrator + multiple specialists, each with own context window) is convergent across the field. The *roster* (PM/Sci/Dev) is bespoke to bioinformatics research — literature integration, biological interpretation, hypothesis design, and results analysis have no analog in pure coding work, so we factor that out as a Scientist role. Other domains would warrant different specialists: UI product → Designer; deployed service → SRE; ML research → Modeller/Data specialist. Future role additions (Cloud Eng, Writer) get justified by domain need, not by analogy to other projects' rosters.
+
+3. **Cerebrum vs project scope.** Cerebrum is the multi-agent meta-framework that lives *above* all projects and roles — it defines the role pattern, memory format conventions, role-binding mechanics. This project (splice-neoepitope-pipeline) is one *instance* using Cerebrum. Frameworks evaluated in this landscape doc are weighed against *this project's* needs (bioinformatics-research workflow), not Cerebrum's meta-level concerns. Cross-project generality is a separate question.
+
+**3-layer orchestration shape:**
+
+```
+human  (conductor / high-level orchestrator — decides what to build, who to dispatch)
+  └─ PM  (section leader / low-level orchestrator — triages, scopes Issues, runs morning routine)
+       ├─ Scientist  (literature, biology, hypothesis, results interpretation)
+       └─ Developer  (implementation, testing, CI, infrastructure)
+```
+
+The standup file (`pm/shared/team_standup.md`), the GitHub Projects v2 board, and the per-role Cerebrum memory directories are the durable substrates that make role-bound sessions coherent across time and across context-window resets.
+
+---
+
+## Maintenance
+
+PM-owned. Update triggers:
+
+- News_log entry tagged `methodology-signal` lands → PM scans during morning routine, decides whether to add an entry here (or whether the item belongs only in news_log).
+- New framing memory in `pm/shared/` cross-references this doc → update [Our position](#our-position) to mention it.
+- New Issue concretely borrows from or extends a framework listed here → backfill the framework's rationale block with the Issue link.
+- Framework deprecated or pivoted → don't delete the entry; update the rationale with the deprecation note (the doc is a journal of *which* options we considered, not just current options).
+
+Last sweep: 2026-05-12 (initial scaffold; 6 backfilled items: Symphony, Trends Report, Managed Agents, Mason, Fugu, Code Agent Orchestra).


### PR DESCRIPTION
**Created by:** PM

## Summary

Scaffolds `research/multi_agent_landscape.md` per [Issue #337](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/337) — see the diff for the doc itself + the lab notebook entry covering design rationale.

Closes [Issue #337](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/337)

## Test plan

- [x] `research/multi_agent_landscape.md` exists with all 6 backfilled items (Symphony, Trends Report, Managed Agents, Mason, Fugu, Code Agent Orchestra)
- [x] "Our position" section cites the 3 framing memories inline (self-contained for portfolio readers)
- [x] Cross-link footer added to all 3 framing memories (cerebrum side, not in this PR — direct edits)
- [x] PM `feedback_morning_routine.md` updated with landscape-doc maintenance hook (cerebrum side)
- [x] `shared/reference_docs_inventory.md` registers the doc as a stale-watch artifact (cerebrum side)
- [x] Lab notebook entry placed at top of pm.md (2026-05-12 14:32 UTC)
- [x] Branch cut from `origin/main` via `gh issue develop`; rebased before lab notebook entry
- [x] PR body uses new minimal template per `shared/feedback_lab_notebook.md` "PR body" rule
- [x] Pattern Language 2026 entry added to Methodology section (commit 1cf8dc1, this morning)
- [x] Managed Agents source swapped from 9to5Mac → Anthropic primary blog (commit 9d66f17, per Claude review)
