### PR TITLE
chore(scripts): run_cloud_gpu.sh ZONE default — west1-b → west4-a (closes #521)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -204,7 +204,7 @@ Snakemake skips the index download if `indices/hisat2/` already exists (it check
 **When changing `hisat2_prebuilt_url`:** delete the index directory on the VM before running:
 
 ```bash
-gcloud compute ssh neoepitope-pipeline --zone=europe-west1-b --tunnel-through-iap \
+gcloud compute ssh neoepitope-pipeline --zone=europe-west4-a --tunnel-through-iap \
   --command="rm -rf ~/splice-neoepitope-pipeline/indices/hisat2/"
 ```
 

--- a/docs/google_cloud_guide.md
+++ b/docs/google_cloud_guide.md
@@ -116,7 +116,7 @@ would on any local machine.
 
 > **Zone availability:** `us-central1-a` is used as the example zone below, but
 > capacity for specific machine types varies. If you get a quota or availability
-> error, try another zone (e.g. `us-central1-c`, `europe-west1-b`, `us-east1-b`).
+> error, try another zone (e.g. `us-central1-c`, `europe-west4-b`, `us-east1-b`).
 > Run `gcloud compute zones list` to see all available zones.
 
 ```bash
@@ -458,7 +458,7 @@ bash scripts/run_cloud_gpu.sh --mode prod
 bash scripts/run_cloud_gpu.sh --mode test --detach
 
 # Specify branch and zone
-bash scripts/run_cloud_gpu.sh --mode prod --branch main --zone europe-west1-b
+bash scripts/run_cloud_gpu.sh --mode prod --branch main --zone europe-west4-b
 
 # Keep VMs running after exit (useful for debugging — stop manually when done)
 bash scripts/run_cloud_gpu.sh --mode test --keep-vm

--- a/research/glossary.md
+++ b/research/glossary.md
@@ -70,7 +70,7 @@ Project-relevant abbreviations and acronyms. The pipeline mixes biology, ML, bio
 
 **GBM** — Glioblastoma (Multiforme). WHO grade 4 astrocytoma; most aggressive primary adult brain tumor (~15-mo median OS post standard-of-care surgery + radiation + temozolomide). MGMT-unmethylated subset has the worst prognosis (resistant to temozolomide); subject of the GNOS-PV01 personalized DNA vaccine Phase 1 ([Garfinkle et al. 2026](https://www.nature.com/articles/s43018-026-01163-w)). *Domain: bio.*
 
-**GCP** — Google Cloud Platform. The cloud provider hosting this pipeline's VMs and storage bucket (zone `europe-west1-b`). *Domain: cloud.*
+**GCP** — Google Cloud Platform. The cloud provider hosting this pipeline's VMs and storage bucket (zone `europe-west4-a`). *Domain: cloud.*
 
 **GCS** — Google Cloud Storage. GCP's object store; pipeline results, logs, and reference data live in `gs://splice-neoepitope-project`. *Domain: cloud.*
 

--- a/scripts/run_cloud_gpu.sh
+++ b/scripts/run_cloud_gpu.sh
@@ -38,7 +38,7 @@ set -euo pipefail
 # Configuration
 # ---------------------------------------------------------------------------
 PIPELINE_VM="neoepitope-pipeline"
-ZONE="europe-west1-b"
+ZONE="europe-west4-a"
 MACHINE_TYPE="n1-highmem-8"   # n1 required for P100; 52 GB RAM for OptiType (~36 GB peak)
 ACCELERATOR="type=nvidia-tesla-p100,count=1"  # T4 quota is 0/0 in europe-west1; P100 standard quota (NVIDIA_P100_GPUS >= 1) required
 DISK_SIZE="200GB"              # pipeline data + Docker image (~25 GB) + reference data


### PR DESCRIPTION
**Created by:** Developer

## Summary

Sweep of stale `europe-west1-b` references left over from the May 2026 production-VM migration to `europe-west4-a` ([Issue #516](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/516) (refs) patched the "Infrastructure" section of CLAUDE.md but missed these). Four files, four single-line changes:

- `scripts/run_cloud_gpu.sh:41` — `ZONE` default `europe-west1-b` → `europe-west4-a`. Bare `bash scripts/run_cloud_gpu.sh --mode test` now routes to the correct zone (previously failed with `GPUS_ALL_REGIONS quota exceeded` trying to provision a new VM in west1-b).
- `docs/google_cloud_guide.md:119` — fallback-zone suggestion list (we migrated *away* from west1-b due to capacity exhaustion — suggesting it as an availability fallback is now bad advice).
- `docs/google_cloud_guide.md:461` — example `--zone` override that demonstrated the *old* zone (contradictory once the script default lands as `europe-west4-a`).
- `CLAUDE.md:207` — copy-paste-able SSH command in the HISAT2 cache invalidation section.
- `research/glossary.md:73` — GCP glossary definition stated the production zone as the pre-migration value.

## Closes

- [Issue #521](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/521) (closes) — surfaced 2026-05-27 during [PR #519](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/519) (refs) cloud verification.

## What's left untouched

- `scripts/run_cloud_gpu.sh:43` — `# T4 quota is 0/0 in europe-west1` historical comment justifying the original P100 choice. Not a runtime default; updating would require fresh quota data for west4.
- CLAUDE.md "Historical P100 unavailability — `europe-west1-b` (pre-migration)" section — historical narrative, intentional.
- All `research/lab_notebook*` entries mentioning west1-b — past-tense recordings, leave as-is.
- The NVIDIA-580 archive 404 driver-install failure — [Issue #522](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/522) (refs), the actual cloud-run blocker for [PR #519](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/519) (refs).

## Test plan

- [x] `bash -n scripts/run_cloud_gpu.sh` — syntax clean.
- [x] `git grep -n 'europe-west1' -- .` (full-repo, ignoring nothing) reviewed — all remaining hits are explicit historical context (Historical P100 unavailability section in CLAUDE.md, the T4-quota comment at run_cloud_gpu.sh:43, past-tense lab notebook entries). No operational defaults remain pointing at west1-b.
- [x] `head -42 scripts/run_cloud_gpu.sh | grep '^ZONE='` confirms the new default; only one ZONE reassignment exists (line 66 CLI override).
- [ ] CI: `pipeline-pytest` green.
- [ ] CI: `pipeline-snakemake-dry-run` green.
- [ ] Bot review (`@-claude review` requested, processed, feedback addressed).
- [ ] Lab notebook entry (post-review, pre-merge).