### PR TITLE
feat(pm): hook target-date re-sync warning on milestone moves

### DIFF
--- a/.claude/hooks/recheck_dispatch.py
+++ b/.claude/hooks/recheck_dispatch.py
@@ -22,6 +22,10 @@ from pathlib import Path
 REPO = "Jin-HoMLee/splice-neoepitope-pipeline"
 SIZE_FIELD_ID = "PVTSSF_lAHOB17eGc4BSomPzhAHGiA"
 STATUS_FIELD_ID = "PVTSSF_lAHOB17eGc4BSomPzhAHFf8"
+PROJECT_ID = "PVT_kwHOB17eGc4BSomP"
+PROJECT_NUMBER = 9
+TARGET_DATE_FIELD_ID = "PVTF_lAHOB17eGc4BSomPzhAHGiM"
+TARGET_DATE_FIELD_NAME = "Target date"
 SCRIPT = str(Path(__file__).resolve().parent.parent.parent / "scripts" / "pm" / "recheck_milestone.py")
 PARENT_STATUS_SCRIPT = str(Path(__file__).resolve().parent.parent.parent / "scripts" / "pm" / "recheck_parent_status.py")
 
@@ -87,6 +91,100 @@ def lookup_issue_for_item(item_id: str) -> int | None:
     return int(out) if out.isdigit() else None
 
 
+def get_issue_milestone(issue: int) -> tuple[str | None, str | None]:
+    """Return (milestone_title, due_on YYYY-MM-DD) for the issue's current milestone."""
+    result = subprocess.run(
+        ["gh", "api", f"repos/{REPO}/issues/{issue}",
+         "--jq", "{title: .milestone.title, due_on: .milestone.due_on}"],
+        capture_output=True, text=True, check=False,
+    )
+    if result.returncode != 0:
+        return (None, None)
+    try:
+        data = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return (None, None)
+    title = data.get("title")
+    due_on = data.get("due_on")
+    if due_on:
+        due_on = due_on[:10]
+    return (title, due_on)
+
+
+def get_issue_target_date(issue: int) -> tuple[str | None, str | None]:
+    """Return (target_date YYYY-MM-DD, project_item_id) for the issue's entry on project #9.
+
+    Returns (None, None) if the issue is not on the project board. Returns
+    (None, item_id) if the issue is on the board but Target date is unset.
+    """
+    query = (
+        'query { repository(owner: "Jin-HoMLee", name: "splice-neoepitope-pipeline") '
+        '{ issue(number: ' + str(issue) + ') { projectItems(first: 10) { nodes { '
+        'id project { number } fieldValues(first: 20) { nodes { '
+        '... on ProjectV2ItemFieldDateValue { date field { ... on ProjectV2FieldCommon { name } } } '
+        '} } } } } } }'
+    )
+    result = subprocess.run(
+        ["gh", "api", "graphql", "-f", f"query={query}"],
+        capture_output=True, text=True, check=False,
+    )
+    if result.returncode != 0:
+        return (None, None)
+    try:
+        data = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return (None, None)
+    issue_node = ((data.get("data") or {}).get("repository") or {}).get("issue") or {}
+    items = (issue_node.get("projectItems") or {}).get("nodes") or []
+    for item in items:
+        if ((item.get("project") or {}).get("number")) != PROJECT_NUMBER:
+            continue
+        item_id = item.get("id")
+        for fv in (item.get("fieldValues") or {}).get("nodes") or []:
+            if not fv:
+                continue
+            field_name = (fv.get("field") or {}).get("name")
+            if field_name == TARGET_DATE_FIELD_NAME:
+                return (fv.get("date"), item_id)
+        return (None, item_id)
+    return (None, None)
+
+
+def target_sync_check(issue: int) -> str | None:
+    """Compare issue's Target date against current milestone due_on. Returns warning or None."""
+    ms_title, ms_due_on = get_issue_milestone(issue)
+    target_date, item_id = get_issue_target_date(issue)
+
+    if item_id is None:
+        return None
+
+    if ms_title:
+        if target_date == ms_due_on:
+            return None
+        return (
+            f"[target re-sync needed — move on #{issue}, new milestone \"{ms_title}\"]\n"
+            f"Project board Target date: {target_date or '(unset)'}\n"
+            f"New milestone due_on:      {ms_due_on or '(unset)'}\n"
+            f"Re-sync via GraphQL `updateProjectV2ItemFieldValue`:\n"
+            f"  projectId: {PROJECT_ID}\n"
+            f"  itemId:    {item_id}\n"
+            f"  fieldId:   {TARGET_DATE_FIELD_ID}  ({TARGET_DATE_FIELD_NAME})\n"
+            f"  date:      {ms_due_on}"
+        )
+
+    if target_date is not None:
+        return (
+            f"[target re-sync needed — demilestone on #{issue}]\n"
+            f"Issue is un-milestoned but Target date is still: {target_date}\n"
+            f"Clear via GraphQL `clearProjectV2ItemFieldValue`:\n"
+            f"  projectId: {PROJECT_ID}\n"
+            f"  itemId:    {item_id}\n"
+            f"  fieldId:   {TARGET_DATE_FIELD_ID}  ({TARGET_DATE_FIELD_NAME})"
+        )
+
+    return None
+
+
 def prior_milestones_for_issue(issue: int) -> list[int]:
     """Return milestone numbers from the 2 most recent milestoned/demilestoned events."""
     result = subprocess.run(
@@ -134,6 +232,9 @@ def dispatch(cmd: str) -> list[str]:
                     f"[milestone recheck — move on #{issue}, milestone {ms}]\n"
                     f"{run_recheck('--milestone', str(ms))}"
                 )
+        sync_warn = target_sync_check(issue)
+        if sync_warn:
+            outputs.append(sync_warn)
 
     if SIZE_FIELD_ID in cmd:
         item_match = PATTERN_ITEMID.search(cmd)

--- a/research/lab_notebook/pm.md
+++ b/research/lab_notebook/pm.md
@@ -8,6 +8,22 @@ Format and rules unchanged from the unified notebook — see `shared/feedback_la
 
 ## 2026-05-21
 
+### 14:40 UTC — Editor: PM
+
+#### [Issue #448](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/448) — target-date re-sync hook ([PR #450](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/450))
+
+**Trigger.** This morning's Roadmap-overdue sweep surfaced 3 Issues; 2 of them ([Issue #324](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/324) per-role model routing, [Issue #304](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/304) sensitivity analysis) had stale project board Target dates from mid-week `gh issue edit --milestone X` moves that never re-synced the date. Rung 2 (inline Always-in-effect rule + `feedback_milestones.md` body update) landed earlier in the same morning; this PR is rung 3 (point-of-action mechanism), completing the layered defense per [[mechanism-over-memory]].
+
+**Mechanism shape.** Extended [`.claude/hooks/recheck_dispatch.py`](.claude/hooks/recheck_dispatch.py) — sibling addition to the milestone-capacity recheck ([PR #397](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/397) precedent) and parent-status drift recheck ([PR #407](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/407) precedent). 4 constants (`PROJECT_ID`, `PROJECT_NUMBER`, `TARGET_DATE_FIELD_ID`, `TARGET_DATE_FIELD_NAME`), 2 helpers (`get_issue_milestone` via REST, `get_issue_target_date` via GraphQL), 1 check (`target_sync_check`) wired into the existing `PATTERN_MOVE` branch alongside milestone-recheck. Report-only via `additionalContext` — same shape as siblings, no auto-mutation; operator runs the fix mutation when surfaced.
+
+**Verified before push.** Clean [Issue #324](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/324) (Target=2026-07-09, milestone due=2026-07-09 post-morning-sync) → no warning. Stale [Issue #258](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/258) (Target=2026-05-15, milestone due=2026-06-13 post-i3-S1 recompute earlier today) → warning emitted with correct projectId, itemId, fieldId, date — all 4 fields suitable for a copy-paste GraphQL mutation. Pre-existing milestone-recheck path fires correctly alongside the new check.
+
+**Review.** `@claude review` returned in 2m1s, verdict approve, 2 cosmetic non-blocking nits: (a) `get_issue_milestone` returns `(None, None)` on both no-milestone AND REST API error — distinct sentinel would tighten signal; (b) `return (None, item_id)` inside the outer fieldValues loop is correct early-exit but implicit. Declined both for this PR: (a) is YAGNI on a report-only hook until a real false warning shows up in session usage; (b) suggested comment is WHAT-not-WHY, against the terseness rule. If false warnings surface later, address (a) at that point.
+
+**Follow-up tracked in PR body.** Promote hook config from `.claude/settings.local.json` (gitignored) to `.claude/settings.json` once it proves out in session usage; extend the check to the milestone-`due_on`-PATCH path so when a milestone's date itself moves, all member Issues' Target dates get flagged at once.
+
+---
+
 ### 09:59 UTC — Editor: PM
 
 #### [Issue #249](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/249) — feedback memory spike-rate alert (XS warm-up); i6-S3 milestone restructure during triage


### PR DESCRIPTION
## Summary

Extends `.claude/hooks/recheck_dispatch.py` to warn when an Issue's project board Target date drifts out of sync with its milestone's `due_on` after a `gh issue edit N --milestone X` move.

- Adds 4 constants (`PROJECT_ID`, `PROJECT_NUMBER`, `TARGET_DATE_FIELD_ID`, `TARGET_DATE_FIELD_NAME`), 2 helpers (`get_issue_milestone`, `get_issue_target_date`), 1 check (`target_sync_check`).
- Wires `target_sync_check` into the existing `PATTERN_MOVE` branch alongside the existing milestone-recheck calls.
- Report-only (`additionalContext` warning, no auto-mutation) — same shape as the existing milestone-level recheck.

Closes [Issue #448](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/448) (target-date re-sync hook).

## Why

The 2026-05-21 morning sweep surfaced three Roadmap-overdue Issues — two of them ([Issue #324](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/324) per-role model routing, [Issue #304](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/304) sensitivity analysis) were caused by PM mid-week edits that changed an Issue's milestone without re-syncing its project board Target date. Memory-only prevention is rung 2; this hook is rung 3 (point-of-action), completing the layered defense documented in `feedback_mechanism_over_memory.md`.

## Test plan

- [x] Syntax-check the modified hook (`python3 -c "import ast; ast.parse(...)"`)
- [x] Hook test #1: known-clean Issue ([Issue #324](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/324) — Target=2026-07-09, milestone due=2026-07-09) → expect no warning → got no warning
- [x] Hook test #2: known-stale Issue ([Issue #258](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/258) — Target=2026-05-15, milestone due=2026-06-13) → expect warning with correct projectId/itemId/fieldId/date → got warning with all four fields correct
- [x] Pre-existing milestone-recheck calls still fire correctly (verified in both tests via `additionalContext` showing milestone reports alongside the new Target sync output).

## Out of scope (future work)

- Promote hook from `.claude/settings.local.json` (gitignored) to `.claude/settings.json` once it proves out in PM session usage.
- Extend the check to milestone-`due_on`-PATCH path (`gh api .../milestones/N -X PATCH`) so when an entire milestone's date moves, all member Issues' Target dates are flagged at once.

Generated with [Claude Code](https://claude.com/claude-code)

