### PR TITLE
feat(alignment): per-sample strandness column + --rna-strandness for HISAT2

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,13 +75,23 @@ snakemake --cores $(nproc) --use-conda ...
 
 **Conda env cleanup after `workflow/envs/*.yaml` changes:** Automatic cleanup was removed from `run_cloud_gpu.sh`. When any `workflow/envs/*.yaml` file changes, manually delete the affected old environment on the VM before running — old envs will not be rebuilt automatically and stale cached packages will be used instead.
 
-## Snakemake 8 `--configfile` Gotcha
+## Snakemake 8 Gotchas
+
+### `--configfile` flag collapsing
 In Snakemake 8, passing `--configfile` as **separate flags** (`--configfile A --configfile B`) causes the second invocation to replace the first due to argparse `nargs="+"` semantics. Only the last file is loaded.
 **Fix:** pass multiple config files in a **single** `--configfile` invocation:
 ```bash
 snakemake --configfile config/test_config.yaml config/gpu_config.yaml   # correct
 # NOT: --configfile config/test_config.yaml --configfile config/gpu_config.yaml
 ```
+
+### `srcdir()` not available at .smk module level
+`srcdir(path)` was a Snakemake-7 helper for resolving paths relative to the calling Snakefile. In Snakemake 8 it is no longer exposed at the `.smk` module scope and a top-level call (`sys.path.insert(0, srcdir("../scripts"))`) fails with `NameError: name 'srcdir' is not defined` at parse time — CI's `snakemake -n` dry-run will catch it.
+**Fix:** use `workflow.basedir` instead, which is always exposed and points at the Snakefile's directory (the repo root in this project):
+```python
+sys.path.insert(0, os.path.join(workflow.basedir, "workflow", "scripts"))
+```
+Caught in [PR #358](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/358) when a code-review suggestion swapped the working `workflow.basedir` form for the deprecated `srcdir()`.
 
 ## HISAT2 Index Cache Invalidation
 

--- a/config/samples/patient_001.tsv
+++ b/config/samples/patient_001.tsv
@@ -1,4 +1,4 @@
-patient_id	sample_id	sample_type	fastq1	fastq2	serology_A1	serology_A2	serology_B1	serology_B2	serology_C1	serology_C2
+patient_id	sample_id	sample_type	fastq1	fastq2	serology_A1	serology_A2	serology_B1	serology_B2	serology_C1	serology_C2	strandness
 # Matched gastric cancer tumor/normal pair (SRR9143066 / SRR9143065)
 # Source: https://www.ebi.ac.uk/ena/browser/view/SRR9143066
 # No clinical HLA serotyping available for this patient.

--- a/config/samples/patient_001_test.tsv
+++ b/config/samples/patient_001_test.tsv
@@ -1,3 +1,3 @@
-patient_id	sample_id	sample_type	fastq1	fastq2	serology_A1	serology_A2	serology_B1	serology_B2	serology_C1	serology_C2
+patient_id	sample_id	sample_type	fastq1	fastq2	serology_A1	serology_A2	serology_B1	serology_B2	serology_C1	serology_C2	strandness
 patient_001_test	SRR9143066_test	Primary Tumor	data/test/SRR9143066_test.fastq.gz
 patient_001_test	SRR9143065_test	Solid Tissue Normal	data/test/SRR9143065_test.fastq.gz

--- a/config/samples/patient_002.tsv
+++ b/config/samples/patient_002.tsv
@@ -1,4 +1,4 @@
-patient_id	sample_id	sample_type	fastq1	fastq2	serology_A1	serology_A2	serology_B1	serology_B2	serology_C1	serology_C2
+patient_id	sample_id	sample_type	fastq1	fastq2	serology_A1	serology_A2	serology_B1	serology_B2	serology_C1	serology_C2	strandness
 # Boston Gene osteosarcoma BG003082, paired-end RNA-seq (Nov 2022).
 # Normal sample (issue #277): Jan 2025 Hudson Lab PBMC scRNA-seq (sorted CD3+ T cells,
 # 10x 3' GEX). Single-end alignment of R2 only — R1 is barcode+UMI, not cDNA. The
@@ -12,4 +12,4 @@ patient_id	sample_id	sample_type	fastq1	fastq2	serology_A1	serology_A2	serology_
 # Serology (Red Cross): A*01:01/A*01:11N, B*08:01/B*27:05, C*01:02/C*07:01.
 # A*01:11N is a null allele (not expressed); excluded from prediction, shown in QC.
 patient_002	BG003082_T0	Primary Tumor	https://b2.osteosarc.com/rna-seq/fastq/bostongene_2022/202211_bostongene_tumor_rna_BG003082_R1.fastq.gz	https://b2.osteosarc.com/rna-seq/fastq/bostongene_2022/202211_bostongene_tumor_rna_BG003082_R2.fastq.gz
-patient_002	PBMC_scRNA_Pool1_L002	Blood Derived Normal	https://b2.osteosarc.com/hudson_lab/PBMC_scRNAseq/FASTQ/Jan2025%20%28250125%29/GEX/Pool%201/23059-22-01-01-01_S3_L002_R2_001.fastq.gz		HLA-A*01:01	HLA-A*01:11N	HLA-B*08:01	HLA-B*27:05	HLA-C*01:02	HLA-C*07:01
+patient_002	PBMC_scRNA_Pool1_L002	Blood Derived Normal	https://b2.osteosarc.com/hudson_lab/PBMC_scRNAseq/FASTQ/Jan2025%20%28250125%29/GEX/Pool%201/23059-22-01-01-01_S3_L002_R2_001.fastq.gz		HLA-A*01:01	HLA-A*01:11N	HLA-B*08:01	HLA-B*27:05	HLA-C*01:02	HLA-C*07:01	forward

--- a/research/lab_notebook/developer.md
+++ b/research/lab_notebook/developer.md
@@ -8,6 +8,30 @@ Format and rules unchanged from the unified notebook — see `shared/feedback_la
 
 ## 2026-05-13
 
+### 10:25 UTC — Editor: Developer
+
+**Headline:** [Issue #279](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/279) (HISAT2 `--rna-strandness F` for 10x R2 SE) shipped via [PR #358](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/358) — per-sample `strandness` column added to `samples.tsv`, pure helper module + 11 pytest cases, `alignment.smk` wires it through `params.strandness`. Closes [Issue #279](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/279) on merge.
+
+**Work shipped:**
+
+- **Schema:** new `strandness` column appended to `config/samples/*.tsv` headers (3 files). Values: `unstranded | forward | reverse` — biological direction, abstracted from tool-specific HISAT2 SE/PE syntax. Backward-compat: missing column / empty / unrecognized value → `unstranded` (no flag passed), preserves current pipeline behavior on `patient_001` / `patient_001_test`.
+- **Pure helper:** `workflow/scripts/strandness.py` — `get_strandness_flag(strandness, is_paired_end)` maps `(biological direction, SE/PE)` → HISAT2 flag string (`F` / `R` / `FR` / `RF` or `""`). 11 pytest cases cover recognized values × SE/PE, missing/empty (backward compat), case-insensitive normalization, unrecognized strings (graceful fallback to `""`).
+- **Rule wiring:** `workflow/rules/alignment.smk` — adds `_get_hisat2_strandness(wildcards)` wrapper that reads the row + delegates to the pure helper. `hisat2_align` gains `params.strandness`; shell conditionally injects `--rna-strandness {value}` only when non-empty (preserves current behavior on rows with no strandness entry).
+- **Sample-side change:** `patient_002` PBMC normal (`PBMC_scRNA_Pool1_L002`) → `forward` (10x R2 = sense strand per [PR #350](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/350) slide 8). All other rows default to unstranded.
+
+**Design decision (per-sample column over sample-type-driven):**
+
+User picked per-sample column over the simpler sample-type-driven default. Tradeoff: per-sample column adds samples.tsv schema change + helper module (re-sized Issue XS → S during the prep body update) but is more robust — handles future non-10x R2 normals or stranded tumors without an `if sample_type == "normal"` heuristic that would break for bulk RNA-seq normals. Documented in [Issue #279](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/279) body + [PR #358](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/358) body.
+
+**Process notes:**
+
+- TDD: wrote `test_strandness.py` (11 cases) before `strandness.py`. Tests passed on first implementation — no debugging cycle.
+- Skipped local `snakemake --dry-run` per the local-pipeline-run-ownership rule (user-only); rely on CI `pipeline-snakemake-dry-run` for rule-parse validation.
+- Skipped DAG visualization — the change adds a `params` entry to an existing rule with no new edges, so DAG topology is unchanged.
+- Issue body locked in the design decision (per-sample column) + re-sized XS → S during prep, documenting the scope change pre-code per `feedback_scope_discipline.md`.
+
+---
+
 ### 08:49 UTC — Editor: Developer
 
 **Headline:** [PR #350](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/350) review fixes + merge ([Issue #348](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/348) closes). [Issue #352](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/352) spike filed — direct evidence the "Last supporting combo is PyTorch 2.7 + CUDA ≤12.6" claim in [CLAUDE.md](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/blob/main/CLAUDE.md) is provably loose; PyTorch 2.12 cu126 wheels may keep Pascal SM 6.0 dispatch alive on our P100s.

--- a/workflow/rules/alignment.smk
+++ b/workflow/rules/alignment.smk
@@ -65,6 +65,29 @@ def _get_fastq2(wildcards):
 _JUNCTION_OUTPUT = os.path.join(_RES, "{patient_id}", "alignment", "{sample}", "junctions.tsv")
 _JUNCTION_DONE   = os.path.join(_RES, "{patient_id}", "alignment", "{sample}", "done")
 
+# Per-sample strandness support — translates samples.tsv `strandness` column
+# (biological direction: `unstranded`/`forward`/`reverse`) into the HISAT2
+# --rna-strandness flag value (`F`/`R`/`FR`/`RF` or empty). Pure helper lives
+# in workflow/scripts/strandness.py and is unit-tested in test_strandness.py.
+import sys as _sys
+_sys.path.insert(0, os.path.join(workflow.basedir, "workflow", "scripts"))
+from strandness import get_strandness_flag
+
+
+def _get_hisat2_strandness(wildcards):
+    """Resolve the HISAT2 --rna-strandness flag value for a single sample.
+
+    Returns the empty string for samples without a `strandness` column entry
+    or with `unstranded` — the rule then omits the flag entirely (preserves
+    backward compat with samples.tsv files predating this column).
+    """
+    for s in _read_samples_tsv(config["samples_tsv"], wildcards.patient_id):
+        if s["sample_id"] == wildcards.sample:
+            is_pe = bool((s.get("fastq2") or "").strip())
+            return get_strandness_flag(s.get("strandness"), is_pe)
+    return ""
+
+
 # ── HISAT2 ───────────────────────────────────────────────────────────────────
 
 if config.get("alignment", {}).get("aligner") == "hisat2":
@@ -164,6 +187,7 @@ if config.get("alignment", {}).get("aligner") == "hisat2":
             os.path.join(_LOGS, "{patient_id}", "alignment", "{sample}_align.log"),
         params:
             index_prefix=_HISAT2_INDEX_PREFIX,
+            strandness=_get_hisat2_strandness,
         threads: config.get("alignment", {}).get("threads", 8)
         resources:
             mem_mb=20000,
@@ -188,9 +212,15 @@ if config.get("alignment", {}).get("aligner") == "hisat2":
                 FASTQ_ARGS="-U {input.fastq1}"
             fi
 
+            STRANDNESS_ARGS=""
+            if [[ -n "{params.strandness}" ]]; then
+                STRANDNESS_ARGS="--rna-strandness {params.strandness}"
+            fi
+
             hisat2 \\
                 -p {threads} \\
                 -x {params.index_prefix} \\
+                $STRANDNESS_ARGS \\
                 $FASTQ_ARGS \\
                 2>> {log} | \\
                 samtools sort -@ {threads} -m 1G -o {output.bam} - 2>> {log}

--- a/workflow/rules/alignment.smk
+++ b/workflow/rules/alignment.smk
@@ -69,8 +69,10 @@ _JUNCTION_DONE   = os.path.join(_RES, "{patient_id}", "alignment", "{sample}", "
 # (biological direction: `unstranded`/`forward`/`reverse`) into the HISAT2
 # --rna-strandness flag value (`F`/`R`/`FR`/`RF` or empty). Pure helpers live
 # in workflow/scripts/strandness.py and are unit-tested in test_strandness.py.
+# `srcdir()` is unavailable in Snakemake 8 — use `workflow.basedir` (which
+# points at the Snakefile's directory, i.e. the repo root here) instead.
 import sys
-sys.path.insert(0, srcdir("../scripts"))
+sys.path.insert(0, os.path.join(workflow.basedir, "workflow", "scripts"))
 from strandness import get_strandness_from_row
 
 

--- a/workflow/rules/alignment.smk
+++ b/workflow/rules/alignment.smk
@@ -65,33 +65,31 @@ def _get_fastq2(wildcards):
 _JUNCTION_OUTPUT = os.path.join(_RES, "{patient_id}", "alignment", "{sample}", "junctions.tsv")
 _JUNCTION_DONE   = os.path.join(_RES, "{patient_id}", "alignment", "{sample}", "done")
 
-# Per-sample strandness support — translates samples.tsv `strandness` column
-# (biological direction: `unstranded`/`forward`/`reverse`) into the HISAT2
-# --rna-strandness flag value (`F`/`R`/`FR`/`RF` or empty). Pure helpers live
-# in workflow/scripts/strandness.py and are unit-tested in test_strandness.py.
-# `srcdir()` is unavailable in Snakemake 8 — use `workflow.basedir` (which
-# points at the Snakefile's directory, i.e. the repo root here) instead.
-import sys
-sys.path.insert(0, os.path.join(workflow.basedir, "workflow", "scripts"))
-from strandness import get_strandness_from_row
-
-
-def _get_hisat2_strandness(wildcards):
-    """Resolve the HISAT2 --rna-strandness flag value for a single sample.
-
-    Returns the empty string for samples without a `strandness` column entry
-    or with `unstranded` — the rule then omits the flag entirely (preserves
-    backward compat with samples.tsv files predating this column).
-    """
-    for s in _read_samples_tsv(config["samples_tsv"], wildcards.patient_id):
-        if s["sample_id"] == wildcards.sample:
-            return get_strandness_from_row(s)
-    return ""
-
-
 # ── HISAT2 ───────────────────────────────────────────────────────────────────
 
 if config.get("alignment", {}).get("aligner") == "hisat2":
+
+    # Per-sample strandness support — translates samples.tsv `strandness` column
+    # (biological direction: `unstranded`/`forward`/`reverse`) into the HISAT2
+    # --rna-strandness flag value (`F`/`R`/`FR`/`RF` or empty). Pure helpers live
+    # in workflow/scripts/strandness.py and are unit-tested in test_strandness.py.
+    # `srcdir()` is unavailable in Snakemake 8 — use `workflow.basedir` (which
+    # points at the Snakefile's directory, i.e. the repo root here) instead.
+    import sys
+    sys.path.insert(0, os.path.join(workflow.basedir, "workflow", "scripts"))
+    from strandness import get_strandness_from_row
+
+    def _get_hisat2_strandness(wildcards):
+        """Resolve the HISAT2 --rna-strandness flag value for a single sample.
+
+        Returns the empty string for samples without a `strandness` column entry
+        or with `unstranded` — the rule then omits the flag entirely (preserves
+        backward compat with samples.tsv files predating this column).
+        """
+        for s in _read_samples_tsv(config["samples_tsv"], wildcards.patient_id):
+            if s["sample_id"] == wildcards.sample:
+                return get_strandness_from_row(s)
+        return ""
 
     # Configurable index directory — allows test (chr22) and production
     # (full genome) to maintain separate indices without overwriting.

--- a/workflow/rules/alignment.smk
+++ b/workflow/rules/alignment.smk
@@ -67,11 +67,11 @@ _JUNCTION_DONE   = os.path.join(_RES, "{patient_id}", "alignment", "{sample}", "
 
 # Per-sample strandness support — translates samples.tsv `strandness` column
 # (biological direction: `unstranded`/`forward`/`reverse`) into the HISAT2
-# --rna-strandness flag value (`F`/`R`/`FR`/`RF` or empty). Pure helper lives
-# in workflow/scripts/strandness.py and is unit-tested in test_strandness.py.
-import sys as _sys
-_sys.path.insert(0, os.path.join(workflow.basedir, "workflow", "scripts"))
-from strandness import get_strandness_flag
+# --rna-strandness flag value (`F`/`R`/`FR`/`RF` or empty). Pure helpers live
+# in workflow/scripts/strandness.py and are unit-tested in test_strandness.py.
+import sys
+sys.path.insert(0, srcdir("../scripts"))
+from strandness import get_strandness_from_row
 
 
 def _get_hisat2_strandness(wildcards):
@@ -83,8 +83,7 @@ def _get_hisat2_strandness(wildcards):
     """
     for s in _read_samples_tsv(config["samples_tsv"], wildcards.patient_id):
         if s["sample_id"] == wildcards.sample:
-            is_pe = bool((s.get("fastq2") or "").strip())
-            return get_strandness_flag(s.get("strandness"), is_pe)
+            return get_strandness_from_row(s)
     return ""
 
 

--- a/workflow/scripts/strandness.py
+++ b/workflow/scripts/strandness.py
@@ -1,0 +1,23 @@
+"""Map biological strandness to HISAT2 --rna-strandness flag values.
+
+Used by alignment.smk to translate per-sample `strandness` column values
+(`unstranded` / `forward` / `reverse`) into the SE/PE flag pair that HISAT2
+expects (`F`/`R` for single-end, `FR`/`RF` for paired-end).
+"""
+
+_FORWARD = {"forward"}
+_REVERSE = {"reverse"}
+
+
+def get_strandness_flag(strandness, is_paired_end):
+    """Return the HISAT2 --rna-strandness value for a (strandness, SE/PE) pair.
+
+    Returns the empty string when unstranded, unrecognized, or missing — the
+    caller suppresses the --rna-strandness flag entirely in that case.
+    """
+    normalized = (strandness or "").strip().lower()
+    if normalized in _FORWARD:
+        return "FR" if is_paired_end else "F"
+    if normalized in _REVERSE:
+        return "RF" if is_paired_end else "R"
+    return ""

--- a/workflow/scripts/strandness.py
+++ b/workflow/scripts/strandness.py
@@ -5,19 +5,35 @@ Used by alignment.smk to translate per-sample `strandness` column values
 expects (`F`/`R` for single-end, `FR`/`RF` for paired-end).
 """
 
-_FORWARD = {"forward"}
-_REVERSE = {"reverse"}
+_VALID = {"", "unstranded", "forward", "reverse"}
 
 
 def get_strandness_flag(strandness, is_paired_end):
     """Return the HISAT2 --rna-strandness value for a (strandness, SE/PE) pair.
 
-    Returns the empty string when unstranded, unrecognized, or missing — the
-    caller suppresses the --rna-strandness flag entirely in that case.
+    Missing values (`None`, empty string, whitespace) and `unstranded` return
+    `""` — the caller then omits the `--rna-strandness` flag entirely. Any
+    non-empty unrecognized string raises `ValueError`: a typo like `forwrd`
+    would otherwise silently produce unstranded alignment for that sample.
     """
     normalized = (strandness or "").strip().lower()
-    if normalized in _FORWARD:
+    if normalized not in _VALID:
+        raise ValueError(
+            f"Unrecognized strandness value {strandness!r}. "
+            "Expected: unstranded | forward | reverse (or empty/missing)."
+        )
+    if normalized == "forward":
         return "FR" if is_paired_end else "F"
-    if normalized in _REVERSE:
+    if normalized == "reverse":
         return "RF" if is_paired_end else "R"
     return ""
+
+
+def get_strandness_from_row(row):
+    """Resolve the HISAT2 strandness flag for a samples.tsv row dict.
+
+    Detects SE vs PE from the presence of a non-empty `fastq2` field and
+    delegates to `get_strandness_flag`.
+    """
+    is_pe = bool((row.get("fastq2") or "").strip())
+    return get_strandness_flag(row.get("strandness"), is_pe)

--- a/workflow/tests/test_strandness.py
+++ b/workflow/tests/test_strandness.py
@@ -1,7 +1,7 @@
 """Unit tests for the strandness helper used by hisat2_align."""
 import pytest
 
-from strandness import get_strandness_flag
+from strandness import get_strandness_flag, get_strandness_from_row
 
 
 class TestGetStrandnessFlag:
@@ -30,9 +30,37 @@ class TestGetStrandnessFlag:
         assert get_strandness_flag("Forward", False) == "F"
         assert get_strandness_flag("REVERSE", True) == "RF"
 
-    def test_unrecognized_value_means_unstranded(self):
-        # Defensive: unknown strings fall through to "" rather than raising. Failure
-        # mode is graceful unstranded fallback, not a crashed alignment rule.
-        assert get_strandness_flag("garbage", False) == ""
-        # HISAT2-flag literal (not a biological direction) is also rejected.
-        assert get_strandness_flag("F", False) == ""
+    @pytest.mark.parametrize("bad", ["garbage", "forwrd", "F", "RF", "fwd"])
+    def test_unrecognized_value_raises(self, bad):
+        # Typos like `forwrd` would silently produce unstranded alignment, masking
+        # a misconfigured sample. HISAT2-flag literals (`F`, `RF`) are also rejected —
+        # the column takes biological direction, not the HISAT2 flag value.
+        with pytest.raises(ValueError, match="Unrecognized strandness value"):
+            get_strandness_flag(bad, False)
+
+
+class TestGetStrandnessFromRow:
+    def test_forward_se_row(self):
+        # PBMC scRNA R2-only row from patient_002.tsv — SE forward-stranded.
+        row = {"sample_id": "PBMC_scRNA_Pool1_L002", "fastq1": "x.fastq.gz", "fastq2": "", "strandness": "forward"}
+        assert get_strandness_from_row(row) == "F"
+
+    def test_unstranded_pe_row(self):
+        # BG003082 tumor row from patient_002.tsv — PE, no strandness column set.
+        row = {"sample_id": "BG003082_T0", "fastq1": "r1.fq.gz", "fastq2": "r2.fq.gz", "strandness": ""}
+        assert get_strandness_from_row(row) == ""
+
+    def test_missing_strandness_key(self):
+        # samples.tsv predating the column — `strandness` key absent entirely.
+        row = {"sample_id": "SRR9143066", "fastq1": "x.fq.gz", "fastq2": ""}
+        assert get_strandness_from_row(row) == ""
+
+    def test_whitespace_fastq2_is_se(self):
+        # Whitespace-only fastq2 must be treated as SE, not PE.
+        row = {"sample_id": "s", "fastq1": "x.fq.gz", "fastq2": "   ", "strandness": "reverse"}
+        assert get_strandness_from_row(row) == "R"
+
+    def test_reverse_pe_row(self):
+        # Hypothetical PE reverse-stranded sample (TruSeq dUTP-style library).
+        row = {"sample_id": "s", "fastq1": "r1.fq.gz", "fastq2": "r2.fq.gz", "strandness": "reverse"}
+        assert get_strandness_from_row(row) == "RF"

--- a/workflow/tests/test_strandness.py
+++ b/workflow/tests/test_strandness.py
@@ -1,0 +1,38 @@
+"""Unit tests for the strandness helper used by hisat2_align."""
+import pytest
+
+from strandness import get_strandness_flag
+
+
+class TestGetStrandnessFlag:
+    @pytest.mark.parametrize(
+        "strandness,is_paired_end,expected",
+        [
+            ("forward", False, "F"),
+            ("forward", True, "FR"),
+            ("reverse", False, "R"),
+            ("reverse", True, "RF"),
+            ("unstranded", False, ""),
+            ("unstranded", True, ""),
+        ],
+    )
+    def test_recognized_values(self, strandness, is_paired_end, expected):
+        assert get_strandness_flag(strandness, is_paired_end) == expected
+
+    @pytest.mark.parametrize("missing_or_empty", [None, "", "  "])
+    def test_missing_or_empty_means_unstranded(self, missing_or_empty):
+        # Backward compat: samples.tsv without the column or with blank cells must
+        # default to unstranded (no flag passed) — preserves current pipeline behavior.
+        assert get_strandness_flag(missing_or_empty, False) == ""
+        assert get_strandness_flag(missing_or_empty, True) == ""
+
+    def test_case_insensitive(self):
+        assert get_strandness_flag("Forward", False) == "F"
+        assert get_strandness_flag("REVERSE", True) == "RF"
+
+    def test_unrecognized_value_means_unstranded(self):
+        # Defensive: unknown strings fall through to "" rather than raising. Failure
+        # mode is graceful unstranded fallback, not a crashed alignment rule.
+        assert get_strandness_flag("garbage", False) == ""
+        # HISAT2-flag literal (not a biological direction) is also rejected.
+        assert get_strandness_flag("F", False) == ""


### PR DESCRIPTION
**Created by:** Developer

Closes [Issue #279](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/279) (10x R2 SE forward-stranded HISAT2 alignment).

## Summary

- **New `strandness` column** in `config/samples/*.tsv` (3 files). Values: `unstranded | forward | reverse` (biological direction; backward-compat default: `unstranded`)
- **Pure helper** `workflow/scripts/strandness.py` — `get_strandness_flag(strandness, is_paired_end)` maps biological direction × SE/PE → HISAT2 flag string (`F` / `R` / `FR` / `RF` or `""`). 11 pytest cases.
- **Rule wiring** in `alignment.smk` — `_get_hisat2_strandness(wildcards)` wrapper reads the sample row + delegates to the pure helper; `hisat2_align` gains `params.strandness`; shell injects `--rna-strandness {value}` only when non-empty.

## Design rationale

User chose **per-sample column** over sample-type-driven default (Issue body sketch option 1). More flexible — handles future non-10x R2 normals or stranded tumors without an `if sample_type == "normal"` heuristic that would break for bulk RNA-seq normals. Re-sized [Issue #279](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/279) XS → S accordingly.

## Sample-side change

- `patient_002` PBMC normal (`PBMC_scRNA_Pool1_L002`) → `forward` (10x R2 = sense strand per [PR #350](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/350) slide 8)
- All other rows: default to unstranded (missing column → no flag passed)

## Test plan

- [x] `pytest workflow/tests/test_strandness.py` — 11 cases pass (recognized values, missing/empty backward compat, case-insensitive, unrecognized strings)
- [ ] CI `pipeline-pytest` passes (full suite — no regression on existing tests)
- [ ] CI `pipeline-snakemake-dry-run` passes (rule wiring + samples.tsv schema validation)
- [ ] Reviewer (optional): render DAG via `bash scripts/visualize_dag.sh` — no topology change expected (only param addition to existing rule); sanity check