### PR TITLE
fix(closure-audit): any-role-satisfies for multi-role Issues (closes #524)

### DIFF
--- a/research/lab_notebook/developer.md
+++ b/research/lab_notebook/developer.md
@@ -8,6 +8,26 @@ Format and rules unchanged from the unified notebook — see `shared/feedback_la
 
 ## 2026-05-28
 
+### 20:38 UTC — Editor: Developer
+
+**Headline:** [PR #545](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/545) (closes [Issue #524](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/524) — closure-audit any-role-satisfies check for multi-role Issues) shipped TDD-first with 7 new tests, then a bot-caught dedup regression got fixed in a follow-up commit + 3 more tests. Origin: [PR #518](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/518)'s false-positive (Scientist's notebook satisfied the reference but the bot only audited Developer's because `resolve_roles` returned `role_labels[0]` after `sorted()`).
+
+**Work shipped:**
+
+- `resolve_roles` returns `list[set[str]]` per-Issue (was: flat dedup `list[str]` that dropped all-but-first-alphabetical role per Issue). Positionally aligned with the input list so callers can zip with the original Issue list.
+- New `check_lab_notebooks_for_issue(roles, date, n, notebooks)`: any-role-satisfies semantic — returns `None` if at least one role's notebook references `#N`, otherwise a single combined `(role_label, description)` tuple (`"developer or scientist"` joined for the multi-role case).
+- `audit_pr` / `audit_issue` callers refactored through a small `collect_notebook_gaps` helper that dedupes by `frozenset(roles)` — added after [bot review](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/545#issuecomment-4567982400) caught a duplicate-gap regression (a PR closing 2 Issues sharing a role label would print the same gap line twice).
+- `_load_notebook` gained `encoding="utf-8"` (defensive, applies to all CI runners regardless of process locale).
+- Test count: 18 → 21 (7 new for the fix, 3 for the dedup helper); 11 pre-existing regression tests preserved.
+
+**Process notes:**
+
+- **TDD discipline paid off twice.** Red→green on the initial 7 tests confirmed the helper shape was right before any caller touched it. Then when the bot caught the dedup regression, the same testable-helper pattern made adding `test_collect_notebook_gaps_dedupes_identical_role_sets` trivial — no subprocess mocks needed for `audit_pr`/`audit_issue` orchestration because the loop body is now a pure function.
+- **Bot caught a regression I didn't.** The old flat-dedup `resolve_roles` had silently dropped a second function — preventing duplicate gap lines when multiple closing Issues shared a role. Refactoring to per-Issue restored the original bug **but** broke this latent behavior. Easy to miss in unit tests; bot's "what if N closing Issues all have role:developer?" reasoning was the right adversarial-thinking lens.
+- **Receiving-code-review on the `[roles] = ...` style note:** bot suggested `roles = resolve_roles([labels])[0]` instead of unpacking. I left the unpack as-is initially (it asserts length), but the dedup refactor made the question moot — `audit_issue` now goes through the same `collect_notebook_gaps` path as `audit_pr`, no more single-element unpacking.
+
+---
+
 ### 19:30 UTC — Editor: Developer
 
 **Headline:** [PR #519](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/519) (closes [Issue #514](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/514) — `torch<2.5` pin lift via cu126 pip channel) finished out: cloud verification on `neoepitope-pipeline` P100 yielded a **bit-identical** MHCflurry chr22 output vs the pre-bump baseline (81 rows, all structural columns identical, numeric drift at FP-noise level), `@-claude review` returned LGTM in 1m 58s with no blocking findings. Merge-ready; unblocked by [PR #526](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/526) earlier today (see 18:00 UTC entry).

--- a/tools/ci/closure_audit.py
+++ b/tools/ci/closure_audit.py
@@ -72,17 +72,46 @@ def is_exempt(changed_files: list[str]) -> bool:
     )
 
 
-def resolve_roles(labels_per_issue: list[list[str]]) -> list[str]:
-    roles: set[str] = set()
-    for labels in labels_per_issue:
-        role_labels = sorted(
-            lbl[len("role:"):]
-            for lbl in labels
-            if lbl.startswith("role:")
-        )
-        if role_labels:
-            roles.add(role_labels[0])
-    return sorted(roles)
+def resolve_roles(labels_per_issue: list[list[str]]) -> list[set[str]]:
+    """Per-Issue role sets, positionally aligned with the input list.
+
+    Multi-role Issues keep ALL their roles (see #524). Issues with no `role:`
+    label produce an empty set — callers should skip those entries.
+    """
+    return [
+        {lbl[len("role:"):] for lbl in labels if lbl.startswith("role:")}
+        for labels in labels_per_issue
+    ]
+
+
+def check_lab_notebooks_for_issue(
+    roles: set[str],
+    date: str,
+    number: int,
+    notebooks: dict[str, str | None],
+) -> tuple[str, str] | None:
+    """Any-role-satisfies notebook check for one Issue's role set.
+
+    Returns None if at least one role's notebook references `#number` in the
+    `## date` block. Otherwise returns a single (role_label, description) tuple
+    summarizing the gap across all roles.
+
+    `notebooks` maps role → notebook text (None for missing file).
+    """
+    per_role_gaps: list[tuple[str, str]] = []
+    for role in sorted(roles):
+        text = notebooks.get(role)
+        if text is None:
+            per_role_gaps.append((role, "lab notebook file missing"))
+            continue
+        if (gap := check_lab_notebook(text, date, number)) is None:
+            return None
+        per_role_gaps.append((role, gap))
+    if len(per_role_gaps) == 1:
+        return per_role_gaps[0]
+    roles_str = " or ".join(r for r, _ in per_role_gaps)
+    descs = "; ".join(f"{r}: {d}" for r, d in per_role_gaps)
+    return (roles_str, descs)
 
 
 def format_comment(
@@ -120,6 +149,11 @@ def format_comment(
 
 
 # --- gh I/O ---
+
+
+def _load_notebook(role: str) -> str | None:
+    path = REPO_ROOT / "research" / "lab_notebook" / f"{role}.md"
+    return path.read_text() if path.exists() else None
 
 
 def _gh(*args: str) -> str:
@@ -175,13 +209,12 @@ def audit_pr(n: int) -> None:
         labels_per_issue = [
             [lbl["name"] for lbl in i.get("labels", [])] for i in issues
         ]
-        for role in resolve_roles(labels_per_issue):
-            path = REPO_ROOT / "research" / "lab_notebook" / f"{role}.md"
-            if not path.exists():
-                nb_gaps.append((role, "lab notebook file missing"))
+        for roles in resolve_roles(labels_per_issue):
+            if not roles:
                 continue
-            if d := check_lab_notebook(path.read_text(), date, n):
-                nb_gaps.append((role, d))
+            notebooks = {r: _load_notebook(r) for r in roles}
+            if gap := check_lab_notebooks_for_issue(roles, date, n, notebooks):
+                nb_gaps.append(gap)
 
     if ac_gaps or pr_gaps or nb_gaps:
         post_comment("pr", n, format_comment(f"PR #{n}", ac_gaps, pr_gaps, nb_gaps))
@@ -203,13 +236,11 @@ def audit_issue(n: int) -> None:
         pr_gaps.append((n, d))
 
     labels = [lbl["name"] for lbl in issue.get("labels", [])]
-    for role in resolve_roles([labels]):
-        path = REPO_ROOT / "research" / "lab_notebook" / f"{role}.md"
-        if not path.exists():
-            nb_gaps.append((role, "lab notebook file missing"))
-            continue
-        if d := check_lab_notebook(path.read_text(), date, n):
-            nb_gaps.append((role, d))
+    [roles] = resolve_roles([labels])
+    if roles:
+        notebooks = {r: _load_notebook(r) for r in roles}
+        if gap := check_lab_notebooks_for_issue(roles, date, n, notebooks):
+            nb_gaps.append(gap)
 
     if ac_gaps or pr_gaps or nb_gaps:
         post_comment("issue", n, format_comment(f"Issue #{n}", ac_gaps, pr_gaps, nb_gaps))

--- a/tools/ci/closure_audit.py
+++ b/tools/ci/closure_audit.py
@@ -114,6 +114,32 @@ def check_lab_notebooks_for_issue(
     return (roles_str, descs)
 
 
+def collect_notebook_gaps(
+    role_sets_per_issue: list[set[str]],
+    date: str,
+    number: int,
+    notebooks: dict[str, str | None],
+) -> list[tuple[str, str]]:
+    """Aggregate notebook gaps across closing Issues, deduped by role set.
+
+    Two Issues with the same role set produce identical gap entries (the
+    underlying check is deterministic on role-set/date/number/notebooks), so
+    only the first is emitted.
+    """
+    gaps: list[tuple[str, str]] = []
+    seen: set[frozenset[str]] = set()
+    for roles in role_sets_per_issue:
+        if not roles:
+            continue
+        key = frozenset(roles)
+        if key in seen:
+            continue
+        seen.add(key)
+        if gap := check_lab_notebooks_for_issue(roles, date, number, notebooks):
+            gaps.append(gap)
+    return gaps
+
+
 def format_comment(
     event_label: str,
     ac_gaps: list[tuple[int, str]],
@@ -153,7 +179,7 @@ def format_comment(
 
 def _load_notebook(role: str) -> str | None:
     path = REPO_ROOT / "research" / "lab_notebook" / f"{role}.md"
-    return path.read_text() if path.exists() else None
+    return path.read_text(encoding="utf-8") if path.exists() else None
 
 
 def _gh(*args: str) -> str:
@@ -209,12 +235,10 @@ def audit_pr(n: int) -> None:
         labels_per_issue = [
             [lbl["name"] for lbl in i.get("labels", [])] for i in issues
         ]
-        for roles in resolve_roles(labels_per_issue):
-            if not roles:
-                continue
-            notebooks = {r: _load_notebook(r) for r in roles}
-            if gap := check_lab_notebooks_for_issue(roles, date, n, notebooks):
-                nb_gaps.append(gap)
+        role_sets = resolve_roles(labels_per_issue)
+        all_roles = {r for rs in role_sets for r in rs}
+        notebooks = {r: _load_notebook(r) for r in all_roles}
+        nb_gaps.extend(collect_notebook_gaps(role_sets, date, n, notebooks))
 
     if ac_gaps or pr_gaps or nb_gaps:
         post_comment("pr", n, format_comment(f"PR #{n}", ac_gaps, pr_gaps, nb_gaps))
@@ -236,11 +260,10 @@ def audit_issue(n: int) -> None:
         pr_gaps.append((n, d))
 
     labels = [lbl["name"] for lbl in issue.get("labels", [])]
-    [roles] = resolve_roles([labels])
-    if roles:
-        notebooks = {r: _load_notebook(r) for r in roles}
-        if gap := check_lab_notebooks_for_issue(roles, date, n, notebooks):
-            nb_gaps.append(gap)
+    role_sets = resolve_roles([labels])
+    all_roles = {r for rs in role_sets for r in rs}
+    notebooks = {r: _load_notebook(r) for r in all_roles}
+    nb_gaps.extend(collect_notebook_gaps(role_sets, date, n, notebooks))
 
     if ac_gaps or pr_gaps or nb_gaps:
         post_comment("issue", n, format_comment(f"Issue #{n}", ac_gaps, pr_gaps, nb_gaps))

--- a/tools/ci/test_closure_audit.py
+++ b/tools/ci/test_closure_audit.py
@@ -153,6 +153,35 @@ def test_lab_notebooks_multi_role_one_missing_other_satisfies():
     ) is None
 
 
+def test_collect_notebook_gaps_dedupes_identical_role_sets():
+    """PR closes 2 Issues sharing the same role → one gap entry, not two."""
+    dev_text = "## 2026-05-27\n\n### 14:00 UTC — Editor: Developer\nOther work.\n"
+    gaps = ca.collect_notebook_gaps(
+        [{"developer"}, {"developer"}], "2026-05-27", 518, {"developer": dev_text}
+    )
+    assert len(gaps) == 1
+    assert gaps[0][0] == "developer"
+
+
+def test_collect_notebook_gaps_keeps_distinct_role_sets():
+    """Different role sets across Issues → distinct gap entries."""
+    text = "## 2026-05-27\n\n### 14:00 UTC — Editor: X\nOther.\n"
+    gaps = ca.collect_notebook_gaps(
+        [{"developer"}, {"scientist"}],
+        "2026-05-27", 518,
+        {"developer": text, "scientist": text},
+    )
+    roles_in_gaps = {g[0] for g in gaps}
+    assert roles_in_gaps == {"developer", "scientist"}
+
+
+def test_collect_notebook_gaps_skips_empty_role_sets():
+    """Issues with no role: label contribute no gap."""
+    assert ca.collect_notebook_gaps(
+        [set(), set()], "2026-05-27", 518, {}
+    ) == []
+
+
 def test_format_comment_clean_state():
     out = ca.format_comment("PR #1", [], [], [])
     assert "all clear" in out.lower()

--- a/tools/ci/test_closure_audit.py
+++ b/tools/ci/test_closure_audit.py
@@ -73,14 +73,84 @@ def test_exempt_paths_all_or_nothing():
     assert ca.is_exempt([]) is False
 
 
-def test_resolve_roles_multi_dedupe_alphabetical():
+def test_resolve_roles_returns_per_issue_sets():
+    """Per-Issue role sets — NOT flattened/deduped across Issues (#524 fix).
+
+    Multi-role Issues must keep ALL their roles. Position is preserved so callers
+    can zip with the original issue list.
+    """
     labels = [
         ["role:scientist", "priority:p2"],
+        ["role:developer", "role:scientist"],  # multi-role
         ["role:developer"],
-        ["role:developer"],
-        ["priority:p2"],
+        ["priority:p2"],  # no role
     ]
-    assert ca.resolve_roles(labels) == ["developer", "scientist"]
+    assert ca.resolve_roles(labels) == [
+        {"scientist"},
+        {"developer", "scientist"},
+        {"developer"},
+        set(),
+    ]
+
+
+def test_lab_notebooks_multi_role_any_satisfies():
+    """Multi-role Issue, at least one notebook references → no gap (PR #518 repro)."""
+    dev_text = "## 2026-05-27\n\n### 14:00 UTC — Editor: Developer\nUnrelated work.\n"
+    sci_text = "## 2026-05-27\n\n### 17:39 UTC — Editor: Scientist\nBoltz-2 eval. Refs PR #518.\n"
+    notebooks = {"developer": dev_text, "scientist": sci_text}
+    assert ca.check_lab_notebooks_for_issue(
+        {"developer", "scientist"}, "2026-05-27", 518, notebooks
+    ) is None
+
+
+def test_lab_notebooks_multi_role_none_satisfies():
+    """Multi-role Issue, neither notebook references → single combined gap entry."""
+    dev_text = "## 2026-05-27\n\n### 14:00 UTC — Editor: Developer\nOther work.\n"
+    sci_text = "## 2026-05-27\n\n### 17:39 UTC — Editor: Scientist\nOther work.\n"
+    notebooks = {"developer": dev_text, "scientist": sci_text}
+    gap = ca.check_lab_notebooks_for_issue(
+        {"developer", "scientist"}, "2026-05-27", 518, notebooks
+    )
+    assert gap is not None
+    role_label, desc = gap
+    assert "developer" in role_label and "scientist" in role_label
+    assert "#518" in desc
+
+
+def test_lab_notebooks_single_role_no_ref_is_gap():
+    """Single-role regression: legacy shape preserved."""
+    text = "## 2026-05-27\n\n### 14:00 UTC — Editor: Developer\nOther.\n"
+    gap = ca.check_lab_notebooks_for_issue(
+        {"developer"}, "2026-05-27", 518, {"developer": text}
+    )
+    assert gap is not None
+    assert gap[0] == "developer"
+
+
+def test_lab_notebooks_single_role_with_ref_no_gap():
+    """Single-role regression: ref present → no gap."""
+    text = "## 2026-05-27\n\n### 14:00 UTC — Editor: Developer\nRefs PR #518.\n"
+    assert ca.check_lab_notebooks_for_issue(
+        {"developer"}, "2026-05-27", 518, {"developer": text}
+    ) is None
+
+
+def test_lab_notebooks_missing_file_is_gap():
+    """Missing notebook file (None) reports a per-role gap."""
+    gap = ca.check_lab_notebooks_for_issue(
+        {"developer"}, "2026-05-27", 518, {"developer": None}
+    )
+    assert gap is not None
+    assert "missing" in gap[1].lower()
+
+
+def test_lab_notebooks_multi_role_one_missing_other_satisfies():
+    """Missing file for one role, the other satisfies → no gap."""
+    sci_text = "## 2026-05-27\n\n### 17:39 UTC — Editor: Scientist\nRefs PR #518.\n"
+    notebooks = {"developer": None, "scientist": sci_text}
+    assert ca.check_lab_notebooks_for_issue(
+        {"developer", "scientist"}, "2026-05-27", 518, notebooks
+    ) is None
 
 
 def test_format_comment_clean_state():


### PR DESCRIPTION
**Created by:** Developer

Closes [Issue #524](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/524) (closes).

## Summary

- `resolve_roles` was picking only the alphabetically-first role per Issue and discarding the rest. Multi-role closures (e.g. [PR #518](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/518) closing [Issue #188](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/188) with both `role:developer` + `role:scientist`) only ever got the developer notebook audited — even when the scientist wrote the actual entry.
- `resolve_roles` now returns per-Issue role sets (`list[set[str]]`), positionally aligned with the input list.
- New helper `check_lab_notebooks_for_issue` implements the **any-role-satisfies** semantic: the gap is reported only when NO role's notebook references the PR/Issue number in the close-date block.
- Single-role behavior is unchanged — the regression tests cover both the no-ref-gap and with-ref-no-gap shapes.

## Test plan

- [x] `pytest tools/ci/test_closure_audit.py` — 18 passed (7 new, 11 regression).
- [x] Multi-role any-satisfies case ([Issue #188](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/188) repro): test exercises `{developer, scientist}` with only scientist.md referencing → no gap.
- [x] Multi-role none-satisfies case: combined gap entry naming both roles + `#N`.
- [x] Single-role regression preserved (with-ref + no-ref shapes).
- [x] CI `ci-tools-pytest` green on push.

## Out of scope

- Inferring role from PR author (deeper redesign — labels work if we use ALL of them).
- Inline `<!-- closure-defer:... -->` suppression markers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)