### PR TITLE
docs(pm): news_log 2026-05-21 — Conductor + Claude Code 2.1.145

### DIFF
--- a/research/glossary.md
+++ b/research/glossary.md
@@ -102,6 +102,8 @@ Project-relevant abbreviations and acronyms. The pipeline mixes biology, ML, bio
 
 **LSF** — Load Sharing Facility (IBM Spectrum). Commercial HPC batch scheduler; used at DKFZ Heidelberg among others. Snakemake has a dedicated LSF executor plugin. *Domain: cloud.*
 
+**LSP** — Language Server Protocol. Microsoft spec (2016) decoupling code-intelligence backends (completion, hover, go-to-definition, diagnostics) from editor frontends — one server, many editors. Claude Code plugins can register LSP servers alongside MCP servers; `/plugin Discover` previews these before install (Claude Code 2.1.145). *Domain: cloud.*
+
 ## M
 
 **MCP** — Model Context Protocol. Anthropic's open spec (late 2024) for AI agents to discover and invoke external tools / data sources via per-purpose MCP servers; the standardized way to expose resources to LLMs without bespoke per-tool integration. *"USB-C for AI agents."* Used by Claude Code, the GitHub MCP server, filesystem servers, etc. *Domain: ml.*
@@ -123,6 +125,8 @@ Project-relevant abbreviations and acronyms. The pipeline mixes biology, ML, bio
 **OKR** — Objectives and Key Results. Goal-setting framework popularised by Intel/Google: one qualitative *Objective* + 3–5 quantitative *Key Results*, usually quarterly. Common in software shops; we use S1–S7 lifecycle stages + iteration capacity instead. *Domain: project.*
 
 **OOD** — Out-of-distribution. Inputs whose features fall in low-density regions of the model's training distribution; predictions on OOD inputs are typically over-confident yet unreliable since the model never learned to constrain them. Detected operationally via density estimators, embedding-space distance to training samples, or ensemble disagreement. Relevant for splice-junction-spanning peptides — systematically under-represented in canonical-proteome MHC training data. *Domain: ml.*
+
+**OTEL** — OpenTelemetry. Vendor-neutral CNCF observability framework: specs + SDKs for distributed traces, metrics, and logs, exportable to backends like Honeycomb, Jaeger, Tempo. Claude Code 2.1.145 added `agent_id` and `parent_agent_id` to `claude_code.tool` spans so nested agent calls show correct trace parenting (relevant if we ever wire trace export from PM/Sci/Dev sessions). *Domain: cloud.*
 
 ## P
 

--- a/research/glossary.md
+++ b/research/glossary.md
@@ -126,7 +126,7 @@ Project-relevant abbreviations and acronyms. The pipeline mixes biology, ML, bio
 
 **OOD** — Out-of-distribution. Inputs whose features fall in low-density regions of the model's training distribution; predictions on OOD inputs are typically over-confident yet unreliable since the model never learned to constrain them. Detected operationally via density estimators, embedding-space distance to training samples, or ensemble disagreement. Relevant for splice-junction-spanning peptides — systematically under-represented in canonical-proteome MHC training data. *Domain: ml.*
 
-**OTEL** — OpenTelemetry. Vendor-neutral CNCF observability framework: specs + SDKs for distributed traces, metrics, and logs, exportable to backends like Honeycomb, Jaeger, Tempo. Claude Code 2.1.145 added `agent_id` and `parent_agent_id` to `claude_code.tool` spans so nested agent calls show correct trace parenting (relevant if we ever wire trace export from PM/Sci/Dev sessions). *Domain: cloud.*
+**OTEL** — OpenTelemetry. Vendor-neutral observability framework under the Cloud Native Computing Foundation (CNCF): specs + libraries for distributed traces, metrics, and logs, exportable to backends like Honeycomb, Jaeger, Tempo. Claude Code 2.1.145 added `agent_id` and `parent_agent_id` to `claude_code.tool` spans so nested agent calls show correct trace parenting (relevant if we ever wire trace export from PM/Sci/Dev sessions). *Domain: cloud.*
 
 ## P
 

--- a/research/lab_notebook/pm.md
+++ b/research/lab_notebook/pm.md
@@ -6,6 +6,23 @@ Format and rules unchanged from the unified notebook — see `shared/feedback_la
 
 ---
 
+## 2026-05-21
+
+### 08:48 UTC — Editor: PM
+
+#### Morning news_log + Microsoft Conductor landscape backfill ([PR #441](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/441)) + new shared memory *deterministic-before-semantic*
+
+Two PM news items today:
+
+- **Microsoft Conductor** (Microsoft Open Source 2026-05-14, [microsoft/conductor](https://github.com/microsoft/conductor)) — YAML-first CLI for multi-agent workflows with **deterministic routing**: Jinja2 conditions + expression evaluation handle branching; orchestration layer itself spends zero LLM tokens. Counter-position to LLM-as-orchestrator frameworks. Backfilled to Frameworks in `research/multi_agent_landscape.md`; sweep bumped to 2026-05-21.
+- **Claude Code 2.1.145** — `claude agents --json` (scripting), `agent_id`/`parent_agent_id` on OTEL spans, `/resume` for background sessions. No-action. OTEL + LSP glossary entries bundled in the same PR per `feedback_bundle_news_derived_docs.md`.
+
+**New shared memory: [[deterministic-before-semantic]].** User articulated the underlying preference while reading the Conductor framing: *"whenever possible, deterministic, zero token solutions should be exhausted before the use of semantic mechanisms."* Saved as `shared/feedback_deterministic_first.md` with explicit cross-link to [[mechanism-over-memory]]. The two together form a clean hierarchy: mechanism-over-memory says *that* mechanism beats memory for repeat-break rules; deterministic-before-semantic says *what kind* of mechanism — regex/schema/hook/YAML over prompted self-check. Applies across mechanism design, workflow encoding, tooling evaluation, and pipeline architecture.
+
+**News_log length slip.** Initial Conductor + 2.1.145 drafts came in at ~29 and ~47 words after the source link — violating `feedback_news_log_length.md` (~20-30 cap). User flagged before commit ("did you show me the news before writing the news log?") — two issues compressed into one: (a) didn't surface item *content* before writing (the AskUserQuestion only asked which items), (b) didn't consult the length memory. Tightened to ~22 and ~24 words; landed in [PR #441](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/441). Asked the user about the systemic fix (link→inline escalation or PreToolUse hook); user chose "just tighten today's draft" — leaving the systemic gap open for now. If it slips again, escalating to rung-3 mechanism (hook that counts words on Write/Edit of `research/news_log.md`) becomes the move.
+
+---
+
 ## 2026-05-20
 
 ### 15:55 UTC — Editor: PM

--- a/research/multi_agent_landscape.md
+++ b/research/multi_agent_landscape.md
@@ -36,6 +36,12 @@ Concrete products / tooling that could plausibly displace, augment, or be borrow
 - **Summary:** GitHub-native desktop client to start agentic dev sessions from an issue/PR/prompt; isolates work in-flight, supports mid-session steering, lands via PR review.
 - **Our rationale:** **Pattern-confirmation, no action.** Same parallel-session UI shape as Claude Code Agent View (news_log 2026-05-13) and convergent with our PM/Sci/Dev orchestration — but GitHub-anchored rather than terminal/IDE-anchored. Fits the "boards-as-control-plane" framing (cf. [OpenAI Symphony](#openai-symphony)). Tech preview only; too early for adoption decision but worth watching for GA + agent-callable surface (per [UI features ≠ agent capabilities](#our-position)). No action.
 
+### Microsoft Conductor
+
+- **Source:** [Microsoft Open Source blog, 2026-05-14](https://opensource.microsoft.com/blog/2026/05/14/conductor-deterministic-orchestration-for-multi-agent-ai-workflows/); [microsoft/conductor](https://github.com/microsoft/conductor) (MIT, Python 3.12+)
+- **Summary:** YAML-first CLI for multi-agent workflows. Routing between agents is **deterministic** — Jinja2 templates + expression evaluation handle conditions and branching; the orchestration layer itself spends zero LLM tokens. Static parallel groups (`fail_fast` / `continue_on_error` / `all_or_nothing`); dynamic for-each over variable-length arrays with batched concurrency. Backends: GitHub Copilot SDK or Anthropic Claude.
+- **Our rationale:** **Explicit counter-position to LLM-as-orchestrator, partial echo of our shape.** Most multi-agent frameworks make the orchestrator itself an LLM that plans which agents to call — that pays token cost, latency, and unpredictability on every routing decision. Conductor argues: when workflow structure is *known*, declarative YAML + deterministic routing wins (diffable like CI/CD, zero token spend on routing). Our equivalent of "the routing layer" is the human + the GitHub Projects board + standup file — also zero LLM tokens spent on routing (the routing artifacts live in non-LLM substrates), also declarative-ish (Status / Priority / Size / Target Date fields are the YAML-analog). Difference: ours stays human-discretionary at every hop (PM judges triage, doesn't follow a fixed graph), Conductor's is fixed-at-definition-time. Useful as a thought-experiment: *which subset of PM's morning routine is workflow-known-enough to encode in a Conductor-style YAML?* Likely candidates: closure audit (mechanical), milestone health check (already script-driven). Unlikely candidates: triage scoping, news interpretation. No adoption action — too early, and Python-3.12+ pin doesn't fit our 3.11 baseline — but the deterministic-vs-LLM-orchestrator axis is now a first-class evaluation criterion when surveying future frameworks (per the user's *deterministic-before-semantic* preference, established 2026-05-21).
+
 ---
 
 ## Methodology / framing
@@ -100,6 +106,7 @@ PM-owned. Update triggers:
 - New Issue concretely borrows from or extends a framework listed here → backfill the framework's rationale block with the Issue link.
 - Framework deprecated or pivoted → don't delete the entry; update the rationale with the deprecation note (the doc is a journal of *which* options we considered, not just current options).
 
-Last sweep: 2026-05-15 (GitHub Copilot desktop app backfilled to Frameworks as pattern-confirmation).
+Last sweep: 2026-05-21 (Microsoft Conductor backfilled to Frameworks as counter-position to LLM-as-orchestrator).
+Prior: 2026-05-15 (GitHub Copilot desktop app backfilled to Frameworks as pattern-confirmation).
 Prior: 2026-05-14 (Gartner cancellation forecast backfilled to `our_position` #2 as external validation).
 Prior: 2026-05-12 (initial scaffold; 6 backfilled items: Symphony, Trends Report, Managed Agents, Mason, Fugu, Code Agent Orchestra).

--- a/research/news_log.md
+++ b/research/news_log.md
@@ -11,6 +11,13 @@ Historical entries (before 2026-05-02) pre-date the time/editor sub-heading conv
 
 ---
 
+## 2026-05-21
+
+### 08:12 UTC — Editor: PM
+
+- **Microsoft Conductor — deterministic multi-agent orchestrator** ([Microsoft Open Source 2026-05-14](https://opensource.microsoft.com/blog/2026/05/14/conductor-deterministic-orchestration-for-multi-agent-ai-workflows/), [microsoft/conductor](https://github.com/microsoft/conductor)) — YAML workflows with zero-token deterministic routing (Jinja2 conditions, parallel groups); Copilot SDK + Anthropic Agents SDK. → Frameworks backfill same PR. *PM. methodology-signal.*
+- **Claude Code 2.1.145** ([2026-05-19 changelog](https://code.claude.com/docs/en/changelog)) — `claude agents --json` for scripting; `agent_id`/`parent_agent_id` on OTEL spans; `/resume` for background sessions. → No action; OTEL + LSP glossary entries same PR. *PM. tooling-relevant.*
+
 ## 2026-05-20
 
 ### 10:02 UTC — Editor: Developer


### PR DESCRIPTION
## Summary

- **news_log:** Microsoft Conductor (methodology-signal) + Claude Code 2.1.145 (tooling-relevant)
- **multi_agent_landscape.md:** Frameworks backfill for Conductor — deterministic YAML-routed orchestrator, zero LLM tokens on the routing layer; explicit counter-position to LLM-as-orchestrator frameworks. Last sweep bumped to 2026-05-21.
- **glossary.md:** OTEL, LSP — both derived from the 2.1.145 changelog (bundled per `feedback_bundle_news_derived_docs.md`)

## Test plan

- [x] news_log entries under ~25 words after source link (per `feedback_news_log_length.md`)
- [x] Conductor landscape entry follows existing Frameworks format (Source / Summary / Our rationale)
- [x] Glossary terms slotted alphabetically with `*Domain: cloud.*` tag
- [x] No literal `@-claude` in body
- [x] **Created by:** line present

Created by: PM

🤖 Generated with [Claude Code](https://claude.com/claude-code)