### PR TITLE
splice/pm: ignore .claude/memory symlink (drop trailing slash)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -243,4 +243,4 @@ CLAUDE.local.md
 # Cross-repo symlink to claude-personas-splice/<role>/ (cwd access to role + shared memory)
 
 # claude-personas role-memory symlink
-/.claude/memory/
+/.claude/memory


### PR DESCRIPTION
## Summary

One-line `.gitignore` fix so the `.claude/memory` symlink stops showing as untracked in all role worktrees after the 2026-05-18 memory migration.

**Root cause:** `/.claude/memory/` had a trailing `/`, which gitignore matches as **directory only**. `.claude/memory` is a **symlink** to `claude-personas-splice-neoepitope-pipeline/<role>/`, so git treated it as a file and the rule missed it.

**Fix:** drop the trailing slash → `/.claude/memory` matches both files and directories. Tested locally: symlink now correctly ignored.

## Test plan

- [x] `git status` no longer lists `.claude/memory` as untracked (verified locally on PM clone)

(Sci + code clones will inherit the fix once they pull main; verification on those clones is out of scope for this PR.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)