### PR TITLE
test(profile): import-cost profiler + memory-tight workaround docs for Issue #364

### DIFF
--- a/research/lab_notebook/developer.md
+++ b/research/lab_notebook/developer.md
@@ -6,6 +6,41 @@ Format and rules unchanged from the unified notebook — see `shared/feedback_la
 
 ---
 
+## 2026-05-20
+
+### 15:30 UTC — Editor: Developer
+
+**Headline:** [PR #424](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/424) shipped, closing [Issue #364](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/364) (local pytest collection hangs under memory pressure). Two deliverables: a committed per-file cold-import profiler at [workflow/tests/scripts/profile_imports.py](workflow/tests/scripts/profile_imports.py) (AC 1) + a "Running on memory-tight machines" section added to [workflow/tests/README.md](workflow/tests/README.md) (AC 2). Remaining AC 3 (verify suite < 60s on M1 8 GB under deliberate paging) carved out as [Issue #425](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/425) and absorbed alongside the lazy-pandas refactor work.
+
+#### 10-min quick-win triage → diagnostic-only investigation
+
+User opened with "any quick wins for the next 10 min?" — I scanned my open dev queue, no PRs blocked on review, and offered three options ([Issue #345](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/345) naming refactor, [Issue #364](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/364) import profile, memory hygiene). Picked #364 as diagnostic-only — concrete signal output, no merge pressure, directly unblocks future local pytest work. The "diagnostic-only" framing kept the budget bounded: the goal was a comment with findings, not a PR.
+
+#### Hypothesis refinement — the original Issue was overstated
+
+Issue body hypothesised that test files import heavy ML libraries (`mhcflurry`, `torch`, `tensorflow`) at module scope. Profiler showed that's **not the case** — none of those are at module scope anywhere. The dominant module-level import is `pandas` (0.26s cold), pulled in by 6 test files + 6 project scripts. Under memory pressure the OS page cache thrashes, amplifying every fresh `pandas` import into a multi-minute event (matches the original `import pandas` hung > 2.5 min observation). Pytest's assertion rewriter compounds it. So the failure mode is **paging-amplified, not import-count-amplified** — refactor target should be lazy-importing pandas in the heavy scripts, which I carved into [Issue #425](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/425).
+
+#### Scope escalation diagnostic → PR
+
+After posting findings as a comment, user asked "are we closing without changes?" — caught me leaving 3 ACs unticked. Two paths offered: fan out to sub-issues, OR ship a small PR covering ACs 1+2 now. User picked the PR route. Profiler script promoted from `/tmp/` to `workflow/tests/scripts/profile_imports.py`, README updated with the two known workarounds (single-file runs, `-p no:assertion`).
+
+#### Workflow correction — close Issues with PR, carve follow-up
+
+Initially left #364 open with "stays open until #425 ships" for the M1-verify AC. User flagged: prefer carving the remaining work into a new Issue and closing the original with the PR. Saved as a new shared memory ([feedback_close_issue_with_pr.md](.claude/memory/shared/feedback_close_issue_with_pr.md)) and applied retroactively — #425 absorbed AC 3, PR body changed from `Refs Issue #364` to `Closes Issue #364`, the three ACs on #364 ticked with deferred-to links. The closure-ritual gate (`scripts/audit_and_merge.sh`) will see all boxes ticked at merge time.
+
+#### Bot review — two nice-to-haves applied, two nits skipped per bot's own non-blocker calls
+
+Bot finished in 2m 4s with "Good to merge as-is" + three observations (commit `79282cb` covers two):
+- **Applied:** docstring note in `truncate_to_imports_and_defs` flagging that `ast.Try` ends truncation early (no module-scope try-blocks today, but future-fragile).
+- **Applied:** surface last non-empty stderr line on subprocess failure as `  └─ [file] exit=N: <error>`. Naive `print(r.stderr)` dumped Python's full traceback including the synthetic exec'd source — truncating to the last line gives the actionable signal.
+- **Skipped:** reversed `'__main__' == __name__` form (no file uses it) + README "while" phrasing nit (bot self-identified as non-blocker).
+
+#### Methodology note — profiler design choice
+
+Tried `python -X importtime -m pytest --collect-only` first; cumulative self-time summed to 0.21s but wall was 20.66s. The 100× gap is pytest's assertion rewriter (bytecode rewriting per test file via a path that bypasses `-X importtime`). So importtime alone is misleading for diagnosing pytest collection cost — needed the cold-subprocess per-file approach (`profile_imports.py`) to isolate the actual import-time-amplifiable cost surface. Documented in the script's docstring so future-me doesn't fall into the same trap.
+
+---
+
 ## 2026-05-19
 
 ### 18:00 UTC — Editor: Developer

--- a/workflow/tests/README.md
+++ b/workflow/tests/README.md
@@ -35,6 +35,26 @@ workflow/tests/.venv/bin/python -m pytest workflow/tests/ -v
 
 The fixture in [test_alignment_star_command.py](test_alignment_star_command.py) calls `pytest.skip` if `snakemake` is not on PATH, so the test suite still runs cleanly without the conda env — those specific tests just skip.
 
+## Running on memory-tight machines (e.g. M1 8 GB)
+
+When the OS page cache is under pressure, `pytest --collect-only` can stall for minutes — fresh `import pandas` and pytest's assertion-rewriter pass both turn into disk-bound page faults. Two workarounds while the suite stays pandas-heavy at module scope (see [Issue #364](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/364)):
+
+```bash
+# 1. Run only the touched test file(s); let CI cover the full suite.
+workflow/tests/.venv/bin/python -m pytest workflow/tests/test_filter_junctions.py -q
+
+# 2. Disable assertion rewriting (faster collection, less helpful assert errors).
+workflow/tests/.venv/bin/python -m pytest workflow/tests/ -p no:assertion -q
+```
+
+To re-measure the static import cost surface (per-test-file and per-script cold module-load):
+
+```bash
+workflow/tests/.venv/bin/python workflow/tests/scripts/profile_imports.py
+```
+
+Last measurement (non-RAM-pressured run): full collection of 287 tests in ~20s; per-test cold module-load 0.03–0.62s, dominated by `pandas` (0.26s cold) imported at module scope in 6 test files and 6 project scripts.
+
 ## Why this split
 
 - **`snakemake` conda env = workflow runner.** Snakemake + solver. Keep pristine; adding test deps risks dep drift in the workhorse env.

--- a/workflow/tests/scripts/profile_imports.py
+++ b/workflow/tests/scripts/profile_imports.py
@@ -40,7 +40,13 @@ def module_level_imports(path: Path) -> list[str]:
 
 def truncate_to_imports_and_defs(src: str) -> str:
     """Return the module's top-level imports + defs/classes/assigns, stopping
-    at the first `if __name__ == "__main__":` block or any other statement."""
+    at the first `if __name__ == "__main__":` block or any other statement.
+
+    Limitation: any node type outside the whitelist (notably `ast.Try` for
+    `try/except ImportError` guards) ends truncation, so imports after it are
+    silently dropped. No file in the repo currently uses such a guard at
+    module scope; revisit if that changes.
+    """
     tree = ast.parse(src)
     body = []
     for node in tree.body:
@@ -64,7 +70,12 @@ def cold_import_time(path: Path, extra_path: Path) -> tuple[float, bool]:
     )
     t0 = time.perf_counter()
     r = subprocess.run([str(PY), "-c", runner], capture_output=True, text=True, timeout=180)
-    return time.perf_counter() - t0, r.returncode == 0
+    dt = time.perf_counter() - t0
+    ok = r.returncode == 0
+    if not ok:
+        last = next((ln for ln in reversed(r.stderr.splitlines()) if ln.strip()), "")
+        print(f"  └─ [{path.name}] exit={r.returncode}: {last}", file=sys.stderr)
+    return dt, ok
 
 
 def profile_dir(label: str, files: list[Path], extra_path: Path) -> None:

--- a/workflow/tests/scripts/profile_imports.py
+++ b/workflow/tests/scripts/profile_imports.py
@@ -1,0 +1,99 @@
+"""Profile cold-subprocess import time for each test file and each project script.
+
+Diagnostic for [Issue #364](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/364):
+local pytest collection hangs under memory pressure because module-level imports
+get amplified by OS paging on the M1 8 GB dev box. This script establishes the
+static cost surface so future refactors (e.g. lazy-pandas) can be measured.
+
+Usage:
+    workflow/tests/.venv/bin/python workflow/tests/scripts/profile_imports.py
+
+Each entry is timed by exec-ing the file's module-level body (imports +
+defs/classes only — `if __name__ == "__main__":` and any trailing statements
+are stripped) in a fresh subprocess. This isolates *import* cost from test
+execution, and matches what pytest pays during the collection phase.
+"""
+from __future__ import annotations
+
+import ast
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+TESTS_DIR = REPO_ROOT / "workflow" / "tests"
+SCRIPTS_DIR = REPO_ROOT / "workflow" / "scripts"
+PY = REPO_ROOT / "workflow" / "tests" / ".venv" / "bin" / "python"
+
+
+def module_level_imports(path: Path) -> list[str]:
+    tree = ast.parse(path.read_text())
+    out: list[str] = []
+    for node in tree.body:
+        if isinstance(node, ast.Import):
+            out.extend(n.name.split(".")[0] for n in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module and node.level == 0:
+            out.append(node.module.split(".")[0])
+    return sorted(set(out))
+
+
+def truncate_to_imports_and_defs(src: str) -> str:
+    """Return the module's top-level imports + defs/classes/assigns, stopping
+    at the first `if __name__ == "__main__":` block or any other statement."""
+    tree = ast.parse(src)
+    body = []
+    for node in tree.body:
+        if isinstance(node, ast.If) and ast.unparse(node.test).startswith("__name__"):
+            break
+        if isinstance(node, (ast.Import, ast.ImportFrom, ast.FunctionDef,
+                             ast.ClassDef, ast.AsyncFunctionDef, ast.Expr,
+                             ast.Assign, ast.AnnAssign)):
+            body.append(node)
+            continue
+        break
+    return ast.unparse(ast.Module(body=body, type_ignores=[]))
+
+
+def cold_import_time(path: Path, extra_path: Path) -> tuple[float, bool]:
+    truncated = truncate_to_imports_and_defs(path.read_text())
+    runner = (
+        "import sys; "
+        f"sys.path.insert(0, {str(extra_path)!r}); "
+        f"exec(compile({truncated!r}, {str(path)!r}, 'exec'))"
+    )
+    t0 = time.perf_counter()
+    r = subprocess.run([str(PY), "-c", runner], capture_output=True, text=True, timeout=180)
+    return time.perf_counter() - t0, r.returncode == 0
+
+
+def profile_dir(label: str, files: list[Path], extra_path: Path) -> None:
+    print(f"\n## {label}")
+    rows: list[tuple[str, float, bool, list[str]]] = []
+    for f in files:
+        dt, ok = cold_import_time(f, extra_path)
+        imps = module_level_imports(f)
+        rows.append((f.name, dt, ok, imps))
+        print(f"  {'OK ' if ok else 'ERR'} {dt:6.2f}s  {f.name}", file=sys.stderr)
+    rows.sort(key=lambda r: -r[1])
+    print(f"\n| {'file':<42s} | {'sec':>6s} | module-level imports |")
+    print(f"| {'-'*42} | {'-'*6} | --- |")
+    for name, dt, ok, imps in rows:
+        marker = "" if ok else " ⚠️"
+        print(f"| `{name}` | {dt:6.2f}{marker} | {', '.join(imps)} |")
+
+
+def main() -> int:
+    if not PY.exists():
+        print(f"ERROR: {PY} not found. Set up the test venv first (see workflow/tests/README.md).",
+              file=sys.stderr)
+        return 1
+    test_files = sorted(TESTS_DIR.glob("test_*.py"))
+    script_files = sorted(SCRIPTS_DIR.glob("*.py"))
+    profile_dir("Per-test-file cold module-load (seconds)", test_files, SCRIPTS_DIR)
+    profile_dir("Per-project-script cold module-load (seconds)", script_files, SCRIPTS_DIR)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
**Created by:** Developer

## Summary

- Adds `workflow/tests/scripts/profile_imports.py` — cold-subprocess per-file import-cost profiler. Establishes the static cost surface so the planned lazy-pandas refactor can be measured before/after.
- Adds a "Running on memory-tight machines" section to `workflow/tests/README.md` covering two workarounds (single-file runs, `-p no:assertion`) and how to re-run the profiler.

Together these tick AC 1 + AC 2 (via the documented-workaround branch) of [Issue #364](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/364). AC 3 (verify suite < 60s on M1 8 GB under pressure) is **carved out and absorbed into [Issue #425](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/425)** (the lazy-pandas refactor follow-up), so this PR can close the original — per the "close Issue with PR, carve follow-up" workflow rather than leaving #364 open on a dependency.

## Findings recap

The Issue's original hypothesis was that test files do heavy ML-library imports at module scope. The profiler shows that's not the case — `mhcflurry`, `torch`, `tensorflow` are NOT imported at module scope anywhere. The real dominant module-level import is `pandas` (0.26s cold), pulled in by 6 test files + 6 project scripts. Under memory pressure, paging amplifies every fresh `pandas` import into a multi-minute event (matches the original `import pandas` hung > 2.5 min observation in the Issue body). Pytest's assertion rewriter compounds it.

## Correction to my prior comment

The [previous Issue comment](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/364#issuecomment-4497945684) claimed `filter_junctions.py` was pandas-free at module scope — incorrect. It does import pandas (line 44). The output table in that comment had truncated the imports list at 8 entries. The committed profiler shows the full list and the corrected number is in the README (6 scripts, not 5).

## Test plan

- [x] Full suite passes locally: `workflow/tests/.venv/bin/python -m pytest workflow/tests/ --ignore=workflow/tests/test_integration.py -q` → 282 passed, 5 skipped in 1.06s
- [x] Profiler runs end-to-end: `workflow/tests/.venv/bin/python workflow/tests/scripts/profile_imports.py` → emits per-test + per-script tables
- [x] No new dependencies added (stdlib + ast only)
- [x] CI green: `ci-tools-pytest` + `pipeline-pytest` + `pipeline-snakemake-dry-run` (all 3 pass on 79282cb)

Closes [Issue #364](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/364) (profiler + workaround docs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

