### PR TITLE
fix(alignment): regtools BED12 anchor outers → intron coords (closes #370)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,6 +145,16 @@ On macOS arm64, sra-tools conda installation is unreliable due to libcurl/openss
 regtools junctions extract -s XS -a 8 -m 50 -M 500000 -o out.bed input.bam
 ```
 
+## regtools BED12 — `chromStart`/`chromEnd` are anchor outers, NOT donor/acceptor
+`regtools junctions extract` emits BED12. Columns 2-3 (`chromStart`, `chromEnd`) are the **anchor outer boundaries** of the spliced read pile-up, not the intron donor/acceptor. The actual intron coords are recovered from `blockSizes` (col 11) and `blockStarts` (col 12):
+```
+donor    (0-based)            = chromStart + blockSizes[0]
+acceptor (0-based, exclusive) = chromStart + blockStarts[1]
+```
+Treating cols 2-3 as donor/acceptor shifts every junction by the anchor lengths (typically 100–150 bp on each side) — and silently misses every GENCODE-annotated junction in downstream filtering. Issue #370 replaced the buggy inline `awk` in `alignment.smk` with `workflow/scripts/bed12_to_junctions.py`, which does the blockSizes math correctly.
+
+The STAR path is unaffected — `SJ.out.tab` cols 2-3 are 1-based intron donor/acceptor directly.
+
 ## UCSC vs ENSEMBL Chromosome Naming
 Both naming conventions use "GRCh38" in filenames, making it easy to mix them silently.
 - `hg38_*` (UCSC) — chromosomes have `chr` prefix: `chr1`, `chr2`, ..., `chrM`

--- a/workflow/rules/alignment.smk
+++ b/workflow/rules/alignment.smk
@@ -235,9 +235,13 @@ if config.get("alignment", {}).get("aligner") == "hisat2":
                 {output.bam} \\
                 2>> {log}
 
-            awk -F'\\t' '{{
-                if ($5 > 0) print $1":"$2":"$3":"$6"\\t"$5
-            }}' {output.bed} > {output.junctions}
+            # regtools BED12 cols 2-3 are anchor outer boundaries, NOT intron
+            # donor/acceptor — see Issue #370. The helper derives the real
+            # intron coords from blockSizes/blockStarts.
+            python workflow/scripts/bed12_to_junctions.py \\
+                --input {output.bed} \\
+                --output {output.junctions} \\
+                2>> {log}
 
             echo "Extracted $(wc -l < {output.junctions}) junctions from HISAT2 output" >> {log}
             """

--- a/workflow/scripts/bed12_to_junctions.py
+++ b/workflow/scripts/bed12_to_junctions.py
@@ -70,6 +70,11 @@ def convert_bed12_to_junctions(input_path: str | Path, output_path: str | Path) 
             if len(block_sizes) < 2 or len(block_starts) < 2:
                 continue
 
+            # Coordinates are genomic (chrom+) orientation regardless of strand.
+            # "donor"/"acceptor" here mean left/right intron boundary in genomic
+            # coords — on the minus strand these are swapped vs. transcript
+            # direction. GENCODE BED uses the same genomic convention, so the
+            # downstream reference lookup matches symmetrically.
             donor_0based = chrom_start + block_sizes[0]
             acceptor_0based_exclusive = chrom_start + block_starts[1]
 
@@ -83,16 +88,6 @@ def convert_bed12_to_junctions(input_path: str | Path, output_path: str | Path) 
     return n_written
 
 
-def _snakemake_main() -> None:
-    log_file = snakemake.log[0]  # type: ignore[name-defined]  # noqa: F821
-    logging.getLogger().addHandler(logging.FileHandler(log_file))
-
-    convert_bed12_to_junctions(
-        snakemake.input.bed,  # type: ignore[name-defined]  # noqa: F821
-        snakemake.output.junctions,  # type: ignore[name-defined]  # noqa: F821
-    )
-
-
 def _cli_main() -> None:
     parser = argparse.ArgumentParser(
         description="Convert regtools BED12 to a 2-column junctions TSV."
@@ -104,8 +99,4 @@ def _cli_main() -> None:
 
 
 if __name__ == "__main__":
-    try:
-        snakemake  # type: ignore[name-defined]  # noqa: F821
-        _snakemake_main()
-    except NameError:
-        _cli_main()
+    _cli_main()

--- a/workflow/scripts/bed12_to_junctions.py
+++ b/workflow/scripts/bed12_to_junctions.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""bed12_to_junctions.py — Convert a regtools BED12 file to junctions.tsv.
+
+regtools' ``junctions extract`` output is BED12 where columns 2–3 are the
+**anchor outer boundaries** (chromStart, chromEnd), NOT the intron donor/
+acceptor coordinates. The actual intron donor/acceptor is derived from
+``blockSizes`` and ``blockStarts``:
+
+    donor    (0-based)            = chromStart + blockSizes[0]
+    acceptor (0-based exclusive)  = chromStart + blockStarts[1]
+
+This script emits a 2-column TSV:
+
+    <chrom>:<donor_1based>:<acceptor_0based_exclusive>:<strand>\\t<reads>
+
+The format matches what ``filter_junctions._parse_junction_id`` consumes:
+``start = int(parts[1]) - 1`` (1-based donor → 0-based intron start) and
+``end = int(parts[2])`` (0-based half-open intron end).
+
+See: https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/370
+"""
+
+import argparse
+import logging
+from pathlib import Path
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
+)
+log = logging.getLogger(__name__)
+
+
+def convert_bed12_to_junctions(input_path: str | Path, output_path: str | Path) -> int:
+    """Convert a regtools BED12 file to a 2-column junctions TSV.
+
+    Args:
+        input_path:  BED12 file produced by ``regtools junctions extract``.
+        output_path: Destination TSV (``<chrom>:<donor>:<end>:<strand>\\treads``).
+
+    Returns:
+        Number of junctions written.
+    """
+    input_path = Path(input_path)
+    output_path = Path(output_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    n_written = 0
+    with input_path.open() as fh_in, output_path.open("w") as fh_out:
+        for line in fh_in:
+            if not line.strip() or line.startswith("#"):
+                continue
+            fields = line.rstrip("\n").split("\t")
+            if len(fields) < 12:
+                continue
+
+            try:
+                reads = int(fields[4])
+            except ValueError:
+                continue
+            if reads <= 0:
+                continue
+
+            chrom = fields[0]
+            chrom_start = int(fields[1])
+            strand = fields[5]
+            block_sizes = [int(x) for x in fields[10].rstrip(",").split(",") if x]
+            block_starts = [int(x) for x in fields[11].rstrip(",").split(",") if x]
+            if len(block_sizes) < 2 or len(block_starts) < 2:
+                continue
+
+            donor_0based = chrom_start + block_sizes[0]
+            acceptor_0based_exclusive = chrom_start + block_starts[1]
+
+            fh_out.write(
+                f"{chrom}:{donor_0based + 1}:{acceptor_0based_exclusive}:{strand}"
+                f"\t{reads}\n"
+            )
+            n_written += 1
+
+    log.info("Wrote %d junctions to %s", n_written, output_path)
+    return n_written
+
+
+def _snakemake_main() -> None:
+    log_file = snakemake.log[0]  # type: ignore[name-defined]  # noqa: F821
+    logging.getLogger().addHandler(logging.FileHandler(log_file))
+
+    convert_bed12_to_junctions(
+        snakemake.input.bed,  # type: ignore[name-defined]  # noqa: F821
+        snakemake.output.junctions,  # type: ignore[name-defined]  # noqa: F821
+    )
+
+
+def _cli_main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Convert regtools BED12 to a 2-column junctions TSV."
+    )
+    parser.add_argument("--input", required=True, help="regtools BED12 input")
+    parser.add_argument("--output", required=True, help="junctions TSV output")
+    args = parser.parse_args()
+    convert_bed12_to_junctions(args.input, args.output)
+
+
+if __name__ == "__main__":
+    try:
+        snakemake  # type: ignore[name-defined]  # noqa: F821
+        _snakemake_main()
+    except NameError:
+        _cli_main()

--- a/workflow/tests/test_bed12_to_junctions.py
+++ b/workflow/tests/test_bed12_to_junctions.py
@@ -1,0 +1,113 @@
+"""Tests for bed12_to_junctions.py — regtools BED12 → junctions.tsv conversion.
+
+Regression test for [Issue #370](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/370):
+The HISAT2/regtools path previously emitted BED12 chromStart/chromEnd (anchor
+outer boundaries) as junction donor/acceptor coords. The correct coords are
+derived from blockSizes/blockStarts and refer to the intron interior.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from bed12_to_junctions import convert_bed12_to_junctions
+
+
+# ---------------------------------------------------------------------------
+# Fixture: a single annotated junction with anchor padding
+# ---------------------------------------------------------------------------
+#
+# Intron: chr22:[100, 200) on + strand (0-based half-open)
+# Anchors: 50 bp on each side
+# So regtools emits a BED12 block:
+#   chromStart = 50  (donor - leftAnchorLen)
+#   chromEnd   = 250 (acceptor + rightAnchorLen)
+#   blockSizes  = "50,50"
+#   blockStarts = "0,150"  (offset of right anchor from chromStart)
+#
+# Expected junctions.tsv line:
+#   chr22:101:200:+\t10
+#         ^^^  ^^^
+#       1-based  0-based
+#       donor   half-open
+#               intron end
+# i.e. <chr>:<1-based donor>:<intron-end-exclusive>:<strand>\t<reads>
+# This matches the convention consumed by filter_junctions._parse_junction_id,
+# which does `start = int(parts[1]) - 1` and `end = int(parts[2])`.
+
+_BED12_LINE = (
+    "chr22\t50\t250\tJUNC0001\t10\t+\t"
+    "50\t250\t255,0,0\t2\t50,50\t0,150"
+)
+
+
+class TestConvertBed12ToJunctions:
+    def test_emits_intron_coords_not_anchor_outers(self, tmp_path):
+        bed = tmp_path / "regtools.bed"
+        bed.write_text(_BED12_LINE + "\n")
+        out = tmp_path / "junctions.tsv"
+
+        convert_bed12_to_junctions(bed, out)
+
+        lines = out.read_text().strip().splitlines()
+        assert lines == ["chr22:101:200:+\t10"]
+
+    def test_skips_zero_read_records(self, tmp_path):
+        zero_reads = _BED12_LINE.replace("\t10\t+\t", "\t0\t+\t")
+        bed = tmp_path / "regtools.bed"
+        bed.write_text(zero_reads + "\n")
+        out = tmp_path / "junctions.tsv"
+
+        convert_bed12_to_junctions(bed, out)
+        assert out.read_text() == ""
+
+    def test_minus_strand(self, tmp_path):
+        minus = _BED12_LINE.replace("\t+\t", "\t-\t")
+        bed = tmp_path / "regtools.bed"
+        bed.write_text(minus + "\n")
+        out = tmp_path / "junctions.tsv"
+
+        convert_bed12_to_junctions(bed, out)
+        assert out.read_text().strip() == "chr22:101:200:-\t10"
+
+    def test_multiple_records(self, tmp_path):
+        second = (
+            "chr1\t1000\t1300\tJUNC0002\t5\t+\t"
+            "1000\t1300\t255,0,0\t2\t100,100\t0,200"
+        )
+        bed = tmp_path / "regtools.bed"
+        bed.write_text(_BED12_LINE + "\n" + second + "\n")
+        out = tmp_path / "junctions.tsv"
+
+        convert_bed12_to_junctions(bed, out)
+        lines = out.read_text().strip().splitlines()
+        # Second intron: donor = 1000 + 100 = 1100 (0-based) → 1101 (1-based)
+        #               end   = 1000 + 200 = 1200 (0-based exclusive)
+        assert lines == [
+            "chr22:101:200:+\t10",
+            "chr1:1101:1200:+\t5",
+        ]
+
+    def test_annotated_junction_matches_gencode_reference(self, tmp_path):
+        """End-to-end: emitted junction parses to coords that match a GENCODE
+        BED reference entry — this is the regression scenario that motivated
+        Issue #370 (annotated_discarded was 0 because coords didn't match)."""
+        from filter_junctions import _load_reference_junctions, _parse_junction_id
+
+        # GENCODE-style reference BED (0-based half-open)
+        ref_bed = tmp_path / "gencode.bed"
+        ref_bed.write_text("chr22\t100\t200\tref_junc\t0\t+\n")
+        ref = _load_reference_junctions(ref_bed)
+
+        bed = tmp_path / "regtools.bed"
+        bed.write_text(_BED12_LINE + "\n")
+        out = tmp_path / "junctions.tsv"
+        convert_bed12_to_junctions(bed, out)
+
+        junction_id = out.read_text().strip().split("\t")[0]
+        parsed = _parse_junction_id(junction_id)
+        assert parsed in ref, (
+            f"Parsed junction {parsed} not in reference {ref}. "
+            "If this fails, the BED12 → junctions.tsv conversion is "
+            "emitting anchor outer boundaries instead of intron coords."
+        )

--- a/workflow/tests/test_bed12_to_junctions.py
+++ b/workflow/tests/test_bed12_to_junctions.py
@@ -88,6 +88,41 @@ class TestConvertBed12ToJunctions:
             "chr1:1101:1200:+\t5",
         ]
 
+    def test_unstranded_record(self, tmp_path):
+        unstranded = _BED12_LINE.replace("\t+\t", "\t.\t")
+        bed = tmp_path / "regtools.bed"
+        bed.write_text(unstranded + "\n")
+        out = tmp_path / "junctions.tsv"
+
+        convert_bed12_to_junctions(bed, out)
+        assert out.read_text().strip() == "chr22:101:200:.\t10"
+
+    def test_skips_malformed_short_lines(self, tmp_path):
+        # Fewer than 12 fields → silently skipped
+        bed = tmp_path / "regtools.bed"
+        bed.write_text(
+            "chr22\t50\t250\tjunc_short\t10\t+\n"  # only 6 fields
+            + _BED12_LINE + "\n"
+        )
+        out = tmp_path / "junctions.tsv"
+
+        convert_bed12_to_junctions(bed, out)
+        # Only the well-formed line emits a junction
+        assert out.read_text().strip() == "chr22:101:200:+\t10"
+
+    def test_skips_comment_and_blank_lines(self, tmp_path):
+        bed = tmp_path / "regtools.bed"
+        bed.write_text(
+            "# regtools v1.0.0 header comment\n"
+            "\n"
+            + _BED12_LINE + "\n"
+            "   \n"  # whitespace-only
+        )
+        out = tmp_path / "junctions.tsv"
+
+        convert_bed12_to_junctions(bed, out)
+        assert out.read_text().strip() == "chr22:101:200:+\t10"
+
     def test_annotated_junction_matches_gencode_reference(self, tmp_path):
         """End-to-end: emitted junction parses to coords that match a GENCODE
         BED reference entry — this is the regression scenario that motivated


### PR DESCRIPTION
**Created by:** Developer

Closes #370.

## Summary

- Replace the buggy inline `awk` in `alignment.smk` (HISAT2 path) with a new Python helper `workflow/scripts/bed12_to_junctions.py`.
- The previous awk emitted BED12 `chromStart`/`chromEnd` (anchor outer boundaries) as junction donor/acceptor — every junction was offset by 100–150 bp on each side, so 0 of N annotated junctions ever matched the GENCODE reference. Every neoepitope ever predicted on the HISAT2 path was derived from incorrect coords.
- The new helper recovers intron coords from BED12 `blockSizes`/`blockStarts`:
  ```
  donor    (0-based)            = chromStart + blockSizes[0]
  acceptor (0-based, exclusive) = chromStart + blockStarts[1]
  ```
- Emitted format matches what `filter_junctions._parse_junction_id` already consumes: `<chrom>:<donor_1based>:<acceptor_0based_exclusive>:<strand>\treads`.
- STAR path is **unaffected** — `SJ.out.tab` cols 2-3 are 1-based intron donor/acceptor directly.
- Adds 5 regression tests for the helper, including a GENCODE-match scenario that fails on the buggy logic.
- CLAUDE.md note added so future readers don't re-introduce the bug.

## Files
- `workflow/scripts/bed12_to_junctions.py` — new helper (111 LOC)
- `workflow/tests/test_bed12_to_junctions.py` — 5 regression tests
- `workflow/rules/alignment.smk` — HISAT2 rule now calls the helper
- `CLAUDE.md` — gotcha note in the regtools section

## Test plan
- [x] `pytest workflow/tests/` — 262 passed, 25 skipped (incl. 8 new tests after polish commits `c3b7f54` + `74e08e5`)
- [x] CI `pipeline-pytest` green (run `25924541450`)
- [x] CI `pipeline-snakemake-dry-run` green (run `25924541450`; local dry-run blocked: conda envs lost in migration; CI is the fallback)
- [x] (post-merge: re-run patient_002 PoC end-to-end; expect `annotated_discarded > 0` and `tumor_exclusive < 57708` vs the pre-fix 0 and 57708 — tracked in [Issue #378](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/378))

## Follow-ups (not in this PR)
- STAR rule: emit col 6 (annotated flag) as a redundancy/verification signal alongside the GENCODE lookup
- CI canary: cross-check a sample against `regtools junctions annotate` to catch silent encoding regressions
- 5-way DA/D/A/NDA/N taxonomy (when there's a downstream consumer)
