### PR TITLE
feat(scripts): board_open_items.py — paginated open-board listing (closes #508)

### DIFF
--- a/research/lab_notebook/developer.md
+++ b/research/lab_notebook/developer.md
@@ -6,6 +6,30 @@ Format and rules unchanged from the unified notebook — see `shared/feedback_la
 
 ---
 
+## 2026-05-27
+
+### 14:30 UTC — Editor: Developer
+
+**Headline:** [PR #510](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/510) shipped, closing [Issue #508](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/508) — added `scripts/board_open_items.py` (paginated open-board listing with role/Status/Priority/Size filters) and promoted the long-existing board-pagination rule from `shared/feedback_board_queries.md` Reference tier into `shared/MEMORY.md` Always-in-effect. Two-layer fix following the established memory ladder (rung 2 inline + rung 3 mechanism). Bot review caught 3 valid robustness issues (GraphQL error envelope unhandled, `subprocess check=True` swallows `gh` stderr, argparse `choices=` missing on enumerated flags) — all applied as one-liners.
+
+#### Slip postmortem: a documented rule sitting at Reference tier behaves the same as no rule
+
+User asked me to "check the board for next best tasks". I ran `gh api graphql` with `first: 100`, returned 2 open Dev items, recommended next picks. User pushed back. Re-query with `pageInfo.hasNextPage` cursor loop → 24 open Dev items (out of 64 total open, 472 board items). Two compounding pitfalls: `first: N` is a cap (not a filter), and the board sorts Done items first — so an unpaginated query returned 97 Done items on the first page, leaving 3 open-state candidates after client-side filtering. The rule was documented at `shared/feedback_board_queries.md` since 2026-05-20, but indexed under "Reference (read when relevant)" — never loaded at session start. Effective rule presence was zero.
+
+#### Memory ladder applied as designed
+
+Per `shared/feedback_memory_escalation.md` ("on 'you forgot X': inline into Always in effect") + `shared/feedback_mechanism_over_memory.md` (repeat-failure shape → mechanism), the fix split cleanly: (1) **rung 2** — promoted the rule into `shared/MEMORY.md` Always-in-effect with telegraphic body + back-link to `feedback_board_queries.md`; (2) **rung 3** — shipped `scripts/board_open_items.py` so future sessions don't redo the cursor loop. Memory teaches the principle (covers cases the script doesn't fit — mutations, unusual fields), script is the canonical implementation for the most common case. **Complementary, not interim/permanent.**
+
+#### Bot review findings — all 3 valid, all 3 robustness gaps
+
+(1) `data["data"]` indexing into the GraphQL response would `KeyError` on `{"errors": [...], "data": null}` envelopes (auth failure, rate limit, partial failure). Bot suggested `if errs := data.get("errors"): print + exit`. (2) `subprocess.run(..., check=True, capture_output=True)` prints a Python traceback instead of the actual `gh` stderr ("Not Found", "requires authentication") — UX-hostile under failure. Fix: drop `check=True`, branch on `r.returncode`, print `r.stderr` to stderr. (3) `--status`/`--priority`/`--size` filters did silent exact-match; passing `--status "in progress"` (lowercase) silently returned 0 results. Free fix: argparse `choices=list(STATUS_ORDER)` etc. since the enumerations already exist for sort ordering. `--role` intentionally kept free-form (extensible label).
+
+#### Pattern: separate-step author flow for review-trigger lifecycle worked clean
+
+Shared Always-in-effect rule: when posting `@claude review`, author flips BOTH PR Status and linked Issue Status to `In review` in the same step as the comment. Done in parallel — three independent calls (gh pr comment + 2× updateProjectV2ItemFieldValue) — clean. After review fixes land, Status stays `In review` (covers both active review and awaiting-iteration), no flip-back to `Ready for review`. Merged → Done auto-set on both PR and Issue by the project workflow.
+
+---
+
 ## 2026-05-26
 
 ### 12:20 UTC — Editor: Developer

--- a/scripts/board_open_items.py
+++ b/scripts/board_open_items.py
@@ -86,8 +86,14 @@ def fetch_all_items() -> list[dict[str, Any]]:
         ]
         if cursor is not None:
             cmd.extend(["-F", f"after={cursor}"])
-        r = subprocess.run(cmd, capture_output=True, text=True, check=True)
+        r = subprocess.run(cmd, capture_output=True, text=True)
+        if r.returncode != 0:
+            print(r.stderr, file=sys.stderr)
+            sys.exit(r.returncode)
         data = json.loads(r.stdout)
+        if errs := data.get("errors"):
+            print(f"GraphQL errors: {errs}", file=sys.stderr)
+            sys.exit(1)
         proj = data["data"]["user"]["projectV2"]["items"]
         items.extend(proj["nodes"])
         pi = proj["pageInfo"]
@@ -183,9 +189,9 @@ def format_table(items: list[dict[str, Any]]) -> str:
 def main() -> int:
     p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     p.add_argument("--role", help='Filter by role label (e.g. "developer", "scientist", "pm")')
-    p.add_argument("--status", help='Filter by board Status (e.g. "Ready", "In progress", "Backlog")')
-    p.add_argument("--priority", help='Filter by Priority (P0/P1/P2/P3)')
-    p.add_argument("--size", help='Filter by Size (XS/S/M/L/XL)')
+    p.add_argument("--status", choices=list(STATUS_ORDER), help="Filter by board Status")
+    p.add_argument("--priority", choices=list(PRIORITY_ORDER), help="Filter by Priority")
+    p.add_argument("--size", choices=list(SIZE_ORDER), help="Filter by Size")
     p.add_argument("--json", dest="as_json", action="store_true", help="Emit JSON array instead of a table")
     args = p.parse_args()
 

--- a/scripts/board_open_items.py
+++ b/scripts/board_open_items.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""List open items on the JH M Lee Lab project board (#9) with Status/Priority/Size.
+
+Wraps the paginated ProjectV2 GraphQL query that the board needs:
+  - GraphQL `first: N` is a cap, not a filter; we loop on `pageInfo.hasNextPage`.
+  - The board sorts Done items first, so unpaginated single-page queries silently
+    truncate open work. See `.claude/memory/shared/feedback_board_queries.md`.
+
+For queries that only need label + state (no Status/Priority/Size columns),
+prefer `gh issue list --label role:<role> --state open` instead — it's a one-liner
+with no pagination needed.
+
+Usage:
+  scripts/board_open_items.py
+  scripts/board_open_items.py --role developer
+  scripts/board_open_items.py --status Ready --priority P1
+  scripts/board_open_items.py --json | jq '.[] | select(.size == "S")'
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from typing import Any
+
+OWNER = "Jin-HoMLee"
+PROJECT_NUMBER = 9
+
+QUERY = """
+query($owner: String!, $number: Int!, $after: String) {
+  user(login: $owner) {
+    projectV2(number: $number) {
+      items(first: 100, after: $after) {
+        pageInfo { hasNextPage endCursor }
+        nodes {
+          content {
+            __typename
+            ... on Issue {
+              number title state url
+              labels(first: 20) { nodes { name } }
+            }
+            ... on PullRequest {
+              number title state url isDraft
+              labels(first: 20) { nodes { name } }
+            }
+          }
+          fieldValues(first: 20) {
+            nodes {
+              ... on ProjectV2ItemFieldSingleSelectValue {
+                name
+                field { ... on ProjectV2SingleSelectField { name } }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+"""
+
+STATUS_ORDER = {
+    "In progress": 0,
+    "In review": 1,
+    "Ready for review": 2,
+    "Ready": 3,
+    "Backlog": 4,
+    "No Status": 5,
+}
+PRIORITY_ORDER = {"P0": 0, "P1": 1, "P2": 2, "P3": 3}
+SIZE_ORDER = {"XS": 0, "S": 1, "M": 2, "L": 3, "XL": 4}
+
+
+def fetch_all_items() -> list[dict[str, Any]]:
+    items: list[dict[str, Any]] = []
+    cursor: str | None = None
+    page = 0
+    while True:
+        page += 1
+        cmd = [
+            "gh", "api", "graphql",
+            "-f", f"query={QUERY}",
+            "-F", f"owner={OWNER}",
+            "-F", f"number={PROJECT_NUMBER}",
+        ]
+        if cursor is not None:
+            cmd.extend(["-F", f"after={cursor}"])
+        r = subprocess.run(cmd, capture_output=True, text=True, check=True)
+        data = json.loads(r.stdout)
+        proj = data["data"]["user"]["projectV2"]["items"]
+        items.extend(proj["nodes"])
+        pi = proj["pageInfo"]
+        print(
+            f"Page {page}: {len(proj['nodes'])} items, hasNext={pi['hasNextPage']}",
+            file=sys.stderr,
+        )
+        if not pi["hasNextPage"]:
+            break
+        cursor = pi["endCursor"]
+    return items
+
+
+def normalize(item: dict[str, Any]) -> dict[str, Any] | None:
+    content = item.get("content") or {}
+    if not content:
+        return None
+    state = content.get("state")
+    if state in ("CLOSED", "MERGED"):
+        return None
+    status = size = priority = None
+    for fv in item["fieldValues"]["nodes"]:
+        if not fv:
+            continue
+        field = fv.get("field", {}) or {}
+        fname = field.get("name")
+        if fname == "Status":
+            status = fv.get("name")
+        elif fname == "Size":
+            size = fv.get("name")
+        elif fname == "Priority":
+            priority = fv.get("name")
+    if status == "Done":
+        return None
+    labels = [l["name"] for l in content.get("labels", {}).get("nodes", [])]
+    role = next((l for l in labels if l.startswith("role:")), None)
+    return {
+        "number": content.get("number"),
+        "title": content.get("title", ""),
+        "url": content.get("url", ""),
+        "kind": "PR" if content.get("__typename") == "PullRequest" else "Issue",
+        "is_draft": content.get("isDraft", False),
+        "state": state,
+        "status": status or "No Status",
+        "priority": priority,
+        "size": size,
+        "role": role,
+        "labels": labels,
+    }
+
+
+def sort_key(it: dict[str, Any]) -> tuple:
+    return (
+        STATUS_ORDER.get(it["status"], 99),
+        PRIORITY_ORDER.get(it["priority"], 99),
+        SIZE_ORDER.get(it["size"], 99),
+        it["number"] or 0,
+    )
+
+
+def matches_filter(it: dict[str, Any], args: argparse.Namespace) -> bool:
+    if args.role:
+        want = args.role if args.role.startswith("role:") else f"role:{args.role}"
+        if it["role"] != want:
+            return False
+    if args.status and it["status"] != args.status:
+        return False
+    if args.priority and it["priority"] != args.priority:
+        return False
+    if args.size and it["size"] != args.size:
+        return False
+    return True
+
+
+def format_table(items: list[dict[str, Any]]) -> str:
+    if not items:
+        return "(no items matched)\n"
+    lines = [
+        f"{'Status':<17} {'P':<3} {'Sz':<3} {'Role':<17} {'Kind':<5} {'#':<5} Title",
+        f"{'-' * 17} {'-' * 3} {'-' * 3} {'-' * 17} {'-' * 5} {'-' * 5} {'-' * 60}",
+    ]
+    for it in items:
+        role = (it["role"] or "(none)").removeprefix("role:")[:16]
+        kind = it["kind"] + ("/D" if it["is_draft"] else "")
+        title = (it["title"] or "")[:60]
+        lines.append(
+            f"{it['status']:<17} {it['priority'] or '?':<3} {it['size'] or '?':<3} "
+            f"{role:<17} {kind:<5} {it['number']:<5} {title}"
+        )
+    return "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--role", help='Filter by role label (e.g. "developer", "scientist", "pm")')
+    p.add_argument("--status", help='Filter by board Status (e.g. "Ready", "In progress", "Backlog")')
+    p.add_argument("--priority", help='Filter by Priority (P0/P1/P2/P3)')
+    p.add_argument("--size", help='Filter by Size (XS/S/M/L/XL)')
+    p.add_argument("--json", dest="as_json", action="store_true", help="Emit JSON array instead of a table")
+    args = p.parse_args()
+
+    raw = fetch_all_items()
+    normalized = [n for it in raw if (n := normalize(it)) is not None]
+    filtered = [it for it in normalized if matches_filter(it, args)]
+    filtered.sort(key=sort_key)
+
+    print(
+        f"Total board items: {len(raw)}; open: {len(normalized)}; "
+        f"after filters: {len(filtered)}",
+        file=sys.stderr,
+    )
+
+    if args.as_json:
+        json.dump(filtered, sys.stdout, indent=2)
+        sys.stdout.write("\n")
+    else:
+        sys.stdout.write(format_table(filtered))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
**Created by:** Developer

Closes [Issue #508](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/508).

## Summary

- Adds `scripts/board_open_items.py`: paginated ProjectV2 query that filters out CLOSED/MERGED + Status=Done items and exposes optional `--role`/`--status`/`--priority`/`--size` flags. Default table sort: Status → Priority → Size → number. `--json` for downstream `jq` piping. Pagination progress logged to stderr so silent single-page truncation is impossible.
- Companion **memory updates land in the personas repo** (separate filesystem, separate lifecycle):
  - `shared/MEMORY.md` — new Always-in-effect entry promoting the rule from the Reference tier where it had been missed.
  - `shared/feedback_board_queries.md` — new "When you DO need board columns" section cross-linking to the script.

## Trigger

Session 2026-05-27: initial `gh api graphql ... first: 100` board check returned 2 open Dev items; the user pushed back, paginated re-query returned 24. Root cause: `feedback_board_queries.md` already documented the foot-gun (both pagination AND the Done-first sort), but it was indexed under Reference (read when relevant) rather than Always-in-effect, so the rule wasn't loaded at session start.

Per `feedback_memory_escalation.md` ("you forgot X" → inline) + `feedback_mechanism_over_memory.md` (repeat-failure → mechanism), the fix is two-layered: promote the rule (memory rung 2) AND ship the script (mechanism rung 3).

## Test plan

- [x] `scripts/board_open_items.py --help` renders module docstring + flag descriptions.
- [x] No-arg invocation: 5 pages enumerated on stderr, 65 open items printed (out of 473 total).
- [x] `--role developer` filters to 30 Dev-tagged items.
- [x] `--status "In progress"` returns just Issue #508 (the one we set this session).
- [x] `--json | jq 'map(select(.size == "S")) | length'` returned 15 (sanity check).
- [x] Lab notebook entry written before merge (per Dev rule: after review, before merge).
- [x] Merged via `scripts/audit_and_merge.sh`.

## Out of scope

- Migrating existing ad-hoc board GraphQL queries elsewhere in the codebase. They migrate organically when next touched.
- Mutation flows (Status flips, field updates). Read-only by design.
- Unit tests under `workflow/tests/` — script is a thin wrapper over `gh api graphql`; smoke tests in the AC list cover correctness.