### PR TITLE
docs(CLAUDE.md): two Snakemake gotchas surfaced by PR #457 chr22 run

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,6 +132,21 @@ sys.path.insert(0, os.path.join(workflow.basedir, "workflow", "scripts"))
 ```
 Caught in [PR #358](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/358) when a code-review suggestion swapped the working `workflow.basedir` form for the deprecated `srcdir()`.
 
+### `from __future__ import annotations` in `script:`-invoked Python files
+Snakemake's `PythonScript.write_script` (`snakemake/script/__init__.py:807`) unconditionally prepends its `snakemake = pickle.loads(...)` preamble before the source. There's a `PY_PREAMBLE_RE` regex on line 44 with a TODO to "use this to find the right place for inserting the preamble", but the regex was never wired up. So **any** workflow script using `from __future__ import annotations` (or any other `__future__` import) at the source level will fail at execute time with `SyntaxError: from __future__ imports must occur at the beginning of the file`. CI's `snakemake -n` dry-run does NOT catch this — the wrapper is only generated at execute time.
+
+**Fix:** drop `from __future__ import annotations` from any file invoked via `script:`. If the file uses PEP 604 syntax (`X | None`) or generic builtins (`list[int]`), rewrite those to `Optional[X]` from `typing` (Python 3.9-compatible). Other workflow scripts may share this latent issue — tracked in [Issue #461](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/461). Caught on [PR #457](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/457) during the chr22 end-to-end run for [Issue #204](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/204).
+
+### What `snakemake -n` (dry-run) does NOT catch
+`pipeline-snakemake-dry-run` in CI walks the DAG without (a) building conda envs or (b) executing scripts. Bug classes structurally invisible to dry-run:
+- **Conda solver failure** — e.g. `IMGTgeneDL>=0.7.0` pinned when PyPI max is `0.6.1`. Envs are built lazily on first execute.
+- **Subprocess CLI typos** — e.g. `stitchr -species HUMAN` (correct flag is `-s` / `--species`). Only the real subprocess argparses the args.
+- **NaN flowing through pandas into subprocesses** — curated unit-test fixtures hide single-chain rows that the production VDJdb TSV contains.
+- **Snakemake `script:` wrapper incompat** (preceding section).
+- **Path discovery silent no-ops** — `if [ -d "$DISCOVERED_PATH" ]; then ...; fi` skips silently when the path is wrong; sentinel still touches.
+
+For new rules, run the chr22 integration locally before merge (see `feedback_integration_run_for_new_rules.md` in role memory). All 5 classes above hit [PR #457](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/457) and were caught only by the first integration run, after the PR had been bot-reviewed + CI-green + reviewer-comments-addressed.
+
 ## HISAT2 Index Cache Invalidation
 
 Snakemake skips the index download if `resources/hisat2_index/` already exists (it checks for an `index.done` sentinel file). Changing `hisat2_prebuilt_url` in `config/config.yaml` does **not** invalidate this cache — the old index silently persists and will be used on the next run.


### PR DESCRIPTION
**Created by:** Developer

## Summary
Adds two new entries to `CLAUDE.md` `## Snakemake 8 Gotchas`:

1. **`from __future__ import annotations` in `script:`-invoked files** — Snakemake's `PythonScript.write_script` unconditionally prepends its preamble; the `PY_PREAMBLE_RE` detection regex has a TODO that was never wired up. So `from __future__` causes `SyntaxError` at execute time. CI dry-run doesn't catch.

2. **What `snakemake -n` does NOT catch** — enumerates 5 bug classes structurally invisible to dry-run (conda solver, subprocess CLI typos, NaN flow, script-wrapper incompat, silent path-discovery no-ops). Cross-references `feedback_integration_run_for_new_rules.md` in role memory for the behavioral rule.

Both lessons originate from the [PR #457](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/457) chr22 end-to-end run for [Issue #204](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/204), which caught 4 bugs that bot review + dry-run + unit tests had all missed. Audit of latent `__future__` bugs in other scripts tracked separately at [Issue #461](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/461).

## Test plan
- [x] CI green (`pipeline-pytest`, `pipeline-snakemake-dry-run`, `ci-tools-pytest`)
- [x] Markdown renders correctly (preview locally)