### PR TITLE
refactor: strict nf-core resources/ separation (closes #63)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,12 +23,12 @@ jobs:
 
       - name: Create placeholder input files
         run: |
-          mkdir -p data/test resources
+          mkdir -p data/test references
           touch data/test/SRR9143066_test.fastq.gz
           touch data/test/SRR9143065_test.fastq.gz
-          touch resources/gencode.v47.annotation.gtf.gz
-          touch resources/GRCh38.primary_assembly.genome.fa
-          touch resources/human_proteome.fasta
+          touch references/gencode.v47.annotation.gtf.gz
+          touch references/GRCh38.primary_assembly.genome.fa
+          touch references/human_proteome.fasta
 
       - name: Dry-run with GPU config overlay
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -207,6 +207,12 @@ marimo/_lsp/
 __marimo__/
 
 # Ignore large data files and pipeline outputs
+# nf-core layout (Issue #63):
+#   references/   user-provided + downloaded reference data (FASTA, GTF, BED, VDJdb, IMGT)
+#   indices/      pipeline-built alignment indices (HISAT2, STAR)
+#   resources/    small committed test fixtures only (resources/test/)
+references/
+indices/
 resources/
 data/
 logs/
@@ -219,7 +225,6 @@ logs/
 .snakemake/
 # Pipeline outputs (Snakemake-rule outputs)
 results/
-resources/mhcflurry_models.done
 
 # Research-notebook outputs — exploratory artefacts, re-derivable from notebooks
 # (e.g. research/notebooks/issue_224_alphagenome_exp1_outputs/chr22_stomach_predicted_junctions.parquet)

--- a/.gitignore
+++ b/.gitignore
@@ -213,7 +213,15 @@ __marimo__/
 #   resources/    small committed test fixtures only (resources/test/)
 references/
 indices/
-resources/
+# Use resources/* (not resources/) so git descends into resources/test/ and the
+# negation below takes effect. Blanket resources/ prevents directory traversal,
+# making the !resources/test/ exception unreachable.
+resources/*
+!resources/test/
+# Within resources/test/, still ignore the chr22 local-dev data cache.
+resources/test/chr22*
+resources/test/hisat2_index/
+resources/test/star_index/
 data/
 logs/
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,18 +147,30 @@ Snakemake's `PythonScript.write_script` (`snakemake/script/__init__.py:807`) unc
 
 For new rules, run the chr22 integration locally before merge (see `feedback_integration_run_for_new_rules.md` in role memory). All 5 classes above hit [PR #457](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/457) and were caught only by the first integration run, after the PR had been bot-reviewed + CI-green + reviewer-comments-addressed.
 
+## Reference + Index Layout (nf-core convention)
+
+Post-Issue #63, the pipeline keeps three distinct top-level directories:
+
+| Dir | Contents | Gitignored | Examples |
+|-----|----------|------------|----------|
+| `references/` | User-provided + downloaded reference data | yes | `GRCh38.primary_assembly.genome.fa`, `gencode.v47.annotation.gtf.gz`, `vdjdb/<release>/`, `imgt_germlines/` |
+| `indices/` | Pipeline-built alignment indices | yes | `indices/hisat2/`, `indices/star/` |
+| `resources/test/` | Small committed test fixtures + chr22 local-dev cache | partial (test fixtures may be committed; chr22 data is gitignored) | `chr22.fa`, `chr22.gtf.gz`, `hisat2_index/` |
+
+The production `resources/` directory is no longer used. `setup_vm.sh` performs a one-shot idempotent migration on existing VMs (moves old `resources/*` → `references/` and `resources/{hisat2,star}_index/` → `indices/{hisat2,star}/`). MHCflurry sentinel moved from `resources/mhcflurry_models.done` to `<mhcflurry.models_cache_dir>/.download_done` (default `~/.mhcflurry/`); the actual model cache still lives in MHCflurry's platformdirs default.
+
 ## HISAT2 Index Cache Invalidation
 
-Snakemake skips the index download if `resources/hisat2_index/` already exists (it checks for an `index.done` sentinel file). Changing `hisat2_prebuilt_url` in `config/config.yaml` does **not** invalidate this cache — the old index silently persists and will be used on the next run.
+Snakemake skips the index download if `indices/hisat2/` already exists (it checks for an `index.done` sentinel file). Changing `hisat2_prebuilt_url` in `config/config.yaml` does **not** invalidate this cache — the old index silently persists and will be used on the next run.
 
 **When changing `hisat2_prebuilt_url`:** delete the index directory on the VM before running:
 
 ```bash
 gcloud compute ssh neoepitope-pipeline --zone=europe-west1-b --tunnel-through-iap \
-  --command="rm -rf ~/splice-neoepitope-pipeline/resources/hisat2_index/"
+  --command="rm -rf ~/splice-neoepitope-pipeline/indices/hisat2/"
 ```
 
-(The chromosome naming mismatch in Issue #148 was caused by this exact scenario.)
+(The chromosome naming mismatch in Issue #148 was caused by this exact scenario, when the index lived at `resources/hisat2_index/` pre-#63.)
 
 ## Config Migration Notes
 

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -106,9 +106,11 @@ mhcflurry:
     B: "HLA-B*07:02"
     C: "HLA-C*07:02"
   threads: 8                  # cores reserved for TF/BLAS within the single genotype predict() call
-  # nf-core layout (Issue #63): MHCflurry model cache lives outside the repo by default
-  # so the sentinel survives a fresh clone. Override to a project-local path (e.g.
-  # "indices/mhcflurry") to share across clones on the same machine.
+  # nf-core layout (Issue #63): location of the MHCflurry "downloads done" sentinel.
+  # Default lives outside the repo so it survives a fresh clone. NOTE: only the
+  # sentinel is controlled by this key — the actual model cache stays in MHCflurry's
+  # platformdirs default (~/.local/share/mhcflurry/) until MHCFLURRY_DATA_DIR wiring
+  # lands (PR follow-up).
   models_cache_dir: "~/.mhcflurry"
   # Percentile thresholds for presentation_class (lower = better, per allele).
   presentation_percentile_strong:  0.5   # top 0.5% by presentation score → strong

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -30,10 +30,13 @@ output:
 reference:
   genome: "GRCh38"
   # Local paths (populated after download / placed by the user)
-  genome_fasta: "resources/GRCh38.primary_assembly.genome.fa"
-  gencode_gtf:  "resources/gencode.v47.annotation.gtf.gz"
+  # nf-core layout (Issue #63): user-provided + downloaded references live in
+  # references/ (gitignored, outside the repo source tree). Override with absolute
+  # paths to use a shared/cached download location across clones.
+  genome_fasta: "references/GRCh38.primary_assembly.genome.fa"
+  gencode_gtf:  "references/gencode.v47.annotation.gtf.gz"
   # Output: reference junction list derived from GENCODE GTF
-  junction_bed: "resources/reference_junctions.bed"
+  junction_bed: "references/reference_junctions.bed"
 
 # -----------------------------------------------------------------
 # Alignment
@@ -42,10 +45,11 @@ reference:
 #   "star"   — Full accuracy, requires ~32 GB RAM
 #   "hisat2" — Lower memory (~8 GB), good for laptops/small servers
 alignment:
-  aligner: "star"                             # "star" (32 GB RAM) or "hisat2" (8 GB RAM)
-  hisat2_index_dir: "resources/hisat2_index"  # where the HISAT2 index lives
-  hisat2_prebuilt_url: "https://genome-idx.s3.amazonaws.com/hisat/hg38_tran.tar.gz"  # leave empty to build from genome_fasta; delete resources/hisat2_index/ to force re-download
-  star_index_dir: "resources/star_index"      # where the prebuilt STAR index lives
+  aligner: "star"                            # "star" (32 GB RAM) or "hisat2" (8 GB RAM)
+  # nf-core layout (Issue #63): pipeline-built indices live in indices/ (gitignored).
+  hisat2_index_dir: "indices/hisat2"         # where the HISAT2 index lives
+  hisat2_prebuilt_url: "https://genome-idx.s3.amazonaws.com/hisat/hg38_tran.tar.gz"  # leave empty to build from genome_fasta; delete indices/hisat2/ to force re-download
+  star_index_dir: "indices/star"             # where the prebuilt STAR index lives
   threads: 8          # threads for index build + alignment
 
 # -----------------------------------------------------------------
@@ -73,7 +77,7 @@ translation:
 # Disable for speed on test runs: set enabled: false.
 proteome_filter:
   enabled: true
-  proteome_fasta: "resources/human_proteome.fasta"
+  proteome_fasta: "references/human_proteome.fasta"
 
 # -----------------------------------------------------------------
 # HLA typing (OptiType)
@@ -102,6 +106,10 @@ mhcflurry:
     B: "HLA-B*07:02"
     C: "HLA-C*07:02"
   threads: 8                  # cores reserved for TF/BLAS within the single genotype predict() call
+  # nf-core layout (Issue #63): MHCflurry model cache lives outside the repo by default
+  # so the sentinel survives a fresh clone. Override to a project-local path (e.g.
+  # "indices/mhcflurry") to share across clones on the same machine.
+  models_cache_dir: "~/.mhcflurry"
   # Percentile thresholds for presentation_class (lower = better, per allele).
   presentation_percentile_strong:  0.5   # top 0.5% by presentation score → strong
   presentation_percentile_weak:    2.0   # top 2.0% by presentation score → weak

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -9,12 +9,12 @@ an overlay file `config/gpu_config.yaml` is merged at runtime.
 
 ```yaml
 reference:
-  genome_fasta: "resources/GRCh38.primary_assembly.genome.fa"
-  gencode_gtf:  "resources/gencode.v47.annotation.gtf.gz"
-  junction_bed: "resources/reference_junctions.bed"   # auto-generated
+  genome_fasta: "references/GRCh38.primary_assembly.genome.fa"
+  gencode_gtf:  "references/gencode.v47.annotation.gtf.gz"
+  junction_bed: "references/reference_junctions.bed"   # auto-generated
 ```
 
-See [`resources/README.md`](../resources/README.md) for download commands.
+See [`docs/resources.md`](resources.md) for download commands. The pipeline follows the nf-core layout convention (Issue #63): user-provided + downloaded references live in `references/`; pipeline-built alignment indices live in `indices/`. Both directories are gitignored.
 
 ---
 
@@ -23,13 +23,13 @@ See [`resources/README.md`](../resources/README.md) for download commands.
 ```yaml
 alignment:
   aligner: "hisat2"                           # "hisat2" (8 GB) or "star" (32 GB)
-  hisat2_index_dir: "resources/hisat2_index"
+  hisat2_index_dir: "indices/hisat2"
   hisat2_prebuilt_url: "https://genome-idx.s3.amazonaws.com/hisat/hg38_tran.tar.gz"
-  star_index_dir:   "resources/star_index"
+  star_index_dir:   "indices/star"
   threads: 8
 ```
 
-`hisat2_prebuilt_url` — URL to a prebuilt HISAT2 splice-aware index. Must use **UCSC naming** (`hg38_*`, `chr` prefix) to match the genome FASTA. Leave empty to build the index locally from `genome_fasta`. Delete `resources/hisat2_index/` on the VM to force re-download when the URL changes.
+`hisat2_prebuilt_url` — URL to a prebuilt HISAT2 splice-aware index. Must use **UCSC naming** (`hg38_*`, `chr` prefix) to match the genome FASTA. Leave empty to build the index locally from `genome_fasta`. Delete `indices/hisat2/` on the VM to force re-download when the URL changes.
 
 See [`docs/data_preparation.md`](data_preparation.md) for aligner comparison.
 

--- a/docs/google_cloud_guide.md
+++ b/docs/google_cloud_guide.md
@@ -203,11 +203,14 @@ snakemake --version
 
 ### Step 5: Download Reference Files
 
-Download the GRCh38 genome and GENCODE annotation into the `resources/` directory.
-These files are required before running the pipeline (~3.1 GB uncompressed + 57 MB).
+Download the GRCh38 genome and GENCODE annotation into the `references/` directory
+(nf-core layout; Issue #63). These files are required before running the pipeline
+(~3.1 GB uncompressed + 57 MB).
 
 ```bash
-cd ~/splice-neoepitope-pipeline/resources
+cd ~/splice-neoepitope-pipeline
+mkdir -p references
+cd references
 
 # Download GENCODE v47 GTF annotation (~57 MB)
 wget https://ftp.ebi.ac.uk/pub/databases/gencode/Gencode_human/release_47/gencode.v47.annotation.gtf.gz
@@ -651,7 +654,7 @@ git clone https://github.com/Jin-HoMLee/splice-neoepitope-pipeline.git
 cd splice-neoepitope-pipeline
 
 # 5. Download reference files
-cd resources
+mkdir -p references && cd references
 wget https://ftp.ebi.ac.uk/pub/databases/gencode/Gencode_human/release_47/gencode.v47.annotation.gtf.gz
 wget https://ftp.ebi.ac.uk/pub/databases/gencode/Gencode_human/release_47/GRCh38.primary_assembly.genome.fa.gz
 gunzip GRCh38.primary_assembly.genome.fa.gz

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -74,9 +74,9 @@ cd splice-neoepitope-pipeline
 
 ## 4. Download Reference Data
 
-Follow the instructions in [`resources/README.md`](../resources/README.md) to
-download the GRCh38 FASTA and GENCODE v47 GTF. These are required for the
-full pipeline; the chr22 test subset is handled automatically by
+Follow the instructions in [`docs/resources.md`](resources.md) to download
+the GRCh38 FASTA and GENCODE v47 GTF into `references/`. These are required
+for the full pipeline; the chr22 test subset is handled automatically by
 `scripts/prepare_test_data.sh`.
 
 ---

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -1,9 +1,15 @@
-# Resources Directory
+# Reference Data Directory
 
-This directory stores large reference files that are **not tracked in git** due
-to their size.  Before running the pipeline you must download or generate the
-following files and place them here (or update the paths in
-`config/config.yaml`).
+The pipeline follows the nf-core layout convention (Issue #63):
+
+| Directory | Contents | Gitignored |
+|-----------|----------|------------|
+| `references/` | User-provided + downloaded reference data (FASTA, GTF, BED, proteome, VDJdb, IMGT) | yes |
+| `indices/` | Pipeline-built alignment indices (HISAT2, STAR) | yes |
+| `resources/test/` | Small committed test fixtures (chr22 local-dev workflow) | partial |
+
+All reference files listed below go in `references/` by default. Override the
+paths in `config/config.yaml` if you cache references at a different location.
 
 ---
 
@@ -57,9 +63,9 @@ locations:
 
 ```yaml
 reference:
-  genome_fasta: "resources/GRCh38.primary_assembly.genome.fa"
-  gencode_gtf:  "resources/gencode.v47.annotation.gtf.gz"
-  junction_bed: "resources/reference_junctions.bed"
+  genome_fasta: "references/GRCh38.primary_assembly.genome.fa"
+  gencode_gtf:  "references/gencode.v47.annotation.gtf.gz"
+  junction_bed: "references/reference_junctions.bed"
 ```
 
 ---

--- a/scripts/setup_vm.sh
+++ b/scripts/setup_vm.sh
@@ -183,11 +183,42 @@ fi
 log ""
 log "[8/8] Downloading reference data (20–60 min)..."
 
-RESOURCES="$REPO_DIR/resources"
-mkdir -p "$RESOURCES"
+# nf-core layout (Issue #63): references/ holds user-provided + downloaded reference
+# data; indices/ holds pipeline-built alignment indices. Both are gitignored.
+REFERENCES="$REPO_DIR/references"
+mkdir -p "$REFERENCES"
 
-FASTA_GZ="$RESOURCES/GRCh38.primary_assembly.genome.fa.gz"
-FASTA="$RESOURCES/GRCh38.primary_assembly.genome.fa"
+# One-shot migration from the pre-Issue-63 resources/ layout. Idempotent — only
+# moves files that exist in the old location AND don't yet exist in the new one.
+OLD_RESOURCES="$REPO_DIR/resources"
+if [[ -d "$OLD_RESOURCES" ]]; then
+    for f in GRCh38.primary_assembly.genome.fa GRCh38.primary_assembly.genome.fa.fai \
+             gencode.v47.annotation.gtf.gz human_proteome.fasta reference_junctions.bed; do
+        if [[ -f "$OLD_RESOURCES/$f" && ! -f "$REFERENCES/$f" ]]; then
+            log "  Migrating $f → references/ (Issue #63 layout)"
+            mv "$OLD_RESOURCES/$f" "$REFERENCES/$f"
+        fi
+    done
+    for d in vdjdb imgt_germlines; do
+        if [[ -d "$OLD_RESOURCES/$d" && ! -d "$REFERENCES/$d" ]]; then
+            log "  Migrating $d/ → references/ (Issue #63 layout)"
+            mv "$OLD_RESOURCES/$d" "$REFERENCES/$d"
+        fi
+    done
+    OLD_INDICES="$OLD_RESOURCES"
+    NEW_INDICES="$REPO_DIR/indices"
+    mkdir -p "$NEW_INDICES"
+    for d in hisat2_index:hisat2 star_index:star; do
+        OLD_NAME="${d%%:*}"; NEW_NAME="${d##*:}"
+        if [[ -d "$OLD_INDICES/$OLD_NAME" && ! -d "$NEW_INDICES/$NEW_NAME" ]]; then
+            log "  Migrating $OLD_NAME/ → indices/$NEW_NAME/ (Issue #63 layout)"
+            mv "$OLD_INDICES/$OLD_NAME" "$NEW_INDICES/$NEW_NAME"
+        fi
+    done
+fi
+
+FASTA_GZ="$REFERENCES/GRCh38.primary_assembly.genome.fa.gz"
+FASTA="$REFERENCES/GRCh38.primary_assembly.genome.fa"
 
 if [[ -f "$FASTA" ]]; then
     log "  GRCh38 FASTA already exists — skipping."
@@ -211,7 +242,7 @@ else
     log "  Saved: $FAI"
 fi
 
-GTF="$RESOURCES/gencode.v47.annotation.gtf.gz"
+GTF="$REFERENCES/gencode.v47.annotation.gtf.gz"
 if [[ -f "$GTF" ]]; then
     log "  GENCODE GTF already exists — skipping."
 else

--- a/workflow/rules/alignment.smk
+++ b/workflow/rules/alignment.smk
@@ -94,7 +94,7 @@ if config.get("alignment", {}).get("aligner") == "hisat2":
     # Configurable index directory — allows test (chr22) and production
     # (full genome) to maintain separate indices without overwriting.
     _HISAT2_INDEX_DIR = config.get("alignment", {}).get(
-        "hisat2_index_dir", "resources/hisat2_index"
+        "hisat2_index_dir", "indices/hisat2"
     )
     _HISAT2_PREBUILT_URL = config.get("alignment", {}).get("hisat2_prebuilt_url", "")
 
@@ -252,7 +252,7 @@ if config.get("alignment", {}).get("aligner") == "hisat2":
 elif config.get("alignment", {}).get("aligner") == "star":
 
     _STAR_INDEX_DIR = config.get("alignment", {}).get(
-        "star_index_dir", "resources/star_index"
+        "star_index_dir", "indices/star"
     )
 
     rule star_index:
@@ -278,9 +278,10 @@ elif config.get("alignment", {}).get("aligner") == "star":
             set -euo pipefail
             GTF_FILE="{input.gtf}"
             if [[ "$GTF_FILE" == *.gz ]]; then
-                trap 'rm -f resources/temp_annotation.gtf' EXIT
-                gunzip -c "$GTF_FILE" > resources/temp_annotation.gtf
-                GTF_FILE="resources/temp_annotation.gtf"
+                TEMP_GTF=$(mktemp)
+                trap 'rm -f "$TEMP_GTF"' EXIT
+                gunzip -c "$GTF_FILE" > "$TEMP_GTF"
+                GTF_FILE="$TEMP_GTF"
             fi
 
             STAR \\

--- a/workflow/rules/download.smk
+++ b/workflow/rules/download.smk
@@ -57,8 +57,8 @@ rule download_vdjdb_release:
     Sentinel-gated for idempotency. Re-runs are no-ops once the sentinel exists.
     """
     output:
-        vdjdb_tsv = f"resources/vdjdb/{config['tcrdock']['vdjdb_release']}/vdjdb_full.txt",
-        sentinel = f"resources/vdjdb/{config['tcrdock']['vdjdb_release']}/.download.done",
+        vdjdb_tsv = f"references/vdjdb/{config['tcrdock']['vdjdb_release']}/vdjdb_full.txt",
+        sentinel = f"references/vdjdb/{config['tcrdock']['vdjdb_release']}/.download.done",
     log:
         f"logs/download/vdjdb_{config['tcrdock']['vdjdb_release']}.log",
     params:
@@ -106,7 +106,7 @@ rule download_imgt_germlines:
     see Known limitations in the design spec).
     """
     output:
-        sentinel = "resources/imgt_germlines/.download.done",
+        sentinel = "references/imgt_germlines/.download.done",
     log:
         "logs/download/imgt_germlines.log",
     conda:
@@ -117,7 +117,7 @@ rule download_imgt_germlines:
         DIR=$(dirname {output.sentinel})
         mkdir -p "$DIR"
         echo "Downloading IMGT germline data via stitchrdl..." >> {log} 2>&1
-        # stitchrdl writes to its default cache; we copy into resources/ for reproducibility
+        # stitchrdl writes to its default cache; we copy into references/ for reproducibility
         stitchrdl --species HUMAN >> {log} 2>&1
         # Discover stitchr's cache dir from python (preferred over hard-coding)
         STITCHR_CACHE=$(python -c "import IMGTgeneDL; from pathlib import Path; print(Path(IMGTgeneDL.__file__).parent / 'data' / 'HUMAN')")

--- a/workflow/rules/mhc_affinity.smk
+++ b/workflow/rules/mhc_affinity.smk
@@ -5,6 +5,15 @@
 _HLA_TYPING_ENABLED  = config.get("hla", {}).get("enabled", False)
 _PROTEOME_FILTER_ENABLED = config.get("proteome_filter", {}).get("enabled", True)
 
+# nf-core layout (Issue #63): sentinel for "mhcflurry-downloads fetch ran" lives
+# outside the repo (default ~/.mhcflurry/.download_done). The actual model cache
+# remains in MHCflurry's own platformdirs location — wiring MHCFLURRY_DATA_DIR to
+# fully co-locate the cache is a follow-up (touches run_mhcflurry.py too).
+_MHCFLURRY_MODELS_DIR = os.path.expanduser(
+    config.get("mhcflurry", {}).get("models_cache_dir", "~/.mhcflurry")
+)
+_MHCFLURRY_SENTINEL = os.path.join(_MHCFLURRY_MODELS_DIR, ".download_done")
+
 # When proteome_filter is enabled, use the filtered novel peptides TSV.
 # When disabled, fall back to the raw translated peptides TSV.
 def _run_mhcflurry_input(wildcards):
@@ -29,10 +38,12 @@ def _run_mhcflurry_input(wildcards):
 
 rule download_mhcflurry_models:
     """Download MHCflurry trained models (~1 GB) on first run.
-    Models are cached in ~/.local/share/mhcflurry/ and reused across runs.
-    A sentinel file is written to resources/ to prevent re-downloading."""
+    Models are cached in MHCflurry's default platformdirs location
+    (~/.local/share/mhcflurry/) and reused across runs. The sentinel marker
+    lives in mhcflurry.models_cache_dir (default ~/.mhcflurry/) — out of the
+    repo per nf-core convention (Issue #63)."""
     output:
-        sentinel=touch("resources/mhcflurry_models.done"),
+        sentinel=touch(_MHCFLURRY_SENTINEL),
     log:
         os.path.join(_LOGS, "mhc_affinity", "mhcflurry_downloads.log"),
     conda:

--- a/workflow/rules/proteome_filter.smk
+++ b/workflow/rules/proteome_filter.smk
@@ -15,7 +15,7 @@
 
 _PROTEOME_FILTER_ENABLED = config.get("proteome_filter", {}).get("enabled", True)
 _PROTEOME_FASTA = config.get("proteome_filter", {}).get(
-    "proteome_fasta", "resources/human_proteome.fasta"
+    "proteome_fasta", "references/human_proteome.fasta"
 )
 
 if _PROTEOME_FILTER_ENABLED:
@@ -24,7 +24,7 @@ if _PROTEOME_FILTER_ENABLED:
         """Download UniProt Swiss-Prot human proteome FASTA.
 
         Source: UniProt REST API — reviewed human entries only (~20k canonical
-        proteins). Downloaded once to resources/ and reused across all patients.
+        proteins). Downloaded once to references/ and reused across all patients.
         """
         output:
             fasta=_PROTEOME_FASTA,

--- a/workflow/rules/tcr_panel.smk
+++ b/workflow/rules/tcr_panel.smk
@@ -24,9 +24,9 @@ if _HLA_ENABLED:
     rule fetch_vdjdb_panel:
         """Build the per-patient VDJdb TCR panel."""
         input:
-            vdjdb_tsv = f"resources/vdjdb/{config['tcrdock']['vdjdb_release']}/vdjdb_full.txt",
-            vdjdb_sentinel = f"resources/vdjdb/{config['tcrdock']['vdjdb_release']}/.download.done",
-            imgt_sentinel = "resources/imgt_germlines/.download.done",
+            vdjdb_tsv = f"references/vdjdb/{config['tcrdock']['vdjdb_release']}/vdjdb_full.txt",
+            vdjdb_sentinel = f"references/vdjdb/{config['tcrdock']['vdjdb_release']}/.download.done",
+            imgt_sentinel = "references/imgt_germlines/.download.done",
             alleles_tsv = os.path.join(_RES, "{patient_id}", "hla_typing", "alleles.tsv"),
         output:
             panel = os.path.join(_RES, "{patient_id}", "tcr_panel", "vdjdb", "panel.tsv"),

--- a/workflow/scripts/assemble_contigs.py
+++ b/workflow/scripts/assemble_contigs.py
@@ -17,7 +17,7 @@ Output: FASTA file where each sequence header encodes the junction coordinates.
 Usage (standalone):
   python assemble_contigs.py \\
       --novel-junctions results/junctions/patient_001/novel_junctions.tsv \\
-      --genome-fasta resources/GRCh38.primary_assembly.genome.fa \\
+      --genome-fasta references/GRCh38.primary_assembly.genome.fa \\
       --output results/contigs/patient_001/contigs.fa \\
       --upstream-nt 27 --downstream-nt 27
 

--- a/workflow/scripts/build_reference_junctions.py
+++ b/workflow/scripts/build_reference_junctions.py
@@ -13,8 +13,8 @@ where ``name`` is ``<chrom>:<start>-<end>:<strand>``.
 
 Usage (standalone):
   python build_reference_junctions.py \\
-      --gtf resources/gencode.v47.annotation.gtf.gz \\
-      --output resources/reference_junctions.bed
+      --gtf references/gencode.v47.annotation.gtf.gz \\
+      --output references/reference_junctions.bed
 
 Usage (Snakemake):
   Called automatically by the ``build_reference_junctions`` rule.

--- a/workflow/scripts/filter_junctions.py
+++ b/workflow/scripts/filter_junctions.py
@@ -24,9 +24,9 @@ Usage (standalone):
   python filter_junctions.py \\
       --junction-files results/{patient_id}/alignment/{sample_id}/junctions.tsv ... \\
       --manifest results/{patient_id}/alignment/manifest.tsv \\
-      --reference-junctions resources/reference_junctions.bed \\
+      --reference-junctions references/reference_junctions.bed \\
       --output results/{patient_id}/junctions/novel_junctions.tsv \\
-      [--gencode-gtf resources/gencode.v47.annotation.gtf.gz]
+      [--gencode-gtf references/gencode.v47.annotation.gtf.gz]
 
 Usage (Snakemake):
   Called automatically by the ``filter_junctions`` rule.

--- a/workflow/scripts/proteome_filter.py
+++ b/workflow/scripts/proteome_filter.py
@@ -27,7 +27,7 @@ Usage (Snakemake):
 Usage (standalone):
   python proteome_filter.py \\
       --peptides-tsv results/.../peptides/peptides.tsv \\
-      --proteome-fasta resources/human_proteome.fasta \\
+      --proteome-fasta references/human_proteome.fasta \\
       --novel-tsv results/.../peptides/peptides_novel.tsv \\
       --excluded-tsv results/.../peptides/peptides_excluded.tsv \\
       --peptide-lengths 8 9 10

--- a/workflow/scripts/run_star_alignment.py
+++ b/workflow/scripts/run_star_alignment.py
@@ -24,7 +24,7 @@ Usage (standalone):
   python run_star_alignment.py \\
       --fastq1 sample_R1.fastq.gz \\
       --fastq2 sample_R2.fastq.gz \\
-      --genome-dir resources/star_index \\
+      --genome-dir indices/star \\
       --output-dir results/raw_data/local/files \\
       --sample-id sample1 \\
       --threads 8


### PR DESCRIPTION
**Created by:** Developer

## Summary

Implements [Issue #63](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/63) (refactor) — strict nf-core separation of pipeline-generated artefacts vs user-provided reference data.

Three top-level directories now have distinct, documented roles:

| Dir | Contents | Gitignored |
|-----|----------|------------|
| \`references/\` | User-provided + downloaded reference data (FASTA, GTF, BED, proteome, VDJdb, IMGT) | yes |
| \`indices/\` | Pipeline-built alignment indices (HISAT2, STAR) | yes |
| \`resources/test/\` | Small committed test fixtures + chr22 local-dev cache | partial |

The pre-#63 production \`resources/\` directory is removed from the default layout. The test config retains its explicit \`resources/test/\` overrides per the Issue spec (small committed test fixtures slot).

## Changes by file

- [.gitignore](.gitignore) — add \`references/\`, \`indices/\`; drop obsolete \`resources/mhcflurry_models.done\` pin
- [config/config.yaml](config/config.yaml) — reference + index paths flip to \`references/\` and \`indices/\`; new \`mhcflurry.models_cache_dir\` key (default \`~/.mhcflurry\`)
- [workflow/rules/alignment.smk](workflow/rules/alignment.smk) — HISAT2 + STAR default index dirs; STAR temp_annotation.gtf → \`mktemp\` (no project-dir pollution)
- [workflow/rules/mhc_affinity.smk](workflow/rules/mhc_affinity.smk) — sentinel relocates to \`<models_cache_dir>/.download_done\`; actual MHCflurry model cache stays in platformdirs (full \`MHCFLURRY_DATA_DIR\` wiring is a follow-up — touches run_mhcflurry.py)
- [workflow/rules/proteome_filter.smk](workflow/rules/proteome_filter.smk), [download.smk](workflow/rules/download.smk), [tcr_panel.smk](workflow/rules/tcr_panel.smk) — proteome + VDJdb + IMGT paths
- [scripts/setup_vm.sh](scripts/setup_vm.sh) — downloads to \`references/\`; one-shot idempotent migration block moves pre-#63 layout into place on existing VMs
- [workflow/scripts/*.py](workflow/scripts/) — Usage docstring examples updated (5 files, no logic change)
- [docs/](docs/) — \`configuration.md\`, \`resources.md\` (renamed-section header), \`installation.md\`, \`google_cloud_guide.md\`
- [CLAUDE.md](CLAUDE.md) — new \"Reference + Index Layout\" section; HISAT2 cache-invalidation rm path updated
- [.github/workflows/tests.yml](.github/workflows/tests.yml) — placeholder input files now created under \`references/\`

## VM migration

Existing VMs (\`neoepitope-pipeline\`, \`pipeline-spot-gpu\`) have data in \`resources/\`. After this PR merges, the next \`setup_vm.sh\` run will migrate \`resources/{FASTA,GTF,proteome,vdjdb,imgt_germlines}/\` → \`references/\` and \`resources/{hisat2,star}_index/\` → \`indices/{hisat2,star}/\`. The block is idempotent — it only moves files that exist in the old location and do not yet exist in the new one.

For VMs that don't re-run setup_vm.sh, the migration can be invoked manually:

\`\`\`bash
cd ~/splice-neoepitope-pipeline
# Re-run the section [8/8] block in scripts/setup_vm.sh, OR move manually:
mkdir -p references indices
mv resources/{GRCh38.primary_assembly.genome.fa*,gencode.v47.annotation.gtf.gz,human_proteome.fasta,reference_junctions.bed} references/ 2>/dev/null || true
mv resources/vdjdb resources/imgt_germlines references/ 2>/dev/null || true
mv resources/hisat2_index indices/hisat2 2>/dev/null || true
mv resources/star_index indices/star 2>/dev/null || true
\`\`\`

The pre-#63 MHCflurry sentinel at \`resources/mhcflurry_models.done\` is harmless to leave — the new \`download_mhcflurry_models\` rule will re-fire on next run, fast-path through \`mhcflurry-downloads fetch\` (models already cached in platformdirs), and touch the new sentinel.

## Verification

- ✅ \`snakemake -n --configfile config/config.yaml\` (production) resolves DAG, 7 rules planned, no errors
- ✅ \`snakemake -n --configfile config/config.yaml config/test_config.yaml\` (chr22 test overlay) resolves DAG, 11 rules planned, no errors
- ✅ \`workflow/tests/.venv/bin/python -m pytest workflow/tests/ -q\` — **350 passed, 6 skipped**
- ✅ chr22 end-to-end integration run (2026-05-25 14:16–14:21): 11/11 steps green, \`EXIT_CODE=0\`. MHCflurry produced 81 prediction rows (0 strong / 3 weak / 78 non-presenters); full report HTML/TSV emitted with 3 top presenters. Note: the test config uses \`resources/test/hisat2_index/\` so the new production \`indices/\` path is not exercised by this run — that gets covered by the first post-merge VM run below.

## Test plan

- [x] Dry-run with production config — passes
- [x] Dry-run with test config overlay — passes
- [x] Pytest suite — 350/350 pass
- [x] Bot review (\`@-claude review\`) — addressed in [a21df77](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/469/commits/a21df77): gitignore exception for \`resources/test/\` + \`models_cache_dir\` comment clarified. Sentinel-naming nit deferred (cost of VM sentinel re-download outweighs style win).
- [x] CI checks green (\`pipeline-pytest\`, \`pipeline-snakemake-dry-run\`, \`ci-tools-pytest\`)

> The migration path on the production VMs is verified by the first post-merge pipeline run; result will be captured in the next lab notebook entry.

## Follow-ups (separate Issues, not blockers)

- Wire \`MHCFLURRY_DATA_DIR\` env var so the actual model cache co-locates with the sentinel under \`mhcflurry.models_cache_dir\` (requires touching \`workflow/scripts/run_mhcflurry.py\`)
- Surface a per-clone migration helper if other contributors hit it locally (not needed for the single-VM production setup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
