### PR TITLE
docs(lab-notebook): PM 2026-05-27 13:55 UTC — Issue #509 Zotero dedup rule memory edit

### DIFF
--- a/research/lab_notebook/pm.md
+++ b/research/lab_notebook/pm.md
@@ -8,6 +8,12 @@ Format and rules unchanged from the unified notebook — see `shared/feedback_la
 
 ## 2026-05-27
 
+### 13:55 UTC — Editor: PM
+
+#### [Issue #509](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/509) — Zotero dedup rule: add `DA3EWEJ9` (methodology corpus)
+
+Followup from 13:10 UTC entry "Followups carried forward" list — pulled forward to same session. Memory edit (personas-repo `shared/feedback_morning_routine.md` Phase 1 dedup line) now references both Zotero collections with scope: `Z38GTJNW` for domain/bio, `DA3EWEJ9` for methodology / multi-agent / agentic-workflow corpus. Cross-domain routing rule added: file under primary-contribution collection, not secondary methodology. Closes the dedup false-positive risk for methodology papers added going forward. Personas-repo git lifecycle is user-managed per the Always-in-effect rule; this PR carries only the project-repo lab notebook entry + Issue closure.
+
 ### 13:10 UTC — Editor: PM
 
 #### Morning routine multi-thread — [Issue #497](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/497) closed via side-effect-of-carve; [Issue #506](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/506) filed for durable fix; pm-i4 carve to new [pm-i6](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/milestone/33)


### PR DESCRIPTION
## Summary

- Memory edit: personas-repo `shared/feedback_morning_routine.md` Phase 1 dedup line now references both Zotero collections (`Z38GTJNW` domain/bio + `DA3EWEJ9` methodology corpus) with scope guidance + cross-domain routing rule.
- This PR carries the project-repo lab notebook entry; personas-repo git lifecycle is user-managed per the Always-in-effect rule.

Closes #509

## Test plan

- [x] Lab notebook entry added at top of [`research/lab_notebook/pm.md`](research/lab_notebook/pm.md) 2026-05-27 date block (new 13:55 UTC time section above the 13:10 entry, per shared format)
- [x] Both AC boxes on [Issue #509](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/509) ticked
- [x] Memory edit applied to `shared/feedback_morning_routine.md` Phase 1 dedup section (verified via Edit tool result; commit lands in personas-repo outside session)
- [x] CI green expected (no code changes, only doc / journal)

**Created by:** PM

🤖 Generated with [Claude Code](https://claude.com/claude-code)