### PR TITLE
docs(manuscript): presenter terminology caveat + pivot phantom Jiang citation to O'Donnell 2020

### DIFF
--- a/research/lab_notebook/scientist.md
+++ b/research/lab_notebook/scientist.md
@@ -8,6 +8,18 @@ Format and rules unchanged from the unified notebook — see `shared/feedback_la
 
 ## 2026-05-12
 
+### 21:10 UTC — Editor: Scientist
+
+#### [Issue #347](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/347) — manuscript §6 hygiene: presenter terminology + phantom Jiang citation cleanup
+
+Terminology-drift scan on `research/manuscript/*` surfaced two bundled issues.
+
+**Issue 1 — phantom citation.** Three places (METHODS.md:202, DISCUSSIONS.md:280-282, REFERENCES.md:56) cited *"Jiang et al. (2024, Communications Biology)"* as the precedent for the 0.5%/2% percentile threshold on MHCflurry's `presentation_percentile`. REFERENCES.md entry had placeholder title "TBD" and the paper cannot be located via Zotero, PubMed, or web search — confirmed unverifiable. Pivoted to O'Donnell et al. 2020 (MHCflurry 2.0, *Cell Systems*, DOI `10.1016/j.cels.2020.06.010`) — the actual source of MHCflurry's documented default cutoffs, already in REFERENCES.md (line 87) but missing from Zotero. Added O'Donnell to Zotero (key `SBQGHWRP`) with three-section note.
+
+**Issue 2 — presenter terminology drift.** Two lines described our pipeline's own outputs using legacy "binder" vocab: METHODS.md:233 ("top strong-binding candidate" → "top strong-presenting candidate") and INTRODUCTION.md:119 ("qualifies as a strong binder" → "…strong presenter"). The remaining 7 "X-binder threshold" hits across the manuscript reference the IEDB/NetMHCPan binder-percentile convention — rather than rewrite all 7, added an explicit *Note on terminology* caveat at METHODS §6 that acknowledges the adaptation and names the cutoffs as "strong/weak presenter thresholds" throughout. INTRODUCTION.md:125 "strongest-binding epitope" legitimately retained (cites Yewdell & Bennink 1999 immunodominance framework — sourced biological vocabulary).
+
+**Edits.** 8 surgical edits across REFERENCES.md (4 — Jiang entry removal + O'Donnell "Cited in" update + tracking-table row + title-TBD list), METHODS.md (2 — caveat + line 233), DISCUSSIONS.md (1 — line 280-282 O'Donnell pivot), INTRODUCTION.md (1 — line 119).
+
 ### 12:30 UTC — Editor: Scientist
 
 #### [Issue #342](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/342) — RESULTS.md prose: duplicate-peptide dedup misrepresentation

--- a/research/lab_notebook/scientist.md
+++ b/research/lab_notebook/scientist.md
@@ -6,6 +6,23 @@ Format and rules unchanged from the unified notebook — see `shared/feedback_la
 
 ---
 
+## 2026-05-13
+
+### 08:45 UTC — Editor: Scientist
+
+#### [PR #349](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/349) bot-review follow-up — 3 residual presenter-drift fixes + REFERENCES "Cited in" tweak
+
+[@claude review](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/349#issuecomment-4434913139) on yesterday's manuscript §6 hygiene PR flagged 3 residual binder-vocab hits I'd intentionally left untouched (they describe our pipeline's own quality-gate output, originally classified borderline). Bot's argument was sharp: the terminology caveat I added asserts "throughout this manuscript", so leaving these contradicts the scope claim. Fixing is the cheaper path than narrowing the note's scope.
+
+**Fixes.**
+- [`METHODS.md`](research/manuscript/METHODS.md) §6 ranking-and-quality-gate paragraph: `weak-binder threshold` → `weak-presenter threshold`; `non-binding alleles` → `non-presenting alleles`.
+- [`DISCUSSIONS.md`](research/manuscript/DISCUSSIONS.md) §"MHC presentation prediction": rewrote `prioritizing candidates that are both strongly bound and well processed` → `prioritizing strong presenters — candidates that combine high MHC affinity with efficient antigen processing` (avoids the "presented + processed" double-counting that MHCflurry 2.x's combined `presentation_score` would otherwise create).
+- [`REFERENCES.md`](research/manuscript/REFERENCES.md) O'Donnell "Cited in" line: `MHC binding prediction section` → `MHC presentation prediction section`. Internal tracking should also follow the manuscript's chosen vocabulary, per the bot's minor catch.
+
+**Deferred.** Bot's secondary observation that the parenthetical `(no allele reaches weak-presenter threshold)` is redundant with the `best_presentation_percentile > 2%` condition — left as a separate style call.
+
+---
+
 ## 2026-05-12
 
 ### 21:10 UTC — Editor: Scientist

--- a/research/lab_notebook/scientist.md
+++ b/research/lab_notebook/scientist.md
@@ -8,6 +8,26 @@ Format and rules unchanged from the unified notebook — see `shared/feedback_la
 
 ## 2026-05-13
 
+### 09:25 UTC — Editor: Scientist
+
+#### [PR #349](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/349) bot 2nd-pass follow-up — 2 more drift fixes in Calibration note + L421 parenthetical drop
+
+[@claude review 2nd pass](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/349#issuecomment-4439100502) confirmed the DISCUSSIONS apposition from the [08:45 UTC commit](research/lab_notebook/scientist.md) is appropriately explanatory (not redundant) and surfaced 3 new hits in the *Calibration note: presentation_score vs. presentation_percentile* subsection that weren't in scope of the first review.
+
+**Fixes (caveat-coherence):**
+- [`DISCUSSIONS.md:411`](research/manuscript/DISCUSSIONS.md) — `weak-binder threshold` → `weak-presenter threshold` (describes pipeline gate behavior).
+- [`DISCUSSIONS.md:423`](research/manuscript/DISCUSSIONS.md) — `weak-binder percentile threshold` → `weak-presenter percentile threshold` (same).
+
+**L421 parenthetical drop — scientifically motivated, not just drift:**
+
+Bot called L421 (`(non-binder territory)`) "defensible either way" — covered by the §6 caveat as field-convention orientation. User pushed back with a sharper critique: the phrase *sounds* like quantitative inference of poor binding from a 3–5% percentile, but `presentation_percentile` is **rank-relative to a random peptide background for that allele**, not absolute affinity. On a promiscuous allele like HLA-A\*02:01, a peptide at 3–5% percentile can still have a competitive IC50 (~200 nM) — it's just outranked by many similarly-scoring peptides in the calibration pool. The parenthetical undercuts the very scale-mismatch argument the surrounding paragraph is trying to motivate.
+
+Resolution: drop the parenthetical entirely on L421. L423 immediately below already explicitly states the gate-failure consequence (`"while all alleles remain below the weak-presenter percentile threshold"`), so dropping is genuinely lossless and cleaner scientifically.
+
+**Style call retained as deferred:** bot's first-pass observation that the parenthetical `(no allele reaches weak-presenter threshold)` on METHODS.md:230 is redundant with `> 2%` — still open, separate style call.
+
+---
+
 ### 08:45 UTC — Editor: Scientist
 
 #### [PR #349](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/349) bot-review follow-up — 3 residual presenter-drift fixes + REFERENCES "Cited in" tweak

--- a/research/lab_notebook/scientist.md
+++ b/research/lab_notebook/scientist.md
@@ -8,6 +8,20 @@ Format and rules unchanged from the unified notebook — see `shared/feedback_la
 
 ## 2026-05-13
 
+### 09:34 UTC — Editor: Scientist
+
+#### [PR #349](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/349) pre-merge grep — one more drift fix at INTRODUCTION:147; section header retained
+
+Final pre-merge `grep -nE "binder|binding"` across `research/manuscript/*.md` surfaced one more caveat-coherence drift hit the bot's two passes missed:
+
+- [`INTRODUCTION.md:147`](research/manuscript/INTRODUCTION.md) — `at least one allele must reach strong or weak binder threshold` → `strong or weak presenter threshold` (describes our pipeline's quality gate, same category as METHODS §6 fix).
+
+**Section-header question closed without rename.** Grep also flagged DISCUSSIONS.md:251 section header `## MHC binding prediction: composite presentation score over affinity-only` and made the REFERENCES.md "Cited in" tweak from [87be2db](research/manuscript/REFERENCES.md) look like it pointed at a non-existent literal header. Inspected: the section's title structure is `Topic: our choice`, where "MHC binding prediction" names the broader field category and "composite presentation score over affinity-only" names our position within it. Renaming `binding` → `presentation` in the header would (a) collapse the rhetorical contrast the section is built around, and (b) create the awkward `"presentation prediction: composite presentation score..."` tautology. The REFERENCES tweak remains valid as an internal-vocabulary description of where O'Donnell is cited; it doesn't require literal header-match because the cross-ref isn't an anchor link.
+
+All other `binder/binding` grep hits classify as biological reality (binding affinity, peptide-binding grooves), Yewdell-quote retention, broader step-name references (the pipeline step is conventionally "MHC binding prediction" across the field), or the §6 caveat itself naming the field convention.
+
+---
+
 ### 09:25 UTC — Editor: Scientist
 
 #### [PR #349](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/349) bot 2nd-pass follow-up — 2 more drift fixes in Calibration note + L421 parenthetical drop

--- a/research/manuscript/DISCUSSIONS.md
+++ b/research/manuscript/DISCUSSIONS.md
@@ -408,7 +408,7 @@ The committed role of each signal in this pipeline is therefore:
 | `best_presentation_percentile` | **Minimum quality gate** | Ensures ≥1 allele generates sufficient pMHC density for T cell recognition at the tumor |
 
 `best_presentation_percentile` as a quality gate means a candidate is filtered out if no
-allele meets the weak-binder threshold (presentation_percentile ≤ 2%), regardless of its
+allele meets the weak-presenter threshold (presentation_percentile ≤ 2%), regardless of its
 genotype_presentation_score — not used to rank candidates against one another.
 
 ### Calibration note: presentation_score vs. presentation_percentile
@@ -418,9 +418,9 @@ The `genotype_presentation_score` formula uses `presentation_score` (an absolute
 of `presentation_score` among a large allele-specific random peptide set). These two
 metrics are calibrated on different scales and can disagree: for a promiscuous allele
 where many random peptides score well, a `presentation_score` of 0.4 may correspond to a
-`presentation_percentile` of 3–5% (non-binder territory). In such a case, six alleles
+`presentation_percentile` of 3–5%. In such a case, six alleles
 each with `presentation_score = 0.4` would yield `genotype_presentation_score ≈ 0.95`
-while all alleles remain below the weak-binder percentile threshold. A peptide could
+while all alleles remain below the weak-presenter percentile threshold. A peptide could
 therefore pass the `genotype_presentation_score` ranking stage but be eliminated by the
 quality gate — which is the
 intended behavior, since the gate is designed to catch exactly this scenario. Future work

--- a/research/manuscript/DISCUSSIONS.md
+++ b/research/manuscript/DISCUSSIONS.md
@@ -277,9 +277,8 @@ A single classification label `presentation_class` is derived from `presentation
 returns one prediction per peptide — the best-allele score across the patient's HLA-A/B/C
 alleles.
 
-The 0.5% strong threshold is the cutoff used by Jiang et al. (2024, *Communications
-Biology*) for MHCflurry-PS predictions. The 2.0% weak threshold is the conventional
-affinity-percentile cutoff applied in the field.
+The 0.5% strong and 2% weak cutoffs are MHCflurry's documented defaults (O'Donnell
+et al. 2020, *Cell Systems*), inheriting the IEDB/NetMHCPan binder-percentile convention.
 
 Epitopes are ranked by `presentation_percentile` (ascending), prioritizing candidates
 that are both strongly bound and well processed — the subset most likely to be immunogenic.

--- a/research/manuscript/DISCUSSIONS.md
+++ b/research/manuscript/DISCUSSIONS.md
@@ -280,8 +280,9 @@ alleles.
 The 0.5% strong and 2% weak cutoffs are MHCflurry's documented defaults (O'Donnell
 et al. 2020, *Cell Systems*), inheriting the IEDB/NetMHCPan binder-percentile convention.
 
-Epitopes are ranked by `presentation_percentile` (ascending), prioritizing candidates
-that are both strongly bound and well processed — the subset most likely to be immunogenic.
+Epitopes are ranked by `presentation_percentile` (ascending), prioritizing strong
+presenters — candidates that combine high MHC affinity with efficient antigen
+processing — as the subset most likely to be immunogenic.
 
 Note: `affinity_percentile` is not included in the output because
 `Class1PresentationPredictor.predict()` (MHCflurry 2.2.x) does not expose it directly.

--- a/research/manuscript/INTRODUCTION.md
+++ b/research/manuscript/INTRODUCTION.md
@@ -144,7 +144,7 @@ formulation (typically 10–20 candidates in current clinical trials; Sahin et a
 *Nature* 2017; Ott et al., *Nature* 2017), GPS becomes the committed primary
 ranking criterion for our application. `best_presentation_percentile` is retained not as a
 competing ranking dimension but as a minimum quality gate — at least one allele must reach
-strong or weak binder threshold to ensure sufficient pMHC density for vaccine-primed T
+strong or weak presenter threshold to ensure sufficient pMHC density for vaccine-primed T
 cells to recognize the tumor at the site of disease.
 
 ### Differential surface expression across HLA loci

--- a/research/manuscript/INTRODUCTION.md
+++ b/research/manuscript/INTRODUCTION.md
@@ -116,7 +116,7 @@ Allele breadth is also clinically relevant beyond the initial ranking:
   three alleles has three independent opportunities to engage a cognate T cell in the
   patient's repertoire.
 
-The integer count of alleles for which a peptide qualifies as a strong binder
+The integer count of alleles for which a peptide qualifies as a strong presenter
 (`n_strong_alleles`) provides a secondary signal: among peptides with equal
 GPS, a peptide classified as strong by three alleles is a
 biologically cleaner winner than one with one strong and five near-zero predictions.

--- a/research/manuscript/METHODS.md
+++ b/research/manuscript/METHODS.md
@@ -227,8 +227,8 @@ Candidates are ranked by `genotype_presentation_score` (descending) as the prima
 with `n_strong_alleles` (descending) as a secondary tie-breaker and
 `best_presentation_percentile` (ascending) as a tertiary tie-breaker. A candidate is
 excluded from the top-candidates list if `best_presentation_percentile > 2%` (no allele
-reaches weak-binder threshold), providing a quality gate against high-GPS candidates
-composed entirely of non-binding alleles.
+reaches weak-presenter threshold), providing a quality gate against high-GPS candidates
+composed entirely of non-presenting alleles.
 
 ---
 

--- a/research/manuscript/METHODS.md
+++ b/research/manuscript/METHODS.md
@@ -199,8 +199,12 @@ Peptides are assigned a single classification label based on `presentation_perce
 
 - **`presentation_class`** — strong (≤ 0.5%), weak (≤ 2%), non (> 2%)
 
-The 0.5% threshold is consistent with Jiang et al. (2024, *Communications Biology*)
-and analogous to the conventional IC50 ≤ 50 nM cutoff.
+*Note on terminology.* The 0.5% (strong) and 2% (weak) cutoffs originate as the canonical
+IEDB/NetMHCPan **binder** percentile thresholds, originally defined on binding-affinity
+percentile. We apply them here to MHCflurry's `presentation_percentile` and refer to them
+as strong/weak **presenter** thresholds throughout this manuscript. These are also
+MHCflurry's documented default thresholds (O'Donnell et al. 2020, *Cell Systems*); the
+0.5% is analogous to the conventional IC50 ≤ 50 nM cutoff.
 
 **Level 2 — genotype presentation score.**
 Per-allele scores are combined into a single genotype-level probability using a
@@ -230,7 +234,7 @@ composed entirely of non-binding alleles.
 
 ## 7. Structural Validation (TCRdock)
 
-The top strong-binding candidate is submitted to TCRdock (Bradley, *eLife* 2023) for structural
+The top strong-presenting candidate is submitted to TCRdock (Bradley, *eLife* 2023) for structural
 prediction of the TCR–peptide–MHC ternary complex. TCRdock uses a modified AlphaFold v2
 multimer backend adapted specifically for TCR:pMHC modelling. Predictions run on a GCP
 Spot GPU VM (NVIDIA P100, 16 GB) inside a Docker container to isolate CUDA/cuDNN

--- a/research/manuscript/REFERENCES.md
+++ b/research/manuscript/REFERENCES.md
@@ -78,7 +78,7 @@
 ## O
 
 **O'Donnell et al., *Cell Syst* 2020** — MHCflurry 2.0: Improved pan-allele prediction of MHC class I-presented peptides by incorporating antigen processing. *Cell Syst* 2020;11(1):42–48. doi:10.1016/j.cels.2020.06.010
-→ Cited in METHODS.md §6 (presentation thresholds; MHCflurry default cutoffs), DISCUSSIONS.md (MHC binding prediction section; composite presentation score)
+→ Cited in METHODS.md §6 (presentation thresholds; MHCflurry default cutoffs), DISCUSSIONS.md (MHC presentation prediction section; composite presentation score)
 
 **Onkar et al., *Cell Rep Med* 2026** — Pipe dream to pipeline: Journey of cancer vaccines and the road ahead. *Cell Rep Med* 2026;7(2):102575. doi:10.1016/j.xcrm.2025.102575
 → Cited in DISCUSSIONS.md (clinical translation section; field synthesis — neoantigen + ICI convergence, off-the-shelf shared-NA vaccines)

--- a/research/manuscript/REFERENCES.md
+++ b/research/manuscript/REFERENCES.md
@@ -51,13 +51,6 @@
 
 ---
 
-## J
-
-**Jiang et al., *Commun Biol* 2024** — [MHCflurry presentation score threshold — title TBD]. *Commun Biol* 2024.
-→ Cited in METHODS.md §6, DISCUSSIONS.md (0.5% strong-binder presentation_percentile threshold)
-
----
-
 ## K
 
 **★ Kim et al., *Cell* 2025** — Mis-splicing-derived neoantigens and cognate TCRs in splicing factor mutant leukemias. *Cell* 2025. doi:10.1016/j.cell.2025.03.047
@@ -84,8 +77,8 @@
 
 ## O
 
-**O'Donnell et al., *Cell Syst* 2020** — MHCflurry 2.0: Improved pan-allele prediction of MHC class I-presented peptides by incorporating antigen processing. *Cell Syst* 2020;11(1):42–48.
-→ Cited in DISCUSSIONS.md (MHC binding prediction section; composite presentation score)
+**O'Donnell et al., *Cell Syst* 2020** — MHCflurry 2.0: Improved pan-allele prediction of MHC class I-presented peptides by incorporating antigen processing. *Cell Syst* 2020;11(1):42–48. doi:10.1016/j.cels.2020.06.010
+→ Cited in METHODS.md §6 (presentation thresholds; MHCflurry default cutoffs), DISCUSSIONS.md (MHC binding prediction section; composite presentation score)
 
 **Onkar et al., *Cell Rep Med* 2026** — Pipe dream to pipeline: Journey of cancer vaccines and the road ahead. *Cell Rep Med* 2026;7(2):102575. doi:10.1016/j.xcrm.2025.102575
 → Cited in DISCUSSIONS.md (clinical translation section; field synthesis — neoantigen + ICI convergence, off-the-shelf shared-NA vaccines)
@@ -197,7 +190,6 @@ The original 8-paper inventory plus Kwok 2025 and Kim 2025 (both added after the
 | Chiappinelli et al., *Cell* 2015 | ✅ | |
 | Coelho et al., *Cancer Cell* 2023 | ✅ | |
 | Iamukova & Alferova, *Asia-Pac J Clin Oncol* 2026 | ✅ | Manuscript uses full form ("Asia-Pacific Journal of Clinical Oncology") |
-| Jiang et al., *Commun Biol* 2024 | ✅ | |
 | Kim et al., *Cell* 2025 | ✅ | |
 | Kwok et al., *Nature* 2025 | ✅ | |
 | Lang et al., *Bioinform Adv* 2024 | ✅ | |
@@ -222,7 +214,7 @@ The original 8-paper inventory plus Kwok 2025 and Kim 2025 (both added after the
 
 ### Open items before submission
 
-1. **Add titles** for entries with title TBD: Trolle et al. 2016, Zemmour & Parham 1992, van Bergen et al. 2004, Bagaev et al., Chen & McCluskey, Coelho et al., Jiang et al., Peacock et al., Sade-Feldman et al. Non-blocking placeholders; titles to be filled before journal submission.
+1. **Add titles** for entries with title TBD: Trolle et al. 2016, Zemmour & Parham 1992, van Bergen et al. 2004, Bagaev et al., Chen & McCluskey, Coelho et al., Peacock et al., Sade-Feldman et al. Non-blocking placeholders; titles to be filled before journal submission.
 2. **Journal-name style normalization** — abbreviated form is the stated house style here, but several recent in-text citations use full forms (`Frontiers in Immunology`, `Nature Methods`, `NAR Genomics and Bioinformatics`, `Cancer Research Communications`). Decide one style and sweep all of `INTRODUCTION.md`, `METHODS.md`, `DISCUSSIONS.md` to match. Non-blocking until pre-submission proofread.
 3. **Citation ordering inconsistency in METHODS.md** — METHODS.md uses year-before-journal format (e.g. `Lang et al., 2024, *Bioinform Adv*` at line 68, `Avsec et al., 2026, *Nature*` at line 76, `Szolek et al., 2014` at line 89, `van Bergen et al., 2004` at line 213) while INTRODUCTION.md and DISCUSSIONS.md use the house-style year-after-journal form (`*Journal* YEAR`). Sweep METHODS.md to match house style during pre-submission proofread. Distinct from the abbreviated-vs-full journal-name issue (item #2).
 4. **AlphaGenome validation strategy entry** — pending [Issue #271](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/271) closure (deferred until [Issue #203](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/203) closes; may add new in-text citations for predicted-normal validation evidence).


### PR DESCRIPTION
**Created by:** Scientist

## Summary

Bundled manuscript hygiene for [Issue #347](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/347) (manuscript §6 hygiene): pivots a phantom unverifiable citation and resolves presenter-terminology drift in §6 and adjacent sections.

### What changed

**1. Phantom citation pivoted.** "Jiang et al. (2024, Communications Biology)" was cited as precedent for MHCflurry's 0.5%/2% percentile threshold in 3 manuscript locations (METHODS.md, DISCUSSIONS.md, REFERENCES.md). The paper cannot be located via Zotero, PubMed, or web search — title placeholder TBD. Pivoted to O'Donnell et al. 2020 (MHCflurry 2.0, *Cell Systems*, DOI `10.1016/j.cels.2020.06.010`), the actual source of these documented default cutoffs. O'Donnell was already in REFERENCES.md but missing from Zotero — now added (key `SBQGHWRP`) with three-section note.

**2. Terminology adaptation caveat at METHODS §6.** New *"Note on terminology"* paragraph explicitly acknowledges that the 0.5%/2% percentile cutoffs originate as the canonical IEDB/NetMHCPan **binder** thresholds but are applied here to MHCflurry's `presentation_percentile`, and names them as strong/weak **presenter** thresholds throughout the manuscript. Covers the 7 remaining "X-binder threshold" hits that legitimately reference the field convention.

**3. Two drift fixes.** Lines that describe **our pipeline's own outputs** using legacy "binder" vocab:
- METHODS.md:233 "top strong-binding candidate" → "...strong-presenting candidate"
- INTRODUCTION.md:119 "qualifies as a strong binder" → "...strong presenter"

INTRODUCTION.md:125 "strongest-binding epitope" retained — sources Yewdell & Bennink 1999 immunodominance framework (cited biological vocabulary, not drift).

## Test plan

- [x] Manuscript grep for residual "binder" drift in our-pipeline contexts — done as **pre-merge** sanity (not post-merge). Two grep passes during bot-review iterations + a final 2026-05-13 09:34 UTC pass that caught one more hit (`INTRODUCTION.md:147` `strong or weak binder threshold` → `presenter threshold`) → fixed in [`8601288`](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/349/commits/8601288). Remaining `binder/binding` hits classify as biological reality, Yewdell-quote retention, broader field step-name references, or the §6 caveat itself.
- [x] O'Donnell entry in Zotero collection verified — key `SBQGHWRP`, DOI `10.1016/j.cels.2020.06.010` confirmed via Zotero API.
