### PR TITLE
feat(hooks): pre-flight grep on gh comment/create bodies for stray at-mentions (closes #360)

### DIFF
--- a/.claude/hooks/check_at_claude.py
+++ b/.claude/hooks/check_at_claude.py
@@ -14,10 +14,14 @@ import sys
 
 
 def main() -> int:
-    data = json.load(sys.stdin)
+    try:
+        data = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError):
+        return 0
+
     cmd = data.get("tool_input", {}).get("command", "")
 
-    if not re.search(r"(^|[;&|]\s*)gh\s+(pr|issue)\s+(comment|create)\b", cmd):
+    if not re.search(r"(^|[;&|]\s*)gh\s+(pr|issue)\s+(comment|create|edit)\b", cmd):
         return 0
 
     if "@claude" not in cmd:
@@ -27,7 +31,7 @@ def main() -> int:
     canonical = len(re.findall(r'--body\s+"@claude review"', cmd)) + len(
         re.findall(r"--body\s+'@claude review'", cmd)
     )
-    if total > 0 and total == canonical:
+    if total == canonical:
         return 0
 
     print(

--- a/.claude/hooks/check_at_claude.py
+++ b/.claude/hooks/check_at_claude.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Pre-flight hook: refuse `gh (pr|issue) (comment|create)` whose body contains
+a literal @claude bot mention, except the canonical `@claude review` trigger.
+
+See memory/shared/feedback_no_at_claude_mention.md for the originating rule.
+Spec: https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/360
+
+Reads PreToolUse hook JSON on stdin, prints a deny decision on stdout when the
+guard fires, exits 0 silently otherwise (the harness treats no-output as allow).
+"""
+import json
+import re
+import sys
+
+
+def main() -> int:
+    data = json.load(sys.stdin)
+    cmd = data.get("tool_input", {}).get("command", "")
+
+    if not re.search(r"(^|[;&|]\s*)gh\s+(pr|issue)\s+(comment|create)\b", cmd):
+        return 0
+
+    if "@claude" not in cmd:
+        return 0
+
+    total = cmd.count("@claude")
+    canonical = len(re.findall(r'--body\s+"@claude review"', cmd)) + len(
+        re.findall(r"--body\s+'@claude review'", cmd)
+    )
+    if total > 0 and total == canonical:
+        return 0
+
+    print(
+        json.dumps(
+            {
+                "hookSpecificOutput": {
+                    "hookEventName": "PreToolUse",
+                    "permissionDecision": "deny",
+                    "permissionDecisionReason": (
+                        "Stray @claude mention in `gh (pr|issue) (comment|create)` body. "
+                        "The Claude Code GitHub Action triggers on ANY literal @claude "
+                        "(incl. inside parens, ACs, code spans, quoted historical refs). "
+                        "See memory/shared/feedback_no_at_claude_mention.md. For "
+                        "non-trigger references, use the zero-width workaround @-claude "
+                        "(literal substring @claude must not appear)."
+                    ),
+                }
+            }
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/check_at_claude.py",
+            "if": "Bash(gh *)",
+            "timeout": 5
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,3 +176,17 @@ snakemake --cores 4 --use-conda --configfile config/test_config.yaml
 - HISAT2 index stored in `resources/test/hisat2_index/` (separate from production)
 - All test outputs go to `results/test/` and `logs/test/`
 - **STAR is not usable for local development** — its genome index build requires >8 GB RAM, exceeding the M1 8 GB limit. HISAT2 was chosen for local testing specifically because its index fits within available memory.
+
+## GitHub Safety Wrappers
+
+Mechanisms that fire automatically to enforce GitHub-related discipline rules that have broken repeatedly despite being documented in memory. Per the mechanism-over-memory ladder (memory → inline Always-in-effect → mechanism), these are the rung-3 escalation when a rule has slipped ≥2× on the same shape.
+
+### `@claude` mention guard ([PreToolUse hook](.claude/settings.json))
+
+Refuses any `gh (pr|issue) (comment|create)` whose `--body` contains a literal `@claude` substring, except the exact canonical review-trigger `--body "@claude review"` (and the single-quoted variant). The hook runs `.claude/hooks/check_at_claude.py` on stdin-piped PreToolUse JSON and emits a `permissionDecision: deny` when the guard fires.
+
+**Why:** the `Claude Code` GitHub Action subscribes to `issues` events and triggers on ANY literal `@claude` — including inside parens, ACs, code spans, quoted historical refs, or markdown link descriptions. The rule lives in `memory/shared/feedback_no_at_claude_mention.md` and is inlined into shared Always-in-effect, yet broke on PR #359 (2026-05-13) and originally on Issue #272 (2026-05-06).
+
+**Workaround for non-trigger references:** use `@-claude` (zero-width hyphen between `@` and `claude`). The literal substring `@claude` must not appear.
+
+**Sister mechanism:** [Issue #357](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/357) (`audit_and_merge.sh` — closure-ritual enforcement at merge time) — same shape, will live in this section once shipped.

--- a/research/lab_notebook/developer.md
+++ b/research/lab_notebook/developer.md
@@ -6,6 +6,57 @@ Format and rules unchanged from the unified notebook — see `shared/feedback_la
 
 ---
 
+## 2026-05-16
+
+### 20:18 UTC — Editor: Developer
+
+**Headline:** [Issue #360](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/360) (pre-flight at-mention grep) shipped via [PR #380](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/380) — a rung-3 mechanism-over-memory PreToolUse hook. Bot review surfaced one real bug + one real coverage gap + one threat-model misread; hardened via `6469096` (try/except fail-open, `gh (pr|issue) edit --body` coverage, redundant guard removed, 12 subprocess tests added under [`tools/ci/`](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/blob/feat/dev-360-at-claude-grep/tools/ci/test_check_at_claude.py)). Pushed back on the "Critical" finding with explicit threat-model reasoning (hook protects local Claude Code Bash sessions, not the bot itself).
+
+**Why this work happened:**
+
+The bot-mention rule (`memory/shared/feedback_no_at_claude_mention.md`) was inlined into shared Always-in-effect at MEMORY.md line 30, yet broke twice on the same shape — [PR #359](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/359) (2026-05-13) and [Issue #272](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/272) (2026-05-06 originating). Per `memory/shared/feedback_mechanism_over_memory.md`, when a rule breaks ≥2× on the same shape despite being inlined, escalation goes from memory → mechanism. The trigger lives many tool calls deep from session start — by the time the agent is composing a `gh issue comment --body "..."`, the at-mention rule has fallen out of working attention. A PreToolUse hook intercepts at the only point where intent and action align (the `gh` Bash invocation itself), so it cannot be forgotten regardless of how much downstream context has accumulated.
+
+**Implementation reasoning:**
+
+Option B (PreToolUse hook) over Option A (wrapper script): zero memory-discipline overhead. Option A would have required every agent to remember "use `gh_safe_comment.sh` instead of bare `gh`" — exactly the kind of memory-discipline rule that already failed twice. Option B fires automatically on every `gh` Bash call regardless of which command form the agent reached for. Per-machine config trade-off (`.claude/settings.json` is project-committed, but the harness has to be configured to load it — which it is in every Claude Code session) is acceptable.
+
+The hook is intentionally narrow in scope:
+
+```python
+re.search(r"(^|[;&|]\s*)gh\s+(pr|issue)\s+(comment|create|edit)\b", cmd)
+```
+
+Matches `gh pr|issue` followed by `comment|create|edit` (the three body-writing subcommands), anchored to start-of-command or after a shell separator (`;&|`) to avoid matching `gh` substrings inside unrelated commands. The downstream regex check then re-filters for the bot-username substring, with a canonical-exception clause for the exact `--body "<bot> review"` form (the legitimate way to trigger the review bot on demand).
+
+**Bot review findings — triage:**
+
+| # | Finding | Triage |
+|---|---|---|
+| 1 | Critical: hook may not fire in GitHub Actions context | **Pushback.** Threat-model mismatch — hook guards local Claude Code sessions, not the bot. The bot posts via the Action's machinery (GitHub API), not Claude Code's Bash tool, so the hook has nothing to enforce on the bot's surface. The "deleted in working tree" observation also self-contradicts: bot quotes `.claude/settings.json:10`/`:11` content while claiming the file is absent. |
+| 2 | Bug: no try/except on `json.load(sys.stdin)` | **Accepted + fixed.** Wrapped in `try/except (JSONDecodeError, ValueError) → return 0`. Fail-open is correct — the regex check is the secondary defense, and a hook traceback on malformed harness input would block every `gh` call without clear remediation. |
+| 3 | Design: relative command path | **Pushback.** Standard Claude Code hook form; paths resolve from project root. |
+| 4 | Design: over-broad `"if": "Bash(gh *)"` | **Pushback.** Script exits in <10ms for non-gh commands; cost is negligible. Tightening would be marginal. |
+| 5 | Minor: redundant `total > 0` clause | **Accepted + fixed.** Preceding `if "<bot>" not in cmd: return 0` already guarantees ≥1 match. |
+| 6 | Missing: `gh pr edit --body` / `gh issue edit --body` | **Accepted + fixed.** Real gap — `edit --body` overwrites a body and bypasses the comment/create guard. Extended regex `(comment\|create)` → `(comment\|create\|edit)` plus 2 new deny-path tests. |
+
+**Test approach:**
+
+Added [`tools/ci/test_check_at_claude.py`](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/blob/feat/dev-360-at-claude-grep/tools/ci/test_check_at_claude.py) with 12 subprocess tests covering allow / deny / fail-open paths. Tests invoke the hook the same way the harness does (pipe PreToolUse JSON to stdin, read deny decision from stdout) — so any wiring drift (e.g. a future settings.json refactor that breaks the hook command path) is caught by `ci-tools-pytest`. Subprocess form was chosen over import-based testing because the hook lives under `.claude/hooks/` (non-standard sys.path) and the subprocess mirror is more honest about what's actually being tested.
+
+**Process notes:**
+
+- Closure ritual applied in full: all 5 ACs on [Issue #360](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/360) ticked before merge (`gh issue edit 360 --body-file ...`).
+- Confirmed PR auto-closes [Issue #360](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/360) via `closingIssuesReferences` (PR title contains `closes #360`) — no manual `gh issue close` needed.
+- Entry written post-review, pre-merge, per the Always-in-effect rule "Lab notebook entry comes AFTER review, before merge — not before commit" — reflects the final post-review state including the `6469096` hardening commit.
+- Sister mechanism [Issue #357](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/357) (`audit_and_merge.sh` — closure-ritual enforcement at merge time) remains open — same shape, same rung-3 escalation, different rule.
+
+**Open follow-ups:**
+
+- None blocking. The `--body-file` foot-gun (a file containing a stray bot at-mention would bypass the regex check since the command line only carries the path) is a known limitation already present for `comment`/`create` and not flagged by the bot — out of scope here.
+- If the hook ever needs to also guard `gh release create --notes "..."`, the regex extends naturally.
+
+---
+
 ## 2026-05-15
 
 ### 18:40 UTC — Editor: Developer

--- a/tools/ci/test_check_at_claude.py
+++ b/tools/ci/test_check_at_claude.py
@@ -1,0 +1,108 @@
+"""Subprocess tests for `.claude/hooks/check_at_claude.py`.
+
+Mirrors how the Claude Code harness invokes the hook: pipe PreToolUse JSON to
+stdin, read deny decision from stdout. Exit code is always 0.
+"""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+HOOK = Path(__file__).parent.parent.parent / ".claude" / "hooks" / "check_at_claude.py"
+
+
+def _run(stdin_payload):
+    """Pipe `stdin_payload` (str) to the hook, return (returncode, stdout, stderr)."""
+    proc = subprocess.run(
+        [sys.executable, str(HOOK)],
+        input=stdin_payload,
+        capture_output=True,
+        text=True,
+        timeout=5,
+    )
+    return proc.returncode, proc.stdout, proc.stderr
+
+
+def _payload(command: str) -> str:
+    return json.dumps({"tool_input": {"command": command}})
+
+
+def _is_deny(stdout: str) -> bool:
+    if not stdout.strip():
+        return False
+    parsed = json.loads(stdout)
+    return (
+        parsed.get("hookSpecificOutput", {}).get("permissionDecision") == "deny"
+    )
+
+
+class TestAllowPaths:
+    def test_non_gh_command_allowed(self):
+        rc, out, _ = _run(_payload("ls -la"))
+        assert rc == 0 and out.strip() == ""
+
+    def test_gh_status_allowed(self):
+        rc, out, _ = _run(_payload("gh pr status"))
+        assert rc == 0 and out.strip() == ""
+
+    def test_gh_comment_without_at_claude_allowed(self):
+        rc, out, _ = _run(_payload('gh pr comment 1 --body "looks good"'))
+        assert rc == 0 and out.strip() == ""
+
+    def test_canonical_review_trigger_double_quoted_allowed(self):
+        rc, out, _ = _run(_payload('gh pr comment 1 --body "@claude review"'))
+        assert rc == 0 and not _is_deny(out)
+
+    def test_canonical_review_trigger_single_quoted_allowed(self):
+        rc, out, _ = _run(_payload("gh pr comment 1 --body '@claude review'"))
+        assert rc == 0 and not _is_deny(out)
+
+
+class TestDenyPaths:
+    def test_stray_at_claude_in_comment_body_denied(self):
+        rc, out, _ = _run(
+            _payload('gh issue comment 1 --body "ping @claude for review"')
+        )
+        assert rc == 0 and _is_deny(out)
+
+    def test_stray_at_claude_in_issue_create_denied(self):
+        rc, out, _ = _run(
+            _payload('gh issue create --title "x" --body "as @claude said"')
+        )
+        assert rc == 0 and _is_deny(out)
+
+    def test_stray_at_claude_in_pr_edit_denied(self):
+        # Coverage extension (#6): `gh pr edit --body` was unguarded before.
+        rc, out, _ = _run(
+            _payload('gh pr edit 1 --body "rewritten body mentioning @claude"')
+        )
+        assert rc == 0 and _is_deny(out)
+
+    def test_stray_at_claude_in_issue_edit_denied(self):
+        # Coverage extension (#6): `gh issue edit --body` was unguarded before.
+        rc, out, _ = _run(
+            _payload('gh issue edit 1 --body "edited @claude reference"')
+        )
+        assert rc == 0 and _is_deny(out)
+
+    def test_canonical_plus_stray_denied(self):
+        rc, out, _ = _run(
+            _payload(
+                'gh pr comment 1 --body "@claude review" && '
+                'echo "also tagging @claude separately"'
+            )
+        )
+        assert rc == 0 and _is_deny(out)
+
+
+class TestFailOpen:
+    """#2: malformed/empty stdin must fail open, not crash."""
+
+    def test_empty_stdin_allowed(self):
+        rc, out, _ = _run("")
+        assert rc == 0 and out.strip() == ""
+
+    def test_malformed_json_allowed(self):
+        rc, out, _ = _run("{not valid json")
+        assert rc == 0 and out.strip() == ""


### PR DESCRIPTION
**Created by:** Developer

Implements Option B (PreToolUse hook) from [Issue #360](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/360) (pre-flight grep on gh body) spec — a `.claude/settings.json`-resident hook that refuses any gh comment/create whose body contains a literal bot at-mention, except the exact canonical review-trigger.

## Summary

- New executable `.claude/hooks/check_at_claude.py` (stdlib only, ~50 lines): reads PreToolUse JSON on stdin, narrows to gh comment/create, emits a `permissionDecision: deny` JSON unless the only at-mention is the canonical `--body "<bot-name> review"` form.
- New `.claude/settings.json` (project-committed): single PreToolUse / Bash hook entry with an `if` filter scoped to gh commands, timeout 5s.
- New "GitHub Safety Wrappers" section in CLAUDE.md documenting the mechanism, the prefix-hyphen zero-width workaround for non-trigger references, and forward-link to [Issue #357](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/357) (audit_and_merge.sh wrapper).

## Why

Rung-3 mechanism-over-memory escalation. The bot-mention rule (`memory/shared/feedback_no_at_claude_mention.md`) is fully inlined in shared Always-in-effect, yet broke twice on the same shape: [PR #359](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/359) (2026-05-13 incident) and originally [Issue #272](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/272) (2026-05-06 originating). Sister mechanism to still-open [Issue #357](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/357) (closure-ritual wrapper).

## Test plan

- [x] Pipe-tested 8 cases pre-commit: canonical double/single-quoted ALLOW; stray mention in prose DENY; zero-width workaround ALLOW; non-gh bash ALLOW; gh comment with empty body ALLOW; canonical-prefix + extra text DENY (e.g. body `"<bot-name> review please"`); gh issue create with stray mention DENY.
- [x] `jq -e` on `.claude/settings.json` validates schema and returns the hook command path.
- [x] **Hook fires in this session already** — caught a non-gh Bash call whose own safety-check grep pattern contained the forbidden literal. Suggests the `if` filter is broader (substring-matching) than docs imply; worth a follow-up to narrow OR accept as a useful over-trigger.
- [x] Lab notebook entry written at `research/lab_notebook/developer.md` (2026-05-16 20:18 UTC, post-review, pre-merge) per `memory/shared/feedback_lab_notebook.md`.

