### PR TITLE
docs(manuscript): update stale junctions.tsv path in RESULTS.md

### DIFF
--- a/research/manuscript/RESULTS.md
+++ b/research/manuscript/RESULTS.md
@@ -51,7 +51,7 @@ median 425, mean 953).
 
 The unannotated, normal-shared, and tumor-exclusive counts are read from `report.tsv`.
 The total-extracted and annotated-discarded rows are derived from the line count of
-`alignment/SRR9143066/junctions.tsv` (post-#148 run); these will be added directly to
+`alignment/SRR9143066/raw_junctions.tsv` (post-#148 run); these will be added directly to
 `report.tsv` once [Issue #104](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/104) lands.
 
 ### Peptide Translation


### PR DESCRIPTION
Closes [Issue #478](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/478).

## Summary

Single-line update at [research/manuscript/RESULTS.md:54](research/manuscript/RESULTS.md#L54) to align manuscript prose with [PR #477](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/477)'s rename:

```
- `alignment/SRR9143066/junctions.tsv` (post-#148 run); these will be added directly to
+ `alignment/SRR9143066/raw_junctions.tsv` (post-#148 run); these will be added directly to
```

[PR #477](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/477) renamed only the per-sample raw output (`alignment/<sample>/junctions.tsv` → `alignment/<sample>/raw_junctions.tsv`); the patient-level `results/junctions/{patient_id}/novel_junctions.tsv` is a different file and intentionally unchanged. The 3 surviving `novel_junctions.tsv` refs in METHODS.md / DISCUSSIONS.md are therefore correct as-is.

## Test plan

- [x] `grep -rEn "\bjunctions\.tsv" research/manuscript/` returns zero bare/stale hits (only `raw_junctions.tsv` or `novel_junctions.tsv`)
- [x] All 6 manuscript files (CONCLUSIONS / DISCUSSIONS / INTRODUCTION / METHODS / REFERENCES / RESULTS) confirmed consistent with PR #477 scope
- [x] CI passes (`pipeline-pytest`, `pipeline-snakemake-dry-run`, `ci-tools-pytest` all green)

**Created by:** Scientist