### PR TITLE
docs(pm): news_log 2026-05-22 08:11 UTC — Issue fields preview + multi-agent token economics

### DIFF
--- a/research/news_log.md
+++ b/research/news_log.md
@@ -11,6 +11,13 @@ Historical entries (before 2026-05-02) pre-date the time/editor sub-heading conv
 
 ---
 
+## 2026-05-22
+
+### 08:11 UTC — Editor: PM
+
+- **GitHub Issues — Fields public preview** ([changelog 2026-05-21](https://github.blog/changelog/2026-05-21-issue-fields-are-now-in-public-preview-for-all-organizations/)) — org-level typed fields (single-select / text / number / date), pinnable per issue type, REST + GraphQL exposed. **Blocked for us:** private projects only AND org-level only; our repo is public + user-owned. → No action now; revisit if GitHub extends to public projects or user accounts. *PM. tooling-signal.*
+- **Multi-agent token economics** ([niteagent 2026 survey](https://niteagent.com/blog/multi-agent-production-2026/)) — multi-agent systems use 15× more tokens than chat; **token usage explains 80% of perf variance**. Three surviving patterns: agent-flow / hub-and-spoke / bounded peer mesh. → Candidate Methodology backfill in [`multi_agent_landscape.md`](research/multi_agent_landscape.md) — cost framing for our PM/Sci/Dev split. *PM. methodology-signal.*
+
 ## 2026-05-21
 
 ### 10:19 UTC — Editor: Scientist


### PR DESCRIPTION
## Summary

Two PM news items logged for 2026-05-22:

- **GitHub Issues — Fields public preview** (changelog 2026-05-21) — blocked for our public + user-account setup; logged for revisit if scope extends.
- **Multi-agent token economics** — 15× token usage vs chat; candidate landscape-doc Methodology backfill.

## Test plan
- [x] Entry inserted at top of \`research/news_log.md\` under new \`## 2026-05-22\` date heading
- [x] \`### HH:MM UTC — Editor: PM\` sub-heading present
- [x] Both items match the \`- **Item** (date) — keywords. → action. *Role. Signal.*\` format
- [x] Branch follows \`docs/pm/news-log-YYYY-MM-DD-HHMM\` convention

**Created by:** PM