### PR TITLE
feat(pm): milestone-health check script + morning-routine wire-up

### DIFF
--- a/research/lab_notebook/pm.md
+++ b/research/lab_notebook/pm.md
@@ -6,6 +6,31 @@ Format and rules unchanged from the unified notebook — see `shared/feedback_la
 
 ---
 
+## 2026-05-20
+
+### 15:00 UTC — Editor: PM
+
+#### Milestone-health mechanism — script + morning-routine phase, triggered by `i1 - S4` going 5d overdue
+
+User flagged that milestone `i1 - S4 - EDA - Junction Filtering Observability` (due 2026-05-15) was 5 days overdue and no session had surfaced it. PM morning routine has 4 PM-only phases (Board recap, Closure audit, Triage, Friday cleanup); none watched milestone-level due-date drift. Per-Issue AC audits catch unticked boxes; the milestone deadline is a separate axis with no automated watch.
+
+**Act on the existing overdue milestone.** Carved + closed `i1 - S4`:
+
+- 5 of 6 Issues closed; original observability scope shipped via [Issue #103](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/103), [Issue #104](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/104), [Issue #161](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/161), [Issue #214](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/214), [Issue #215](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/215)
+- One open straggler [Issue #304](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/304) (sensitivity analysis utility) was forward-looking — triggered by Prélot et al. 2025, not original observability scope. Stripped milestone field, left a carve-forward comment on the Issue
+- Closed milestone 4 via `gh api -X PATCH state=closed`; precedent for not holding milestones open with "stays open until [Issue #X] ships" is [feedback_close_issue_with_pr.md](.claude/memory/shared/feedback_close_issue_with_pr.md) generalized one rung up
+
+**Durable mechanism so this doesn't repeat — [Issue #429](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/429):**
+
+- **[`scripts/check_milestone_health.sh`](scripts/check_milestone_health.sh)** — gh API + jq script that lists open milestones with `due_on` past OR within `THRESHOLD_DAYS` (default 7). Columns: `TITLE | DUE_ON | DAYS | OPEN | CLOSED | URL`. Sorted by `due_on` ascending. Exit 0 (clean/imminent) or 2 (any overdue). All-clear path prints a single-line summary instead of a table.
+- **PM morning-routine wire-up** — new `Phase 2.6 — Milestone health` between Closure audit (2.5) and Triage (3). Calls the script; surfaces overdue + imminent milestones with proposed move (push-to-ship / carve-forward / extend-due_on). Visual formatting section updated with `## 📅 Milestone health` emoji marker. Phase order in `MEMORY.md` index also updated (4 → 5 PM-only phases).
+
+**Hook interaction (interesting).** The PostToolUse recheck hook (`PR #397` milestone-capacity mechanism, sibling to PR #407 parent-status drift) fired twice during this work — once on the `gh issue edit 304 --milestone ""` stripping (briefly read stale state showing #304 still attached, proposed extending `due_on` +17d), then again post-close (correctly reported "no remaining capacity"). The first fire was a stale-read race, not a real recommendation; verifying via `gh api .../milestones/4` confirmed the strip had landed and the hook caught up by its second fire. Surfaced to user explicitly rather than silently following the hook — important precedent for hook discrepancies.
+
+**Why mechanism, not just memory.** First miss of this shape (one prior incident, today's). Per [feedback_mechanism_over_memory.md](.claude/memory/shared/feedback_mechanism_over_memory.md), memory alone would have been defensible — but the script is cheap (~80 lines), reusable for ad-hoc audits, and pre-empts the ≥2× repeat threshold. Memory ladder: this lands on rung 2 (inline Always-in-effect via Phase 2.6) AND rung 3 (mechanism via script invocation), both reinforcing each other.
+
+---
+
 ## 2026-05-19
 
 ### 14:24 UTC — Editor: PM

--- a/research/lab_notebook/pm.md
+++ b/research/lab_notebook/pm.md
@@ -8,6 +8,21 @@ Format and rules unchanged from the unified notebook — see `shared/feedback_la
 
 ## 2026-05-20
 
+### 15:55 UTC — Editor: PM
+
+#### Bot review on [PR #431](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/431) — 3 of 4 findings addressed, none blocking
+
+Bot returned in 1m 46s with 4 findings (1 cosmetic, 3 nits). Addressed 1+2+3, skipped 4. Verified each before applying:
+
+- **Cosmetic (fix 1):** overdue display rendered `-5d overdue` due to passing `${days}` directly. Swapped to `${days#-}d overdue` (bash param expansion strips a single leading `-`). Matters because this is the first thing the morning-routine surfaces on a real overdue case.
+- **Nit (fix 2):** added a `# NOTE:` comment about the `per_page=100` soft cap on milestones. Bot suggested `gh api --paginate | jq --slurp 'add | ...'` — declined the heavier change, the comment documents the limit without adding pipeline complexity at this repo scale.
+- **Nit (fix 3):** added `[[ -n "${2:-}" ]] || { echo "..." >&2; exit 1; }` missing-value guards for `--threshold` and `--repo`. Under `set -euo pipefail`, calling `--threshold` as the last argument would have given a cryptic `$2: unbound variable`; now it gives an actionable error.
+- **Skipped (issue 4):** bot suggested replacing `sed -n '2,22p'` for help text extraction with an `awk` sentinel-anchored pipeline. Declined — current sed range works for the comment header's stable size, awk swap trades simplicity for a hypothetical (header growing past line 22).
+
+Smoke-tested all three fixes locally before commit (`bash scripts/check_milestone_health.sh --threshold` triggers guard with `exit 1`; normal run still produces the same table; minus-strip path is conceptually verified, can't be exercised today since no live milestone is overdue post-i1-S4-close).
+
+---
+
 ### 15:00 UTC — Editor: PM
 
 #### Milestone-health mechanism — script + morning-routine phase, triggered by `i1 - S4` going 5d overdue

--- a/scripts/check_milestone_health.sh
+++ b/scripts/check_milestone_health.sh
@@ -29,8 +29,8 @@ THRESHOLD="${MILESTONE_HEALTH_THRESHOLD_DAYS:-7}"
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
-        --threshold) THRESHOLD="$2"; shift 2 ;;
-        --repo) REPO="$2"; shift 2 ;;
+        --threshold) [[ -n "${2:-}" ]] || { echo "--threshold requires a value" >&2; exit 1; }; THRESHOLD="$2"; shift 2 ;;
+        --repo) [[ -n "${2:-}" ]] || { echo "--repo requires a value" >&2; exit 1; }; REPO="$2"; shift 2 ;;
         -h|--help)
             sed -n '2,22p' "$0" | sed 's|^# \{0,1\}||'
             exit 0
@@ -41,6 +41,9 @@ done
 
 [[ "$THRESHOLD" =~ ^[0-9]+$ ]] || { echo "threshold must be a non-negative integer, got: $THRESHOLD" >&2; exit 1; }
 
+# NOTE: fetches first 100 open milestones only; GitHub's milestones endpoint
+# paginates silently past per_page=100. If this repo ever exceeds 100 open
+# milestones, swap to `gh api --paginate ... | jq --slurp 'add | ...'`.
 FILTERED=$(gh api "repos/${REPO}/milestones?state=open&per_page=100" | jq --argjson threshold "$THRESHOLD" '
     [
         .[]
@@ -72,7 +75,7 @@ echo "$FILTERED" | jq -r '
     ] | @tsv
 ' | while IFS=$'\t' read -r title due days open closed url; do
     if [[ "$days" -lt 0 ]]; then
-        days_display="${days}d overdue"
+        days_display="${days#-}d overdue"
     elif [[ "$days" -eq 0 ]]; then
         days_display="due today"
     else

--- a/scripts/check_milestone_health.sh
+++ b/scripts/check_milestone_health.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# scripts/check_milestone_health.sh
+#
+# Surfaces open GitHub milestones that are overdue OR imminent (within
+# THRESHOLD days of due_on). Intended for the PM morning-routine
+# "Milestone health" phase.
+#
+# Why: per-Issue AC audits catch unticked boxes, but the milestone-level
+# deadline is a separate axis that has no automated watch. Caught
+# 2026-05-20 when `i1 - S4 - EDA - Junction Filtering Observability`
+# went 5 days overdue without any session noticing.
+#
+# Usage:
+#   bash scripts/check_milestone_health.sh [--threshold <days>] [--repo <owner/repo>]
+#
+# Env:
+#   MILESTONE_HEALTH_THRESHOLD_DAYS  override default threshold (7)
+#   REPO                             override default repo
+#
+# Exit codes:
+#   0 — all clear OR only imminent (no overdue)
+#   2 — at least one open milestone is overdue
+#   1 — usage / runtime error
+
+set -euo pipefail
+
+REPO="${REPO:-Jin-HoMLee/splice-neoepitope-pipeline}"
+THRESHOLD="${MILESTONE_HEALTH_THRESHOLD_DAYS:-7}"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --threshold) THRESHOLD="$2"; shift 2 ;;
+        --repo) REPO="$2"; shift 2 ;;
+        -h|--help)
+            sed -n '2,22p' "$0" | sed 's|^# \{0,1\}||'
+            exit 0
+            ;;
+        *) echo "unknown arg: $1" >&2; exit 1 ;;
+    esac
+done
+
+[[ "$THRESHOLD" =~ ^[0-9]+$ ]] || { echo "threshold must be a non-negative integer, got: $THRESHOLD" >&2; exit 1; }
+
+FILTERED=$(gh api "repos/${REPO}/milestones?state=open&per_page=100" | jq --argjson threshold "$THRESHOLD" '
+    [
+        .[]
+        | select(.due_on != null)
+        | . + {days_until: (((.due_on | fromdateiso8601) - now) / 86400 | floor)}
+        | select(.days_until <= $threshold)
+    ]
+    | sort_by(.days_until)
+')
+
+COUNT=$(echo "$FILTERED" | jq 'length')
+
+if [[ "$COUNT" -eq 0 ]]; then
+    echo "Milestone health: all clear — no overdue or imminent open milestones (threshold ${THRESHOLD}d)."
+    exit 0
+fi
+
+printf "%-65s %-12s %-14s %5s %6s   %s\n" "TITLE" "DUE_ON" "DAYS" "OPEN" "CLOSED" "URL"
+printf '%.0s-' {1..65}; printf ' '; printf '%.0s-' {1..12}; printf ' '; printf '%.0s-' {1..14}; printf ' '; printf '%.0s-' {1..5}; printf ' '; printf '%.0s-' {1..6}; printf '   '; printf '%.0s-' {1..40}; printf '\n'
+
+echo "$FILTERED" | jq -r '
+    .[] | [
+        (.title | .[0:65]),
+        (.due_on | sub("T.*$"; "")),
+        (.days_until | tostring),
+        (.open_issues | tostring),
+        (.closed_issues | tostring),
+        .html_url
+    ] | @tsv
+' | while IFS=$'\t' read -r title due days open closed url; do
+    if [[ "$days" -lt 0 ]]; then
+        days_display="${days}d overdue"
+    elif [[ "$days" -eq 0 ]]; then
+        days_display="due today"
+    else
+        days_display="${days}d left"
+    fi
+    printf "%-65s %-12s %-14s %5s %6s   %s\n" "$title" "$due" "$days_display" "$open" "$closed" "$url"
+done
+
+OVERDUE=$(echo "$FILTERED" | jq '[.[] | select(.days_until < 0)] | length')
+if [[ "$OVERDUE" -gt 0 ]]; then
+    exit 2
+fi
+exit 0


### PR DESCRIPTION
Closes [Issue #429](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/429) (milestone-health mechanism).

## Summary

Adds [`scripts/check_milestone_health.sh`](scripts/check_milestone_health.sh) — gh API + jq script that lists open milestones with `due_on` past OR within `THRESHOLD_DAYS` (default 7). Surfaces stage-level deadline drift that the per-Issue closure audit doesn't watch.

**Triggered by:** milestone `i1 - S4 - EDA - Junction Filtering Observability` (due 2026-05-15) went **5 days overdue** without any session noticing — closure audit watches per-Issue AC ticking; the milestone-level deadline is a separate axis. Resolution earlier today: original observability scope was already shipped via [Issue #103](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/103), [Issue #104](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/104), [Issue #161](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/161), [Issue #214](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/214), [Issue #215](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/215); the one open straggler [Issue #304](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/304) (sensitivity analysis utility) was forward-looking — carved off + milestone closed. This PR delivers the mechanism so the next overdue milestone surfaces during PM morning routine, not after a 5-day drift.

## Script behavior

- Output columns: `TITLE | DUE_ON | DAYS | OPEN | CLOSED | URL`
- Sorted by `due_on` ascending (most-overdue first)
- Days formatted as `Xd overdue`, `due today`, or `Xd left`
- Configurable: `--threshold <days>` flag or `MILESTONE_HEALTH_THRESHOLD_DAYS` env var; `--repo <owner/repo>` flag or `REPO` env var
- Exit 0 if clean / only imminent; exit 2 if any overdue (CI-friendly)
- All-clear path prints a single-line summary instead of an empty table

## Memory updates (PM personas repo, not in this PR)

Sibling edits to `.claude/memory/feedback_morning_routine.md` (PM):

- New **Phase 2.6 — Milestone health** between Closure audit (2.5) and Triage (3) — invokes the script, surfaces overdue/imminent milestones, proposes per-milestone move (push-to-ship / carve-forward / extend-due_on)
- Phase order updated (5 PM-only phases now instead of 4)
- Visual formatting section: added `## 📅 Milestone health` emoji marker
- `MEMORY.md` index updated to reflect new phase

These live in the personas repo via the `.claude/memory/` symlink — outside this PR's git scope per the memory-tracking convention.

## Test plan

- [x] Script runs cleanly against the live repo (`bash scripts/check_milestone_health.sh`)
- [x] Surfaces `pm-i1` and `i3 - S1` (both due 2026-05-21) as imminent in the smoke test
- [x] All-clear path tested (no overdue → exit 0 with single-line summary)
- [x] Threshold flag verified (`--threshold 0` includes only "due today" + overdue)
- [x] `pm.md` lab notebook entry added for 2026-05-20

**Created by:** PM