### PR TITLE
docs(scientist): news_log 2026-05-20 — Dark Matter NA + MHC1-TIP

### DIFF
--- a/research/glossary.md
+++ b/research/glossary.md
@@ -110,6 +110,8 @@ Project-relevant abbreviations and acronyms. The pipeline mixes biology, ML, bio
 
 **MHC** — Major Histocompatibility Complex. Cell-surface proteins that present peptides to T cells; class I (all nucleated cells, presents endogenous peptides) drives this pipeline. Human MHC = HLA. *Domain: bio.*
 
+**MHC1-TIP** — MHC class I 1-Tube Immunopeptidomics. Low-input, single-tube MHC-I ligandome workflow ([Dollinger et al. 2026, *Comm Bio*](https://www.nature.com/articles/s42003-026-09570-6)); scales to cell lines, patient-derived organoids, and sub-mg ex-vivo tumor fragments — replaces traditional workflows requiring hundreds of millions of cells. Primary RCC application revealed widespread **intratumoral heterogeneity in antigen presentation that is poorly correlated with source protein expression** — relevant to the RNA-Seq-abundance ≠ surface-presentation framing in this pipeline. *Domain: bio.*
+
 ## N
 
 **NJ** — Neojunction. Tumor-specific or recurrent splice junction absent from canonical normal-tissue annotation; the upstream substrate from which splice neoepitopes are translated. Notation introduced by Nejo et al. (*Nat. Med.* 2023). Kwok et al. additionally use **NEJ** (neoepitope-encoding junction) for the validated subset yielding a presented peptide (e.g. NEJ<sub>GNAS</sub>, NEJ<sub>RPL22</sub>). *Domain: bio.*

--- a/research/news_log.md
+++ b/research/news_log.md
@@ -13,6 +13,12 @@ Historical entries (before 2026-05-02) pre-date the time/editor sub-heading conv
 
 ## 2026-05-20
 
+### 09:25 UTC — Editor: Scientist
+
+- **Rwandamuriye et al. — "Dark Matter" Neoantigens** ([Vaccines 2026](https://www.mdpi.com/2076-393X/14/1/104)) — review of non-canonical NA: AS / intron retention / ncRNA / fusions / retroelements. → INTRO + DISCUSSION; Zotero deferred. *Scientist. portfolio-differentiator.*
+- **Sultan & Schreiber — Cancer NA Vaccines field review** ([Annu Rev Med 2026](https://www.annualreviews.org/content/journals/10.1146/annurev-med-071723-045853)) — personalized NA vaccine synthesis: mRNA / peptide / DNA / viral-vector. → DISCUSSION; Zotero deferred. *Scientist. clinical-validation.*
+- **Dollinger et al. — MHC1-TIP** ([Comm Bio 2026](https://www.nature.com/articles/s42003-026-09570-6)) — single-tube low-input MHC-I immunopeptidomics; RCC ITH uncoupled from protein expression. → Glossary same PR; DISCUSSION flag. *Scientist. methodology-signal.*
+
 ### 09:15 UTC — Editor: PM
 
 - **Claude Agent SDK dual-bucket billing — effective 2026-06-15** ([Apiyi 2026-05](https://help.apiyi.com/en/anthropic-claude-subscription-agent-sdk-billing-split-june-2026-en.html)) — Agent SDK + `claude -p` + `Claude Code` GitHub Actions split into a separate dollar credit pool. → `@claude review` cost-forecast input; [Issue #305](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/305) gains billing constraint. *PM. ops-signal.*


### PR DESCRIPTION
## Summary

- Three news_log items at 09:25 UTC: Rwandamuriye "Dark Matter" NA review (Vaccines 2026), Sultan & Schreiber NA-vaccines field review (Annu Rev Med 2026), Dollinger MHC1-TIP single-tube immunopeptidomics (Comm Bio 2026)
- MHC1-TIP glossary entry added under M (bundled per the news-derived-docs convention)

## Test plan

- [x] CI green
- [x] news_log entry under today's date, Editor: Scientist, above PM's 09:15 UTC block
- [x] glossary entry alphabetized after MHC
- [x] no lab notebook entry (news_log PRs are exempt)

**Created by:** Scientist