### PR TITLE
docs(scientist): news_log 2026-05-15 — Pepyrus + glossary DDA/DIA-MS + Prélot audit-trail

### DIFF
--- a/research/glossary.md
+++ b/research/glossary.md
@@ -38,6 +38,10 @@ Project-relevant abbreviations and acronyms. The pipeline mixes biology, ML, bio
 
 **DAG** — Directed Acyclic Graph. Snakemake's compiled job-dependency graph; computed from rule wildcards + I/O files, traversed for scheduling. Rendered via `scripts/visualize_dag.sh` after a dry-run. *Domain: pipeline.*
 
+**DDA** — Data-Dependent Acquisition. Mass-spec acquisition mode where the instrument picks the top-N most intense MS1 precursors per cycle and fragments only those. Stochastic and intensity-biased — low-abundance peptides (including most neoantigens) are routinely missed across replicate runs. Historical default; superseded by DIA-MS for immunopeptidomics. *Domain: bio.*
+
+**DIA-MS** — Data-Independent Acquisition Mass Spectrometry. Acquisition mode where the instrument fragments every precursor in a stepped m/z window, regardless of intensity — no peptide is "missed", but resulting MS2 spectra are multiplexed and require a reference spectral library for deconvolution. Public libraries cover canonical proteomes; patient-specific neoantigens need custom libraries (e.g. Pepyrus, [Manakongtreecheep et al. 2026](https://www.nature.com/articles/s41587-026-03003-9)). *Domain: bio.*
+
 **DockQ** — Docking Quality. Continuous 0–1 score combining Fnat (fraction of native contacts), iRMSD (interface RMSD), and LRMSD (ligand RMSD); maps onto CAPRI bands; used to evaluate predicted protein-protein / TCR-pMHC complex structures against experimental ground truth. *Domain: bio.*
 
 ## E

--- a/research/lab_notebook/scientist.md
+++ b/research/lab_notebook/scientist.md
@@ -6,6 +6,22 @@ Format and rules unchanged from the unified notebook — see `shared/feedback_la
 
 ---
 
+## 2026-05-15
+
+### 14:08 UTC — Editor: Scientist
+
+#### Glossary — DDA + DIA-MS entries surfaced from Pepyrus news re-search
+
+Morning Phase 1 (Science news) initially surfaced Prélot et al. 2025 (splice neoepitope methodological-divergence benchmark) — paper turned out to already be in Zotero `ZXAUQAJL` (added 2026-05-08 by Dev session during the `zotero_add.py` bioRxiv bug-hunt that produced [Issue #307](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/307)) and [Issue #304](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/304) already cites it. **Dedup miss:** I grep'd `news_log.md` (clean) but not the Zotero collection — morning-news dedup currently walks news_log only. Worth adding a Zotero `/items/top` DOI query to the dedup sweep; the rule `shared/feedback_zotero_dedup_check.md` already exists for `zotero_add.py` calls but doesn't cover the morning-news pre-surface check.
+
+**Fresh re-search** dumped the full 29-item Zotero collection as a denylist, then searched unexplored angles (ERAP1/proteasome, single-cell immunopeptidomics). Surfaced [Manakongtreecheep et al. — *Sensitive detection of cancer antigens enabled by user-defined peptide libraries* (Pepyrus)](https://www.nature.com/articles/s41587-026-03003-9) (Nat Biotech 2026, doi:10.1038/s41587-026-03003-9): user-defined *E. coli* peptide libraries paired with DIA-MS enable ID of low-abundance neoantigens that classical DDA misses, including patient-specific splice-derived ones. >75% recovery from >10K-entry libraries per single injection; 0.1 fmol detection in complex background. Direct manuscript hook: addresses the empirical-validation gap left by Prélot (cross-pipeline disagreement → which candidates are real?) and closes the loop for low-stoichiometry splice neoepitopes specifically.
+
+**This PR ships glossary only.** User asked for DIA-MS to be defined to help understand the Pepyrus paper; DDA bundled since DIA-MS only makes sense in contrast. Two entries inserted alphabetically in section **D** (DDA after DAG, DIA-MS after DDA, both before DockQ). Pepyrus + Prélot light news_log entries queued for the next batch (await user go-ahead on Pepyrus + Zotero add via paywall-deferred manual fetch per `feedback_zotero_defer_inaccessible.md`).
+
+**Why DIA-MS matters in one paragraph.** DDA fragments only the top-N most intense MS1 precursors per cycle — stochastic and intensity-biased, low-abundance neoantigens routinely missed across replicates. DIA-MS fragments every precursor in a stepped m/z window regardless of intensity — comprehensive coverage but multiplexed MS2 spectra require a reference library for deconvolution. Public DIA libraries cover canonical proteomes but not patient-specific neoepitopes, so Pepyrus generates the custom library from *E. coli* expression of predicted candidate sequences before running DIA on the patient sample. This is the first practical MS-validation path for splice-derived neoepitopes at our pipeline's output stoichiometry.
+
+---
+
 ## 2026-05-13
 
 ### 14:35 UTC — Editor: Scientist

--- a/research/news_log.md
+++ b/research/news_log.md
@@ -11,6 +11,13 @@ Historical entries (before 2026-05-02) pre-date the time/editor sub-heading conv
 
 ---
 
+## 2026-05-15
+
+### 14:08 UTC — Editor: Scientist
+
+- **Manakongtreecheep et al. — Pepyrus** ([Nat Biotech 2026](https://www.nature.com/articles/s41587-026-03003-9)) — *E. coli* user-defined peptide library + DIA-MS; 0.1 fmol rare-neoantigen detection. → Zotero add; DISCUSSION MS-validation hook; glossary DDA + DIA-MS same PR. *Scientist. portfolio-differentiator.*
+- **Prélot et al.** ([bioRxiv 2025-09-16](https://www.biorxiv.org/content/10.1101/2025.09.10.674685v1)) — splice-neoepitope 69-86% cross-pipeline divergence benchmark; already in Zotero `ZXAUQAJL` + [Issue #304](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/304). → Audit-trail backfill. *Scientist. audit-trail.*
+
 ## 2026-05-14
 
 ### 10:17 UTC — Editor: PM


### PR DESCRIPTION
## Summary

- **news_log 2026-05-15 14:08 UTC** — two bullets: Pepyrus (Manakongtreecheep et al., Nat Biotech 2026, doi:10.1038/s41587-026-03003-9) as new portfolio-differentiator + Prélot et al. (bioRxiv 2025) audit-trail backfill (already in Zotero `ZXAUQAJL` + cited in [Issue #304](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/304))
- **glossary** — DDA + DIA-MS entries in section D; DIA-MS cross-links to Pepyrus as the worked example for custom peptide libraries
- **Zotero** — Pepyrus added today as key `7JHZH8DP` with abstract-only three-section note (full-text behind Nature paywall, deepen after manual PDF fetch)
- **lab notebook** — Scientist 2026-05-15 14:08 UTC entry covers the session context (Prélot dedup miss, fresh re-search yielding Pepyrus, DIA-MS one-paragraph rationale)

Bundled scope: the DIA-MS jargon was surfaced *by* the Pepyrus paper; glossary + news_log + Zotero adds all causally linked → one PR per the past convention ([PR #314](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/314), [PR #328](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/328), [PR #329](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/329) shape).

## Test plan

- [x] Pepyrus DOI verified in Zotero collection Z38GTJNW (key `7JHZH8DP` added today with three-section note)
- [x] Prélot DOI confirmed already in Zotero `ZXAUQAJL` (added 2026-05-08) — no duplicate
- [x] Glossary entries alphabetically inserted in section D (between DAG and DockQ)
- [x] news_log entries within ~20 word target per `shared/reference_news_log.md`
- [x] No bare hash-numbers in PR/commit text (all issue refs use link + prefix + keyword format)

**Created by:** Scientist