### PR TITLE
research(tcr): Issue #218 HERMES eval — (a) integrate + per-tool deck convention

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -245,6 +245,12 @@ research/slides/**/*_files/
 research/slides/**/.quarto/
 research/slides/**/slides.tex
 research/slides/**/slides.log
+research/evals/**/*.html
+research/evals/**/*.pdf
+research/evals/**/*_files/
+research/evals/**/.quarto/
+research/evals/**/slides.tex
+research/evals/**/slides.log
 
 # Feature-doc slide-deck build artefacts — same convention, docs/ location
 docs/features/**/*.html

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,7 +91,7 @@ Every tool-evaluation Issue (e.g. [Issue #218](https://github.com/Jin-HoMLee/spl
 
 **Why required even though evals are XS/S-sized:** visual condensation per tool is a different artifact from the consolidating decision deck (e.g. [Issue #432](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/432) TCR-pMHC scorer landscape). The per-tool deck answers *"what is this tool, and how does it work?"* — a comprehension precondition that lab notebook prose alone doesn't satisfy. The consolidating deck answers *"why this (a/b/c) decision across all 5 evals?"*. Both have value.
 
-**Format (~6-8 slides):** (i) the question (should we integrate?), (ii) tool primer (architecture, citation, code/weights status), (iii) why-it-works mechanism, (iv) integration map (block diagram showing where it'd plug in), (v) reasons-to-(a)/decline-(b)/skip-(c), (vi) decision + sub-issue ref, (vii) open scientific questions for the integration (if (a)). [`research/evals/issue_218_hermes/`](research/evals/issue_218_hermes/) is the reference example.
+**Format (~8-10 slides; title + 7-9 content):** (i) the question (should we integrate?), (ii) tool primer (architecture, citation, code/weights status), (iii) why-it-works mechanism, (iv) integration map (block diagram showing where it'd plug in), (v) reasons-to-(a)/decline-(b)/skip-(c), (vi) decision + sub-issue ref, (vii) open scientific questions for the integration (if (a)), (viii) references. [`research/evals/issue_218_hermes/`](research/evals/issue_218_hermes/) is the reference example (9 slides total).
 
 **Scope:** one deck per eval Issue. Established 2026-05-26 alongside the HERMES + ImmSET evals. Audience: lab seminar / external talk + manuscript-figure rehearsal for the consolidating publication Issue.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,6 +85,16 @@ Every experiment-tier Issue ships a Quarto slide deck alongside the per-patient 
 
 **Render tooling:** Quarto via `brew install --cask quarto` (macOS dev). PDF render (beamer) is currently disabled in decks — Quarto/pandoc's auto-emitted preamble hits a `\makesavenoteenv{longtable}` interaction with `footnotehyper.sty` that fails LaTeX compile. HTML reveal.js is the primary delivery; for a PDF handout, "Print → Save as PDF" from Chrome works on `slides.html`. A proper LaTeX fix is tracked as a follow-up.
 
+## Slide decks for eval Issues
+
+Every tool-evaluation Issue (e.g. [Issue #218](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/218) HERMES, [Issue #201](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/201) ImmSET, [Issue #188](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/188) Boltz-2) also ships a Quarto deck — a **tool primer** distinct from the consolidating publication deck. Decks live at `research/evals/issue_NNN_<tool>/slides.qmd`, sibling to `research/experiments/`. Shared scaffolding (`_template.qmd`, `nature.csl`) at `research/slides/` is referenced via `csl: ../../slides/nature.csl`.
+
+**Why required even though evals are XS/S-sized:** visual condensation per tool is a different artifact from the consolidating decision deck (e.g. [Issue #432](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/432) TCR-pMHC scorer landscape). The per-tool deck answers *"what is this tool, and how does it work?"* — a comprehension precondition that lab notebook prose alone doesn't satisfy. The consolidating deck answers *"why this (a/b/c) decision across all 5 evals?"*. Both have value.
+
+**Format (~6-8 slides):** (i) the question (should we integrate?), (ii) tool primer (architecture, citation, code/weights status), (iii) why-it-works mechanism, (iv) integration map (block diagram showing where it'd plug in), (v) reasons-to-(a)/decline-(b)/skip-(c), (vi) decision + sub-issue ref, (vii) open scientific questions for the integration (if (a)). [`research/evals/issue_218_hermes/`](research/evals/issue_218_hermes/) is the reference example.
+
+**Scope:** one deck per eval Issue. Established 2026-05-26 alongside the HERMES + ImmSET evals. Audience: lab seminar / external talk + manuscript-figure rehearsal for the consolidating publication Issue.
+
 ## MHC Presentation Vocabulary
 
 This pipeline uses **`Class1PresentationPredictor`** (MHCflurry 2.x), which scores *presentation likelihood* — a combined estimate of binding affinity + antigen processing. It is distinct from the older `Class1AffinityPredictor` (affinity-only).

--- a/research/evals/issue_218_hermes/refs.bib
+++ b/research/evals/issue_218_hermes/refs.bib
@@ -4,19 +4,17 @@
   journal = {Proceedings of the National Academy of Sciences},
   year = {2025},
   month = oct,
-  day = 21,
   doi = {10.1073/pnas.2504783122},
   note = {Zotero: MWZFINV6},
 }
 
-@misc{aipredictedtcr2026,
+@misc{robben2026aipredictedtcr,
   title = {{AI} predicted {TCR-pMHC} structures differentiate immune interactions},
-  author = {Anonymous},
+  author = {Robben, Michael},
   year = {2026},
   month = feb,
-  day = 26,
   howpublished = {bioRxiv 2026.02.24.707744},
   doi = {10.64898/2026.02.24.707744},
   url = {https://www.biorxiv.org/content/10.64898/2026.02.24.707744v1.full},
-  note = {Zotero: 654D8NFP},
+  note = {Zotero: 654D8NFP. Author confirmed via CrossRef API 2026-05-27 as sole-authored.},
 }

--- a/research/evals/issue_218_hermes/refs.bib
+++ b/research/evals/issue_218_hermes/refs.bib
@@ -1,0 +1,22 @@
+@article{visani2025hermes,
+  title = {T cell receptor specificity landscape revealed through de novo peptide design},
+  author = {Visani, Gian Marco and Pun, Michael N. and Minervina, Anastasia and Bradley, Philip and Thomas, Paul G. and Nourmohammad, Armita},
+  journal = {Proceedings of the National Academy of Sciences},
+  year = {2025},
+  month = oct,
+  day = 21,
+  doi = {10.1073/pnas.2504783122},
+  note = {Zotero: MWZFINV6},
+}
+
+@misc{aipredictedtcr2026,
+  title = {{AI} predicted {TCR-pMHC} structures differentiate immune interactions},
+  author = {Anonymous},
+  year = {2026},
+  month = feb,
+  day = 26,
+  howpublished = {bioRxiv 2026.02.24.707744},
+  doi = {10.64898/2026.02.24.707744},
+  url = {https://www.biorxiv.org/content/10.64898/2026.02.24.707744v1.full},
+  note = {Zotero: 654D8NFP},
+}

--- a/research/evals/issue_218_hermes/slides.qmd
+++ b/research/evals/issue_218_hermes/slides.qmd
@@ -28,15 +28,9 @@ execute:
 
 ## The question
 
-::: {.r-fit-text}
-Should HERMES
-:::
-
-::: {.r-fit-text}
-join the post-TCRdock
-:::
-
-::: {.r-fit-text}
+::: {style="text-align: center; font-size: 2.2em; font-weight: bold; line-height: 1.2; margin-top: 0.4em;"}
+Should HERMES join\
+the post-TCRdock\
 structural-QC stack?
 :::
 

--- a/research/evals/issue_218_hermes/slides.qmd
+++ b/research/evals/issue_218_hermes/slides.qmd
@@ -1,0 +1,180 @@
+---
+title: "HERMES as a post-TCRdock structural confidence cross-check"
+subtitle: "Tool evaluation · Issue #218 · 2026-05-26"
+author: "Jin-Ho Lee"
+institute: "Splice Neoepitope Pipeline · JH M Lee Lab"
+date: 2026-05-26
+date-format: "YYYY-MM-DD"
+format:
+  revealjs:
+    theme: simple
+    incremental: false
+    slide-number: c/t
+    progress: true
+    fig-align: center
+    fig-cap-location: bottom
+    transition: fade
+    background-transition: fade
+    width: 1280
+    height: 720
+# PDF (beamer) render disabled — same Quarto/pandoc longtable issue as the pilot deck.
+# HTML reveal.js is the primary delivery; "Print → Save as PDF" in Chrome for handouts.
+bibliography: refs.bib
+csl: ../../slides/nature.csl
+execute:
+  echo: false
+  warning: false
+---
+
+## The question
+
+::: {.r-fit-text}
+Should HERMES
+:::
+
+::: {.r-fit-text}
+join the post-TCRdock
+:::
+
+::: {.r-fit-text}
+structural-QC stack?
+:::
+
+. . .
+
+::: {.callout-note appearance="simple"}
+**Why now:** parent [Issue #432](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/432) AC requires a per-scorer integration verdict — **(a)** Modeling sub-issue under [milestone 29](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/milestone/29) **or (b)** decline-with-rationale — for each of HERMES, Boltz-2 ([Issue #188](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/188)), ImmSET ([Issue #201](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/201)), t2pmhc/TCRLens ([Issue #236](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/236)), and the [Issue #316](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/316) outcome.
+:::
+
+---
+
+## The tool — HERMES at a glance {.smaller}
+
+**HERMES** — *Holographic Equivariant neuRal network model for Mutational Effect and Stability prediction* — Visani et al., **PNAS** 2025-10-21 [@visani2025hermes].
+
+::: {.incremental}
+- **Architecture:** 3D rotationally equivariant neural network; predicts amino-acid propensity at a site from its local 3D structural environment.
+- **Training:** pre-trained on the **full protein universe** (~10k CASP12 chains) — *zero TCR-pMHC-specific training data*.
+- **Input/output:** consumes PDB structures; emits per-site amino-acid logits (CSV) + optional embeddings (.npy).
+- **Code + weights:** [`StatPhysBio/hermes`](https://github.com/StatPhysBio/hermes) — **MIT-licensed**, pretrained weights bundled + on Zenodo. Python 3.9, PyTorch, `e3nn==0.5.0`.
+:::
+
+. . .
+
+::: {.callout-tip appearance="simple"}
+**One-line CLI:** `python run_hermes_on_pdbfiles.py -pd pdbs -m hermes_bp_000 -o results.csv`
+:::
+
+---
+
+## Why it works on TCR-pMHC (despite zero TCR-pMHC training) {.smaller}
+
+::: {.columns}
+
+::: {.column width="55%"}
+
+**Implicit physical reasoning** from protein-universe pre-training generalises to TCR-pMHC interfaces:
+
+::: {.incremental}
+- 0.72 correlation with experimental TCR-pMHC binding affinities [@visani2025hermes]
+- Up to 50% T cell activation rate for de novo–designed peptides (≤ 5 substitutions, 3 TCR–MHC systems)
+- Feb 2026 follow-up [@aipredictedtcr2026]: applies HERMES to **AF-predicted** TCR-pMHC structures, discriminates interacting from non-interacting complexes (1000 randomised TCR/pMHC pairs as negative set)
+:::
+
+:::
+
+::: {.column width="45%"}
+
+::: {.callout-important appearance="simple"}
+**Key methodological claim:** HERMES doesn't model TCR-pMHC *binding* directly. It models **how plausible the local 3D environment is** under the protein-universe prior. A correct TCR-pMHC interface scores well because it looks like a real interface; a wrong one doesn't.
+:::
+
+:::
+
+:::
+
+---
+
+## Where it would plug in {.smaller}
+
+```{mermaid}
+%%| fig-width: 11
+flowchart LR
+    A["Top neoepitope<br/>candidate<br/>(MHCflurry rank 1)"] --> B["TCRdock<br/>(AF-Multimer)"]
+    F["VDJdb TCR panel<br/>or fallback DMF5"] --> B
+    B --> C["PDB structure<br/>+ ipTM, pLDDT, PAE"]
+    C --> D["NetTCR-struc<br/>(Issue #422 / #433)"]
+    C --> E["HERMES<br/>(Issue #218 → #492)"]
+    D --> G["docking-quality<br/>score"]
+    E --> H["interface AA<br/>propensity score"]
+    G --> I["candidate retained<br/>/ dropped"]
+    H --> I
+
+    style E fill:#ffe6a3,stroke:#b8860b,stroke-width:3px
+    style I fill:#a3d8ff,stroke:#1e5ba8,stroke-width:2px
+```
+
+**Two structural-QC dimensions on the same TCRdock output PDB:**
+
+| Scorer | Dimension | Output |
+|---|---|---|
+| AF-Multimer (inside TCRdock) | structural prediction confidence | ipTM, pLDDT, PAE |
+| **NetTCR-struc** ([Issue #433](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/433)) | **docking quality** | predicted DockQ |
+| **HERMES** (this Issue → [Issue #492](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/492)) | **interface AA propensity** (binding-affinity proxy) | per-site log-probs |
+
+---
+
+## Three reasons to integrate {.smaller}
+
+::: {.incremental}
+1. **No integration blockers** *(contrast: ImmSET [Issue #201](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/201) blocked on all three)*
+    - Code released ✅ — MIT license at [`StatPhysBio/hermes`](https://github.com/StatPhysBio/hermes)
+    - Pretrained weights released ✅ — bundled + on Zenodo
+    - Training data public ✅ — protein universe, no proprietary dataset dependency
+2. **Orthogonal signal to AF confidence.** AF measures *prediction certainty*; HERMES measures *structural plausibility under the protein-universe prior*. The Feb 2026 follow-up [@aipredictedtcr2026] is concrete evidence the signals don't collapse — HERMES discriminates interacting vs. non-interacting AF predictions.
+3. **Niche complementarity with NetTCR-struc.** Docking quality + binding-affinity proxy = the two structural-QC dimensions of a TCR-pMHC complex, both consuming the same TCRdock PDB. Single new env, single new Snakemake rule.
+:::
+
+---
+
+## Decision
+
+::: {style="text-align: center; font-size: 3em; font-weight: bold; margin-top: 0.5em;"}
+\(a\) Integrate
+:::
+
+::: {style="text-align: center; font-size: 1.4em; margin-top: 0.5em;"}
+as post-TCRdock structural confidence cross-check
+:::
+
+. . .
+
+**Modeling sub-issue filed:** [Issue #492](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/492) under [milestone 29](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/milestone/29).
+
+Title: `feat(scoring): integrate HERMES as post-TCRdock structure-based confidence cross-check`. `role:developer`, P2. Gated by TCRdock end-to-end pipeline functional.
+
+. . .
+
+::: {.callout-note appearance="simple"}
+**[Issue #432](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/432) verdict progress:** 2 of 5 scorers resolved today — ImmSET → (b), HERMES → (a). Remaining: Boltz-2, t2pmhc/TCRLens, [Issue #316](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/316) outcome.
+:::
+
+---
+
+## Open scientific questions for the integration sub-issue {.smaller}
+
+When [Issue #492](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/492) lands on Dev's plate, Sci consult points:
+
+::: {.incremental}
+1. **Interface-residue aggregation strategy** — HERMES emits per-site logits. How to summarise across peptide residues? Mean log-prob, sum, softmax-weighted, or per-site retained?
+2. **Reference set for normalising scores** — what's the unbiased baseline? ESM-IF1 on the same residues? AF-confidence-only as a sanity-check stratifier?
+3. **Calibration on chr22 PoC patient_001** — single-pair calibration before declaring a keep/drop threshold; same shape as the AlphaGenome chr22 PoC ([Issue #393](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/393)).
+4. **OOD on novel splice-junction peptides** — HERMES's protein-universe prior doesn't see splice neoantigens specifically. Plausible failure mode: high score on canonical-looking peptides regardless of true binding. To be tested empirically.
+:::
+
+---
+
+## References {.smaller}
+
+::: {#refs}
+:::

--- a/research/evals/issue_218_hermes/slides.qmd
+++ b/research/evals/issue_218_hermes/slides.qmd
@@ -12,6 +12,8 @@ format:
     incremental: false
     slide-number: c/t
     progress: true
+    chalkboard: false
+    code-line-numbers: false
     fig-align: center
     fig-cap-location: bottom
     transition: fade
@@ -73,7 +75,7 @@ structural-QC stack?
 ::: {.incremental}
 - 0.72 correlation with experimental TCR-pMHC binding affinities [@visani2025hermes]
 - Up to 50% T cell activation rate for de novo–designed peptides (≤ 5 substitutions, 3 TCR–MHC systems)
-- Feb 2026 follow-up [@aipredictedtcr2026]: applies HERMES to **AF-predicted** TCR-pMHC structures, discriminates interacting from non-interacting complexes (1000 randomised TCR/pMHC pairs as negative set)
+- Feb 2026 follow-up [@robben2026aipredictedtcr]: applies HERMES to **AF-predicted** TCR-pMHC structures, discriminates interacting from non-interacting complexes (1000 randomised TCR/pMHC pairs as negative set)
 :::
 
 :::
@@ -126,7 +128,7 @@ flowchart LR
     - Code released ✅ — MIT license at [`StatPhysBio/hermes`](https://github.com/StatPhysBio/hermes)
     - Pretrained weights released ✅ — bundled + on Zenodo
     - Training data public ✅ — protein universe, no proprietary dataset dependency
-2. **Orthogonal signal to AF confidence.** AF measures *prediction certainty*; HERMES measures *structural plausibility under the protein-universe prior*. The Feb 2026 follow-up [@aipredictedtcr2026] is concrete evidence the signals don't collapse — HERMES discriminates interacting vs. non-interacting AF predictions.
+2. **Orthogonal signal to AF confidence.** AF measures *prediction certainty*; HERMES measures *structural plausibility under the protein-universe prior*. The Feb 2026 follow-up [@robben2026aipredictedtcr] is concrete evidence the signals don't collapse — HERMES discriminates interacting vs. non-interacting AF predictions.
 3. **Niche complementarity with NetTCR-struc.** Docking quality + binding-affinity proxy = the two structural-QC dimensions of a TCR-pMHC complex, both consuming the same TCRdock PDB. Single new env, single new Snakemake rule.
 :::
 

--- a/research/evals/issue_218_hermes/slides.qmd
+++ b/research/evals/issue_218_hermes/slides.qmd
@@ -7,7 +7,8 @@ date: 2026-05-26
 date-format: "YYYY-MM-DD"
 format:
   revealjs:
-    theme: simple
+    theme: [simple, ../../slides/custom.scss]
+    footer: "Splice Neoepitope Pipeline · JH M Lee Lab"
     incremental: false
     slide-number: c/t
     progress: true

--- a/research/lab_notebook/scientist.md
+++ b/research/lab_notebook/scientist.md
@@ -6,6 +6,28 @@ Format and rules unchanged from the unified notebook — see `shared/feedback_la
 
 ---
 
+## 2026-05-26
+
+### 11:55 UTC — Editor: Scientist
+
+#### [Issue #218](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/218) — HERMES evaluation closed as (a) integrate; sub-issue [#492](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/492) filed under milestone 29
+
+[HERMES — Visani et al., *PNAS* 2025-10-21 (DOI 10.1073/pnas.2504783122)](https://doi.org/10.1073/pnas.2504783122). 3D-equivariant ML model pre-trained on the protein universe (~10k CASP12 chains); predicts amino-acid propensities at sites from local 3D structural environments. **Zero-shot on TCR-pMHC** (no domain-specific training data) yet achieves 0.72 correlation with experimental binding affinities + up to 50% T cell activation rate for de novo peptide designs across 3 TCR-MHC systems. Feb 2026 follow-up ([bioRxiv 707744](https://www.biorxiv.org/content/10.64898/2026.02.24.707744v1.full)) applies HERMES to AF-predicted TCR-pMHC structures and discriminates interacting from non-interacting complexes — exactly our use case (TCRdock outputs AF-Multimer PDBs).
+
+**Decision: (a) integrate as post-TCRdock structure-based confidence cross-check.** Three reasons:
+
+1. **No integration blockers.** Open-source ([StatPhysBio/hermes](https://github.com/StatPhysBio/hermes), MIT-licensed), pretrained weights bundled + on Zenodo, Python 3.9 + PyTorch + e3nn==0.5.0 — drops into our `workflow/envs/` pattern cleanly. CLI: `python run_hermes_on_pdbfiles.py -pd pdbs -m hermes_bp_000 -o results.csv`.
+2. **Orthogonal signal to AF confidence.** TCRdock outputs AF-Multimer ipTM + pLDDT + PAE; HERMES outputs per-site amino-acid propensities from the 3D environment. The Feb 2026 follow-up demonstrates HERMES discriminates interacting from non-interacting predicted TCR-pMHC complexes — concrete evidence the signal complements AF's own confidence on the same input.
+3. **Niche complementarity with NetTCR-struc** ([Issue #422](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/422) / [Issue #433](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/433)). NetTCR-struc predicts DockQ (docking quality); HERMES predicts amino-acid propensity at the interface (binding affinity proxy). Together they cover the two structural-QC dimensions for TCR-pMHC.
+
+**Modeling sub-issue filed: [Issue #492](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/492)** under [`milestone 29 (i5 - S5 - Modeling - TCR-pMHC Scorer Integration)`](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/milestone/29). Title: `feat(scoring): integrate HERMES as post-TCRdock structure-based confidence cross-check`. `role:developer`, P2. Gated by TCRdock end-to-end pipeline functional (same prerequisite as [Issue #433](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/433) NetTCR-struc sibling).
+
+**Manuscript carry-forward to [Issue #432](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/432):** HERMES + NetTCR-struc as a complementary structural-QC pair (binding-affinity + docking-quality dimensions). Concrete (a)-integrate verdict to pair with today's ImmSET (b)-decline ([Issue #201](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/201)) — balanced manuscript example.
+
+**Verdict progress on [Issue #432](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/432) per-scorer AC:** 2 of 5 scorers resolved today (ImmSET → b, HERMES → a). Remaining: Boltz-2 ([Issue #188](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/188)), t2pmhc/TCRLens ([Issue #236](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/236)), [Issue #316](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/316) outcome.
+
+---
+
 ## 2026-05-25
 
 ### 19:24 UTC — Editor: Scientist

--- a/research/slides/README.md
+++ b/research/slides/README.md
@@ -31,6 +31,13 @@ research/slides/
 
 **File naming:** `slides.qmd` (generic; doesn't repeat folder name).
 
+**Decks live in two sibling trees, not under `research/slides/`:**
+
+- `research/experiments/issue_NNN_<short>/slides.qmd` — co-located with the experiment notebook + outputs. See [`CLAUDE.md` "Slide decks for experiment Issues"](../../CLAUDE.md).
+- `research/evals/issue_NNN_<tool>/slides.qmd` — per-tool primer for a tool-evaluation Issue. See [`CLAUDE.md` "Slide decks for eval Issues"](../../CLAUDE.md). Example: [`research/evals/issue_218_hermes/`](../evals/issue_218_hermes/).
+
+`research/slides/` itself holds **only the shared scaffolding** (`_template.qmd`, `custom.scss`, `nature.csl`, this README). Decks reference the scaffolding via `theme: [simple, ../../slides/custom.scss]` and `csl: ../../slides/nature.csl`. (`research/slides/issue_393_alphagenome_chr22_poc/` predates the co-location rule and migrates under [Issue #455](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/455).)
+
 ## Shared theme (`custom.scss`)
 
 All decks share a single SCSS theme at [`custom.scss`](custom.scss) — palette (deep blue primary `#1e5ba8` + muted gold accent `#b8860b`, derived from existing mermaid-diagram colors), typography (Inter / Source Sans 3 with system fallbacks; JetBrains Mono for code), heading underline accents, callout styling, table styling, footer + slide-number layout. Reference from a deck YAML via:

--- a/research/slides/README.md
+++ b/research/slides/README.md
@@ -17,6 +17,8 @@ Audience target: **lab seminar / external talk** (~20-25 min, conference-quality
 research/slides/
 ├── README.md                                       # this file
 ├── _template.qmd                                   # reusable template
+├── custom.scss                                     # shared project theme (palette, fonts, footers)
+├── nature.csl                                      # citation style
 └── issue_NNN_<short-content-desc>/                 # one folder per deck
     ├── slides.qmd                                  # the deck
     ├── refs.bib                                    # bibliography (BibTeX)
@@ -28,6 +30,20 @@ research/slides/
 **Folder naming:** `issue_NNN_<short-content-desc>` — ties to Issue # AND describes content. Example: `issue_393_alphagenome_chr22_poc/`.
 
 **File naming:** `slides.qmd` (generic; doesn't repeat folder name).
+
+## Shared theme (`custom.scss`)
+
+All decks share a single SCSS theme at [`custom.scss`](custom.scss) — palette (deep blue primary `#1e5ba8` + muted gold accent `#b8860b`, derived from existing mermaid-diagram colors), typography (Inter / Source Sans 3 with system fallbacks; JetBrains Mono for code), heading underline accents, callout styling, table styling, footer + slide-number layout. Reference from a deck YAML via:
+
+```yaml
+format:
+  revealjs:
+    theme: [simple, ../../slides/custom.scss]    # for decks under research/evals/ or research/experiments/
+    # theme: [simple, custom.scss]               # for decks inside research/slides/ itself
+    footer: "Splice Neoepitope Pipeline · JH M Lee Lab"
+```
+
+The theme overrides the `simple` reveal.js base — `simple` provides the structural CSS, `custom.scss` layers the project identity on top. **Don't fork the SCSS per deck** — edit `custom.scss` in place to evolve the shared look, and every deck picks up the change on next render.
 
 ## Why Quarto (not Marp / PowerPoint / Keynote)
 

--- a/research/slides/_template.qmd
+++ b/research/slides/_template.qmd
@@ -7,7 +7,8 @@ date: today
 date-format: "YYYY-MM-DD"
 format:
   revealjs:
-    theme: simple
+    theme: [simple, custom.scss]   # ↳ shared project theme (research/slides/custom.scss); for decks outside research/slides/, use `[simple, ../../slides/custom.scss]`
+    footer: "Splice Neoepitope Pipeline · JH M Lee Lab"
     incremental: false
     slide-number: c/t
     progress: true

--- a/research/slides/_template.qmd
+++ b/research/slides/_template.qmd
@@ -51,6 +51,31 @@ for the convention. Replace TITLE/Issue # and edit slides below; delete this com
 Decision-rule outcome lands on slide N (results) → slide N+1 (decision).
 :::
 
+<!--
+ALTERNATIVE "big-question" pattern (for tool-eval decks or when a punchier
+opening reads better):
+
+::: {style="text-align: center; font-size: 2.2em; font-weight: bold; line-height: 1.2; margin-top: 0.4em;"}
+First line of the question\
+second line\
+third line?
+:::
+
+. . .
+
+::: {.callout-note appearance="simple"}
+**Why now:** parent-Issue context.
+:::
+
+AVOID `r-fit-text` for multi-line big-question slides. The reveal.js
+`.r-fit-text` class scales each block to canvas WIDTH regardless of
+content height — stacking 3 r-fit-text lines silently consumes the
+entire vertical canvas and pushes any follow-up callout off the bottom
+(caught in HERMES eval deck, Issue #218, 2026-05-26). Use a controlled
+`font-size` in `em` units instead — it's predictable across multi-line
+content and leaves explicit room for the callout-note underneath.
+-->
+
 ---
 
 ## Method (block diagram) {.smaller}

--- a/research/slides/custom.scss
+++ b/research/slides/custom.scss
@@ -43,6 +43,10 @@ $presentation-heading-line-height: 1.15;
 
 // Link colors
 $link-color: $primary-color;
+// Keep legacy `lighten()`: `@use "sass:color"` must precede all rules, but Quarto
+// composes its preamble before this file's scss:defaults block, so the modern
+// `color.adjust(...)` form cannot be wired in here. Dart Sass still supports
+// lighten() with a deprecation warning; revisit if Quarto stops accepting it.
 $link-color-hover: lighten($primary-color, 12%);
 
 /*-- scss:rules --*/

--- a/research/slides/custom.scss
+++ b/research/slides/custom.scss
@@ -1,0 +1,276 @@
+/*-- scss:defaults --*/
+
+// =============================================================================
+// Splice Neoepitope Pipeline — shared slide theme
+// =============================================================================
+//
+// Reused by every deck under research/evals/ + research/experiments/.
+// Reference via `theme: [simple, ../../slides/custom.scss]` from the deck YAML
+// (or `[simple, custom.scss]` from a deck inside research/slides/ itself).
+//
+// Design intent: restrained scientific seminar aesthetic, no flashy gradients.
+// Lab-seminar / external-talk audience; lives next to manuscript figures.
+//
+// Palette derives from the existing mermaid-diagram conventions in the
+// AlphaGenome PoC deck — blue primary accent + muted-gold secondary.
+// =============================================================================
+
+// Palette
+$primary-color:    #1e5ba8;   // deep blue — main accent (headings, links, dividers)
+$primary-tint:     #a3d8ff;   // light blue — backgrounds, mermaid result nodes
+$accent-color:     #b8860b;   // muted gold — highlight strokes
+$accent-tint:      #ffe6a3;   // pale gold — callout-important fill, mermaid highlight
+$ok-color:         #2f855a;   // green — callout-tip
+$warn-color:       #c05621;   // burnt orange — callout-warning
+$text-color:       #2d3748;   // body text — dark grey, not pure black (easier on eyes)
+$heading-color:    #1a202c;   // headings — near-black
+$muted-color:      #718096;   // captions, footer, slide number
+$border-color:     #e2e8f0;   // dividers
+$bg-tint:          #f7fafc;   // callout backgrounds, subtle panels
+
+// Typography
+$font-family-sans-serif: "Inter", "Source Sans 3", "Lato", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+$font-family-monospace:  "JetBrains Mono", "Fira Code", "SF Mono", Menlo, Consolas, monospace;
+$mainFont: $font-family-sans-serif;
+$headingFont: $font-family-sans-serif;
+$presentation-font-size-root: 32px;
+$presentation-h1-font-size: 2em;
+$presentation-h2-font-size: 1.45em;
+$presentation-h3-font-size: 1.15em;
+$presentation-heading-font: $font-family-sans-serif;
+$presentation-heading-color: $heading-color;
+$presentation-heading-line-height: 1.15;
+
+// Link colors
+$link-color: $primary-color;
+$link-color-hover: lighten($primary-color, 12%);
+
+/*-- scss:rules --*/
+
+// Optional web-font import (commented by default — uncomment if you want
+// pixel-identical typography offline + online; needs network at first render).
+// @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap');
+
+// Force sans-serif body text — override any upstream theme's serif default.
+.reveal,
+.reveal p,
+.reveal li,
+.reveal td,
+.reveal th,
+.reveal .slides {
+  font-family: $font-family-sans-serif;
+}
+
+.reveal h1, .reveal h2, .reveal h3, .reveal h4, .reveal h5, .reveal h6,
+.reveal .title, .reveal .subtitle {
+  font-family: $font-family-sans-serif;
+}
+
+// ---- Headings ----
+
+.reveal h2 {
+  border-bottom: 3px solid $primary-color;
+  padding-bottom: 0.12em;
+  margin-bottom: 0.45em;
+  font-weight: 600;
+  color: $heading-color;
+  letter-spacing: -0.005em;
+}
+
+.reveal h3 {
+  color: $primary-color;
+  font-weight: 600;
+}
+
+// ---- Title slide ----
+
+.reveal .slide.title-slide {
+  text-align: left;
+}
+
+.reveal .slide.title-slide .title {
+  color: $primary-color;
+  font-weight: 700;
+  border-bottom: 4px solid $primary-color;
+  padding-bottom: 0.15em;
+  margin-bottom: 0.3em;
+  letter-spacing: -0.01em;
+}
+
+.reveal .slide.title-slide .subtitle {
+  color: $muted-color;
+  font-size: 0.55em;
+  font-weight: 400;
+  margin-top: 0.4em;
+}
+
+.reveal .slide.title-slide .author,
+.reveal .slide.title-slide .institute {
+  color: $text-color;
+  font-size: 0.45em;
+  margin-top: 0.5em;
+}
+
+.reveal .slide.title-slide .date {
+  color: $muted-color;
+  font-size: 0.4em;
+  margin-top: 0.3em;
+}
+
+// ---- Body text ----
+
+.reveal {
+  color: $text-color;
+}
+
+.reveal strong {
+  color: $heading-color;
+  font-weight: 600;
+}
+
+// ---- Links ----
+
+.reveal a {
+  color: $link-color;
+  text-decoration: none;
+  border-bottom: 1px dotted $link-color;
+  transition: color 0.15s ease, border-color 0.15s ease;
+}
+
+.reveal a:hover {
+  color: $link-color-hover;
+  border-bottom-style: solid;
+}
+
+// ---- Tables ----
+
+.reveal table {
+  margin: 0.4em auto;
+  border-collapse: collapse;
+  font-size: 0.85em;
+}
+
+.reveal table th {
+  border-bottom: 2px solid $primary-color;
+  color: $heading-color;
+  font-weight: 600;
+  padding: 0.35em 0.7em;
+  text-align: left;
+}
+
+.reveal table td {
+  border-bottom: 1px solid $border-color;
+  padding: 0.3em 0.7em;
+}
+
+.reveal table tr:last-child td {
+  border-bottom: none;
+}
+
+// ---- Callouts ----
+
+.reveal .callout {
+  border-radius: 4px;
+  background-color: $bg-tint;
+  margin: 0.6em 0;
+  border-left-width: 4px;
+}
+
+.reveal .callout-note { border-left-color: $primary-color; }
+.reveal .callout-tip { border-left-color: $ok-color; }
+.reveal .callout-important { border-left-color: $accent-color; }
+.reveal .callout-warning { border-left-color: $warn-color; }
+
+.reveal .callout-title {
+  font-weight: 600;
+  color: $heading-color;
+}
+
+// ---- Code ----
+
+.reveal pre code,
+.reveal code {
+  font-family: $font-family-monospace;
+}
+
+.reveal pre code {
+  font-size: 0.7em;
+  border-radius: 4px;
+  background-color: $bg-tint;
+  border: 1px solid $border-color;
+  padding: 0.6em 0.8em;
+}
+
+.reveal :not(pre) > code {
+  color: $accent-color;
+  background-color: rgba($accent-color, 0.08);
+  padding: 0.05em 0.3em;
+  border-radius: 3px;
+  font-size: 0.9em;
+}
+
+// ---- Slide number + progress ----
+
+.reveal .progress {
+  color: $primary-color;
+  height: 4px;
+}
+
+.reveal .slide-number {
+  color: $muted-color;
+  font-size: 0.4em;
+  background: transparent;
+  right: 1em;
+  bottom: 0.6em;
+}
+
+// ---- Section divider slides (h2-only, no body) ----
+
+.reveal section.has-dark-background h2 {
+  color: white;
+  border-bottom-color: $accent-color;
+}
+
+// ---- Lists ----
+
+.reveal ul {
+  list-style: none;
+  padding-left: 1.4em;
+}
+
+.reveal ul li {
+  position: relative;
+}
+
+.reveal ul li::before {
+  content: "▸";
+  position: absolute;
+  left: -1.2em;
+  color: $primary-color;
+  font-weight: 600;
+}
+
+.reveal ol {
+  padding-left: 1.6em;
+}
+
+// ---- Blockquote ----
+
+.reveal blockquote {
+  border-left: 4px solid $primary-color;
+  background-color: $bg-tint;
+  padding: 0.5em 1em;
+  margin: 0.5em 0;
+  font-style: italic;
+  color: $muted-color;
+}
+
+// ---- Footer (when defined in YAML `footer:`) ----
+
+.reveal .footer {
+  color: $muted-color;
+  font-size: 0.4em;
+  bottom: 0.6em;
+  left: 1em;
+  position: absolute;
+}


### PR DESCRIPTION
## Summary

Closes [Issue #218](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/218) (HERMES eval) as **(a) integrate** as post-TCRdock structural confidence cross-check. Contributes one (a)-integrate verdict to [Issue #432](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/432)'s per-scorer integration AC (2 of 5 resolved today — pairs with ImmSET → (b) on [PR #491](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/491)).

**HERMES** — Visani et al., PNAS 2025-10-21. Holographic Equivariant neuRal network model for Mutational Effect and Stability prediction. Pre-trained on the full protein universe (~10k CASP12 chains), zero TCR-pMHC-specific training data. Code (MIT) + weights released at [`StatPhysBio/hermes`](https://github.com/StatPhysBio/hermes); the Feb 2026 follow-up confirms generalization to AF-predicted TCR-pMHC structures.

**Three reasons to integrate:**
1. No integration blockers (contrast ImmSET) — code + weights + training data all public.
2. Orthogonal signal to AF confidence — measures *structural plausibility under protein-universe prior*, not prediction certainty.
3. Niche complementarity with NetTCR-struc ([Issue #422](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/422) / [Issue #433](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/433)) — docking-quality + binding-affinity-proxy, both consuming the same TCRdock PDB.

**Modeling sub-issue filed:** [Issue #492](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/492) under [milestone 29](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/milestone/29). `role:developer`, P2. Gated by TCRdock end-to-end functional.

**New convention codified:** Per-tool primer deck for every eval Issue under `research/evals/issue_NNN_<tool>/slides.qmd`. Rationale: visual condensation per-tool answers *"what is this tool?"* — different artifact from the consolidating [Issue #432](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/432) publication deck which answers *"why this (a/b/c) decision across all 5 evals?"*. Both have value. CLAUDE.md updated with new "Slide decks for eval Issues" section.

## Artifacts

- **Lab notebook entry** ([`research/lab_notebook/scientist.md`](research/lab_notebook/scientist.md)) — 2026-05-26 11:55 UTC, (a)-integrate closeout
- **HERMES eval deck** ([`research/evals/issue_218_hermes/slides.qmd`](research/evals/issue_218_hermes/slides.qmd)) — 9-slide tool primer; visually verified via headless Chrome
- **Shared SCSS theme** ([`research/slides/custom.scss`](research/slides/custom.scss)) — palette + typography + heading-underlines + colored callouts + footer band; reusable across all decks under `research/evals/` and `research/experiments/`
- **r-fit-text fix** ([`research/slides/_template.qmd`](research/slides/_template.qmd)) — warning + controlled-font alternative pattern after slide-overflow incident on this deck
- **CLAUDE.md** — new "Slide decks for eval Issues" section codifying the convention
- **.gitignore** — Quarto build-artefact exclusions under `research/evals/`
- **Zotero `654D8NFP`** in collection Z38GTJNW (Feb 2026 follow-up paper) — `MWZFINV6` (PNAS) already existed

## Commits

| SHA | Diff |
|---|---|
| `41fa7dd` | Lab notebook entry (Issue #218 closeout) |
| `041abc6` | HERMES eval deck + CLAUDE.md eval-deck convention + .gitignore |
| `1a4d02e` | r-fit-text fix on question slide + template warning |
| `0d0196d` | Shared SCSS theme — palette + typography + headings + callouts + footer |

Closes #218

## Test plan

- [x] HERMES preprint + Feb 2026 follow-up read (architecture, training-data scope, integration map drafted)
- [x] Decision (a/b/c) with rationale — (a) integrate; closeout comment posted on [Issue #218](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/218)
- [x] Sub-issue [Issue #492](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/492) filed under milestone 29; role:developer, P2
- [x] All 4 task boxes on [Issue #218](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/218) body ticked + edit-history line
- [x] Zotero `654D8NFP` (Feb 2026 follow-up) added with three-section note
- [x] HERMES eval deck renders cleanly (`quarto render --to revealjs`)
- [x] All 9 slides visually verified via headless Chrome (no overflow, citations resolve)
- [x] Shared SCSS theme applied — heading-underlines, gold/blue/green callouts, footer band confirmed across slides 0/1/3/4/6/8

**Created by:** Scientist