### PR TITLE
feat(ci): closure-audit honors routine-ship lab-notebook skip marker (closes #555)

### DIFF
--- a/research/lab_notebook/developer.md
+++ b/research/lab_notebook/developer.md
@@ -8,6 +8,26 @@ Format and rules unchanged from the unified notebook — see `shared/feedback_la
 
 ## 2026-05-29
 
+### 14:02 UTC — Editor: Developer
+
+**Headline:** [PR #556](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/556) (closes [Issue #555](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/555) — closure-audit bot honors a routine-ship lab-notebook skip marker). Closes the **enforcement half** of [Issue #483](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/483): that Issue made routine single-PR-closes-single-Issue notebook entries optional *and* dropped the `audit_and_merge.sh` notebook gate — but never taught the post-merge closure-audit bot the exemption. The bot's only skip was **file-based** (`is_exempt`: all-glossary/notebook diffs), so any routine PR touching code still drew a "Lab notebook entry missing" gap. Rule and enforcement contradicted each other.
+
+**Decision (AC 1):** deterministic **opt-out marker** `<!-- skip-lab-notebook: routine -->` in the PR body, over the two alternatives — heuristic trigger-detection ([Issue #483](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/483) itself called this "too brittle") and decline-and-document. The marker mirrors the existing `❎ … deferred` AC-deferral convention: author-controlled, greppable, no false negatives.
+
+**Work shipped:**
+
+- `skip_lab_notebook(pr_body)` — case-insensitive, whitespace-tolerant regex `<!--\s*skip-lab-notebook\b[^>]*-->`. `fetch_pr` now requests `body`; `audit_pr` short-circuits **only** the notebook-check block (`and not skip_lab_notebook(...)`). AC-checkbox + Priority-rationale checks unaffected.
+- `audit_issue` deliberately **untouched** — the marker is PR-body-scoped, and decomposition Issues closed without a PR still require an entry, so no skip should reach that path.
+- TDD: 6 tests RED→GREEN (skip-honored: value/bare/whitespace+case; skip-absent: no-marker/empty/unrelated-HTML-comment). 32 `tools/ci` tests green locally + in CI.
+
+**Process notes:**
+
+- **Cross-repo AC (item 3).** The `shared/feedback_lab_notebook.md` cross-reference lives in the separate `claude-personas` repo, whose working tree is mid-flight on the MEMORY-slim epic (#538–#542). Made the edit but left it **uncommitted** per the maintainer's call — to be folded into that epic rather than committed onto a parallel session's dirty branch.
+- **Review.** Bot review found no bugs; applied the one doc nit (marker value must be `>`-free, since `[^>]*` stops at the first `>` — c75c68b), declined the suggested `audit_pr` integration test (YAGNI for a 2-line short-circuit; the suite is intentionally lean on live-`gh` paths).
+- **Not self-exempting.** This is a meta-decision/workflow-rule session → non-routine → entry required. Did *not* place the new marker on this very PR.
+
+---
+
 ### 10:55 UTC — Editor: Developer
 
 **Headline:** [PR #554](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/554) (closes [Issue #495](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/495) — closure_audit accepts a PR # **or** any closing-Issue # in the lab-notebook check) shipped TDD-first: 5 new tests, 96 total. Read-side fix for the [PR #494](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/494) false positive — that entry named only its closing Issue (#484), not the PR, and tripped the bot's PR-number-only check.

--- a/tools/ci/closure_audit.py
+++ b/tools/ci/closure_audit.py
@@ -42,7 +42,8 @@ _EXEMPT_PREFIX = ("research/lab_notebook/",)
 # notebook check by placing this marker in the PR body. Honors the routine
 # single-PR-closes-single-Issue skip that #483 declared optional — the bot must
 # not coerce an entry the lab-notebook rule says is unnecessary. The value after
-# the colon (e.g. `routine`) is free-text rationale; presence is what matters.
+# the colon (e.g. `routine`) is free-text rationale with no `>` (the regex stops
+# at the first `>`); presence of the marker is what matters, not the value.
 _SKIP_LAB_NOTEBOOK = re.compile(r"<!--\s*skip-lab-notebook\b[^>]*-->", re.IGNORECASE)
 
 

--- a/tools/ci/closure_audit.py
+++ b/tools/ci/closure_audit.py
@@ -6,6 +6,14 @@ Trying Sakana Fugu "critic-as-default" on PR-merge / issue-close. Posts a
 single marker-tagged gap comment, or stays silent if all 3 checks pass.
 No edit-in-place — comment is a post-only snapshot of close-time state.
 
+The three checks: AC checkboxes, Priority-rationale line, lab-notebook entry.
+The lab-notebook check is skipped when the PR is file-exempt (only glossary /
+lab-notebook files touched) OR the PR body carries the routine-ship opt-out
+marker `<!-- skip-lab-notebook: routine -->` (#555). The marker honors the
+routine single-PR-closes-single-Issue skip that #483 declared optional, so the
+bot stops coercing entries the lab-notebook rule says are unnecessary. The AC
+and Priority-rationale checks are unaffected by the marker.
+
 Usage (called by .github/workflows/closure-audit.yml):
     python closure_audit.py --event-type {pr|issue} --number <N>
 """
@@ -30,6 +38,12 @@ _UNTICKED = re.compile(r"^\s*-\s*\[\s\]\s", re.MULTILINE)
 _TICKED = re.compile(r"^\s*-\s*\[[xX]\]\s", re.MULTILINE)
 _EXEMPT_FILES = {"research/glossary.md"}
 _EXEMPT_PREFIX = ("research/lab_notebook/",)
+# Routine-ship lab-notebook opt-out (see #555): a PR author may skip the
+# notebook check by placing this marker in the PR body. Honors the routine
+# single-PR-closes-single-Issue skip that #483 declared optional — the bot must
+# not coerce an entry the lab-notebook rule says is unnecessary. The value after
+# the colon (e.g. `routine`) is free-text rationale; presence is what matters.
+_SKIP_LAB_NOTEBOOK = re.compile(r"<!--\s*skip-lab-notebook\b[^>]*-->", re.IGNORECASE)
 
 
 # --- pure checks ---
@@ -81,6 +95,16 @@ def is_exempt(changed_files: list[str]) -> bool:
         p in _EXEMPT_FILES or p.startswith(_EXEMPT_PREFIX)
         for p in changed_files
     )
+
+
+def skip_lab_notebook(pr_body: str | None) -> bool:
+    """True if the PR body carries the routine-ship lab-notebook opt-out marker.
+
+    Marker form: `<!-- skip-lab-notebook: routine -->` (see #555). Matched
+    case-insensitively and tolerant of comment whitespace. Skips only the
+    lab-notebook check — AC-checkbox and priority-rationale checks still run.
+    """
+    return bool(_SKIP_LAB_NOTEBOOK.search(pr_body or ""))
 
 
 def resolve_roles(labels_per_issue: list[list[str]]) -> list[set[str]]:
@@ -207,7 +231,7 @@ def _gh(*args: str) -> str:
 def fetch_pr(n: int) -> dict:
     return json.loads(_gh(
         "pr", "view", str(n),
-        "--json", "mergedAt,closingIssuesReferences,files,number",
+        "--json", "mergedAt,closingIssuesReferences,files,number,body",
     ))
 
 
@@ -247,7 +271,7 @@ def audit_pr(n: int) -> None:
         if d := check_priority_rationale(body):
             pr_gaps.append((issue["number"], d))
 
-    if not is_exempt(changed):
+    if not is_exempt(changed) and not skip_lab_notebook(pr.get("body")):
         labels_per_issue = [
             [lbl["name"] for lbl in i.get("labels", [])] for i in issues
         ]

--- a/tools/ci/test_closure_audit.py
+++ b/tools/ci/test_closure_audit.py
@@ -71,6 +71,43 @@ def test_collect_notebook_gaps_threads_also_accept_for_pr_path():
     assert gaps == []
 
 
+# --- #555: routine-ship opt-out marker skips the lab-notebook check ---
+
+
+def test_skip_lab_notebook_marker_present_with_value():
+    """Canonical marker with a rationale value → skip honored."""
+    body = "Routine ship.\n\n<!-- skip-lab-notebook: routine -->\n"
+    assert ca.skip_lab_notebook(body) is True
+
+
+def test_skip_lab_notebook_marker_present_bare():
+    """Marker with no `: value` suffix → still honored (presence is what matters)."""
+    body = "Routine ship.\n\n<!-- skip-lab-notebook -->\n"
+    assert ca.skip_lab_notebook(body) is True
+
+
+def test_skip_lab_notebook_marker_tolerates_whitespace_and_case():
+    """Comment spacing/case shouldn't matter — authors hand-type this."""
+    assert ca.skip_lab_notebook("<!--   SKIP-LAB-NOTEBOOK : routine  -->") is True
+
+
+def test_skip_lab_notebook_marker_absent():
+    """No marker → not skipped (check runs normally)."""
+    body = "Real feature work that needs a journal entry.\n"
+    assert ca.skip_lab_notebook(body) is False
+
+
+def test_skip_lab_notebook_empty_body():
+    """Empty/None body → not skipped."""
+    assert ca.skip_lab_notebook("") is False
+    assert ca.skip_lab_notebook(None) is False
+
+
+def test_skip_lab_notebook_does_not_match_unrelated_html_comment():
+    """A different HTML comment must not trip the skip."""
+    assert ca.skip_lab_notebook("<!-- closure-audit -->\nsome text") is False
+
+
 def test_ac_deferral_comment_unblocks_unticked():
     body = "- [x] one\n- [ ] two\n"
     assert ca.check_ac(body, comments=[]) is not None


### PR DESCRIPTION
**Created by:** Developer

Closes #555.

## Summary

The closure-audit bot's only lab-notebook exemption was **file-based** ([closure_audit.py `is_exempt`](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/blob/main/tools/ci/closure_audit.py)) — a diff touching *solely* glossary / lab-notebook files. A routine single-PR-closes-single-Issue ship that touches **code** is not file-exempt, so the notebook check fired and the bot posted a "Lab notebook entry missing" gap — on exactly the routine skips that [Issue #483](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/483) (closed) declared optional. **Rule and enforcement contradicted each other.**

This teaches the bot the deterministic opt-out preferred by [Issue #555](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/555): a PR-body marker `<!-- skip-lab-notebook: routine -->` skips **only** the lab-notebook check. AC-checkbox and Priority-rationale checks are unaffected. Mirrors the existing AC-deferral comment convention.

**Decision (AC item 1):** implement the opt-out marker (option (a) — deterministic), not decline. Heuristic detection was rejected by [Issue #483](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/483) (closed) as too brittle; the explicit marker is author-controlled and deterministic.

## Changes

- `skip_lab_notebook(pr_body)` — case-insensitive, whitespace-tolerant marker grep
- `fetch_pr` now requests the PR `body`; `audit_pr` short-circuits the notebook check when the marker is present
- module docstring documents the marker
- cross-reference added to `shared/feedback_lab_notebook.md` (separate `claude-personas` repo — shipped alongside)

**Scope note:** `audit_issue` is intentionally left unchanged — the marker is PR-body-scoped, and decomposition Issues closed without a PR still require an entry.

## Test plan

- [x] New unit tests cover the **skip-honored** path (marker with value, bare marker, whitespace/case tolerance)
- [x] New unit tests cover the **skip-absent** path (no marker, empty/None body, unrelated HTML comment)
- [x] Full `tools/ci/` suite green (`pytest tools/ci/` → 32 passed)
- [x] Module docstring documents the marker (AC item 1)
- [x] `shared/feedback_lab_notebook.md` cross-reference shipped in `claude-personas` repo (AC item 3) — _(deferred: cross-reference written in the `claude-personas` working tree; commit folded into the in-flight MEMORY-slim epic [Issue #538](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/538) per maintainer)_
- [x] Lab notebook entry for this meta-decision session (AC item 4 — added after review, before merge per the tightened #483 rule)

