### PR TITLE
feat(pm): milestone capacity recheck via PostToolUse hook (Phase 0)

### DIFF
--- a/.claude/hooks/recheck_milestone_dispatch.py
+++ b/.claude/hooks/recheck_milestone_dispatch.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""PostToolUse hook: trigger milestone recheck on capacity-change events.
+
+Watches Bash commands for 4 trigger shapes from feedback_milestones.md:
+  1. gh issue close N                              -> recheck issue's milestone
+  2. gh issue edit N ... --milestone X             -> recheck old + new milestones (via /events history)
+  3. project board Size mutation (Size field ID)   -> recheck affected issue's milestone
+  4. gh api .../milestones/N PATCH (due_on edit)   -> recheck milestone N
+
+For each match, invokes scripts/pm/recheck_milestone.py and emits its output as
+`additionalContext` so it appears in the next prompt.
+"""
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = "Jin-HoMLee/splice-neoepitope-pipeline"
+SIZE_FIELD_ID = "PVTSSF_lAHOB17eGc4BSomPzhAHGiA"
+SCRIPT = str(Path(__file__).resolve().parent.parent.parent / "scripts" / "pm" / "recheck_milestone.py")
+
+PATTERN_CLOSE = re.compile(r"\bgh\s+issue\s+close\s+(\d+)")
+PATTERN_MOVE = re.compile(r"\bgh\s+issue\s+edit\s+(\d+)\b[^|;&]*--milestone\b")
+PATTERN_GH_API = re.compile(r"\bgh\s+api\b")
+PATTERN_MILESTONE_PATH = re.compile(r"/milestones/(\d+)\b")
+PATTERN_PATCH_METHOD = re.compile(r"-X\s+PATCH|--method\s+PATCH|method=PATCH")
+PATTERN_ITEMID = re.compile(r'itemId:\s*"(PVTI_[A-Za-z0-9_-]+)"')
+
+
+def run_recheck(*args: str) -> str:
+    try:
+        result = subprocess.run(
+            ["python3", SCRIPT, *args],
+            capture_output=True, text=True, timeout=30, check=False,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError) as exc:
+        return f"(recheck error: {exc})"
+    out = result.stdout
+    if result.returncode == 1:
+        out += result.stderr
+    return out
+
+
+def lookup_milestone_number_by_title(title: str) -> int | None:
+    result = subprocess.run(
+        ["gh", "api", f"repos/{REPO}/milestones?state=all&per_page=100"],
+        capture_output=True, text=True, check=False,
+    )
+    if result.returncode != 0:
+        return None
+    try:
+        data = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return None
+    for m in data:
+        if m.get("title") == title:
+            return m.get("number")
+    return None
+
+
+def lookup_issue_for_item(item_id: str) -> int | None:
+    query = f'query {{ node(id: "{item_id}") {{ ... on ProjectV2Item {{ content {{ ... on Issue {{ number }} }} }} }} }}'
+    result = subprocess.run(
+        ["gh", "api", "graphql", "-f", f"query={query}",
+         "--jq", ".data.node.content.number"],
+        capture_output=True, text=True, check=False,
+    )
+    out = result.stdout.strip()
+    return int(out) if out.isdigit() else None
+
+
+def prior_milestones_for_issue(issue: int) -> list[int]:
+    """Return milestone numbers from the 2 most recent milestoned/demilestoned events."""
+    result = subprocess.run(
+        ["gh", "api", f"repos/{REPO}/issues/{issue}/events?per_page=100",
+         "--jq",
+         'map(select(.event == "milestoned" or .event == "demilestoned")) '
+         '| sort_by(.created_at) | reverse | .[0:2] | .[].milestone.title'],
+        capture_output=True, text=True, check=False,
+    )
+    titles = [line.strip() for line in result.stdout.splitlines() if line.strip()]
+    numbers: list[int] = []
+    for title in titles:
+        ms = lookup_milestone_number_by_title(title)
+        if ms is not None and ms not in numbers:
+            numbers.append(ms)
+    return numbers
+
+
+def dispatch(cmd: str) -> list[str]:
+    outputs: list[str] = []
+
+    m = PATTERN_CLOSE.search(cmd)
+    if m:
+        outputs.append(
+            f"[milestone recheck — close #{m.group(1)}]\n{run_recheck('--issue', m.group(1))}"
+        )
+
+    m = PATTERN_MOVE.search(cmd)
+    if m:
+        issue = int(m.group(1))
+        ms_numbers = prior_milestones_for_issue(issue)
+        if not ms_numbers:
+            outputs.append(
+                f"[milestone recheck — move on #{issue} "
+                f"(milestone history empty; rechecking current only)]\n"
+                f"{run_recheck('--issue', str(issue))}"
+            )
+        else:
+            for ms in ms_numbers:
+                outputs.append(
+                    f"[milestone recheck — move on #{issue}, milestone {ms}]\n"
+                    f"{run_recheck('--milestone', str(ms))}"
+                )
+
+    if SIZE_FIELD_ID in cmd:
+        item_match = PATTERN_ITEMID.search(cmd)
+        if item_match:
+            issue = lookup_issue_for_item(item_match.group(1))
+            if issue:
+                outputs.append(
+                    f"[milestone recheck — size change on #{issue}]\n"
+                    f"{run_recheck('--issue', str(issue))}"
+                )
+
+    if PATTERN_GH_API.search(cmd) and PATTERN_PATCH_METHOD.search(cmd):
+        m = PATTERN_MILESTONE_PATH.search(cmd)
+        if m:
+            outputs.append(
+                f"[milestone recheck — due_on PATCH on milestone {m.group(1)}]\n"
+                f"{run_recheck('--milestone', m.group(1))}"
+            )
+
+    return outputs
+
+
+def main() -> int:
+    try:
+        payload = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError):
+        return 0  # fail open
+
+    cmd = (payload.get("tool_input") or {}).get("command", "")
+    if not cmd:
+        return 0
+
+    outputs = dispatch(cmd)
+    if not outputs:
+        return 0
+
+    print(json.dumps({
+        "hookSpecificOutput": {
+            "hookEventName": "PostToolUse",
+            "additionalContext": "\n\n".join(outputs),
+        }
+    }))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/hooks/recheck_milestone_dispatch.py
+++ b/.claude/hooks/recheck_milestone_dispatch.py
@@ -31,6 +31,8 @@ PATTERN_ITEMID = re.compile(r'itemId:\s*"(PVTI_[A-Za-z0-9_-]+)"')
 
 
 def run_recheck(*args: str) -> str:
+    if not Path(SCRIPT).is_file():
+        return f"(recheck error: script not found at {SCRIPT})"
     try:
         result = subprocess.run(
             ["python3", SCRIPT, *args],
@@ -39,12 +41,14 @@ def run_recheck(*args: str) -> str:
     except (subprocess.TimeoutExpired, FileNotFoundError) as exc:
         return f"(recheck error: {exc})"
     out = result.stdout
-    if result.returncode == 1:
+    if result.stderr:
         out += result.stderr
     return out
 
 
 def lookup_milestone_number_by_title(title: str) -> int | None:
+    # per_page=100 covers the current ~17 milestones with headroom. If this repo
+    # ever exceeds 100 (closed + open), switch to --paginate.
     result = subprocess.run(
         ["gh", "api", f"repos/{REPO}/milestones?state=all&per_page=100"],
         capture_output=True, text=True, check=False,

--- a/research/lab_notebook/pm.md
+++ b/research/lab_notebook/pm.md
@@ -6,6 +6,67 @@ Format and rules unchanged from the unified notebook — see `shared/feedback_la
 
 ---
 
+## 2026-05-18
+
+### 10:36 UTC — Editor: PM
+
+#### Morning routine + dev-i1 milestone close + [Issue #247](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/247) Phase 0 ship — PostToolUse recheck hook
+
+Monday morning routine ran clean: PM news (zero items — territory swept yesterday), closure audit (4/4 closed-issue checks passed; one soft observation on [Issue #357](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/357)'s missing lab notebook entry, folded into a standup celebration broadcast at 08:52 UTC), board recap, triage. Weekly full-board sweep surfaced 4 field-incomplete issues, all triaged auto + 1 by-prompt ([Issue #345](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/345) → i5-S3 / P3 / XS; [Issue #352](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/352) → **new dev-i2 milestone** / P2 / XS; [Issue #364](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/364) → dev-i2 / P3 / S; [Issue #394](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/394) → P3 / XS).
+
+**`dev-i1` milestone closed 7/7 one day early.** Created `dev-i2 - Dev Tooling Quick Wins II` (milestone 25, due 2026-06-18) for Dev's follow-up tooling axis. Posted [`team_standup.md` celebration broadcast at 08:52 UTC](memory/shared/team_standup.md) addressed to Developer (cc: Scientist) covering: 7/7 closed, 0 carry-over, the complete closure-ritual safety net (pre-merge gate [Issue #357](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/357) + post-merge detective [Issue #325](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/325) + [Issue #360](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/360) at-mention guard = 3 rung-3 mechanism-over-memory escalations in a single iteration), and the soft observation that [Issue #357](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/357)'s ship merits its own time section in [`developer.md`](research/lab_notebook/developer.md) (substance is in the [2026-05-17 20:15 UTC standup post](memory/shared/team_standup.md) but per the spirit of the closure-ritual rule the lab notebook should mirror it).
+
+**pm-i1 closing-run survey.** Burndown was 4 closed / 3 open with due Thu 2026-05-21. Opted for 6/7 shape: land [Issue #247](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/247) (P1, fully scoped) + [Issue #243](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/243) (P2, fully scoped); slip [Issue #324](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/324) (per-role model routing — M, still skeletal) to `pm-i2 - PM Self-Improvement Tooling`. Per-role model routing belongs in pm-i2 by topic anyway; the slip is honest, not corner-cutting. Audit-trail comment posted on [Issue #324](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/324) explaining the move ([comment](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/324#issuecomment-4476433931)).
+
+**[Issue #247](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/247) Phase 0 implementation — recheck atom + dispatch hook + settings.local.json wiring.**
+
+Three artifacts shipped on branch `feat/pm/issue-247-milestone-recheck-hook`:
+
+1. [`scripts/pm/recheck_milestone.py`](scripts/pm/recheck_milestone.py) (~110 lines) — recheck atom. CLI: `--issue N` or `--milestone N`. Sums size-weighted days from open issues (XS=0.5, S=1, M=2.5, L=3.5, XL=5 capacity-days), applies `new_due_on = today + remaining/1.5 × 7 days`, prints standardized output, exits 0 (`[No change]`) or 2 (`[UPDATE NEEDED]` when |delta| > 7 days) per AC spec. Single-query GraphQL with aliases for per-issue Size lookup — efficient enough for any milestone size.
+
+2. [`.claude/hooks/recheck_milestone_dispatch.py`](.claude/hooks/recheck_milestone_dispatch.py) (~120 lines) — PostToolUse hook entry. Reads PostToolUse JSON from stdin, pattern-matches the Bash command against 4 trigger shapes, invokes the recheck script, emits `additionalContext` wrapped in `hookSpecificOutput` JSON. Patterns:
+   - `\bgh\s+issue\s+close\s+(\d+)` → recheck issue's milestone (trigger 1, close)
+   - `\bgh\s+issue\s+edit\s+(\d+)\b[^|;&]*--milestone\b` → recheck **both** milestones via `/issues/N/events` history lookup (resolves title → number) (trigger 2, move)
+   - Size field ID (`PVTSSF_lAHOB17eGc4BSomPzhAHGiA`) present in command + `itemId: "PVTI_..."` → resolve item → issue → milestone, recheck (trigger 3, resize)
+   - `gh api` + (`-X PATCH` OR `--method PATCH`) + `/milestones/N` (order-agnostic — initial regex required PATCH after milestones path, broke on real commands) → recheck milestone (trigger 4, due_on edit)
+
+3. [`.claude/settings.local.json`](.claude/settings.local.json) (Phase 0, gitignored per AC spec) — added `hooks.PostToolUse` array with single Bash matcher + `if: "Bash(gh *)"` filter + 30s timeout. Phase 1 (promote to committed [`.claude/settings.json`](.claude/settings.json)) deferred to follow-up Issue.
+
+**Three real findings surfaced by the recheck script** during smoke-testing — drift that would otherwise have stayed invisible:
+
+| Milestone | Current `due_on` | Proposed | Delta | Action taken |
+|---|---|---|---|---|
+| `pm-i3 - PM Workflow Quick Wins II` | 2026-05-24 | 2026-06-06 | +13 days | ✓ PATCHed to 2026-06-06 (live test AC 6) |
+| `i2 - S4 - AlphaGenome Predicted-Normal Filter Validation` | 2026-05-22 | 2026-07-04 | +43 days | ⚠ pending decision (scope vs date) |
+| `pm-i2 - PM Self-Improvement Tooling` | 2026-06-11 | 2026-08-03 | +53 days | ⚠ pending decision (likely needs displacement to a pm-i4) |
+
+The pm-i3 PATCH was a real `gh api -X PATCH` invocation — the hook fired live and surfaced the post-PATCH recheck as `additionalContext` confirming `[No change]` (delta now 0). That's AC 6 verified live; the harness reloads `settings.local.json` mid-session (good to know — Claude Code doesn't require a session restart for hook config changes).
+
+**AC status at merge:**
+
+- AC 1–3 (script, formula, hook config): ✓ shipped
+- AC 4 (manual close test): pattern verified via dispatch unit test with mocked stdin (Test 1 above shows correct JSON output); live `gh issue close N` trigger deferred — rare in practice since most closes happen via `gh pr merge`'s `closingIssuesReferences` auto-close path, which is NOT caught by the current `\bgh\s+issue\s+close\s+(\d+)` pattern. Adding a `gh pr merge` trigger is a clean Phase 1 extension (parse the PR's linked issues, recheck each one's milestone) — surfaced as a known coverage gap, not landed in Phase 0.
+- AC 5 (manual move test): pattern verified via dispatch unit test (Test 5 above — used [Issue #324](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/324)'s real move history; both pm-i1 source + pm-i2 destination rechecked correctly via `/issues/N/events` lookup). Live trigger deferred to next natural move event.
+- AC 6 (manual due_on PATCH test): ✓ live trigger verified end-to-end as above.
+- AC 7 (update [`memory/feedback_milestones.md`](memory/feedback_milestones.md)): ✓ reframed "Recheck `due_on`" section from memory-led to mechanism-led; also tightened the "Sub-issues closed" bullet (was awkward double-duty as both trigger and rationale snippet) to a cleaner "Issue closes" generalization per user catch.
+- AC 8 (this entry): ✓
+
+**Phase 1 follow-up candidates** (to be filed as separate Issues, not landed here):
+
+- Promote hook to committed [`.claude/settings.json`](.claude/settings.json) — makes the recheck available to all 3 roles' worktrees.
+- Add `gh pr merge` trigger covering the auto-close-via-`closingIssuesReferences` path.
+- Add `gh issue reopen` as a counterpart to close (remaining capacity goes back up).
+- **Heredoc false-positive guard** — surfaced live during this Issue's own ship. The `gh issue edit 247 --body-file ...` command (with the body file written via `cat > ... <<EOF` heredoc inline) caused the dispatch script to match the close pattern + due_on PATCH pattern against text inside the heredoc body (the body documents these very triggers). Both rechecks were harmless `[No change]`, but the false-positive is real. Mitigation in this session was to run `gh issue edit --body-file <existing-file>` as a standalone Bash command (no inline heredoc) — the standalone command string is clean. Phase 1 hardening should detect heredoc structure and exclude its content before pattern matching.
+- Optional: pytest coverage for the dispatch script (mirroring [`tools/ci/test_check_at_claude.py`](tools/ci/test_check_at_claude.py) pattern from [Issue #360](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/360) — clean precedent).
+
+**Process notes:**
+
+- Lab notebook entry written before merge per closure ritual; PR opens next.
+- Plan to ship via [`scripts/audit_and_merge.sh`](scripts/audit_and_merge.sh) — inaugural PM-side use of yesterday's [Issue #357](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/357) closure-ritual gate.
+- Three "UPDATE NEEDED" findings on milestones (pm-i3, i2-S4, pm-i2) are independent of [Issue #247](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/247)'s ship — but the script's job is to make them visible, and one (pm-i3) was actioned during the smoke test. The other two need separate triage decisions (scope reduction on i2-S4 with Sci; capacity displacement on pm-i2 — perhaps create pm-i4 to absorb overflow).
+
+---
+
 ## 2026-05-17
 
 ### 19:12 UTC — Editor: PM

--- a/scripts/pm/recheck_milestone.py
+++ b/scripts/pm/recheck_milestone.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""Recheck a milestone's due_on against its remaining size-weighted capacity.
+
+Implements the recheck rule from memory/feedback_milestones.md:
+  new_due_on = today + remaining-days / 1.5 * 7 days
+
+Usage:
+  scripts/pm/recheck_milestone.py --issue N
+  scripts/pm/recheck_milestone.py --milestone N
+
+Exits 0 if delta within +-7 days, 2 if UPDATE NEEDED, 1 on error.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from datetime import date, datetime, timedelta
+
+REPO = "Jin-HoMLee/splice-neoepitope-pipeline"
+PROJECT_NUMBER = 9
+THRESHOLD_DAYS = 7
+AVAILABILITY_RATE = 1.5  # capacity-days per calendar-week
+
+# Size weight in capacity-days (midpoints of feedback_milestones.md ranges)
+SIZE_WEIGHTS = {"XS": 0.5, "S": 1.0, "M": 2.5, "L": 3.5, "XL": 5.0}
+
+
+def gh(*args: str, parse_json: bool = True) -> object:
+    result = subprocess.run(["gh", *args], capture_output=True, text=True, check=True)
+    return json.loads(result.stdout) if parse_json else result.stdout
+
+
+def milestone_for_issue(issue_number: int) -> int | None:
+    data = gh("issue", "view", str(issue_number), "--repo", REPO, "--json", "milestone")
+    return data["milestone"]["number"] if data.get("milestone") else None
+
+
+def milestone_meta(milestone_number: int) -> dict:
+    return gh("api", f"repos/{REPO}/milestones/{milestone_number}")
+
+
+def open_issues_in_milestone(milestone_title: str) -> list[int]:
+    data = gh(
+        "issue", "list",
+        "--repo", REPO,
+        "--milestone", milestone_title,
+        "--state", "open",
+        "--limit", "100",
+        "--json", "number",
+    )
+    return [issue["number"] for issue in data]
+
+
+def sizes_for_issues(issue_numbers: list[int]) -> dict[int, str | None]:
+    if not issue_numbers:
+        return {}
+    owner, name = REPO.split("/")
+    aliases = " ".join(
+        f'i{n}: issue(number: {n}) {{ '
+        f'projectItems(first: 5) {{ nodes {{ project {{ number }} '
+        f'fieldValues(first: 20) {{ nodes {{ '
+        f'... on ProjectV2ItemFieldSingleSelectValue {{ name field {{ ... on ProjectV2SingleSelectField {{ name }} }} }} '
+        f'}} }} }} }} }}'
+        for n in issue_numbers
+    )
+    query = f'query {{ repository(owner: "{owner}", name: "{name}") {{ {aliases} }} }}'
+    data = gh("api", "graphql", "-f", f"query={query}")
+    repo = data["data"]["repository"]
+    sizes: dict[int, str | None] = {}
+    for n in issue_numbers:
+        node = repo.get(f"i{n}") or {}
+        size: str | None = None
+        for pi in node.get("projectItems", {}).get("nodes", []):
+            if (pi.get("project") or {}).get("number") != PROJECT_NUMBER:
+                continue
+            for fv in pi.get("fieldValues", {}).get("nodes", []):
+                if (fv.get("field") or {}).get("name") == "Size":
+                    size = fv.get("name")
+        sizes[n] = size
+    return sizes
+
+
+def compute_recheck(milestone_number: int) -> int:
+    meta = milestone_meta(milestone_number)
+    title = meta["title"]
+    current_due_raw = meta.get("due_on")
+    current_due_date = (
+        datetime.fromisoformat(current_due_raw.replace("Z", "+00:00")).date()
+        if current_due_raw else None
+    )
+
+    issue_numbers = open_issues_in_milestone(title)
+    sizes = sizes_for_issues(issue_numbers)
+
+    print(f"Milestone: {title}")
+    print(f"Current due_on: {current_due_date or '—'}")
+    print(f"Open issues ({len(issue_numbers)}):")
+    remaining = 0.0
+    for n in sorted(issue_numbers):
+        size = sizes.get(n)
+        weight = SIZE_WEIGHTS.get(size or "", 0)
+        remaining += weight
+        size_disp = f"{size}, ~{weight}d" if size else "no size, 0d"
+        print(f"  - #{n} ({size_disp})")
+    print(f"Remaining capacity: {remaining}d")
+
+    if remaining == 0:
+        print("Proposed due_on: (no open work)")
+        print("Status: [No change] — milestone has no remaining capacity")
+        return 0
+
+    calendar_days = int(round(remaining / AVAILABILITY_RATE * 7))
+    proposed_due = date.today() + timedelta(days=calendar_days)
+    delta = (proposed_due - current_due_date).days if current_due_date else None
+    delta_str = f"{delta:+d}" if delta is not None else "n/a"
+    print(f"Proposed due_on: {proposed_due} (delta {delta_str} days)")
+
+    if delta is None or abs(delta) <= THRESHOLD_DAYS:
+        print("Status: [No change]")
+        return 0
+    print("Status: [UPDATE NEEDED]")
+    return 2
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--issue", type=int, help="Issue number; recheck its milestone")
+    group.add_argument("--milestone", type=int, help="Milestone number")
+    args = parser.parse_args()
+
+    if args.issue:
+        ms = milestone_for_issue(args.issue)
+        if ms is None:
+            print(f"error: issue #{args.issue} has no milestone", file=sys.stderr)
+            return 1
+        return compute_recheck(ms)
+    return compute_recheck(args.milestone)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/pm/recheck_milestone.py
+++ b/scripts/pm/recheck_milestone.py
@@ -107,6 +107,11 @@ def compute_recheck(milestone_number: int) -> int:
     print(f"Remaining capacity: {remaining}d")
 
     if remaining == 0:
+        unsized_count = sum(1 for n in issue_numbers if sizes.get(n) is None)
+        if unsized_count > 0:
+            print(f"Proposed due_on: (cannot compute — {unsized_count} open issue(s) missing Size)")
+            print("Status: [UNSIZED] — assign Size on the project board, then re-run")
+            return 2
         print("Proposed due_on: (no open work)")
         print("Status: [No change] — milestone has no remaining capacity")
         return 0


### PR DESCRIPTION
## Summary

- **Mechanism-over-memory escalation** for the milestone-recheck rule that drifted between trigger and recheck (memory wording alone was insufficient — rung-3 mechanism per `memory/shared/feedback_mechanism_over_memory.md`)
- **PostToolUse hook** at `.claude/hooks/recheck_milestone_dispatch.py` fires on 4 trigger shapes (close, move, resize, due_on PATCH) and surfaces a recheck report as `additionalContext` in the next prompt
- **Recheck atom** at `scripts/pm/recheck_milestone.py` (--issue N or --milestone N) — computes `new_due_on = today + remaining-days / 1.5 × 7 days` from open-issue size-weighted capacity, exits 0 / 2 on No change / UPDATE NEEDED
- **Phase 0** wiring in `.claude/settings.local.json` (gitignored, PM worktree only) per the Issue spec; Phase 1 promotion to committed `.claude/settings.json` is a separate follow-up

Live test confirmed end-to-end on a real `gh api PATCH` of `pm-i3 - PM Workflow Quick Wins II` due_on — hook fired, recheck output appeared. Smoke-test against the existing board surfaced 3 real UPDATE NEEDED milestones (pm-i3 +13d, i2-S4 +43d, pm-i2 +53d) — drift the script's job is to make visible.

Memory file reframe (`memory/feedback_milestones.md` Recheck section) + the "Sub-issues closed" trigger-bullet tighten landed in the personas repo (memory/ symlinks outside this worktree).

## Test plan

- [x] `python3 scripts/pm/recheck_milestone.py --milestone 19` (pm-i1) — delta +6 → `[No change]`, exit 0
- [x] `python3 scripts/pm/recheck_milestone.py --milestone 22` (pm-i3) — delta +13 → `[UPDATE NEEDED]`, exit 2
- [x] `python3 scripts/pm/recheck_milestone.py --milestone 17` (i2-S4) — delta +43 → `[UPDATE NEEDED]`, exit 2
- [x] Dispatch unit test: close pattern → correct JSON output with recheck of issue's milestone
- [x] Dispatch unit test: move pattern → BOTH old + new milestones rechecked via /events history lookup (used #324's real move history)
- [x] Dispatch unit test: due_on PATCH pattern → milestone rechecked (after fixing the order-agnostic regex)
- [x] Dispatch unit test: size mutation pattern → item ID → issue → milestone recheck
- [x] **Live test**: real `gh api -X PATCH .../milestones/22` fired the hook; `additionalContext` appeared in next prompt confirming `[No change]` post-PATCH
- [x] All 8 ACs on Issue #247 ticked with Verification notes section explaining what was tested how
- [x] Lab notebook entry on `research/lab_notebook/pm.md` (2026-05-18 10:36 UTC) before merge

Known limitation (Phase 1 candidate): the dispatch script matches patterns textually across the full `tool_input.command`, which includes shell heredoc bodies. Surfaced live during this Issue's own ship — `gh issue edit 247 --body-file ...` with a heredoc-written body file mentioning the triggers caused 2 harmless false positives. Documented in the Issue body Phase 1 list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
