### PR TITLE
docs(news_log): PM 2026-05-26 10:57 UTC — Claude Code 2.1.149 + GH PR coverage preview

### DIFF
--- a/research/news_log.md
+++ b/research/news_log.md
@@ -11,6 +11,13 @@ Historical entries (before 2026-05-02) pre-date the time/editor sub-heading conv
 
 ---
 
+## 2026-05-26
+
+### 10:57 UTC — Editor: PM
+
+- **Claude Code 2.1.149** ([2026-05-22 changelog](https://code.claude.com/docs/en/changelog)) — `/usage` per-category breakdown (skills / subagents / plugins / MCP-server costs); GFM task-list checkboxes render. → Cost-forecast input for [Issue #305](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/305) (Agent SDK dual-bucket billing, effective 2026-06-15); pairs with 2026-05-20 billing-split entry. *PM. ops-signal.*
+- **Code coverage on PRs — public preview** ([changelog 2026-05-26](https://github.blog/changelog/2026-05-26-code-coverage-in-pull-requests-is-now-in-public-preview)) — visual coverage diff inline in PR review surface (was Codecov-only territory). → No action yet; `pipeline-pytest` already emits coverage but doesn't surface on PR; revisit when [Issue #461](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/461) (script-wrapper test hardening) lands. *PM. tooling-signal.*
+
 ## 2026-05-22
 
 ### 08:46 UTC — Editor: Scientist


### PR DESCRIPTION
## Summary

PM news_log entry for 2026-05-26 10:57 UTC. Two items:

- **Claude Code 2.1.149** — `/usage` per-category breakdown; cost-forecast input for [Issue #305](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/305) (Agent SDK billing).
- **GitHub PR code coverage public preview** — tooling-signal; no action yet, revisit with [Issue #461](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/461).

## Test plan

- [x] Entry inserted at top of file under new \`## 2026-05-26\` date section
- [x] Format matches \`### HH:MM UTC — Editor: PM\` convention
- [x] Both items have concrete hooks (linked Issue + action lane)
- [x] Bundled with no other changes (news_log-only PR)

**Created by:** PM