### PR TITLE
chore: .gitignore reflects claude-personas v3.1 memory path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -237,4 +237,6 @@ CLAUDE.local.md
 .claude/scheduled_tasks.json
 
 # Cross-repo symlink to claude-personas-splice/<role>/ (cwd access to role + shared memory)
-/memory
+
+# claude-personas role-memory symlink
+/.claude/memory/


### PR DESCRIPTION
Migrates the role-memory symlink ignore pattern from `/memory` to `/.claude/memory/` per claude-personas v3.1.0 (released today, 2026-05-18, https://github.com/Jin-HoMLee/claude-personas/releases/tag/v3.1.0).

## Background

The 3 splice clones (developer / pm / scientist) all share this remote. Each clone's role-memory symlink moved from `<clone>/memory` (v3.0) to `<clone>/.claude/memory/` (v3.1). The on-disk migration in each clone was performed via `scripts/init-clone.sh --force <role>` (run from the splice-memory sibling repo). This is the single tracked `.gitignore` diff produced by that migration.

## Scope

Only this PR's `.gitignore` change is committed; the per-clone symlink itself stays gitignored. Other feature branches will pick up this change when they next merge/rebase `main`.

## Test plan
- [x] `init-clone.sh --force developer` succeeded with new .gitignore + `.claude/memory` symlink correctly wired
- [ ] `init-clone.sh --force pm` (deferred — PM clone has in-flight milestone-recheck hook work; run when ready)
- [ ] `init-clone.sh --force scientist` (deferred — same precondition)

🤖 Generated with [Claude Code](https://claude.com/claude-code)