### PR TITLE
chore(gitignore): ignore /memory symlink for multi-role personas setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -235,3 +235,6 @@ CLAUDE.local.md
 # Claude Code — transient scheduler state (per-session lock + durable cron jobs)
 .claude/scheduled_tasks.lock
 .claude/scheduled_tasks.json
+
+# Cross-repo symlink to claude-personas-splice/<role>/ (cwd access to role + shared memory)
+/memory


### PR DESCRIPTION
**Created by:** Developer

## Summary
- Add `/memory` to `.gitignore` — cross-repo symlink to `claude-personas-splice/<role>/` for cwd access to role + shared memory
- Tooling-only change, no pipeline impact

## Test plan
- [x] `.gitignore` syntax valid (single new pattern)
- [x] No code paths touched; CI (`pipeline-pytest`, `pipeline-snakemake-dry-run`) will confirm