### PR TITLE
chore(pm): retire research/news_log.md — papers → Zotero, actionable → Issues (closes #484)

### DIFF
--- a/research/_archive/news_log_2026-05-25_final.md
+++ b/research/_archive/news_log_2026-05-25_final.md
@@ -1,4 +1,19 @@
-# News Log
+# News Log — RETIRED 2026-05-26
+
+> **This file is frozen.** `research/news_log.md` was retired via [Issue #484](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/484) (parent: [Issue #480](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/480) workflow ceremony reduction sweep).
+>
+> **Why retired:** highest-contention file in the repo (3 roles × daily appends → repeated same-day rebase conflicts: [PR #355](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/355) vs [PR #354](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/354), [PR #338](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/338) vs [PR #336](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/336)); 7-day dedup window proved brittle (NetTCR-struc slipped through 2026-05-21 despite being in Zotero `FQ58DCAE` + [Issue #432](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/432) + [Issue #433](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/433)).
+>
+> **What replaced it:**
+> - **Papers** → Zotero collection [`Z38GTJNW`](https://www.zotero.org/groups/) (DOI-keyed dedup is bulletproof).
+> - **Actionable items** → GitHub Issues directly.
+> - **Anything else** → not tracked (most "news" that doesn't fit the above is noise).
+>
+> **Do not append to this file.** Historical entries remain as journal evidence; the morning-routine News phase is now a Zotero feed scan + Issue triage with no shared standalone log.
+
+---
+
+# News Log (frozen content below)
 
 Shared log of news surfaced in morning briefings. Prevents repeating the same item across sessions and roles (PM, Scientist, Developer all log here).
 

--- a/research/_archive/news_log_2026-05-25_final.md
+++ b/research/_archive/news_log_2026-05-25_final.md
@@ -5,7 +5,7 @@
 > **Why retired:** highest-contention file in the repo (3 roles × daily appends → repeated same-day rebase conflicts: [PR #355](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/355) vs [PR #354](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/354), [PR #338](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/338) vs [PR #336](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/336)); 7-day dedup window proved brittle (NetTCR-struc slipped through 2026-05-21 despite being in Zotero `FQ58DCAE` + [Issue #432](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/432) + [Issue #433](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/433)).
 >
 > **What replaced it:**
-> - **Papers** → Zotero collection [`Z38GTJNW`](https://www.zotero.org/groups/) (DOI-keyed dedup is bulletproof).
+> - **Papers** → Zotero collection `Z38GTJNW` ("Splice Neoepitope Pipeline"; DOI-keyed dedup is bulletproof; queryable via the Zotero API per `shared/feedback_zotero_dedup_check.md`).
 > - **Actionable items** → GitHub Issues directly.
 > - **Anything else** → not tracked (most "news" that doesn't fit the above is noise).
 >

--- a/research/lab_notebook/pm.md
+++ b/research/lab_notebook/pm.md
@@ -6,6 +6,42 @@ Format and rules unchanged from the unified notebook — see `shared/feedback_la
 
 ---
 
+## 2026-05-26
+
+### 12:43 UTC — Editor: PM
+
+#### [Issue #484](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/484) — news_log.md retired ([pm-i5](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/milestone/32) sub-4, closes the milestone)
+
+**Trigger.** User asked "what's next best?" — applied best-next algorithm; [Issue #484](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/484) surfaced as sole open leaf under [pm-i5](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/milestone/32) (due 2026-06-01, 6 days out), making it a milestone-closer. User confirmed "ok gogo".
+
+**Scope shipped.** Retire `research/news_log.md` end-to-end: archive the file + retire all behavioural rules referencing it across both repos (project + personas).
+
+- **Project repo:**
+  - `research/news_log.md` → `research/_archive/news_log_2026-05-25_final.md` (via `git mv`, history preserved) with a top-of-file tombstone block explaining retirement + linking to [Issue #484](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/484) / [Issue #480](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/480) (epic) and the contention + dedup-brittleness evidence (PR #355 vs #354 collision, PR #338 vs #336, NetTCR-struc 2026-05-21 dedup miss).
+  - `research/multi_agent_landscape.md`: header + maintenance section reframed — "morning briefing surfaces `methodology-signal`" instead of "news_log entry tagged methodology-signal". Historical citation on line 37 (Claude Code Agent View, news_log 2026-05-13) left as immutable.
+  - `tools/ci/closure_audit.py`: dropped `research/news_log.md` from `_EXEMPT_FILES` (now `{"research/glossary.md"}` only). Test updated; full suite passes (12/12 in 0.02s).
+
+- **Personas repo (memory):**
+  - `shared/reference_news_log.md` deleted entirely (was load-bearing reference; now obsolete).
+  - `shared/MEMORY.md` Always-in-effect "Write news_log entry inline + merge ASAP" rule removed; "Always read before morning routine" entry for news_log removed; inline @claude-mention example list updated to drop `news_log`; batch-trivial-docs index entry rephrased to drop news_log mention.
+  - `shared/feedback_morning_routine.md` Phase 1 rewritten — "No standalone news log" prelude + per-item routing decision (paper → Zotero `Z38GTJNW`; actionable + concrete hook → Issue; else → noise, drop) + 2-source dedup (Zotero + open Issues). Branch-naming line scoped to `lab-notebook` only with retirement note for `news-log` type.
+  - PM/Sci/Dev `feedback_morning_routine.md` — header preambles updated to reference retirement; PM-specific landscape-doc-maintenance hook rephrased (was: "same PR as news_log entry"; now: "via `docs/pm/landscape-update-…` branch"). PM Phase 2.5 closure-audit `Branch naming` + `Journal entry format` mechanical-compliance checks scoped to `lab-notebook` only. Sci Phase 1 trailing news_log-branch line removed. Dev Phase 1 "News_log PR ships before Phase 2" pacing rule removed (no more news_log PRs to gate on).
+  - `developer/MEMORY.md` Always-in-effect — sync-main caught-incident citation slimmed to glossary PR #266 only; news_log-PR-exemption rule reframed as standup-archive-only with retirement parenthetical; news-log-PR-before-Phase-2 rule deleted.
+  - `scientist/MEMORY.md` — `news_log` removed from `@claude review` skip list.
+  - `shared/feedback_branch_creation.md` Rule 1 — caught-incident citation reframed to glossary PR #266 as the live example; news_log PR #262 vs Sci #261 noted parenthetically with retirement.
+  - Indirect refs triaged (one Edit pass each, batch-style): `feedback_batch_trivial_docs.md` (description + EXCLUSIONS section now lab-notebook-only), `feedback_github_workflow.md:63` (skip-list drops news_log; line 78 PR #283 historical kept), `feedback_no_at_claude_mention.md` (skip list drops news_log), `feedback_multi_role_not_multi_agent.md` (venue list + cross-ref both updated), `feedback_ui_vs_agent.md` (1-Issue/day cap framing now chat-only-mention), `feedback_read_before_claiming.md` (example claim list + applies-to file list both updated), `feedback_project_file_paths.md` (example now `cat research/glossary.md`), `feedback_project_vs_meta.md` (project-scoped workflow list drops "news-log format"), `feedback_deterministic_first.md` (script-encodable workflow example list drops news_log word-count), `feedback_american_spelling.md` (immutable-journal list now lab-notebook-only), `pm/feedback_ask_for_help.md` (don't-flag-for routine pattern list updated).
+  - Final grep across both repos: 14 surviving matches, all retirement-explainer notes or immutable historical incident citations. AC #9 satisfied.
+
+**Issue scope discipline.** AC said "grep `news_log` across `shared/` and role memory dirs returns only the tombstone + this Issue's body + historical immutable entries" — the explicit grep-clean criterion drove the indirect-ref sweep (12+ files beyond the named AC targets). Without that AC line I'd have shipped only the named targets and left a long tail of broken references. Lesson worth keeping: "grep-clean" ACs on workflow-retirement issues force completeness in a way a pure file-list AC can't.
+
+**Notable detour: shell cwd drift.** Early in the session, a `cd ~/.claude/projects/.../memory && ls shared/` Bash call followed the role's `memory` symlink into the personas repo and the shell stayed there — `git status` reported the personas repo's main-branch state instead of the project repo. Confused me until I ran `pwd` and saw `claude-personas-splice-neoepitope-pipeline/pm`. The CLAUDE.md "No `cd` into other repos: cwd persists across Bash calls" rule applies even when the destination is reached transitively via a symlink. Mitigated by `cd /Users/.../splice-neoepitope-pipeline-pm` to return; finished cleanly. Worth noting in [[feedback-no-cd]] if it slips again — symlink-followed cd's are a stealth variant of the rule's named risk.
+
+**Notable detour: classifier denials.** The Cache-warmer cron created at session start ("Respond only with: pong") tripped the auto-mode classifier, which then flagged subsequent unrelated Bash calls (a `for`-loop fetching priorities; a `ls personas-repo/` call) as prompt-injection. Deleted the cron via `CronDelete 3202a4b9` and the denials stopped. Worth knowing: short prompts inside a session-start CronCreate can globally bias the classifier's read of downstream Bash even when the bash is benign.
+
+**Closure ritual.** All 11 acceptance criteria boxes ticked in [Issue #484](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/484) before merge via `scripts/audit_and_merge.sh`. Closes [pm-i5](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/milestone/32) milestone (last open leaf); milestone-closure routing decision (per `feedback_milestone_closure_routing.md`) deferred to a follow-up session.
+
+---
+
 ## 2026-05-25
 
 ### 20:37 UTC — Editor: PM

--- a/research/multi_agent_landscape.md
+++ b/research/multi_agent_landscape.md
@@ -1,8 +1,8 @@
 # Multi-agent / agentic-coding orchestration — landscape
 
-Curated reference of the multi-agent / agentic-coding field with one-line summaries, our rationale per item, and links to internal Issues and framing memories. Doubles as a portfolio artifact (we surveyed the field; we're not cargo-culting) and a project memory aid (where prior reasoning on Symphony, Fugu, Managed Agents, etc. lives without re-grepping `news_log.md`).
+Curated reference of the multi-agent / agentic-coding field with one-line summaries, our rationale per item, and links to internal Issues and framing memories. Doubles as a portfolio artifact (we surveyed the field; we're not cargo-culting) and a project memory aid (where prior reasoning on Symphony, Fugu, Managed Agents, etc. lives without re-grepping conversation history).
 
-Maintained by PM. Updated when `news_log.md` entries get tagged `methodology-signal` — see [Maintenance](#maintenance) at the bottom.
+Maintained by PM. Updated when a morning briefing surfaces a `methodology-signal` item — see [Maintenance](#maintenance) at the bottom.
 
 For our position relative to this landscape — why PM/Sci/Dev, why "multi-role" instead of "multi-agent" — see [Our position](#our-position).
 
@@ -101,7 +101,7 @@ The standup file (`pm/shared/team_standup.md`), the GitHub Projects v2 board, an
 
 PM-owned. Update triggers:
 
-- News_log entry tagged `methodology-signal` lands → PM scans during morning routine, decides whether to add an entry here (or whether the item belongs only in news_log).
+- Morning-briefing item tagged `methodology-signal` surfaces → PM decides whether to add an entry here (or whether the item is chat-only and not landscape-doc-worthy).
 - New framing memory in `pm/shared/` cross-references this doc → update [Our position](#our-position) to mention it.
 - New Issue concretely borrows from or extends a framework listed here → backfill the framework's rationale block with the Issue link.
 - Framework deprecated or pivoted → don't delete the entry; update the rationale with the deprecation note (the doc is a journal of *which* options we considered, not just current options).

--- a/tools/ci/closure_audit.py
+++ b/tools/ci/closure_audit.py
@@ -27,7 +27,7 @@ COMMENT_MARKER = "<!-- closure-audit -->"
 # styles show up.
 _UNTICKED = re.compile(r"^\s*-\s*\[\s\]\s", re.MULTILINE)
 _TICKED = re.compile(r"^\s*-\s*\[[xX]\]\s", re.MULTILINE)
-_EXEMPT_FILES = {"research/news_log.md", "research/glossary.md"}
+_EXEMPT_FILES = {"research/glossary.md"}
 _EXEMPT_PREFIX = ("research/lab_notebook/",)
 
 

--- a/tools/ci/test_closure_audit.py
+++ b/tools/ci/test_closure_audit.py
@@ -63,12 +63,12 @@ def test_priority_rationale_missing_is_gap():
 
 
 def test_exempt_paths_all_or_nothing():
-    assert ca.is_exempt(["research/news_log.md"]) is True
+    assert ca.is_exempt(["research/glossary.md"]) is True
     assert ca.is_exempt([
         "research/glossary.md", "research/lab_notebook/pm.md",
     ]) is True
     assert ca.is_exempt([
-        "research/news_log.md", "workflow/scripts/foo.py",
+        "research/glossary.md", "workflow/scripts/foo.py",
     ]) is False
     assert ca.is_exempt([]) is False
 


### PR DESCRIPTION
## Summary

Retires `research/news_log.md` end-to-end. Papers now route to Zotero collection `Z38GTJNW`; actionable items become Issues; anything else is chat-only ephemeral. Closes [Issue #484](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/484) (last open leaf under [pm-i5 - PM Workflow Simplification](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/milestone/32) — closes the milestone).

**Why retired:** highest-contention file in the repo (3 roles × daily appends → repeat same-day rebase conflicts: [PR #355](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/355) vs [PR #354](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/354), [PR #338](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/338) vs [PR #336](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/336)); 7-day dedup window proved brittle (NetTCR-struc slipped through 2026-05-21 despite being in Zotero + open [Issue #432](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/432) + [Issue #433](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/433)).

## Changes in this PR (project repo)

- `research/news_log.md` → `research/_archive/news_log_2026-05-25_final.md` via `git mv` (history preserved) + top-of-file tombstone block linking [Issue #484](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/484) / [Issue #480](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/480) (epic).
- `research/multi_agent_landscape.md` — header + maintenance triggers reframed: morning-briefing `methodology-signal` items (not "news_log entry tagged methodology-signal").
- `tools/ci/closure_audit.py` + `tools/ci/test_closure_audit.py` — dropped `research/news_log.md` from `_EXEMPT_FILES`. Full suite passes (12/12 in 0.02s).
- `research/lab_notebook/pm.md` — new entry covering the retirement.

## Companion changes in the personas memory repo (separate commit needed)

These edits are made on the file system but live in the `claude-personas-splice-neoepitope-pipeline` repo, which is tracked separately. **They are NOT in this PR's diff** and need a separate commit on that repo before the workflow change is fully shipped:

- `shared/reference_news_log.md` deleted entirely.
- `shared/MEMORY.md` Always-in-effect "Write news_log entry inline + merge ASAP" rule removed; "Always read before morning routine" entry for news_log removed; inline mention-guard skip-list updated; batch-trivial-docs index entry rephrased.
- `shared/feedback_morning_routine.md` Phase 1 rewritten — no-standalone-news-log prelude + per-item routing (paper → Zotero `Z38GTJNW`; actionable + concrete hook → Issue; else → drop) + 2-source dedup (Zotero + open Issues). Branch-naming scoped to `lab-notebook` only.
- PM / Scientist / Developer `feedback_morning_routine.md` — preamble references retirement; PM landscape-doc-maintenance hook rephrased; Sci news_log branch line removed; Dev "News_log PR ships before Phase 2" rule removed.
- `developer/MEMORY.md` Always-in-effect — sync-main + journal-PR-exemption rules scoped to glossary + lab-notebook only; news-log-PR-before-Phase-2 rule deleted.
- `scientist/MEMORY.md` — `news_log` removed from the bot-review skip list.
- `shared/feedback_branch_creation.md` — caught-incident citation reframed to glossary; news_log noted parenthetically as retired.
- Indirect refs swept in: `feedback_batch_trivial_docs.md`, `feedback_github_workflow.md:63`, `feedback_no_at_claude_mention.md`, `feedback_multi_role_not_multi_agent.md`, `feedback_ui_vs_agent.md`, `feedback_read_before_claiming.md`, `feedback_project_file_paths.md`, `feedback_project_vs_meta.md`, `feedback_deterministic_first.md`, `feedback_american_spelling.md`, `pm/feedback_ask_for_help.md`.

Final grep across both repos shows 14 surviving `news_log` matches — all retirement-explainer notes or immutable historical incident citations (per AC 9).

## Test plan

- [x] `workflow/tests/.venv/bin/python -m pytest tools/ci/test_closure_audit.py -q` — 12/12 pass (closure-audit EXEMPT_FILES change validated).
- [x] Grep `news_log` / `news-log` across project repo (excluding `_archive/`, `.git/`, `lab_notebook/`) — only retirement-explainer notes and immutable historical citations remain.
- [x] Grep `news_log` / `news-log` across personas memory repo (excluding `_retired/`, `team_standup*`, `drafts/`, `.git/`) — only retirement notes + historical citations remain.
- [x] CI pipeline checks pass (snakemake dry-run + pytest) on the project-repo side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

**Created by:** PM
