### PR TITLE
chore(docs): fix stale memory/ refs after .claude/memory/ migration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -224,7 +224,7 @@ Mechanisms that fire automatically to enforce GitHub-related discipline rules th
 
 Refuses any `gh (pr|issue) (comment|create)` whose `--body` contains a literal `@claude` substring, except the exact canonical review-trigger `--body "@claude review"` (and the single-quoted variant). The hook runs `.claude/hooks/check_at_claude.py` on stdin-piped PreToolUse JSON and emits a `permissionDecision: deny` when the guard fires.
 
-**Why:** the `Claude Code` GitHub Action subscribes to `issues` events and triggers on ANY literal `@claude` — including inside parens, ACs, code spans, quoted historical refs, or markdown link descriptions. The rule lives in `memory/shared/feedback_no_at_claude_mention.md` and is inlined into shared Always-in-effect, yet broke on PR #359 (2026-05-13) and originally on Issue #272 (2026-05-06).
+**Why:** the `Claude Code` GitHub Action subscribes to `issues` events and triggers on ANY literal `@claude` — including inside parens, ACs, code spans, quoted historical refs, or markdown link descriptions. The rule lives in `.claude/memory/shared/feedback_no_at_claude_mention.md` and is inlined into shared Always-in-effect, yet broke on PR #359 (2026-05-13) and originally on Issue #272 (2026-05-06).
 
 **Workaround for non-trigger references:** use `@-claude` (zero-width hyphen between `@` and `claude`). The literal substring `@claude` must not appear.
 
@@ -234,7 +234,7 @@ Refuses to run `gh pr merge` if any `- [ ]` remains on the PR body Test plan OR 
 
 **Why:** the closure-ritual rule has broken 4× in 10 days despite being inlined into shared MEMORY.md — [Issue #280](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/280), [Issue #299](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/299), [PR #328](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/328), [Issue #347](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/347). Memory of a declarative rule cannot reliably survive the action-distance from session start to `gh pr merge`. The script enforces at the exact moment of action — the merge invocation itself — so the gate cannot be forgotten regardless of how much downstream context has accumulated.
 
-**Workaround for genuine deferrals:** comment-defer per `memory/shared/feedback_closure_ritual.md` by ticking `- [x]` with a link to the carrier Issue (or remove the line entirely). The script does NOT parse "deferred" inline tags — keep the tick/remove convention explicit.
+**Workaround for genuine deferrals:** comment-defer per `.claude/memory/shared/feedback_closure_ritual.md` by ticking `- [x]` with a link to the carrier Issue (or remove the line entirely). The script does NOT parse "deferred" inline tags — keep the tick/remove convention explicit.
 
 ## Merge workflow
 

--- a/docs/superpowers/specs/2026-05-19-parent-status-drift-audit-design.md
+++ b/docs/superpowers/specs/2026-05-19-parent-status-drift-audit-design.md
@@ -6,7 +6,7 @@
 
 ## Background
 
-Parent-epic Issues on project board #9 can drift to `Status: In progress` during decomposition (when sub-issues are being added/triaged) and never flip back even after sub-issues settle to Backlog. Per the parent-vs-sub-issues rule (`memory/shared/feedback_parent_sub_issues.md`), parents should carry a **mirrored Status** reflecting their children's collective state — but no mechanism enforces this, so drift accumulates silently.
+Parent-epic Issues on project board #9 can drift to `Status: In progress` during decomposition (when sub-issues are being added/triaged) and never flip back even after sub-issues settle to Backlog. Per the parent-vs-sub-issues rule (`.claude/memory/shared/feedback_parent_sub_issues.md`), parents should carry a **mirrored Status** reflecting their children's collective state — but no mechanism enforces this, so drift accumulates silently.
 
 Today's PM mid-day board sweep (2026-05-19) found 3 epics drifted In progress with all open sub-issues in Backlog ([#24](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/24), [#86](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/86), [#126](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/126)). All 3 were manually corrected to `Ready`, but the drift was only caught by happening to look.
 
@@ -148,8 +148,8 @@ Three test surfaces:
 
 ## Related
 
-- Parent-vs-sub-issue rule: `memory/shared/feedback_parent_sub_issues.md` ("mirrored Status")
+- Parent-vs-sub-issue rule: `.claude/memory/shared/feedback_parent_sub_issues.md` ("mirrored Status")
 - Sibling mechanism: [PR #397](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/397) (milestone-capacity recheck hook) closing [#247](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/247)
 - Eventual-consistency companion: [#406](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/406)
-- Today's standup post surfacing the pattern: `memory/shared/team_standup.md` (2026-05-19 11:56 UTC PM → Sci)
+- Today's standup post surfacing the pattern: `.claude/memory/shared/team_standup.md` (2026-05-19 11:56 UTC PM → Sci)
 - Original drift-discovery board sweep that motivated this issue: same session 2026-05-19 11:30–12:00 UTC


### PR DESCRIPTION
## Summary

- Updates 5 stale path references from pre-migration `memory/` to post-personas-v3.1 `.claude/memory/`
- Affected files: `CLAUDE.md` (2 refs in GitHub Safety Wrappers section) + `docs/superpowers/specs/2026-05-19-parent-status-drift-audit-design.md` (3 refs in Background + Related)
- Lab notebook historical citations (`research/lab_notebook/developer.md`) intentionally left at the old `memory/` path — those are frozen-in-time migration changelog entries describing pre-migration state, not active pointers

## Context

The `memory/` → `.claude/memory/` move rode in on the claude-personas v3.1 infra bump (commit [4b08fa5](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/commit/4b08fa5)) and did not get a tracking Issue; the 2 in-scope files retained stale cross-refs. The design spec was authored same-day as the migration, so its refs were stale from day one of the spec's life — they're active pointers to live rule definitions + the standup ledger, not historical citations.

## Test plan

- [x] All 4 referenced memory files exist at the new `.claude/memory/shared/` path (verified locally)
- [x] No remaining backtick-prefixed `memory/(shared|pm|scientist|developer)/` refs in the 2 edited files
- [x] Lab notebook historical refs intentionally preserved at the old path (frozen-in-time convention, matches cerebrum spec precedent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)