### PR TITLE
splice/pm: scope /standup command to project-level

### DIFF
--- a/.claude/commands/standup.md
+++ b/.claude/commands/standup.md
@@ -1,0 +1,1 @@
+Apply the [Team standup protocol](feedback_team_standup.md) — Full standup rules: confirm with user, delete own stale messages (>7 days, Pending)

--- a/.gitignore
+++ b/.gitignore
@@ -234,7 +234,6 @@ dag.pdf
 
 # Claude Code — per-machine, per-worktree notes (e.g. role binding, local paths)
 CLAUDE.local.md
-.claude/commands/
 
 # Claude Code — transient scheduler state (per-session lock + durable cron jobs)
 .claude/scheduled_tasks.lock


### PR DESCRIPTION
## Summary

Move `/standup` from `~/.claude/commands/standup.md` (user-level, system-wide) to `.claude/commands/standup.md` (project-level, splice-clone-only). Per Jin-Ho's handoff: `/standup` should only resolve inside a splice clone.

**Changes:**
- New `.claude/commands/standup.md` — verbatim 1-line copy of the user-level file (target link `feedback_team_standup.md` resolves to `.claude/memory/shared/feedback_team_standup.md`, already present in the shared memory).
- Drop `.claude/commands/` from `.gitignore` so project-level slash commands can be tracked going forward.

**Coordinated step (not in this PR — post-merge):** `rm ~/.claude/commands/standup.md` to remove the user-level shadow. Delaying the delete until after merge means `/standup` keeps resolving system-wide during the transition.

Sibling clones (sci, code) inherit the project-level file once they `git pull main`.

## Test plan

- [x] Project-level file created at `.claude/commands/standup.md` (verified locally; `git status` shows `A .claude/commands/standup.md`)
- [x] Claude Code harness now lists `standup:` twice in available skills (user-level + project-level both loaded, project-level shadows when invoked inside this clone) — confirmed via system-reminder after file creation
- [x] Link target `feedback_team_standup.md` exists at `.claude/memory/shared/feedback_team_standup.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)