### PR TITLE
docs(scientist): lab notebook 2026-05-25 18:47 UTC — PR #472 closure-audit follow-up (#473)

### DIFF
--- a/research/lab_notebook/scientist.md
+++ b/research/lab_notebook/scientist.md
@@ -8,6 +8,18 @@ Format and rules unchanged from the unified notebook — see `shared/feedback_la
 
 ## 2026-05-25
 
+### 18:47 UTC — Editor: Scientist
+
+#### [PR #472](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/472) ([Issue #271](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/271)) merged — AlphaGenome DISCUSSION shipped; closure-audit follow-up filed as [Issue #473](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/473)
+
+[PR #472](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/472) (AlphaGenome predicted-normal filter NO-GO DISCUSSION subsection) merged at 18:46:59 UTC, squashed as [`70a2b9a`](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/commit/70a2b9a) on `main`; [Issue #271](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/271) auto-closed at 18:47:00 UTC. @-claude review pass returned an approve verdict with 4 pre-submission style notes; 1 applied in-cycle ([`4a8c71d`](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/commit/4a8c71d), "invert" → "AlphaGenome-unique junctions … emerge" precision fix), 3 deferred to the pre-submission proofread window alongside REFERENCES.md Open-items #2 and #3.
+
+**Closure-audit follow-up.** The closure-audit bot flagged that the 18:16 UTC entry below doesn't reference [PR #472](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/472) — root cause: the 18:16 entry was written before the PR was opened, and lab notebook entries are immutable once committed. This 18:47 entry closes the gap forward (not by edit). Filed [Issue #473](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/473) as the tracking carrier so the follow-up branch could use `gh issue develop` per the ALWAYS-use rule, rather than `git checkout -b`.
+
+**Generalisable lesson.** When a lab notebook entry is committed *before* the corresponding PR opens, the closure-audit bot (which scans the merge-day date block for the PR number) will flag a gap even though the audit-trail intent is preserved across the entry + commit history. Two patterns avoid this: (i) defer the lab notebook entry until *after* the PR is opened so the PR number is in scope from the first commit (preferred when the work is small enough that the PR is imminent), or (ii) write the entry first and add a post-merge supplementary entry referencing the PR (this PR's path). Not codifying as a feedback memory until a second incident calibrates the preference.
+
+---
+
 ### 18:16 UTC — Editor: Scientist
 
 #### [Issue #271](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/271) — AlphaGenome DISCUSSION subsection drafted and inserted into `research/manuscript/DISCUSSIONS.md`


### PR DESCRIPTION
## Summary

- Closes [Issue #473](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/473) (closure-audit gap on the now-merged [PR #472](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/472) for AlphaGenome DISCUSSION subsection / [Issue #271](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/271)).
- Adds a 18:47 UTC post-merge entry to `research/lab_notebook/scientist.md` referencing [PR #472](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/472), the merge SHA [`70a2b9a`](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/commit/70a2b9a), the @-claude review triage outcome (1 applied / 3 deferred), and the closure-audit gap-root-cause + the entry-before-PR vs. entry-after-PR tradeoff.
- Forward-fix only — the 18:16 UTC entry below it remains immutable per lab notebook convention.

## Test plan

- [x] New 18:47 UTC entry at top of 2026-05-25 date block (newer time at top of date block per `shared/feedback_lab_notebook.md`)
- [x] Entry references [PR #472](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/472) and [Issue #271](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/271)
- [x] Closure-audit bot's date-block scan will pick up `#472` on the next pass (literal `#472` substring present in the date block)
- [x] Existing 18:16 UTC entry preserved verbatim — no retro-edit
- [x] Branch created via `gh issue develop` (not `git checkout -b`) — Development link attached to [Issue #473](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/473)

🤖 Generated with [Claude Code](https://claude.com/claude-code)