### PR TITLE
docs: document Python execution contexts; fix stale `.venv/bin/python` plan-file refs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,6 +81,26 @@ snakemake --cores $(nproc) --use-conda ...
 
 **Conda env cleanup after `workflow/envs/*.yaml` changes:** Automatic cleanup was removed from `run_cloud_gpu.sh`. When any `workflow/envs/*.yaml` file changes, manually delete the affected old environment on the VM before running — old envs will not be rebuilt automatically and stale cached packages will be used instead.
 
+## Python environments
+
+The project has **4 functional Python environments**, each with a different use case. **No root-level `.venv` exists or should exist** — any reference to `.venv/bin/python` at the project root is wrong.
+
+| Use case | Canonical path | Setup recipe | Documented at |
+|---|---|---|---|
+| Pytest test suite | `workflow/tests/.venv` | `pyenv local 3.13.5 && python -m venv workflow/tests/.venv && workflow/tests/.venv/bin/pip install -r workflow/tests/requirements-test.txt` | [workflow/tests/README.md](workflow/tests/README.md) |
+| Research / Jupyter notebooks | `research/.venv` | `cd research/ && pyenv local 3.14.4 && python -m venv .venv && .venv/bin/pip install -r requirements.txt` | [research/README.md](research/README.md) |
+| Snakemake orchestration (and ad-hoc `python -c` quick checks) | `conda activate snakemake` | `bash scripts/setup_local.sh` | "Snakemake Conda Activation" above |
+| Per-rule Python (`workflow/scripts/*.py` invoked by Snakemake rules) | rule's own `--use-conda` env | auto-created from `workflow/envs/*.yaml` on first `snakemake --use-conda` run | implicit; each rule declares `conda: "envs/<env>.yaml"` |
+
+**Per-clone setup.** The two pyenv venvs (`workflow/tests/.venv` and `research/.venv`) are per-clone and gitignored. After the 2026-05-14 separate-clone migration, each clone needs its own one-time setup — neither is auto-created by `scripts/setup_local.sh`. The `.python-version` files are also gitignored so clones stay independent.
+
+**Picking an interpreter:**
+- Pytest invocations: `workflow/tests/.venv/bin/python -m pytest workflow/tests/...` (never `.venv/bin/python -m pytest`).
+- Ad-hoc `python -c "..."` quick checks (yaml parse, file compile-check, one-off imports): `conda activate snakemake` first, then call bare `python -c "..."` — no separate path.
+- Running `workflow/scripts/*.py` directly outside Snakemake is rarely needed; if you must, activate the rule's conda env explicitly (e.g. `conda activate .snakemake/conda/<hash>` after Snakemake has built it).
+
+The `snakemake` conda env stays pristine on purpose — adding test or notebook deps risks dep drift in the workhorse env ([workflow/tests/README.md "Why this split"](workflow/tests/README.md)).
+
 ## Snakemake 8 Gotchas
 
 ### `--configfile` flag collapsing

--- a/docs/superpowers/plans/2026-05-19-issue-17-star-aligner.md
+++ b/docs/superpowers/plans/2026-05-19-issue-17-star-aligner.md
@@ -217,7 +217,7 @@ def test_star_align_does_not_throttle_min_total_count(star_dry_run_output):
 
 Run:
 ```bash
-.venv/bin/python -m pytest workflow/tests/test_alignment_star_command.py -v
+workflow/tests/.venv/bin/python -m pytest workflow/tests/test_alignment_star_command.py -v
 ```
 Expected: tests collected. The fixture should produce captured stdout successfully. Then the 5 test functions split as follows on current `main`:
 - `test_star_align_uses_twopass_mode` → **FAIL** (current rule lacks `--twopassMode Basic`)
@@ -301,7 +301,7 @@ Net diff:
 
 Run:
 ```bash
-.venv/bin/python -m pytest workflow/tests/test_alignment_star_command.py -v
+workflow/tests/.venv/bin/python -m pytest workflow/tests/test_alignment_star_command.py -v
 ```
 Expected: 5 passed, 0 failed.
 
@@ -519,7 +519,7 @@ Expected: commit lands; `git status` clean.
 
 Run:
 ```bash
-.venv/bin/python -m pytest workflow/tests/ -v 2>&1 | tail -30
+workflow/tests/.venv/bin/python -m pytest workflow/tests/ -v 2>&1 | tail -30
 ```
 Expected: all tests pass. The new `test_alignment_star_command.py` reports 5 passed. No regression in existing tests (`test_strandness`, `test_star_sj_to_junctions`, `test_bed12_to_junctions`, etc.).
 
@@ -580,7 +580,7 @@ Design spec: [docs/superpowers/specs/2026-05-19-issue-17-star-aligner-design.md]
 ## Test plan
 
 - [x] New pytest `workflow/tests/test_alignment_star_command.py` (5 assertions) passes locally
-- [x] Full pytest suite (`.venv/bin/python -m pytest workflow/tests/`) green — no regressions
+- [x] Full pytest suite (`workflow/tests/.venv/bin/python -m pytest workflow/tests/`) green — no regressions
 - [x] `snakemake -n` with `aligner: star` config parses cleanly
 - [x] `snakemake -n` with `config/test_config.yaml` confirms hisat2 path still resolves (M1 8 GB stays on hisat2)
 - [x] `dag.pdf` regenerated via `bash scripts/visualize_dag.sh`

--- a/research/README.md
+++ b/research/README.md
@@ -15,7 +15,7 @@ Per-patient result interpretation notebooks. Each patient run gets its own noteb
 **Setup (one-time):**
 ```bash
 cd research/
-pyenv local 3.14.4            # sets .python-version (already committed)
+pyenv local 3.14.4            # sets .python-version (gitignored, per-clone)
 python -m venv .venv
 source .venv/bin/activate
 pip install -r requirements.txt

--- a/research/lab_notebook/developer.md
+++ b/research/lab_notebook/developer.md
@@ -6,6 +6,30 @@ Format and rules unchanged from the unified notebook — see `shared/feedback_la
 
 ---
 
+## 2026-05-21
+
+### 17:50 UTC — Editor: Developer
+
+**Headline:** [PR #449](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/449) shipped, closing [Issue #447](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/447) (document Python execution contexts; fix stale `.venv/bin/python` plan-file refs). In-tree: [CLAUDE.md](CLAUDE.md) gains a `## Python environments` section (4-env matrix + no-root-`.venv` invariant) and 4 stale refs in [docs/superpowers/plans/2026-05-19-issue-17-star-aligner.md](docs/superpowers/plans/2026-05-19-issue-17-star-aligner.md) corrected. Out-of-tree (in `.claude/memory/`): new `shared/feedback_python_environments.md` Always-in-effect rule, `shared/MEMORY.md` index entry, Developer `MEMORY.md` inline pointer + line 30 stale-ref fix, `feedback_test_before_pr.md` body fix. Bot review (`@claude review`) = **Approve** with two non-blocking observations folded into follow-ups, not this PR.
+
+#### "5 envs" collapsed to "4 envs" under critical review — `python -c` is not a separate env
+
+Initial surfacing brief framed this as 5 functional Python envs in the project (per-rule conda, snakemake conda, `workflow/tests/.venv`, `research/.venv`, ad-hoc `python -c`). On critical re-read before drafting CLAUDE.md, the 5th case wasn't actually distinct — a bare `python -c "..."` invocation just uses whatever interpreter the active env exposes, which in practice means the `snakemake` conda env after `conda activate snakemake`. Calling it a separate env was a count-inflation artifact of the original "I keep getting confused about which Python" symptom (every interpreter touch felt like its own decision). Collapsing to 4 envs in the docs was both honest and more useful: the matrix gets a cleaner "use case → canonical path" mapping, and the `python -c` row in the quick-lookup table folds into the `conda activate snakemake` row. The recursion-on-pitch happened **before** any commits — worth recording because the impulse to ship the original framing was strong; the rewrite was 3 minutes of work that prevented stale doc debt.
+
+#### Out-of-tree memory changes don't show in `git diff`, but ARE the bulk of the work
+
+The PR's `git diff main --stat` shows 2 files changed (24 insertions, 4 deletions). The actual session output was 6 files modified: 4 of them inside `.claude/memory/` (gitignored). For future-me looking at the merged commit and wondering "where did the shared rule go?" — it's out-of-tree by design (each role's memory is a per-clone artifact, not source-tree state). The PR + the Issue body + this lab notebook entry are the durable record that ties in-tree to out-of-tree. The shape worked here because Issue #447's AC list explicitly enumerated both halves, so the closure-ritual gate would catch any miss.
+
+#### Vdjdb plan fix (24 hits) deferred via Issue #204 carrier — the file lives on that branch
+
+AC #6 said "Two plan files corrected." Only the star-aligner one is reachable from main (4 hits → 0). The vdjdb plan file ([docs/superpowers/plans/2026-05-20-vdjdb-panel-plan.md](docs/superpowers/plans/2026-05-20-vdjdb-panel-plan.md), 24 hits) lives exclusively on the `204-...` branch — fixing it here would need a cross-branch merge or a rebase dance, and the file will land on main when [Issue #204](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/204) work merges anyway. Solution: defer-tick AC #6 with a link to a heads-up comment filed on Issue #204 ([comment](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/204#issuecomment-4509276737)) that explicitly enumerates the canonical replacements (pytest invocations → `workflow/tests/.venv/bin/python`; `python -c` quick checks → bare `python` post `conda activate snakemake`). This is the closure-ritual deferral pattern in action — tick `- [x]` with link to carrier Issue, mechanism passes, work doesn't get forgotten. The grep AC (`grep -rn '\.venv/bin/python' docs/ scripts/ workflow/ .github/ | grep -v 'workflow/tests/\.venv'`) returns empty on the 447 branch because the vdjdb file isn't on main yet — so the AC is honestly green at merge-time even with the deferral.
+
+#### Memory broadcast skipped — shared/MEMORY.md absorption is enough
+
+[team_memory_broadcasts.md](.claude/memory/shared/team_memory_broadcasts.md) is the channel for cross-role rule changes that need explicit attention before next session start. For this Python-envs rule, the change is already indexed in `shared/MEMORY.md` as an Always-in-effect entry — Scientist + PM will absorb it automatically at next `/memory` without a broadcast nudge. Broadcasting would have been noise. AC #4 ticked with the rationale inline rather than removed entirely, so the closed Issue carries an audit trail of the deliberate skip (vs. an oversight). [Issue #451](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/451) filed as the open follow-up — would consolidate `workflow/tests/.venv` + `research/.venv` into a single repo-root `.venv`, making `.venv/bin/python` actually correct and dissolving the whole 4-env distinction; gated on Sci sign-off because it crosses notebook-deps ownership.
+
+---
+
 ## 2026-05-20
 
 ### 16:01 UTC — Editor: Developer


### PR DESCRIPTION
**Created by:** Developer

Closes [Issue #447](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/447) (close).

## Summary

Adds canonical documentation for the project's **4 functional Python environments** and fixes stale `.venv/bin/python` references (which assumed a non-existent root-level venv).

- `CLAUDE.md` gains a `## Python environments` section with the 4-env matrix, no-root-`.venv` invariant, per-clone setup note, and interpreter-picking guidance.
- `docs/superpowers/plans/2026-05-19-issue-17-star-aligner.md` — 4 stale `.venv/bin/python` references replaced with the canonical `workflow/tests/.venv/bin/python` path.

## Out-of-tree changes (memory)

The following changes landed in the personas/memory store outside this PR (memory is git-tracked in the personas repo, managed outside this session):

- `shared/feedback_python_environments.md` — new shared memory file with the env-selection rule.
- `shared/MEMORY.md` — added the rule to "Always in effect" + Reference index entry. **All 3 roles (Dev/Sci/PM) get this rule loaded via `/memory` at session start** — no per-role MEMORY.md edits needed.
- Developer `MEMORY.md` — inline pointer under "Always in effect" (belt-and-suspenders); also fixed stale `.venv/bin/python` reference on line 30 (Reference link to `feedback_test_before_pr.md`).
- Developer `feedback_test_before_pr.md` — fixed stale `.venv/bin/python` in body.

## Companion task on #204 branch

The vdjdb plan file (`docs/superpowers/plans/2026-05-20-vdjdb-panel-plan.md`, 24 hits) lives only on the in-flight #204 branch. Posted a comment on [Issue #204](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/204) to fix it as part of that PR's finalisation before merge.

## Follow-up

Filing a separate Issue: **Consider unifying `workflow/tests/.venv` + `research/.venv` into a single repo-root `.venv`** — would make `.venv/bin/python` *actually* correct and eliminate the foot-gun at the architectural level. Needs Sci sign-off (crosses notebook-deps ownership boundary). Out of scope for this docs cleanup PR.

## Design rationale (4 envs vs 5)

The surfacing brief described "5 envs" (including an ad-hoc `python -c` slot). On critical review, the 5th case is not a separate env — it's just usage of the activated `snakemake` conda env. Documenting 4 instead of 5 reduces apparent complexity without losing any information.

## Test plan

- [x] `grep -rn '\.venv/bin/python' docs/ scripts/ workflow/ .github/ | grep -v 'workflow/tests/\.venv'` returns empty (verified pre-commit)
- [x] `workflow/tests/.venv/bin/python -m pytest workflow/tests/ -q -m "not network"` → 282 passed, 30 skipped (network-marker)
- [x] `snakemake -n --configfile config/test_config.yaml` → 17 jobs queued, dry-run clean
- [x] CI `pipeline-pytest` green
- [x] CI `pipeline-snakemake-dry-run` green
