### PR TITLE
fix(star): rescue strand from intron motif when STAR col 4 is undefined (Issue #374)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,7 +166,27 @@ acceptor (0-based, exclusive) = chromStart + blockStarts[1]
 ```
 Treating cols 2-3 as donor/acceptor shifts every junction by the anchor lengths (typically 100–150 bp on each side) — and silently misses every GENCODE-annotated junction in downstream filtering. Issue #370 replaced the buggy inline `awk` in `alignment.smk` with `workflow/scripts/bed12_to_junctions.py`, which does the blockSizes math correctly.
 
-The STAR path is unaffected — `SJ.out.tab` cols 2-3 are 1-based intron donor/acceptor directly.
+The STAR path is unaffected by the anchor-outer issue — `SJ.out.tab` cols 2-3 are 1-based intron donor/acceptor directly. STAR has its own silent-contamination bug class on **col 4** instead (next section).
+
+## STAR `SJ.out.tab` — `strand=0` rescue from intron motif
+
+`SJ.out.tab` col 4 encodes strand: `0=undefined, 1=+, 2=-`. STAR sets col 4 = 0 when it cannot infer strand from the intron motif (non-canonical splice site, or insufficient evidence in a non-stranded library). The original inline awk in `alignment.smk` silently emitted these records with strand `.`, which flowed through to `assemble_contigs.py` — `bedtools getfasta` without `-s` takes forward-orientation flanking sequence for strand-`.` records, so true minus-strand junctions got sequence-reversed contigs and `translate_peptides.py` read them in the wrong frame.
+
+**Fix:** `workflow/scripts/star_sj_to_junctions.py` rescues strand from **col 5** (intron motif) when col 4 = 0:
+
+| col 5 | motif    | strand |
+|-------|----------|--------|
+| 0     | non-canonical | dropped (cannot infer) |
+| 1     | GT/AG    | `+` |
+| 2     | CT/AC    | `-` |
+| 3     | GC/AG    | `+` |
+| 4     | CT/GC    | `-` |
+| 5     | AT/AC    | `+` |
+| 6     | GT/AT    | `-` |
+
+Truly non-canonical (col 5 = 0) and unknown codes are **dropped** rather than emitted as strand `.`, on the theory that contaminating the candidate set is worse than slightly under-recalling. Per-run breakdown (direct vs rescued vs dropped) is logged at INFO. Issue #374 replaced the inline awk with this script, mirroring the HISAT2 path's [bed12_to_junctions.py](workflow/scripts/bed12_to_junctions.py) extraction.
+
+The HISAT2 path is unaffected by this — `regtools junctions extract` derives strand from the XS BAM tag set during alignment and never emits `.` strand.
 
 ## UCSC vs ENSEMBL Chromosome Naming
 Both naming conventions use "GRCh38" in filenames, making it easy to mix them silently.

--- a/research/lab_notebook/developer.md
+++ b/research/lab_notebook/developer.md
@@ -6,6 +6,35 @@ Format and rules unchanged from the unified notebook — see `shared/feedback_la
 
 ---
 
+## 2026-05-18
+
+### 21:59 UTC — Editor: Developer
+
+**Headline:** [PR #402](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/402) (STAR strand=0 motif rescue, closes [Issue #374](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/374)) review-response shipped — second silent-contamination axis on the splice-junction extraction surface, sibling to the HISAT2 BED12 anchor-outer bug fixed in [PR #372](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/372). Inline awk in `alignment.smk` was emitting STAR `SJ.out.tab` records with strand `.` whenever STAR couldn't infer strand directly (col 4 = 0); `bedtools getfasta` (called without `-s` in [`assemble_contigs.py`](workflow/scripts/assemble_contigs.py)) then treated `.` as forward orientation, yielding reverse-orientation flanking sequence for true minus-strand junctions and wrong-frame translation downstream.
+
+**Implementation:** new [`workflow/scripts/star_sj_to_junctions.py`](workflow/scripts/star_sj_to_junctions.py) mirrors the structure of [`bed12_to_junctions.py`](workflow/scripts/bed12_to_junctions.py) introduced in [PR #372](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/372). Uses STAR's col 4 directly when ∈ {1,2}; rescues strand from col 5 (intron motif) when col 4 = 0, with the 6 canonical/semi-canonical motifs mapping to ± and motif=0 (truly non-canonical) dropped rather than emitted as `.`. Drop-vs-`.` policy is the explicit lesson from PR #372: contaminating the candidate set is worse than under-recalling. Output format unchanged (`<chrom>:<donor>:<end>:<strand>\t<reads>`), so DAG stays identical and downstream rules are aligner-agnostic.
+
+**Review iteration:** bot review at [comment-4479665786](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/402#issuecomment-4479665786) surfaced 2 actionable items + 3 verified-correct observations. Both items applied:
+
+- `e14b560` — added 4-case parametric test pinning the "col 4 takes priority over motif" invariant (`strand=1 motif=2 → +`, `strand=2 motif=1 → -`, plus the non-canonical-motif counterparts). Reviewer correctly identified that the priority rule was the core of the rescue logic and had no test coverage — `TestDirectStrand` only exercised the agreeing pairs.
+- `d3f02d1` — made the `strand_code == 0` branch in `_resolve_strand` explicit; any other code now returns `None` (drop) rather than falling through to motif lookup. No behavior change for STAR-spec inputs (col 4 ∈ {0,1,2}), just tightens intent. Borderline against "don't validate scenarios that can't happen" — applied for clarity, not defense.
+
+Reply at [comment-4482564368](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/402#issuecomment-4482564368).
+
+**Verification trail:**
+
+- Full pytest suite **282 passed, 25 skipped** on `d3f02d1` (was 278 pre-review; +4 new priority cases, no regressions).
+- All 3 CI checks (`pipeline-pytest`, `pipeline-snakemake-dry-run`, `ci-tools-pytest`) green on the post-review SHA.
+- DAG sanity: `snakemake --rulegraph` output on `origin/main` vs HEAD is identical when sorted (only edge-emission order differs, which is non-deterministic in snakemake's dot output). Required running `bash scripts/prepare_test_data.sh` first to materialize `resources/test/chr22.fa` — `--rulegraph` still does an input-existence check at DAG-build time.
+
+**Process notes:**
+
+- DAG render attempt initially failed with `MissingInputException` because this clone had no `resources/test/`. `--clean` mode in [`visualize_dag.sh`](scripts/visualize_dag.sh) generates placeholders for sample FASTQs only, not for reference files like `chr22.fa` — the symlink workspace inherits the missing parent. Followed user's call to download via `prepare_test_data.sh` rather than tick the box on inspection alone; the airtight sort-diff result was worth the ~15 min download.
+- Spurious `git -c commit.gpgsign=true` slipped into the first commit attempt and failed because no GPG secret key is configured for `jinho.michael.lee@gmail.com`. Recent branch commits are unsigned (`git log --pretty='%G?' → N`), so signing is opt-out by user config — re-ran without the override. Not a memory-worthy slip; just a stray flag.
+- Two review-response commits split per-concern (test first, then refactor) to match the existing branch's per-file commit pattern (`921fabf test`, `3dff7bb feat`, `160ba9e refactor`, `d7dffec docs`).
+
+---
+
 ## 2026-05-17
 
 ### 19:31 UTC — Editor: Developer

--- a/workflow/rules/alignment.smk
+++ b/workflow/rules/alignment.smk
@@ -348,14 +348,14 @@ elif config.get("alignment", {}).get("aligner") == "star":
                 --outSJfilterCountTotalMin 1 1 1 1 \\
                 2>&1 | tee {log}
 
-            awk -F'\\t' '{{
-                strand = ".";
-                if ($4 == 1) strand = "+";
-                else if ($4 == 2) strand = "-";
-                if ($7 > 0) print $1":"$2":"$3":"strand"\\t"$7
-            }}' {params.output_prefix}SJ.out.tab > {output.junctions}
-
-            echo "Converted $(wc -l < {output.junctions}) junctions from STAR output"
+            # SJ.out.tab col 4=0 means STAR couldn't infer strand; rescue from
+            # col 5 (intron motif) where possible, drop truly non-canonical —
+            # see Issue #374. The helper also handles the col 7 > 0 filter
+            # and emits the same junctions.tsv format as the HISAT2 path.
+            python workflow/scripts/star_sj_to_junctions.py \\
+                --input {params.output_prefix}SJ.out.tab \\
+                --output {output.junctions} \\
+                2>&1 | tee -a {log}
             """
 
 else:

--- a/workflow/scripts/star_sj_to_junctions.py
+++ b/workflow/scripts/star_sj_to_junctions.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""star_sj_to_junctions.py — Convert STAR ``SJ.out.tab`` to junctions.tsv.
+
+STAR emits 9 tab-separated columns in ``SJ.out.tab``:
+
+    1: chromosome
+    2: intron first base (1-based)
+    3: intron last base  (1-based, inclusive)
+    4: strand    (0=undefined, 1=+, 2=-)
+    5: intron motif (0=non-canonical, 1=GT/AG +, 2=CT/AC -, 3=GC/AG +,
+                     4=CT/GC -, 5=AT/AC +, 6=GT/AT -)
+    6: annotated (0=novel, 1=annotated)
+    7: # uniquely-mapping reads crossing the junction
+    8: # multi-mapping reads crossing the junction
+    9: maximum spliced alignment overhang
+
+This script emits the same 2-column TSV that ``bed12_to_junctions.py`` produces
+on the HISAT2 path, so downstream rules are aligner-agnostic:
+
+    <chrom>:<1-based donor>:<1-based inclusive end>:<strand>\\t<reads>
+
+Numerically, STAR's 1-based inclusive end equals the 0-based half-open exclusive
+end consumed by ``filter_junctions._parse_junction_id`` (``end = int(parts[2])``).
+
+Strand resolution (Issue #374):
+    Previously inline awk emitted strand `.` whenever col 4 = 0, silently
+    contaminating the candidate set — ``assemble_contigs.py`` then took
+    forward-orientation flanking sequence for what may have been minus-strand
+    introns. The rescue uses col 5 (intron motif) when col 4 = 0:
+      motif ∈ {1,3,5} → '+' (GT/AG, GC/AG, AT/AC)
+      motif ∈ {2,4,6} → '-' (CT/AC, CT/GC, GT/AT)
+      motif = 0 or unknown → drop (truly non-canonical; cannot infer)
+
+See: https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/374
+"""
+
+import argparse
+import logging
+from pathlib import Path
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
+)
+log = logging.getLogger(__name__)
+
+
+_MOTIF_TO_STRAND = {1: "+", 2: "-", 3: "+", 4: "-", 5: "+", 6: "-"}
+
+
+def _resolve_strand(strand_code: int, motif_code: int) -> str | None:
+    """Return '+'/'-' for this junction, or None if it should be dropped.
+
+    STAR's col 4 takes priority — if STAR inferred strand directly, use it.
+    Otherwise fall back to the motif table. Motif 0 (truly non-canonical) and
+    unknown codes return None so the caller drops the record entirely rather
+    than emitting strand '.', which downstream `bedtools getfasta` would treat
+    as forward orientation.
+    """
+    if strand_code == 1:
+        return "+"
+    if strand_code == 2:
+        return "-"
+    return _MOTIF_TO_STRAND.get(motif_code)
+
+
+def convert_sj_to_junctions(input_path: str | Path, output_path: str | Path) -> int:
+    """Convert STAR ``SJ.out.tab`` to a 2-column junctions TSV.
+
+    Args:
+        input_path:  STAR ``SJ.out.tab`` (9-column TSV).
+        output_path: Destination TSV (``<chrom>:<donor>:<end>:<strand>\\treads``).
+
+    Returns:
+        Number of junctions written.
+    """
+    input_path = Path(input_path)
+    output_path = Path(output_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    n_written = 0
+    n_direct = 0
+    n_rescued = 0
+    n_dropped_motif = 0
+    n_dropped_zero_reads = 0
+    n_dropped_malformed = 0
+
+    with input_path.open() as fh_in, output_path.open("w") as fh_out:
+        for line in fh_in:
+            if not line.strip():
+                continue
+            fields = line.rstrip("\n").split("\t")
+            if len(fields) < 7:
+                n_dropped_malformed += 1
+                continue
+
+            try:
+                strand_code = int(fields[3])
+                motif_code = int(fields[4])
+                reads = int(fields[6])
+            except ValueError:
+                n_dropped_malformed += 1
+                continue
+
+            if reads <= 0:
+                n_dropped_zero_reads += 1
+                continue
+
+            strand = _resolve_strand(strand_code, motif_code)
+            if strand is None:
+                n_dropped_motif += 1
+                continue
+
+            if strand_code in (1, 2):
+                n_direct += 1
+            else:
+                n_rescued += 1
+
+            chrom = fields[0]
+            start = fields[1]
+            end = fields[2]
+            fh_out.write(f"{chrom}:{start}:{end}:{strand}\t{reads}\n")
+            n_written += 1
+
+    log.info(
+        "Wrote %d junctions to %s "
+        "(direct=%d, rescued_via_motif=%d, "
+        "dropped_motif_unknown=%d, dropped_zero_reads=%d, dropped_malformed=%d)",
+        n_written,
+        output_path,
+        n_direct,
+        n_rescued,
+        n_dropped_motif,
+        n_dropped_zero_reads,
+        n_dropped_malformed,
+    )
+    return n_written
+
+
+def _cli_main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Convert STAR SJ.out.tab to a 2-column junctions TSV."
+    )
+    parser.add_argument("--input", required=True, help="STAR SJ.out.tab input")
+    parser.add_argument("--output", required=True, help="junctions TSV output")
+    args = parser.parse_args()
+    convert_sj_to_junctions(args.input, args.output)
+
+
+if __name__ == "__main__":
+    _cli_main()

--- a/workflow/scripts/star_sj_to_junctions.py
+++ b/workflow/scripts/star_sj_to_junctions.py
@@ -53,16 +53,18 @@ def _resolve_strand(strand_code: int, motif_code: int) -> str | None:
     """Return '+'/'-' for this junction, or None if it should be dropped.
 
     STAR's col 4 takes priority — if STAR inferred strand directly, use it.
-    Otherwise fall back to the motif table. Motif 0 (truly non-canonical) and
-    unknown codes return None so the caller drops the record entirely rather
-    than emitting strand '.', which downstream `bedtools getfasta` would treat
-    as forward orientation.
+    Only ``strand_code == 0`` (STAR could not infer) triggers the motif rescue.
+    Motif 0 (truly non-canonical), unknown motif codes, and unknown strand codes
+    all return None so the caller drops the record rather than emitting strand
+    '.', which downstream `bedtools getfasta` would treat as forward orientation.
     """
     if strand_code == 1:
         return "+"
     if strand_code == 2:
         return "-"
-    return _MOTIF_TO_STRAND.get(motif_code)
+    if strand_code == 0:
+        return _MOTIF_TO_STRAND.get(motif_code)
+    return None
 
 
 def convert_sj_to_junctions(input_path: str | Path, output_path: str | Path) -> int:

--- a/workflow/tests/test_star_sj_to_junctions.py
+++ b/workflow/tests/test_star_sj_to_junctions.py
@@ -63,6 +63,23 @@ class TestDirectStrand:
         convert_sj_to_junctions(sj, out)
         assert out.read_text().strip() == "chr22:101:200:-\t10"
 
+    @pytest.mark.parametrize("strand,motif,expected", [
+        (1, 2, "+"),  # col 4 says +, motif says -; col 4 wins
+        (2, 1, "-"),  # col 4 says -, motif says +; col 4 wins
+        (1, 0, "+"),  # col 4 says +, motif is non-canonical; col 4 wins
+        (2, 0, "-"),  # col 4 says -, motif is non-canonical; col 4 wins
+    ])
+    def test_direct_strand_takes_priority_over_motif(
+        self, tmp_path, strand, motif, expected
+    ):
+        """Core invariant: when STAR sets col 4 (1 or 2), motif is ignored."""
+        sj = tmp_path / "SJ.out.tab"
+        sj.write_text(_sj_line(strand=strand, motif=motif) + "\n")
+        out = tmp_path / "junctions.tsv"
+
+        convert_sj_to_junctions(sj, out)
+        assert out.read_text().strip() == f"chr22:101:200:{expected}\t10"
+
 
 class TestMotifRescue:
     """When col 4 = 0, col 5 (intron motif) recovers strand for codes 1-6."""

--- a/workflow/tests/test_star_sj_to_junctions.py
+++ b/workflow/tests/test_star_sj_to_junctions.py
@@ -1,0 +1,199 @@
+"""Tests for star_sj_to_junctions.py — STAR SJ.out.tab → junctions.tsv conversion.
+
+Regression test for [Issue #374](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/374):
+STAR emits strand=0 (col 4 = 0) when it cannot infer strand from intron motif —
+the previous inline awk silently wrote these as strand `.`, leading to wrong-
+orientation flanking sequence in downstream `assemble_contigs.py`. The rescue
+uses col 5 (intron motif) to recover strand for the 6 canonical/semi-canonical
+motifs and drops the non-canonical (motif=0) remainder rather than corrupting it.
+
+STAR SJ.out.tab columns (per the STAR manual):
+    1: chrom
+    2: intron first base (1-based)
+    3: intron last base  (1-based, inclusive)
+    4: strand    (0=undefined, 1=+, 2=-)
+    5: motif     (0=non-canonical, 1=GT/AG +, 2=CT/AC -, 3=GC/AG +,
+                  4=CT/GC -, 5=AT/AC +, 6=GT/AT -)
+    6: annotated (0=novel, 1=annotated)  — used by Issue #375
+    7: # uniquely-mapping reads crossing
+    8: # multi-mapping reads crossing
+    9: max overhang
+"""
+
+from pathlib import Path
+
+import pytest
+
+from star_sj_to_junctions import convert_sj_to_junctions
+
+
+def _sj_line(
+    chrom="chr22",
+    start=101,
+    end=200,
+    strand=1,
+    motif=1,
+    annotated=0,
+    unique=10,
+    multi=0,
+    overhang=50,
+):
+    """Build one SJ.out.tab line (9 tab-separated fields, integers)."""
+    return "\t".join(
+        str(x) for x in (chrom, start, end, strand, motif, annotated, unique, multi, overhang)
+    )
+
+
+class TestDirectStrand:
+    """When STAR sets col 4 directly (1 or 2), no motif lookup is needed."""
+
+    def test_strand_plus_direct(self, tmp_path):
+        sj = tmp_path / "SJ.out.tab"
+        sj.write_text(_sj_line(strand=1, motif=1) + "\n")
+        out = tmp_path / "junctions.tsv"
+
+        convert_sj_to_junctions(sj, out)
+        assert out.read_text().strip() == "chr22:101:200:+\t10"
+
+    def test_strand_minus_direct(self, tmp_path):
+        sj = tmp_path / "SJ.out.tab"
+        sj.write_text(_sj_line(strand=2, motif=2) + "\n")
+        out = tmp_path / "junctions.tsv"
+
+        convert_sj_to_junctions(sj, out)
+        assert out.read_text().strip() == "chr22:101:200:-\t10"
+
+
+class TestMotifRescue:
+    """When col 4 = 0, col 5 (intron motif) recovers strand for codes 1-6."""
+
+    @pytest.mark.parametrize("motif,expected_strand", [
+        (1, "+"),  # GT/AG
+        (3, "+"),  # GC/AG
+        (5, "+"),  # AT/AC
+    ])
+    def test_plus_motifs_rescue_to_plus(self, tmp_path, motif, expected_strand):
+        sj = tmp_path / "SJ.out.tab"
+        sj.write_text(_sj_line(strand=0, motif=motif) + "\n")
+        out = tmp_path / "junctions.tsv"
+
+        convert_sj_to_junctions(sj, out)
+        assert out.read_text().strip() == f"chr22:101:200:{expected_strand}\t10"
+
+    @pytest.mark.parametrize("motif,expected_strand", [
+        (2, "-"),  # CT/AC
+        (4, "-"),  # CT/GC
+        (6, "-"),  # GT/AT
+    ])
+    def test_minus_motifs_rescue_to_minus(self, tmp_path, motif, expected_strand):
+        sj = tmp_path / "SJ.out.tab"
+        sj.write_text(_sj_line(strand=0, motif=motif) + "\n")
+        out = tmp_path / "junctions.tsv"
+
+        convert_sj_to_junctions(sj, out)
+        assert out.read_text().strip() == f"chr22:101:200:{expected_strand}\t10"
+
+    def test_motif_zero_strand_zero_dropped(self, tmp_path):
+        """strand=0 + motif=0 (truly non-canonical) is dropped, not emitted as '.'.
+
+        The whole point of the bug fix — silently emitting these as strand `.`
+        causes wrong-orientation flanking sequence downstream.
+        """
+        sj = tmp_path / "SJ.out.tab"
+        sj.write_text(_sj_line(strand=0, motif=0) + "\n")
+        out = tmp_path / "junctions.tsv"
+
+        convert_sj_to_junctions(sj, out)
+        assert out.read_text() == ""
+
+    def test_motif_out_of_range_dropped(self, tmp_path):
+        """Defensive: unknown motif code (>6) is treated as motif=0 (drop)."""
+        sj = tmp_path / "SJ.out.tab"
+        sj.write_text(_sj_line(strand=0, motif=7) + "\n")
+        out = tmp_path / "junctions.tsv"
+
+        convert_sj_to_junctions(sj, out)
+        assert out.read_text() == ""
+
+
+class TestFiltering:
+    """Reads-count filter + malformed-line tolerance."""
+
+    def test_zero_unique_reads_skipped(self, tmp_path):
+        sj = tmp_path / "SJ.out.tab"
+        sj.write_text(_sj_line(unique=0) + "\n")
+        out = tmp_path / "junctions.tsv"
+
+        convert_sj_to_junctions(sj, out)
+        assert out.read_text() == ""
+
+    def test_skips_short_malformed_lines(self, tmp_path):
+        sj = tmp_path / "SJ.out.tab"
+        sj.write_text(
+            "chr22\t101\t200\t1\n"  # only 4 fields — malformed
+            + _sj_line() + "\n"
+        )
+        out = tmp_path / "junctions.tsv"
+
+        convert_sj_to_junctions(sj, out)
+        assert out.read_text().strip() == "chr22:101:200:+\t10"
+
+    def test_skips_blank_lines(self, tmp_path):
+        sj = tmp_path / "SJ.out.tab"
+        sj.write_text(
+            "\n"
+            + _sj_line() + "\n"
+            "   \n"
+        )
+        out = tmp_path / "junctions.tsv"
+
+        convert_sj_to_junctions(sj, out)
+        assert out.read_text().strip() == "chr22:101:200:+\t10"
+
+    def test_skips_non_integer_count(self, tmp_path):
+        sj = tmp_path / "SJ.out.tab"
+        sj.write_text(
+            "chr22\t101\t200\t1\t1\t0\tnotanum\t0\t50\n"
+            + _sj_line() + "\n"
+        )
+        out = tmp_path / "junctions.tsv"
+
+        convert_sj_to_junctions(sj, out)
+        assert out.read_text().strip() == "chr22:101:200:+\t10"
+
+
+class TestMultipleRecords:
+    """Mixed direct + rescued + dropped in one file."""
+
+    def test_mixed_records_preserve_order(self, tmp_path):
+        sj = tmp_path / "SJ.out.tab"
+        sj.write_text(
+            _sj_line(strand=1, motif=1, unique=5) + "\n"            # direct +
+            + _sj_line(start=300, end=400, strand=0, motif=2, unique=3) + "\n"  # rescued -
+            + _sj_line(start=500, end=600, strand=0, motif=0, unique=7) + "\n"  # dropped
+            + _sj_line(start=700, end=800, strand=2, motif=2, unique=2) + "\n"  # direct -
+        )
+        out = tmp_path / "junctions.tsv"
+
+        convert_sj_to_junctions(sj, out)
+        lines = out.read_text().strip().splitlines()
+        assert lines == [
+            "chr22:101:200:+\t5",
+            "chr22:300:400:-\t3",
+            "chr22:700:800:-\t2",
+        ]
+
+
+class TestReturnValue:
+    """The function returns the number of junctions written."""
+
+    def test_returns_count_of_written_records(self, tmp_path):
+        sj = tmp_path / "SJ.out.tab"
+        sj.write_text(
+            _sj_line(strand=1, motif=1, unique=5) + "\n"
+            + _sj_line(start=300, end=400, strand=0, motif=2, unique=3) + "\n"
+            + _sj_line(start=500, end=600, strand=0, motif=0, unique=7) + "\n"  # dropped
+        )
+        out = tmp_path / "junctions.tsv"
+
+        assert convert_sj_to_junctions(sj, out) == 2


### PR DESCRIPTION
**Created by:** Developer

Closes [Issue #374](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/374).

## Summary

STAR's `SJ.out.tab` col 4 (strand) is `0` whenever STAR cannot infer strand directly — non-canonical splice sites, non-stranded libraries, or insufficient evidence. The previous inline awk in [alignment.smk](workflow/rules/alignment.smk) silently emitted these as strand `.`, which then flowed into [`assemble_contigs.py`](workflow/scripts/assemble_contigs.py) where `bedtools getfasta` (called without `-s`) treats `.` as forward orientation — producing reverse-orientation flanking sequence for true minus-strand junctions, which [`translate_peptides.py`](workflow/scripts/translate_peptides.py) then translates in the wrong frame. Same silent-contamination class as the HISAT2 BED12 bug fixed in [PR #372](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/372), different aligner path.

This PR replaces the inline awk with [`workflow/scripts/star_sj_to_junctions.py`](workflow/scripts/star_sj_to_junctions.py), which:

- Uses STAR's col 4 directly when it is 1 or 2 (matches old behavior)
- Falls back to **col 5** (intron motif) when col 4 = 0:
  - motif ∈ {1, 3, 5} (GT/AG, GC/AG, AT/AC) → `+`
  - motif ∈ {2, 4, 6} (CT/AC, CT/GC, GT/AT) → `-`
- **Drops** junctions where motif = 0 (truly non-canonical) or unknown — never emits strand `.`. Drop-vs-`.` policy chosen for the same reason `assemble_contigs.py` would otherwise corrupt them
- Logs a per-run breakdown at INFO: `direct` / `rescued_via_motif` / `dropped_motif_unknown` / `dropped_zero_reads` / `dropped_malformed`

Output format is unchanged (`<chrom>:<donor>:<end>:<strand>\t<reads>`) so downstream rules are aligner-agnostic and DAG-structurally identical to before.

## Changes

| File | Change |
| --- | --- |
| [workflow/scripts/star_sj_to_junctions.py](workflow/scripts/star_sj_to_junctions.py) | New — 154 LOC, mirrors `bed12_to_junctions.py` structure |
| [workflow/tests/test_star_sj_to_junctions.py](workflow/tests/test_star_sj_to_junctions.py) | New — 20 tests, parametric over all 7 motif codes + col-4-priority invariant |
| [workflow/rules/alignment.smk](workflow/rules/alignment.smk) | STAR `awk` block swapped for `python` script call (same I/O contract) |
| [CLAUDE.md](CLAUDE.md) | New "STAR `SJ.out.tab` — `strand=0` rescue from intron motif" section; scoped the existing "STAR path is unaffected" line to cols 2-3 only |

## Test plan

- [x] 20 unit tests pass (direct ±, col-4-priority over contradicting motif, motif-rescue ±, motif=0 drop, motif>6 drop, zero-reads filter, malformed/blank tolerance, ordered mixed-records, return value)
- [x] Full pytest suite green: `282 passed, 25 skipped` — no regressions
- [x] `pipeline-pytest` + `pipeline-snakemake-dry-run` + `ci-tools-pytest` CI green on post-review SHA `d3f02d1`
- [x] DAG sanity check: `snakemake --rulegraph` output between `origin/main` and HEAD is identical (sorted diff confirms same node + edge set; only line ordering differs, which is non-deterministic in snakemake's dot output). `bash scripts/visualize_dag.sh` renders `dag.svg` cleanly on HEAD.
- [x] Lab notebook entry added post-review per [`feedback_lab_notebook.md`](memory/shared/feedback_lab_notebook.md) — see [research/lab_notebook/developer.md](research/lab_notebook/developer.md) 2026-05-18 21:59 UTC section (commit `012f85a`)

## Related

- [PR #372](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/372) (parent bug-class fix) — HISAT2 BED12 anchor-outer extraction (parallel silent-contamination axis on the HISAT2 path)
- [Issue #375](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/375) (companion) — STAR SJ.out.tab col 6 (annotated flag) emission + reader extension
- [Issue #377](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/377) (companion) — CI canary cross-check against `regtools junctions annotate`
- [Issue #378](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/378) (verification) — patient_002 PoC re-run with the [PR #372](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/372) + this fix
