### PR TITLE
docs(landscape): pm 2026-05-17 — Managed Agents per-feature mapping (closes #305)

### DIFF
--- a/research/lab_notebook/pm.md
+++ b/research/lab_notebook/pm.md
@@ -6,6 +6,22 @@ Format and rules unchanged from the unified notebook — see `shared/feedback_la
 
 ---
 
+## 2026-05-17
+
+### 19:12 UTC — Editor: PM
+
+#### [Issue #305](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/305) closure — landscape-doc tightening, not memory edit
+
+Issue scope said tighten [`shared/feedback_multi_role_not_multi_agent.md`](memory/shared/feedback_multi_role_not_multi_agent.md) against Anthropic Managed Agents (2026-05-07) OR comment-defer. Initial proposal was a "Concrete contrast" paragraph inside the memory file. **User correction:** the contrast already lives in [`research/multi_agent_landscape.md`](research/multi_agent_landscape.md) (Frameworks → Anthropic Managed Agents) — the memory's job is rule-enforcement, the landscape doc's job is concrete tracking. The memory's own footer cross-references the landscape doc; that pointer was the signal I missed.
+
+**Landed instead.** Tightened the existing Managed Agents entry in [`research/multi_agent_landscape.md`](research/multi_agent_landscape.md) with per-feature mapping: Multiagent Orchestration ↔ multi-role-not-multi-agent autonomy bar; Dreaming ↔ `/memory` rehydration (auto vs human-initiated); Outcomes ↔ no direct analog. Added the third feature (Outcomes) that the prior entry missed; added 9to5Mac source alongside the Anthropic blog primary. Memory file unchanged.
+
+**Adjacent finding — `/cerebrum` → `/memory` rename incomplete.** Landscape doc still used `/cerebrum` (old skill name); fixed in this edit. ~18 other `/cerebrum` references remain across the personas repo (`shared/team_memory_broadcasts.md` at minimum) — out of scope for [Issue #305](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/305), surfaced for follow-up Issue.
+
+**Process slip recap.** Two user corrections in this issue: (1) initial session-opening recommendation surfaced a Developer PR while in PM session (role-boundary slip, caught with *"but PR 389 is the Developer's work"*); (2) initial proposal placed concrete contrast in the memory file when it belonged in the landscape doc (adjacent-artifact slip, caught with *"why did we write this whole memory file again? We also have the research/multi_agent_landscape.md file"*). Sister failures — both about *where* content/work lives in the artifact map. [`feedback_best_next_issue.md`](memory/shared/feedback_best_next_issue.md) Step 1 already covers slip (1); the duplicate-check rule ([`feedback_memory_duplicate_check.md`](memory/shared/feedback_memory_duplicate_check.md)) could be extended to cover slip (2) by adding an adjacent-artifact scan. Candidate follow-up memory-update; not landed here.
+
+---
+
 ## 2026-05-16
 
 ### 20:08 UTC — Editor: PM

--- a/research/multi_agent_landscape.md
+++ b/research/multi_agent_landscape.md
@@ -12,11 +12,11 @@ For our position relative to this landscape — why PM/Sci/Dev, why "multi-role"
 
 Concrete products / tooling that could plausibly displace, augment, or be borrowed from for our PM/Sci/Dev workflow.
 
-### Anthropic Managed Agents — Dreaming + Multiagent Orchestration
+### Anthropic Managed Agents — Multiagent Orchestration + Dreaming + Outcomes
 
-- **Source:** [Anthropic blog, 2026-05-06](https://claude.com/blog/new-in-claude-managed-agents)
-- **Summary:** Agents review past sessions to self-improve ("dreaming"); a lead agent delegates to specialists rather than the human dispatching each role.
-- **Our rationale:** **Observe.** Dreaming is the closest production analog to our `/cerebrum` memory-rehydration pattern. Orchestrator-delegation is what PM does for Sci/Dev today, *but in our setup the human opens the next session* — we don't have agent-to-agent triggers (per [multi-role, not multi-agent](#our-position)). Tracking via [Issue #305](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/305) (PM eval + memory tightening borrow).
+- **Source:** [Anthropic blog, 2026-05-06](https://claude.com/blog/new-in-claude-managed-agents); [9to5Mac coverage, 2026-05-07](https://9to5mac.com/2026/05/07/anthropic-updates-claude-managed-agents-with-three-new-features/).
+- **Summary:** Three features. **Multiagent Orchestration:** a lead agent delegates to autonomous specialist agents on a shared filesystem; specialists run in parallel, lead checks back mid-workflow, persistent events so every agent remembers what it has done. **Dreaming:** scheduled review of past sessions to extract patterns and curate memory across agents — auto-update by default, optional human review gate. **Outcomes:** users write success rubrics; agents iterate autonomously toward them, with an independent grader that "isn't influenced by the agent's reasoning"; webhook on completion.
+- **Our rationale:** **Observe — per-feature mapping.** **Multiagent Orchestration** maps directly onto the autonomous pattern that [multi-role, not multi-agent](#our-position) explicitly does *not* claim — in our setup the human opens the next session and there is no agent-to-agent trigger. The model vendor itself using "multi-agent" in this autonomous sense validates the framing distinction. **Dreaming** is the closest production analog to our `/memory` memory-rehydration pattern, but inverted: their default is auto-update with optional review; ours is always human-initiated and reviewed at write time. **Outcomes** has no direct analog in our setup (we don't yet codify success rubrics for autonomous iteration; closest precursor is the GitHub-Actions `Claude Code` review trigger, which has a human-set criterion but no agent-driven re-iteration). Closed [Issue #305](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/305) with landscape-tightening (the concrete contrast belongs here; the framing rule in `shared/feedback_multi_role_not_multi_agent.md` stays unchanged).
 
 ### OpenAI Symphony
 


### PR DESCRIPTION
**Created by:** PM

## Summary

Tighten the Anthropic Managed Agents entry in [`research/multi_agent_landscape.md`](research/multi_agent_landscape.md) with per-feature mapping. Resolution of [Issue #305](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/305) (PM eval — tighten `feedback_multi_role_not_multi_agent.md` OR comment-defer).

**Decision flipped mid-issue:** the concrete Managed Agents contrast belongs in the landscape doc (concrete map of products), not in the framing-rule memory (abstract vocabulary discipline). The memory file's footer already cross-references the landscape doc; that pointer was the signal to land the tightening there.

## Changes

**`research/multi_agent_landscape.md`** — Frameworks → Anthropic Managed Agents entry:

- Title updated from "Dreaming + Multiagent Orchestration" to "Multiagent Orchestration + Dreaming + Outcomes" — the prior entry missed the third feature.
- Summary expanded to per-feature descriptions (was a one-line generic summary).
- **Our rationale** rewritten as a per-feature mapping:
  - **Multiagent Orchestration** ↔ [multi-role, not multi-agent](#our-position) autonomy bar — model vendor uses "multi-agent" in the autonomous sense, validating the framing distinction.
  - **Dreaming** ↔ `/memory` rehydration pattern — inverted polarity (their default is auto-update; ours is always human-initiated).
  - **Outcomes** ↔ no direct analog (we don't codify success rubrics for autonomous iteration).
- 9to5Mac source link added alongside the Anthropic blog primary.
- Replaced `/cerebrum` (old skill name) with `/memory` on the Dreaming line.

**`research/lab_notebook/pm.md`** — 2026-05-17 19:12 UTC entry capturing the closure decision, the artifact-split rationale, and the two process slips caught during the session (role-boundary on initial recommendation; adjacent-artifact on the initial proposal).

## Adjacent finding (out of scope, surfaced for follow-up)

The landscape doc still used `/cerebrum` (old skill name) on the Dreaming line; replaced here. ~3-5 mutable `/cerebrum` refs remain in `shared/team_memory_broadcasts.md` instructional prose; ~30 other refs are immutable historical record (lab notebooks, archives, past Done broadcasts) and won't be touched. Filing as a small role:pm follow-up Issue post-merge.

## Test plan

- [x] Landscape doc edit reviewed against Anthropic announcement (multiagent + dreaming + outcomes coverage)
- [x] Per-feature mapping matches the framing-rule memory's contrast points
- [x] Lab notebook entry follows the format conventions (top-of-file insertion, full date header, time + editor line, markdown-link issue refs)
- [x] No `@-claude` mentions or stray bot-triggers (hook check)
- [x] CI green (`pipeline-pytest`, `pipeline-snakemake-dry-run`, `ci-tools-pytest`) — all 3 SUCCESS as of 2026-05-17 ~19:25 UTC
- [x] PR squash-merged with "Closes #305" auto-close — `closingIssuesReferences` confirms #305 link; mergeStateStatus = CLEAN before merge

Closes #305