### PR TITLE
feat(envs): add alphagenome.yaml for AlphaGenome SDK (closes #385)

### DIFF
--- a/workflow/envs/alphagenome.yaml
+++ b/workflow/envs/alphagenome.yaml
@@ -1,0 +1,16 @@
+name: splice-neoepitope-alphagenome
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - python >=3.11,<3.13
+  - pandas >=2.0
+  - numpy >=1.25
+  - matplotlib >=3.8
+  - scipy >=1.11
+  - seaborn >=0.13
+  - pyarrow >=15.0
+  - ipykernel
+  - pip
+  - pip:
+    - alphagenome >=0.6,<0.7


### PR DESCRIPTION
## Summary

Pin DeepMind AlphaGenome SDK (pip-only, 0.6.x) in
`workflow/envs/alphagenome.yaml` so the Exp 1 notebook work on parent
[Issue #224](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/224)
can use a reproducible env. Includes notebook-side deps (numpy, pandas,
matplotlib, scipy, seaborn, pyarrow, ipykernel) so the env is
self-contained and can serve as the Jupyter kernel.

Closes #385 — Task 3 of parent [Issue #224](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/224).

## Test plan

- [x] `mamba env create -n alphagenome-smoketest -f workflow/envs/alphagenome.yaml --dry-run` resolves 160 conda-forge packages cleanly (macOS arm64)
- [x] `pip install --dry-run "alphagenome>=0.6,<0.7"` resolves cleanly — alphagenome-0.6.1 + 21 transitive deps
- [x] CI green (snakemake dry-run + pytest) — 3/3 passed

## Auto-close audit

- Sub-issue 385 auto-closes on merge: (a) `gh issue develop 385` dev-link, (b) explicit `Closes #385` in title + body. Both paths align.
- Parent [Issue #224](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/224) stays open: no trigger keyword adjacent to its number; no dev-link from this branch to it. Will verify via `gh pr view <N> --json closingIssuesReferences` after open.

**Created by:** Scientist

