### PR TITLE
chore(naming): rename alignment/<sample>/junctions.tsv → raw_junctions.tsv (#345)

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ results/
     ├── alignment/
     │   ├── manifest.tsv              # Sample manifest (file_id → sample_type)
     │   └── {sample}/
-    │       └── junctions.tsv         # Junction read counts from aligner
+    │       └── raw_junctions.tsv     # Junction read counts from aligner
     ├── hla_typing/                   # (when hla.enabled: true)
     │   ├── {sample}/
     │   │   └── {sample}_result.tsv   # Per-sample OptiType output

--- a/research/lab_notebook/developer.md
+++ b/research/lab_notebook/developer.md
@@ -8,6 +8,32 @@ Format and rules unchanged from the unified notebook — see `shared/feedback_la
 
 ## 2026-05-25
 
+### 19:37 UTC — Editor: Developer
+
+**Headline:** [PR #477](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/477) shipped, closing [Issue #345](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/345) — per-sample raw regtools/STAR quantification renamed `alignment/<sample>/junctions.tsv` → `alignment/<sample>/raw_junctions.tsv` to disambiguate from patient-level `junctions/novel_junctions.tsv`. 10 files (9 in the rename commit + 1 README fix from bot review), pure rename, no behavior change. Local chr22 integration verified end-to-end (HISAT2 path, 4/4 steps, 155 records in `novel_junctions.tsv` = 151 tumor_exclusive + 4 normal_shared, matching the post-#370 baseline). Bot review caught one real miss + flagged two correctly-classified frozen-script references; one follow-up [Issue #478](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/478) filed for the stale `RESULTS.md:54` Scientist-territory reference.
+
+#### Scope discipline: extending beyond the AC for a rename is correct if the goal is grep-cleanliness
+
+[Issue #345](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/345)'s AC listed only `alignment.smk`, `filter_junctions.smk`, and `test_filter_junctions.py`. I extended to the two converter scripts (`bed12_to_junctions.py`, `star_sj_to_junctions.py`) + their unit tests because the Issue's stated motivation is **grep-cleanliness** (`find . -name junctions.tsv` returning mixed-meaning hits). Leaving 24 `junctions.tsv` strings in converter tests + docstrings would defeat that. The PR body called this out explicitly so reviewers could push back if they disagreed — bot didn't. **Pattern: when an Issue's AC is narrower than its stated motivation, extend to satisfy the motivation, and document the extension upfront in the PR body so reviewers can challenge it.**
+
+#### Bot review missed in my own pre-PR grep: live README output-tree diagram
+
+My pre-PR grep used `--include="*.py" --include="*.smk" --include="*.yaml" --include="*.yml" --include="*.sh" --include="Snakefile"` to find live references. README.md was excluded from the file-type filter — I only added `*.md` to the *exclusion* sweep (which filtered OUT frozen plans/specs/notebooks). Net effect: README.md:223 never appeared in any grep. Bot review caught it. **Lesson: when greping for rename impact, the include-filter must cover every file class where the renamed string is meaningful — for path-shape renames that's `*.md` (READMEs, docs), not just code.** No memory rule warranted yet (1st instance of this shape; bot caught it free); user and I agreed to wait for a 2nd instance before escalating.
+
+#### Frozen `_regenerate_figures.py` scripts: pushed back on bot's soft "add a note" suggestion
+
+Bot flagged two frozen-experiment scripts (`research/experiments/issue_225_*/figures/_regenerate_figures.py`, `research/slides/issue_393_*/figures/_regenerate_figures.py`) that hardcode the old path, marked informational-not-blocking, and suggested README notes. Skipped both: per the [CLAUDE.md frozen-experiment convention](CLAUDE.md), `research/experiments/issue_NNN_*` and `research/slides/issue_NNN_*` are point-in-time records. Retroactively rewriting frozen scripts weakens "frozen reference" semantics; accreting "this filename used to be X" stickers in experiment READMEs for every future rename creates a maintenance burden. A regeneration attempt fails loudly with `FileNotFoundError` — clear, recoverable failure mode. Bot agreed in framing (informational). **Pattern: when a "useful but not blocking" suggestion conflicts with an established codebase convention, default to the convention and document the reasoning in the reply — don't accrete stickers.**
+
+#### CLAUDE.md:146-153 left as-is — generic placeholder, not a content reference
+
+Bot's own analysis: CLAUDE.md:146-153 uses `results/.../junctions.tsv` as a generic illustrative path in the `--configfile` argparse gotcha example. The filename is incidental to the pitfall being demonstrated. Updating would be scope creep without payoff (the rename's grep-cleanliness goal targets `find -name`, not markdown content search). Left untouched per bot's recommendation.
+
+#### Local integration run targeted only `filter_junctions` to keep verification scoped
+
+For the chr22 belt-and-suspenders run, I targeted `results/patient_001_test/junctions/novel_junctions.tsv` rather than the full `report.html` to skip mhcflurry/tcrdock (heavy models / Docker — out of scope for a rename validation). The rename only touches the alignment → filter chain; CI dry-run + pytest already cover downstream rule-graph wiring. The full DAG is verified weekly via cloud runs anyway. **Pattern: for pure-rename PRs, scope the local integration run to the directly-affected rule's output, not the terminal `all` target.**
+
+---
+
 ### 18:49 UTC — Editor: Developer
 
 **Headline:** [PR #469](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/469) shipped, closing [Issue #63](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/63) — strict nf-core separation of `references/` (user-provided + downloaded data) vs `indices/` (pipeline-built alignment indices) vs `resources/test/` (small committed test fixtures + chr22 local-dev cache). 19 files across config, rules, setup_vm.sh, .gitignore, docs, and CI placeholder paths; idempotent migration block in [scripts/setup_vm.sh](scripts/setup_vm.sh) moves pre-#63 layout into place on existing VMs. Local chr22 end-to-end verified (11/11 rules, exit 0) BEFORE PR opened — the verification table covered the new `references/{human_proteome.fasta,vdjdb/<release>,imgt_germlines}` + `~/.mhcflurry/.download_done` sentinel paths, but the production `indices/{hisat2,star}/` path is exercised post-merge (test config keeps `resources/test/hisat2_index/` per the Issue spec). Bot review surfaced 3 items; applied 2 with [a21df77](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/469/commits/a21df77), deferred 1 with reasoning.

--- a/workflow/rules/alignment.smk
+++ b/workflow/rules/alignment.smk
@@ -62,7 +62,7 @@ def _get_fastq2(wildcards):
 
 
 # Shared output paths for both align rules — defined once to avoid drift.
-_JUNCTION_OUTPUT = os.path.join(_RES, "{patient_id}", "alignment", "{sample}", "junctions.tsv")
+_JUNCTION_OUTPUT = os.path.join(_RES, "{patient_id}", "alignment", "{sample}", "raw_junctions.tsv")
 _JUNCTION_DONE   = os.path.join(_RES, "{patient_id}", "alignment", "{sample}", "done")
 
 # ── HISAT2 ───────────────────────────────────────────────────────────────────
@@ -348,7 +348,7 @@ elif config.get("alignment", {}).get("aligner") == "star":
             # SJ.out.tab col 4=0 means STAR couldn't infer strand; rescue from
             # col 5 (intron motif) where possible, drop truly non-canonical —
             # see Issue #374. The helper also handles the col 7 > 0 filter
-            # and emits the same junctions.tsv format as the HISAT2 path.
+            # and emits the same raw_junctions.tsv format as the HISAT2 path.
             python workflow/scripts/star_sj_to_junctions.py \\
                 --input {params.output_prefix}SJ.out.tab \\
                 --output {output.junctions} \\

--- a/workflow/rules/filter_junctions.smk
+++ b/workflow/rules/filter_junctions.smk
@@ -42,7 +42,7 @@ def _get_junction_files_input(wildcards):
             if pid == wildcards.patient_id and sid and not sid.startswith("#"):
                 sample_ids.append(sid)
     return expand(
-        os.path.join(_RES, wildcards.patient_id, "alignment", "{sample_id}", "junctions.tsv"),
+        os.path.join(_RES, wildcards.patient_id, "alignment", "{sample_id}", "raw_junctions.tsv"),
         sample_id=sample_ids,
     )
 

--- a/workflow/scripts/bed12_to_junctions.py
+++ b/workflow/scripts/bed12_to_junctions.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""bed12_to_junctions.py — Convert a regtools BED12 file to junctions.tsv.
+"""bed12_to_junctions.py — Convert a regtools BED12 file to raw_junctions.tsv.
 
 regtools' ``junctions extract`` output is BED12 where columns 2–3 are the
 **anchor outer boundaries** (chromStart, chromEnd), NOT the intron donor/

--- a/workflow/scripts/filter_junctions.py
+++ b/workflow/scripts/filter_junctions.py
@@ -22,7 +22,7 @@ annotation is informational only; all three frames are still translated downstre
 
 Usage (standalone):
   python filter_junctions.py \\
-      --junction-files results/{patient_id}/alignment/{sample_id}/junctions.tsv ... \\
+      --junction-files results/{patient_id}/alignment/{sample_id}/raw_junctions.tsv ... \\
       --manifest results/{patient_id}/alignment/manifest.tsv \\
       --reference-junctions references/reference_junctions.bed \\
       --output results/{patient_id}/junctions/novel_junctions.tsv \\

--- a/workflow/scripts/star_sj_to_junctions.py
+++ b/workflow/scripts/star_sj_to_junctions.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""star_sj_to_junctions.py — Convert STAR ``SJ.out.tab`` to junctions.tsv.
+"""star_sj_to_junctions.py — Convert STAR ``SJ.out.tab`` to raw_junctions.tsv.
 
 STAR emits 9 tab-separated columns in ``SJ.out.tab``:
 

--- a/workflow/tests/test_alignment_star_command.py
+++ b/workflow/tests/test_alignment_star_command.py
@@ -61,7 +61,7 @@ def star_dry_run_output(tmp_path_factory):
           star_index_dir: "{star_index_dir}"
     """))
 
-    target = "results/testpatient/alignment/testsample/junctions.tsv"
+    target = "results/testpatient/alignment/testsample/raw_junctions.tsv"
 
     result = subprocess.run(
         [

--- a/workflow/tests/test_bed12_to_junctions.py
+++ b/workflow/tests/test_bed12_to_junctions.py
@@ -1,4 +1,4 @@
-"""Tests for bed12_to_junctions.py — regtools BED12 → junctions.tsv conversion.
+"""Tests for bed12_to_junctions.py — regtools BED12 → raw_junctions.tsv conversion.
 
 Regression test for [Issue #370](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/370):
 The HISAT2/regtools path previously emitted BED12 chromStart/chromEnd (anchor
@@ -25,7 +25,7 @@ from bed12_to_junctions import convert_bed12_to_junctions
 #   blockSizes  = "50,50"
 #   blockStarts = "0,150"  (offset of right anchor from chromStart)
 #
-# Expected junctions.tsv line:
+# Expected raw_junctions.tsv line:
 #   chr22:101:200:+\t10
 #         ^^^  ^^^
 #       1-based  0-based
@@ -45,7 +45,7 @@ class TestConvertBed12ToJunctions:
     def test_emits_intron_coords_not_anchor_outers(self, tmp_path):
         bed = tmp_path / "regtools.bed"
         bed.write_text(_BED12_LINE + "\n")
-        out = tmp_path / "junctions.tsv"
+        out = tmp_path / "raw_junctions.tsv"
 
         convert_bed12_to_junctions(bed, out)
 
@@ -56,7 +56,7 @@ class TestConvertBed12ToJunctions:
         zero_reads = _BED12_LINE.replace("\t10\t+\t", "\t0\t+\t")
         bed = tmp_path / "regtools.bed"
         bed.write_text(zero_reads + "\n")
-        out = tmp_path / "junctions.tsv"
+        out = tmp_path / "raw_junctions.tsv"
 
         convert_bed12_to_junctions(bed, out)
         assert out.read_text() == ""
@@ -65,7 +65,7 @@ class TestConvertBed12ToJunctions:
         minus = _BED12_LINE.replace("\t+\t", "\t-\t")
         bed = tmp_path / "regtools.bed"
         bed.write_text(minus + "\n")
-        out = tmp_path / "junctions.tsv"
+        out = tmp_path / "raw_junctions.tsv"
 
         convert_bed12_to_junctions(bed, out)
         assert out.read_text().strip() == "chr22:101:200:-\t10"
@@ -77,7 +77,7 @@ class TestConvertBed12ToJunctions:
         )
         bed = tmp_path / "regtools.bed"
         bed.write_text(_BED12_LINE + "\n" + second + "\n")
-        out = tmp_path / "junctions.tsv"
+        out = tmp_path / "raw_junctions.tsv"
 
         convert_bed12_to_junctions(bed, out)
         lines = out.read_text().strip().splitlines()
@@ -92,7 +92,7 @@ class TestConvertBed12ToJunctions:
         unstranded = _BED12_LINE.replace("\t+\t", "\t.\t")
         bed = tmp_path / "regtools.bed"
         bed.write_text(unstranded + "\n")
-        out = tmp_path / "junctions.tsv"
+        out = tmp_path / "raw_junctions.tsv"
 
         convert_bed12_to_junctions(bed, out)
         assert out.read_text().strip() == "chr22:101:200:.\t10"
@@ -104,7 +104,7 @@ class TestConvertBed12ToJunctions:
             "chr22\t50\t250\tjunc_short\t10\t+\n"  # only 6 fields
             + _BED12_LINE + "\n"
         )
-        out = tmp_path / "junctions.tsv"
+        out = tmp_path / "raw_junctions.tsv"
 
         convert_bed12_to_junctions(bed, out)
         # Only the well-formed line emits a junction
@@ -118,7 +118,7 @@ class TestConvertBed12ToJunctions:
             + _BED12_LINE + "\n"
             "   \n"  # whitespace-only
         )
-        out = tmp_path / "junctions.tsv"
+        out = tmp_path / "raw_junctions.tsv"
 
         convert_bed12_to_junctions(bed, out)
         assert out.read_text().strip() == "chr22:101:200:+\t10"
@@ -136,13 +136,13 @@ class TestConvertBed12ToJunctions:
 
         bed = tmp_path / "regtools.bed"
         bed.write_text(_BED12_LINE + "\n")
-        out = tmp_path / "junctions.tsv"
+        out = tmp_path / "raw_junctions.tsv"
         convert_bed12_to_junctions(bed, out)
 
         junction_id = out.read_text().strip().split("\t")[0]
         parsed = _parse_junction_id(junction_id)
         assert parsed in ref, (
             f"Parsed junction {parsed} not in reference {ref}. "
-            "If this fails, the BED12 → junctions.tsv conversion is "
+            "If this fails, the BED12 → raw_junctions.tsv conversion is "
             "emitting anchor outer boundaries instead of intron coords."
         )

--- a/workflow/tests/test_filter_junctions.py
+++ b/workflow/tests/test_filter_junctions.py
@@ -135,9 +135,9 @@ class TestClassifyJunctions:
         path.write_text("".join(lines))
 
     def test_tumor_exclusive_labeled_correctly(self, tmp_path):
-        # Files must live at {sample_id}/junctions.tsv so fp.parent.name == sample_id
-        tumor_f = tmp_path / "tumor" / "junctions.tsv"
-        normal_f = tmp_path / "normal" / "junctions.tsv"
+        # Files must live at {sample_id}/raw_junctions.tsv so fp.parent.name == sample_id
+        tumor_f = tmp_path / "tumor" / "raw_junctions.tsv"
+        normal_f = tmp_path / "normal" / "raw_junctions.tsv"
         tumor_f.parent.mkdir()
         normal_f.parent.mkdir()
 
@@ -172,8 +172,8 @@ class TestClassifyJunctions:
         assert df.iloc[0]["junction_origin"] == "tumor_exclusive"
 
     def test_normal_shared_labeled_correctly(self, tmp_path):
-        tumor_f = tmp_path / "tumor" / "junctions.tsv"
-        normal_f = tmp_path / "normal" / "junctions.tsv"
+        tumor_f = tmp_path / "tumor" / "raw_junctions.tsv"
+        normal_f = tmp_path / "normal" / "raw_junctions.tsv"
         tumor_f.parent.mkdir()
         normal_f.parent.mkdir()
 
@@ -206,8 +206,8 @@ class TestClassifyJunctions:
         assert df.iloc[0]["junction_origin"] == "normal_shared"
 
     def test_annotated_junctions_discarded(self, tmp_path):
-        tumor_f = tmp_path / "tumor" / "junctions.tsv"
-        normal_f = tmp_path / "normal" / "junctions.tsv"
+        tumor_f = tmp_path / "tumor" / "raw_junctions.tsv"
+        normal_f = tmp_path / "normal" / "raw_junctions.tsv"
         tumor_f.parent.mkdir()
         normal_f.parent.mkdir()
 
@@ -239,7 +239,7 @@ class TestClassifyJunctions:
         assert len(df) == 0
 
     def test_no_normal_sample_all_labeled_tumor_exclusive(self, tmp_path):
-        tumor_f = tmp_path / "tumor" / "junctions.tsv"
+        tumor_f = tmp_path / "tumor" / "raw_junctions.tsv"
         tumor_f.parent.mkdir()
 
         self._write_junction_file(tumor_f, [
@@ -291,8 +291,8 @@ class TestClassifyJunctionsStats:
         # Tumor sample with one annotated, one unannotated tumor_exclusive,
         # one unannotated normal_shared. Plus a noise junction below the mean
         # filter so the high-read ones survive.
-        tumor_f = tmp_path / "tumor" / "junctions.tsv"
-        normal_f = tmp_path / "normal" / "junctions.tsv"
+        tumor_f = tmp_path / "tumor" / "raw_junctions.tsv"
+        normal_f = tmp_path / "normal" / "raw_junctions.tsv"
         tumor_f.parent.mkdir()
         normal_f.parent.mkdir()
 
@@ -344,8 +344,8 @@ class TestClassifyJunctionsStats:
 
     def test_funnel_reconciles_arithmetically(self, tmp_path):
         """junctions_raw must equal the sum of the 4 downstream categories."""
-        tumor_f = tmp_path / "tumor" / "junctions.tsv"
-        normal_f = tmp_path / "normal" / "junctions.tsv"
+        tumor_f = tmp_path / "tumor" / "raw_junctions.tsv"
+        normal_f = tmp_path / "normal" / "raw_junctions.tsv"
         tumor_f.parent.mkdir()
         normal_f.parent.mkdir()
 
@@ -389,8 +389,8 @@ class TestClassifyJunctionsStats:
         )
 
     def test_stats_tsv_omits_normal_samples(self, tmp_path):
-        tumor_f = tmp_path / "tumor" / "junctions.tsv"
-        normal_f = tmp_path / "normal" / "junctions.tsv"
+        tumor_f = tmp_path / "tumor" / "raw_junctions.tsv"
+        normal_f = tmp_path / "normal" / "raw_junctions.tsv"
         tumor_f.parent.mkdir()
         normal_f.parent.mkdir()
 
@@ -427,8 +427,8 @@ class TestClassifyJunctionsStats:
         assert "normal" not in set(stats["sample_id"])
 
     def test_multi_tumor_samples_each_get_their_own_rows(self, tmp_path):
-        tumor1 = tmp_path / "tumor1" / "junctions.tsv"
-        tumor2 = tmp_path / "tumor2" / "junctions.tsv"
+        tumor1 = tmp_path / "tumor1" / "raw_junctions.tsv"
+        tumor2 = tmp_path / "tumor2" / "raw_junctions.tsv"
         tumor1.parent.mkdir()
         tumor2.parent.mkdir()
 
@@ -467,7 +467,7 @@ class TestClassifyJunctionsStats:
 
     def test_stats_tsv_optional(self, tmp_path):
         """Existing callers that don't pass stats_output_path still work."""
-        tumor_f = tmp_path / "tumor" / "junctions.tsv"
+        tumor_f = tmp_path / "tumor" / "raw_junctions.tsv"
         tumor_f.parent.mkdir()
         self._write_junction_file(tumor_f, [
             ("chr22:201:300:+", 100),
@@ -494,7 +494,7 @@ class TestClassifyJunctionsStats:
         These rows let the Scientist sanity-check the silent per-file mean
         threshold against the sample's actual read-count distribution.
         """
-        tumor_f = tmp_path / "tumor" / "junctions.tsv"
+        tumor_f = tmp_path / "tumor" / "raw_junctions.tsv"
         tumor_f.parent.mkdir()
         # Read counts: 1, 5, 10, 100. min=1, median=7.5, mean=29.0, max=100.
         self._write_junction_file(tumor_f, [
@@ -653,7 +653,7 @@ class TestClassifyJunctionsReadingFrame:
         # Junction chr1:201:300:+ → donor (0-based start) = 200
         # GTF CDS: start=198 (1-based) → start0=197, end0=200, len=3, frame=0
         # phase=0, frame_offset=0
-        tumor_f = tmp_path / "tumor" / "junctions.tsv"
+        tumor_f = tmp_path / "tumor" / "raw_junctions.tsv"
         tumor_f.parent.mkdir()
         self._write_junction_file(tumor_f, [("chr1:201:300:+", 100), ("chr1:401:500:+", 1)])
         manifest = tmp_path / "manifest.tsv"
@@ -672,7 +672,7 @@ class TestClassifyJunctionsReadingFrame:
         assert df.iloc[0]["reading_frame"] == "0"
 
     def test_reading_frame_empty_when_no_cds_match(self, tmp_path):
-        tumor_f = tmp_path / "tumor" / "junctions.tsv"
+        tumor_f = tmp_path / "tumor" / "raw_junctions.tsv"
         tumor_f.parent.mkdir()
         self._write_junction_file(tumor_f, [("chr1:201:300:+", 100), ("chr1:401:500:+", 1)])
         manifest = tmp_path / "manifest.tsv"
@@ -690,7 +690,7 @@ class TestClassifyJunctionsReadingFrame:
         assert df.iloc[0]["reading_frame"] == ""
 
     def test_reading_frame_empty_when_no_gtf(self, tmp_path):
-        tumor_f = tmp_path / "tumor" / "junctions.tsv"
+        tumor_f = tmp_path / "tumor" / "raw_junctions.tsv"
         tumor_f.parent.mkdir()
         self._write_junction_file(tumor_f, [("chr1:201:300:+", 100), ("chr1:401:500:+", 1)])
         manifest = tmp_path / "manifest.tsv"
@@ -709,7 +709,7 @@ class TestClassifyJunctionsReadingFrame:
         # Two genes share donor coord 200 (end0); different frame offsets → union
         # G1: start=99 (1-based) → start0=98, end0=200, len=102, phase=0, offset=0
         # G2: start=100 (1-based) → start0=99, end0=200, len=101, phase=2, offset=1
-        tumor_f = tmp_path / "tumor" / "junctions.tsv"
+        tumor_f = tmp_path / "tumor" / "raw_junctions.tsv"
         tumor_f.parent.mkdir()
         self._write_junction_file(tumor_f, [("chr1:201:300:+", 100), ("chr1:401:500:+", 1)])
         manifest = tmp_path / "manifest.tsv"
@@ -736,7 +736,7 @@ class TestClassifyJunctionsReadingFrame:
         # Junction chr1:100:201:- → end=201, donor_coord=201
         # CDS: start=202 (1-based) → start0=201, end0=300, len=99, frame=0
         # phase=(99-0)%3=0, offset=(-0)%3=0 → reading_frame "0"
-        tumor_f = tmp_path / "tumor" / "junctions.tsv"
+        tumor_f = tmp_path / "tumor" / "raw_junctions.tsv"
         tumor_f.parent.mkdir()
         self._write_junction_file(tumor_f, [("chr1:100:201:-", 100), ("chr1:400:500:-", 1)])
         manifest = tmp_path / "manifest.tsv"

--- a/workflow/tests/test_star_sj_to_junctions.py
+++ b/workflow/tests/test_star_sj_to_junctions.py
@@ -1,4 +1,4 @@
-"""Tests for star_sj_to_junctions.py — STAR SJ.out.tab → junctions.tsv conversion.
+"""Tests for star_sj_to_junctions.py — STAR SJ.out.tab → raw_junctions.tsv conversion.
 
 Regression test for [Issue #374](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/374):
 STAR emits strand=0 (col 4 = 0) when it cannot infer strand from intron motif —
@@ -50,7 +50,7 @@ class TestDirectStrand:
     def test_strand_plus_direct(self, tmp_path):
         sj = tmp_path / "SJ.out.tab"
         sj.write_text(_sj_line(strand=1, motif=1) + "\n")
-        out = tmp_path / "junctions.tsv"
+        out = tmp_path / "raw_junctions.tsv"
 
         convert_sj_to_junctions(sj, out)
         assert out.read_text().strip() == "chr22:101:200:+\t10"
@@ -58,7 +58,7 @@ class TestDirectStrand:
     def test_strand_minus_direct(self, tmp_path):
         sj = tmp_path / "SJ.out.tab"
         sj.write_text(_sj_line(strand=2, motif=2) + "\n")
-        out = tmp_path / "junctions.tsv"
+        out = tmp_path / "raw_junctions.tsv"
 
         convert_sj_to_junctions(sj, out)
         assert out.read_text().strip() == "chr22:101:200:-\t10"
@@ -75,7 +75,7 @@ class TestDirectStrand:
         """Core invariant: when STAR sets col 4 (1 or 2), motif is ignored."""
         sj = tmp_path / "SJ.out.tab"
         sj.write_text(_sj_line(strand=strand, motif=motif) + "\n")
-        out = tmp_path / "junctions.tsv"
+        out = tmp_path / "raw_junctions.tsv"
 
         convert_sj_to_junctions(sj, out)
         assert out.read_text().strip() == f"chr22:101:200:{expected}\t10"
@@ -92,7 +92,7 @@ class TestMotifRescue:
     def test_plus_motifs_rescue_to_plus(self, tmp_path, motif, expected_strand):
         sj = tmp_path / "SJ.out.tab"
         sj.write_text(_sj_line(strand=0, motif=motif) + "\n")
-        out = tmp_path / "junctions.tsv"
+        out = tmp_path / "raw_junctions.tsv"
 
         convert_sj_to_junctions(sj, out)
         assert out.read_text().strip() == f"chr22:101:200:{expected_strand}\t10"
@@ -105,7 +105,7 @@ class TestMotifRescue:
     def test_minus_motifs_rescue_to_minus(self, tmp_path, motif, expected_strand):
         sj = tmp_path / "SJ.out.tab"
         sj.write_text(_sj_line(strand=0, motif=motif) + "\n")
-        out = tmp_path / "junctions.tsv"
+        out = tmp_path / "raw_junctions.tsv"
 
         convert_sj_to_junctions(sj, out)
         assert out.read_text().strip() == f"chr22:101:200:{expected_strand}\t10"
@@ -118,7 +118,7 @@ class TestMotifRescue:
         """
         sj = tmp_path / "SJ.out.tab"
         sj.write_text(_sj_line(strand=0, motif=0) + "\n")
-        out = tmp_path / "junctions.tsv"
+        out = tmp_path / "raw_junctions.tsv"
 
         convert_sj_to_junctions(sj, out)
         assert out.read_text() == ""
@@ -127,7 +127,7 @@ class TestMotifRescue:
         """Defensive: unknown motif code (>6) is treated as motif=0 (drop)."""
         sj = tmp_path / "SJ.out.tab"
         sj.write_text(_sj_line(strand=0, motif=7) + "\n")
-        out = tmp_path / "junctions.tsv"
+        out = tmp_path / "raw_junctions.tsv"
 
         convert_sj_to_junctions(sj, out)
         assert out.read_text() == ""
@@ -139,7 +139,7 @@ class TestFiltering:
     def test_zero_unique_reads_skipped(self, tmp_path):
         sj = tmp_path / "SJ.out.tab"
         sj.write_text(_sj_line(unique=0) + "\n")
-        out = tmp_path / "junctions.tsv"
+        out = tmp_path / "raw_junctions.tsv"
 
         convert_sj_to_junctions(sj, out)
         assert out.read_text() == ""
@@ -150,7 +150,7 @@ class TestFiltering:
             "chr22\t101\t200\t1\n"  # only 4 fields — malformed
             + _sj_line() + "\n"
         )
-        out = tmp_path / "junctions.tsv"
+        out = tmp_path / "raw_junctions.tsv"
 
         convert_sj_to_junctions(sj, out)
         assert out.read_text().strip() == "chr22:101:200:+\t10"
@@ -162,7 +162,7 @@ class TestFiltering:
             + _sj_line() + "\n"
             "   \n"
         )
-        out = tmp_path / "junctions.tsv"
+        out = tmp_path / "raw_junctions.tsv"
 
         convert_sj_to_junctions(sj, out)
         assert out.read_text().strip() == "chr22:101:200:+\t10"
@@ -173,7 +173,7 @@ class TestFiltering:
             "chr22\t101\t200\t1\t1\t0\tnotanum\t0\t50\n"
             + _sj_line() + "\n"
         )
-        out = tmp_path / "junctions.tsv"
+        out = tmp_path / "raw_junctions.tsv"
 
         convert_sj_to_junctions(sj, out)
         assert out.read_text().strip() == "chr22:101:200:+\t10"
@@ -190,7 +190,7 @@ class TestMultipleRecords:
             + _sj_line(start=500, end=600, strand=0, motif=0, unique=7) + "\n"  # dropped
             + _sj_line(start=700, end=800, strand=2, motif=2, unique=2) + "\n"  # direct -
         )
-        out = tmp_path / "junctions.tsv"
+        out = tmp_path / "raw_junctions.tsv"
 
         convert_sj_to_junctions(sj, out)
         lines = out.read_text().strip().splitlines()
@@ -211,6 +211,6 @@ class TestReturnValue:
             + _sj_line(start=300, end=400, strand=0, motif=2, unique=3) + "\n"
             + _sj_line(start=500, end=600, strand=0, motif=0, unique=7) + "\n"  # dropped
         )
-        out = tmp_path / "junctions.tsv"
+        out = tmp_path / "raw_junctions.tsv"
 
         assert convert_sj_to_junctions(sj, out) == 2


### PR DESCRIPTION
**Created by:** Developer

Closes [Issue #345](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/345) (closes).

## Summary

Per-sample raw regtools/STAR quantification renamed `junctions.tsv` → `raw_junctions.tsv` to disambiguate from the patient-level `junctions/novel_junctions.tsv`. Pure rename, no behavior change.

The Issue AC lists only `alignment.smk`, `filter_junctions.smk`, and `test_filter_junctions.py`. I extended the touch list to the two converter scripts (`bed12_to_junctions.py`, `star_sj_to_junctions.py`) and their unit-test files because the stated goal is grep-cleanliness — leaving 24 `junctions.tsv` strings in converter tests + docstrings would defeat that. No behavior change in any of those (test `tmp_path` is arbitrary; docstrings are descriptive).

## Touch list

- `workflow/rules/alignment.smk` — `_JUNCTION_OUTPUT` constant (shared by HISAT2 + STAR rules) + a comment string referencing the format
- `workflow/rules/filter_junctions.smk` — input lambda path
- `workflow/scripts/filter_junctions.py` — docstring CLI example
- `workflow/scripts/bed12_to_junctions.py` + `workflow/scripts/star_sj_to_junctions.py` — docstring (format name)
- `workflow/tests/test_filter_junctions.py` — ~25 fixture paths + the explanatory comment
- `workflow/tests/test_bed12_to_junctions.py` + `workflow/tests/test_star_sj_to_junctions.py` — `tmp_path` output filenames
- `workflow/tests/test_alignment_star_command.py` — snakemake CLI target string

## Scope deliberately excluded

- **Frozen plan/spec docs** under `docs/superpowers/{plans,specs}/` and frozen experiment notebooks under `research/experiments/issue_225_*` + `research/notebooks/issue_224_*` reference historical pipeline outputs — point-in-time records, not rewritten.
- **`research/lab_notebook.md`** — historical entries with the old path; not rewriting history.
- **`research/manuscript/RESULTS.md:54`** — has one stale reference (`alignment/SRR9143066/junctions.tsv`). Manuscript files are [Scientist territory](.claude/memory/feedback_role_scope.md); follow-up Issue filed separately and linked in this PR.

## Test plan

- [x] `workflow/tests/.venv/bin/python -m pytest workflow/tests/` → 350 passed, 6 skipped
- [x] `snakemake -n --configfile config/config.yaml config/gpu_config.yaml --config samples_tsv=config/samples/patient_001_test.tsv` → 13 jobs, DAG resolves with `raw_junctions.tsv` on both ends of `filter_junctions` (STAR path)
- [x] `snakemake -n --configfile config/test_config.yaml` → DAG resolves cleanly (HISAT2 path)
- [x] `pipeline-pytest` CI green
- [x] `pipeline-snakemake-dry-run` CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
