### PR TITLE
docs(news_log): 2026-05-22 Developer briefing

### DIFF
--- a/research/news_log.md
+++ b/research/news_log.md
@@ -13,6 +13,11 @@ Historical entries (before 2026-05-02) pre-date the time/editor sub-heading conv
 
 ## 2026-05-22
 
+### 08:20 UTC — Editor: Developer
+
+- **uv 0.11.16** ([2026-05-21](https://github.com/astral-sh/uv/releases/tag/0.11.16)) — TAR parser security fix + entry-points-escape guard; follow-up to 0.11.14 logged 2026-05-17. → No action; portfolio-tracking only. *Developer. industry-standard.*
+- **JAX 0.10.1** ([2026-05-20](https://github.com/jax-ml/jax/releases)) — GPU eigh/SVD perf nudges. TCRdock pins JAX 0.3.25 (frozen in Docker), so this is informational; relevant if/when [Issue #285](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/285) (P100 contingency / TCRdock rebuild) lands. *Developer. pipeline-adjacent.*
+
 ### 08:11 UTC — Editor: PM
 
 - **GitHub Issues — Fields public preview** ([changelog 2026-05-21](https://github.blog/changelog/2026-05-21-issue-fields-are-now-in-public-preview-for-all-organizations/)) — org-level typed fields (single-select / text / number / date), pinnable per issue type, REST + GraphQL exposed. **Blocked for us:** private projects only AND org-level only; our repo is public + user-owned. → No action now; revisit if GitHub extends to public projects or user accounts. *PM. tooling-signal.*


### PR DESCRIPTION
**Created by:** Developer

## Summary
- Add `### 08:20 UTC — Editor: Developer` section under `## 2026-05-22` in `research/news_log.md`
- Two minor Dev-scope items, neither clears the Issue-creation gate

## Items
- **uv 0.11.16** (2026-05-21) — TAR parser security fix + entry-points-escape guard; continues the Astral toolchain entry from 2026-05-17. *industry-standard.*
- **JAX 0.10.1** (2026-05-20) — minor GPU eigh/SVD improvements; TCRdock pins JAX 0.3.25 (frozen in Docker), so informational only. *pipeline-adjacent.*

## Test plan
- [x] CI: pipeline-pytest + pipeline-snakemake-dry-run green
- [x] news_log.md format intact (date order, time order, editor attribution)