### PR TITLE
feat(hooks): PostToolUse hook auto-boards a created PR + sets Status (closes #550)

### DIFF
--- a/.claude/hooks/post_gh_pr_create.py
+++ b/.claude/hooks/post_gh_pr_create.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""PostToolUse hook: auto-add a freshly-created PR to project board #9 and set
+its Status to match the PR's review-readiness.
+
+Automates the deterministic steps of the PR-open 4-step checklist
+(`feedback_pr_open_checklist.md`); steps 3 (`**Created by:**` attribution) and 4
+(Issue mirror on review request) stay manual — they need author judgment a hook
+can't infer. Sibling of `scripts/audit_and_merge.sh` (closure-ritual gate on
+`gh pr merge`).
+
+Status is **draft-aware**: a non-draft PR-open is the review request, so Status
+→ "Ready for review"; a draft PR is opened mid-In-progress (CI / shareable URL,
+not up for review yet), so Status → "In progress". Either way the PR lands ON
+the board — the original failure (PRs #6 + #543 stuck at Backlog 2026-05-28
+because the rule lived in memory, not a mechanism) was about board-absence.
+Draft-ness is read from the PR's authoritative `isDraft` field, not the command
+string, so `--draft`, `-d`, and repo defaults are all covered.
+
+Reads PostToolUse hook JSON on stdin, parses the PR URL from the tool output,
+then runs the `gh` mutations. Fails OPEN on any parse miss, untracked repo, or
+`gh` error — a board-automation hook must never break the user's flow. On a
+successful set it emits an `additionalContext` confirmation and logs one line to
+`.claude/hook_fires.jsonl` (gitignored) per the fire-log infra (Issue #453).
+
+See Issue #550 for the originating rule.
+"""
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+# Project #9 ("JH M Lee Lab") — a user-level project, so these IDs are stable
+# and repo-independent (same values used by recheck_dispatch.py).
+PROJECT_ID = "PVT_kwHOB17eGc4BSomP"
+PROJECT_NUMBER = 9
+PROJECT_OWNER = "Jin-HoMLee"
+STATUS_FIELD_ID = "PVTSSF_lAHOB17eGc4BSomPzhAHFf8"
+IN_PROGRESS_OPTION = "47fc9ee4"
+READY_FOR_REVIEW_OPTION = "8bf9192f"
+
+# Only PRs in these repos feed project #9. A guard against accidentally boarding
+# an unrelated PR the session happens to open elsewhere.
+TRACKED_REPOS = {
+    "splice-neoepitope-pipeline",
+    "claude-personas-splice-neoepitope-pipeline",
+}
+
+LOG_PATH = Path(__file__).resolve().parent.parent.parent / ".claude" / "hook_fires.jsonl"
+_PR_CREATE_RE = re.compile(r"(^|[;&|]\s*)gh\s+pr\s+create\b")
+_PR_URL_RE = re.compile(r"https://github\.com/([\w.-]+)/([\w.-]+)/pull/(\d+)")
+
+
+# --- pure helpers (unit-tested) ---
+
+
+def matches_pr_create(cmd: str) -> bool:
+    """True if `cmd` invokes `gh pr create` (at the start or after ; && |)."""
+    return bool(_PR_CREATE_RE.search(cmd or ""))
+
+
+def has_project_flag(cmd: str) -> bool:
+    """True if the create command already passed `--project`."""
+    return "--project" in (cmd or "")
+
+
+def parse_pr_url(text: str) -> tuple[str, str, int] | None:
+    """Return (owner, repo, number) of the LAST PR URL in `text`, or None.
+
+    `gh pr create` prints the new PR's URL to stdout; taking the last match is
+    robust to leading log lines that may reference other URLs.
+    """
+    matches = _PR_URL_RE.findall(text or "")
+    if not matches:
+        return None
+    owner, repo, number = matches[-1]
+    return owner, repo, int(number)
+
+
+def should_track(owner: str, repo: str) -> bool:
+    """True only for PRs that belong on project board #9."""
+    return owner == PROJECT_OWNER and repo in TRACKED_REPOS
+
+
+def status_for_draft(is_draft: bool) -> tuple[str, str]:
+    """(human label, single-select option id) for the PR's board Status.
+
+    A draft PR is mid-In-progress; a non-draft PR-open is the review request.
+    """
+    if is_draft:
+        return "In progress", IN_PROGRESS_OPTION
+    return "Ready for review", READY_FOR_REVIEW_OPTION
+
+
+def extract_output(tool_response) -> str:
+    """Coax a searchable string out of the PostToolUse `tool_response`.
+
+    Bash tool responses are usually a dict with a `stdout` key, but the shape is
+    not contractually fixed — fall back to stringifying the whole object so a
+    URL anywhere in it is still found.
+    """
+    if tool_response is None:
+        return ""
+    if isinstance(tool_response, str):
+        return tool_response
+    if isinstance(tool_response, dict):
+        stdout = tool_response.get("stdout")
+        if isinstance(stdout, str) and stdout:
+            return stdout
+    return json.dumps(tool_response)
+
+
+# --- gh I/O (fail-open) ---
+
+
+def _gh(*args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["gh", *args], capture_output=True, text=True, timeout=15, check=True
+    )
+
+
+def _pr_is_draft(pr_url: str) -> bool:
+    res = _gh("pr", "view", pr_url, "--json", "isDraft")
+    return bool(json.loads(res.stdout).get("isDraft"))
+
+
+def _add_to_board(pr_url: str) -> str | None:
+    """Idempotently add the PR to project #9; return its project-item id.
+
+    `gh project item-add` no-ops server-side if the PR is already on the board
+    (the project dedupes by content) and returns the existing item either way,
+    so this is safe to call unconditionally.
+    """
+    res = _gh(
+        "project", "item-add", str(PROJECT_NUMBER),
+        "--owner", PROJECT_OWNER, "--url", pr_url, "--format", "json",
+    )
+    return json.loads(res.stdout).get("id")
+
+
+def _set_status(item_id: str, option_id: str) -> None:
+    _gh(
+        "api", "graphql", "-f",
+        "query=mutation($p:ID!,$i:ID!,$f:ID!,$o:String!){"
+        "updateProjectV2ItemFieldValue(input:{projectId:$p,itemId:$i,fieldId:$f,"
+        "value:{singleSelectOptionId:$o}}){projectV2Item{id}}}",
+        "-f", f"p={PROJECT_ID}", "-f", f"i={item_id}",
+        "-f", f"f={STATUS_FIELD_ID}", "-f", f"o={option_id}",
+    )
+
+
+def _log_fire(number: int, repo: str, status_label: str) -> None:
+    """Append one fire-log line (Issue #453 infra). Never raises."""
+    payload = {
+        "ts": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "hook": "post_gh_pr_create",
+        "issue": number,
+        "repo": repo,
+        "action": f"board-add+status:{status_label}",
+    }
+    line = json.dumps(payload, separators=(",", ":")) + "\n"
+    try:
+        LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+        with open(LOG_PATH, "a", encoding="utf-8") as f:
+            f.write(line)
+    except OSError:
+        pass
+
+
+# --- orchestration ---
+
+
+def main() -> int:
+    try:
+        payload = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError):
+        return 0  # fail open
+
+    cmd = (payload.get("tool_input") or {}).get("command", "")
+    if not matches_pr_create(cmd):
+        return 0
+
+    parsed = parse_pr_url(extract_output(payload.get("tool_response")))
+    if parsed is None:
+        return 0  # create failed / --web / --dry-run — nothing to board
+    owner, repo, number = parsed
+    if not should_track(owner, repo):
+        return 0
+
+    pr_url = f"https://github.com/{owner}/{repo}/pull/{number}"
+    try:
+        label, option = status_for_draft(_pr_is_draft(pr_url))
+        item_id = _add_to_board(pr_url)
+        if not item_id:
+            return 0
+        _set_status(item_id, option)
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired,
+            json.JSONDecodeError, FileNotFoundError):
+        return 0  # fail open — never break the user's flow on a gh hiccup
+
+    _log_fire(number, f"{owner}/{repo}", label)
+    print(json.dumps({
+        "hookSpecificOutput": {
+            "hookEventName": "PostToolUse",
+            "additionalContext": (
+                f"✅ post_gh_pr_create: PR #{number} ({owner}/{repo}) added to "
+                f"board #{PROJECT_NUMBER} + Status → {label}. Remaining manual "
+                f"checklist steps: `**Created by:**` body attribution + mirror "
+                f"the linked Issue's Status on review request."
+            ),
+        }
+    }))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/hooks/post_gh_pr_create.py
+++ b/.claude/hooks/post_gh_pr_create.py
@@ -62,11 +62,6 @@ def matches_pr_create(cmd: str) -> bool:
     return bool(_PR_CREATE_RE.search(cmd or ""))
 
 
-def has_project_flag(cmd: str) -> bool:
-    """True if the create command already passed `--project`."""
-    return "--project" in (cmd or "")
-
-
 def parse_pr_url(text: str) -> tuple[str, str, int] | None:
     """Return (owner, repo, number) of the LAST PR URL in `text`, or None.
 
@@ -153,11 +148,16 @@ def _set_status(item_id: str, option_id: str) -> None:
 
 
 def _log_fire(number: int, repo: str, status_label: str) -> None:
-    """Append one fire-log line (Issue #453 infra). Never raises."""
+    """Append one fire-log line (Issue #453 infra). Never raises.
+
+    Uses a `pr` key (not the base schema's `issue`) because this hook fires on a
+    PR, not an Issue; `scripts/check_hook_health.sh` aggregates only on `hook`
+    and `ts`, so the field name is free.
+    """
     payload = {
         "ts": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
         "hook": "post_gh_pr_create",
-        "issue": number,
+        "pr": number,
         "repo": repo,
         "action": f"board-add+status:{status_label}",
     }

--- a/.claude/hooks/post_gh_pr_create.py
+++ b/.claude/hooks/post_gh_pr_create.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 
 import json
 import re
+import shlex
 import subprocess
 import sys
 from datetime import datetime, timezone
@@ -50,16 +51,42 @@ TRACKED_REPOS = {
 }
 
 LOG_PATH = Path(__file__).resolve().parent.parent.parent / ".claude" / "hook_fires.jsonl"
-_PR_CREATE_RE = re.compile(r"(^|[;&|]\s*)gh\s+pr\s+create\b")
 _PR_URL_RE = re.compile(r"https://github\.com/([\w.-]+)/([\w.-]+)/pull/(\d+)")
+_PR_CREATE_PREFIX = ("gh", "pr", "create")
+_PUNCT = set("();<>|&")  # shell punctuation_chars → standalone separator tokens
 
 
 # --- pure helpers (unit-tested) ---
 
 
 def matches_pr_create(cmd: str) -> bool:
-    """True if `cmd` invokes `gh pr create` (at the start or after ; && |)."""
-    return bool(_PR_CREATE_RE.search(cmd or ""))
+    """True only if `cmd` actually *invokes* `gh pr create` as a command.
+
+    Tokenizes with shlex (quotes + shell punctuation respected) rather than
+    substring-matching the raw command line, so `gh pr create` appearing INSIDE
+    a quoted argument — e.g. a `gh pr comment` body that discusses the command —
+    does NOT match. That false positive tripped on this hook's own PR #558
+    review-reply (`... git push && gh pr create ...` inside the comment body).
+
+    Compound commands are handled: a `gh pr create` segment after a real shell
+    separator (`&&`, `||`, `;`, `|`) matches; one buried in quotes does not.
+    Untokenizable input (unbalanced quotes) fails safe → no match.
+    """
+    try:
+        lex = shlex.shlex(cmd or "", posix=True, punctuation_chars=True)
+        lex.whitespace_split = True
+        tokens = list(lex)
+    except ValueError:
+        return False
+    at_command_start = True
+    for i, tok in enumerate(tokens):
+        if tok and all(ch in _PUNCT for ch in tok):  # pure-punctuation = separator
+            at_command_start = True
+            continue
+        if at_command_start and tuple(tokens[i:i + 3]) == _PR_CREATE_PREFIX:
+            return True
+        at_command_start = False
+    return False
 
 
 def parse_pr_url(text: str) -> tuple[str, str, int] | None:

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -13,6 +13,19 @@
           }
         ]
       }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/post_gh_pr_create.py",
+            "if": "Bash(gh *)",
+            "timeout": 35
+          }
+        ]
+      }
     ]
   }
 }

--- a/research/lab_notebook/developer.md
+++ b/research/lab_notebook/developer.md
@@ -8,6 +8,25 @@ Format and rules unchanged from the unified notebook — see `shared/feedback_la
 
 ## 2026-05-29
 
+### 15:10 UTC — Editor: Developer
+
+**Headline:** [PR #558](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/558) (closes [Issue #550](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/550) — `PostToolUse` hook auto-boards a created PR + sets Status). The **rung-3 mechanism** for the board-Status-flip slip that left [PR #6](https://github.com/Jin-HoMLee/claude-personas-splice-neoepitope-pipeline/pull/6) + [PR #543](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/543) at Backlog 2026-05-28 — the rule lived in `feedback_project_board.md` (memory, rung-2) and didn't fire on the create beat. Sibling of `scripts/audit_and_merge.sh` (closure-ritual gate on merge).
+
+**Two design pivots + a self-caught bug — the reason this entry exists (non-routine):**
+
+#### Pivot 1 — draft-awareness (caught in review of my own design)
+The first cut flipped *every* created PR to "Ready for review". Wrong: a `gh pr create --draft` is opened mid-In-progress (CI / shareable URL), not for review. Fixed to branch on the PR's authoritative `isDraft`: draft → "In progress", non-draft → "Ready for review". Either way it lands ON the board — board-*absence* was the real failure. (User flagged the always-Ready assumption before wiring.)
+
+#### Pivot 2 — the hook caught its OWN false positive, live
+The instant it went live this session it fired on my **review-reply comment** to the bot — that comment's `--body` contained the example `… git push && gh pr create …`, and the original `matches_pr_create` regex searched the *raw command line*, so the `&&`-prefixed occurrence **inside the quoted body** matched. It then parsed #558 from the comment URL and re-flipped it (idempotent + one spurious fire-log line). Exact substring-in-body class the `@-claude` mention guard exists for. Fix: tokenize with `shlex` (posix + `punctuation_chars`) so quoted args stay single tokens; only a real `gh pr create` segment (command-start or after a true shell separator) matches; unbalanced quotes fail safe. Verified `cd foo;gh pr create` → match, `gh pr comment … "… && gh pr create …"` → no match.
+
+#### Self-modification gate
+The harness **refused** my first edit to `.claude/hooks/` + committed `settings.json` — correct: wiring a hook that fires for all sessions/roles is agent self-modification, and "ok gogo" didn't specifically authorize it. Got explicit sign-off, then proceeded.
+
+**Verification:** 20 tests (pure matcher/parse/should_track/status_for_draft/extract_output + subprocess fail-open/no-op); full `tools/ci` suite green; CI green. **Live dogfood:** hook flipped #558 itself Backlog → Ready for review and wrote its fire-log line — non-draft path end-to-end. Bot review: one real finding (dead `has_project_flag` → removed) + fire-log key `issue`→`pr` clarity; two non-blocking notes declined with reasons.
+
+---
+
 ### 14:02 UTC — Editor: Developer
 
 **Headline:** [PR #556](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/556) (closes [Issue #555](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/555) — closure-audit bot honors a routine-ship lab-notebook skip marker). Closes the **enforcement half** of [Issue #483](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/483): that Issue made routine single-PR-closes-single-Issue notebook entries optional *and* dropped the `audit_and_merge.sh` notebook gate — but never taught the post-merge closure-audit bot the exemption. The bot's only skip was **file-based** (`is_exempt`: all-glossary/notebook diffs), so any routine PR touching code still drew a "Lab notebook entry missing" gap. Rule and enforcement contradicted each other.

--- a/tools/ci/test_post_gh_pr_create.py
+++ b/tools/ci/test_post_gh_pr_create.py
@@ -1,0 +1,135 @@
+"""Tests for `.claude/hooks/post_gh_pr_create.py` (Issue #550).
+
+Pure-function unit tests import the module directly (no network). The fail-open /
+no-op subprocess tests mirror the harness invocation (pipe PostToolUse JSON to
+stdin) and never reach a live `gh` call because no actionable PR URL is parsed.
+
+The full add+flip path is inherently a live-`gh` integration and is verified by
+dogfooding the hook against this Issue's own PR, not in this suite.
+"""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+HOOKS_DIR = Path(__file__).parent.parent.parent / ".claude" / "hooks"
+HOOK = HOOKS_DIR / "post_gh_pr_create.py"
+sys.path.insert(0, str(HOOKS_DIR))
+
+import post_gh_pr_create as h  # noqa: E402
+
+
+class TestMatchesPrCreate:
+    def test_plain_invocation(self):
+        assert h.matches_pr_create("gh pr create --title x --body y") is True
+
+    def test_after_separator(self):
+        assert h.matches_pr_create("git push -u origin br && gh pr create --fill") is True
+
+    def test_pr_view_not_matched(self):
+        assert h.matches_pr_create("gh pr view 1") is False
+
+    def test_pr_list_not_matched(self):
+        assert h.matches_pr_create("gh pr list") is False
+
+    def test_echoed_string_not_matched(self):
+        # "echo gh pr create" is not an invocation of the command
+        assert h.matches_pr_create("echo gh pr create") is False
+
+
+class TestParsePrUrl:
+    def test_basic_url(self):
+        assert h.parse_pr_url(
+            "https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/556"
+        ) == ("Jin-HoMLee", "splice-neoepitope-pipeline", 556)
+
+    def test_url_embedded_in_output(self):
+        text = (
+            "Creating pull request for branch into main\n"
+            "https://github.com/Jin-HoMLee/claude-personas-splice-neoepitope-pipeline/pull/7\n"
+        )
+        assert h.parse_pr_url(text)[2] == 7
+
+    def test_no_url_returns_none(self):
+        assert h.parse_pr_url("error: pull request create failed") is None
+
+    def test_takes_last_url(self):
+        text = (
+            "see https://github.com/Jin-HoMLee/x/pull/1 then "
+            "created https://github.com/Jin-HoMLee/x/pull/2"
+        )
+        assert h.parse_pr_url(text)[2] == 2
+
+
+def test_has_project_flag():
+    assert h.has_project_flag('gh pr create --project "JH M Lee Lab"') is True
+    assert h.has_project_flag("gh pr create --title x --body y") is False
+
+
+def test_should_track():
+    assert h.should_track("Jin-HoMLee", "splice-neoepitope-pipeline") is True
+    assert h.should_track("Jin-HoMLee", "claude-personas-splice-neoepitope-pipeline") is True
+    assert h.should_track("someone-else", "splice-neoepitope-pipeline") is False
+    assert h.should_track("Jin-HoMLee", "some-unrelated-repo") is False
+
+
+def test_status_for_draft():
+    # draft PR opened mid-In-progress → In progress; non-draft → Ready for review
+    assert h.status_for_draft(True) == ("In progress", "47fc9ee4")
+    assert h.status_for_draft(False) == ("Ready for review", "8bf9192f")
+
+
+def test_extract_output_handles_shapes():
+    # bare string
+    assert "pull/9" in h.extract_output("done https://github.com/a/b/pull/9")
+    # dict with stdout
+    assert "pull/9" in h.extract_output({"stdout": "https://github.com/a/b/pull/9\n"})
+    # unknown dict shape falls back to stringifying the whole object
+    assert "pull/9" in h.extract_output({"weird_key": "https://github.com/a/b/pull/9"})
+    # None is safe
+    assert h.extract_output(None) == ""
+
+
+# --- subprocess fail-open / no-op paths (no live gh reached) ---
+
+
+def _run(stdin_payload: str):
+    proc = subprocess.run(
+        [sys.executable, str(HOOK)],
+        input=stdin_payload,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    return proc.returncode, proc.stdout, proc.stderr
+
+
+def _payload(command: str, output: str = "") -> str:
+    return json.dumps({"tool_input": {"command": command}, "tool_response": output})
+
+
+class TestSubprocessNoOp:
+    def test_empty_stdin_fail_open(self):
+        rc, out, _ = _run("")
+        assert rc == 0 and out.strip() == ""
+
+    def test_malformed_json_fail_open(self):
+        rc, out, _ = _run("{not valid json")
+        assert rc == 0 and out.strip() == ""
+
+    def test_non_pr_create_command_noop(self):
+        rc, out, _ = _run(_payload("gh pr view 1", "anything"))
+        assert rc == 0 and out.strip() == ""
+
+    def test_pr_create_without_url_noop(self):
+        # matched command but no PR URL in output → no gh call, no output
+        rc, out, _ = _run(_payload("gh pr create --fill", "error: validation failed"))
+        assert rc == 0 and out.strip() == ""
+
+    def test_untracked_repo_noop(self):
+        # a parsed PR URL for an untracked owner/repo must not be boarded
+        rc, out, _ = _run(
+            _payload("gh pr create --fill", "https://github.com/someone-else/other/pull/3")
+        )
+        assert rc == 0 and out.strip() == ""

--- a/tools/ci/test_post_gh_pr_create.py
+++ b/tools/ci/test_post_gh_pr_create.py
@@ -37,6 +37,21 @@ class TestMatchesPrCreate:
         # "echo gh pr create" is not an invocation of the command
         assert h.matches_pr_create("echo gh pr create") is False
 
+    def test_create_inside_quoted_comment_body_not_matched(self):
+        # Real false positive (PR #558): a `gh pr comment` whose body discusses
+        # `gh pr create` must NOT match — the substring is inside a quoted arg.
+        cmd = 'gh pr comment 1 --body "narrow if to Bash(gh pr create *)"'
+        assert h.matches_pr_create(cmd) is False
+
+    def test_create_after_literal_separator_in_quoted_body_not_matched(self):
+        # The `&&` lives inside the quoted body, so it is not a shell separator.
+        cmd = 'gh pr comment 1 --body "example: git push && gh pr create --fill"'
+        assert h.matches_pr_create(cmd) is False
+
+    def test_unbalanced_quotes_fail_safe(self):
+        # Untokenizable command → fail safe (do not fire).
+        assert h.matches_pr_create('gh pr comment 1 --body "oops') is False
+
 
 class TestParsePrUrl:
     def test_basic_url(self):

--- a/tools/ci/test_post_gh_pr_create.py
+++ b/tools/ci/test_post_gh_pr_create.py
@@ -62,11 +62,6 @@ class TestParsePrUrl:
         assert h.parse_pr_url(text)[2] == 2
 
 
-def test_has_project_flag():
-    assert h.has_project_flag('gh pr create --project "JH M Lee Lab"') is True
-    assert h.has_project_flag("gh pr create --title x --body y") is False
-
-
 def test_should_track():
     assert h.should_track("Jin-HoMLee", "splice-neoepitope-pipeline") is True
     assert h.should_track("Jin-HoMLee", "claude-personas-splice-neoepitope-pipeline") is True


### PR DESCRIPTION
**Created by:** Developer

Closes #550.

## Summary

The `PR opened → set Status` rule lived in `feedback_project_board.md` (memory, rung-2 of the mechanism-over-memory ladder) and didn't fire on [PR #6](https://github.com/Jin-HoMLee/claude-personas-splice-neoepitope-pipeline/pull/6) + [PR #543](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/543) (both stuck at Backlog 2026-05-28). This is the **rung-3 mechanism**: a `PostToolUse` hook on `gh pr create` that adds the new PR to project board #9 and sets its Status at create time, so the slip can't recur.

**Draft-aware** (design pivot from review of the original always-Ready-for-review approach): a non-draft PR-open *is* the review request → Status **Ready for review**; a draft PR is opened mid-In-progress → Status **In progress**. Draft-ness is read from the PR's authoritative `isDraft` field, not the command string (covers `--draft`, `-d`, repo defaults). Either way the PR lands on the board — board-absence was the actual failure mode.

Sibling of `scripts/audit_and_merge.sh` (closure-ritual gate on `gh pr merge`). Steps 3 (`**Created by:**` attribution) + 4 (Issue mirror on review request) of the 4-step checklist stay **manual** — author judgment a hook can't infer.

## Design notes

- **Fail-open everywhere** — parse miss, untracked repo, or any `gh` error → silent no-op. A board-automation hook must never break the user's flow.
- **Tracked-repo guard** — only `Jin-HoMLee/{splice-neoepitope-pipeline, claude-personas-splice-neoepitope-pipeline}` PRs get boarded (project #9 is user-level, so a stray PR elsewhere won't be swept in).
- **Idempotent** — `gh project item-add` no-ops server-side if already added and returns the item id either way.
- **Fire-log** — one line to gitignored `.claude/hook_fires.jsonl` per the Issue #453 infra.

## Test plan

- [x] Hook script at `.claude/hooks/post_gh_pr_create.py`
- [x] Wired in **committed** `.claude/settings.json` (`PostToolUse:Bash`, `if Bash(gh *)`)
- [x] Parses PR URL from tool output; gracefully no-ops on parse failure (unit + subprocess tests)
- [x] Step 1: idempotent project-add (skips server-side if already added)
- [x] Step 2: Status set — Ready for review (non-draft) / In progress (draft)
- [x] Fire-log entry per `feedback_hook_proves_out.md` infra
- [x] 18 hook tests + full `tools/ci` suite (120) green; `settings.json` valid JSON
- [x] Live dogfood: PR #558 flipped Backlog → Ready for review via the hook (non-draft path; fire-log line written) — verified 2026-05-29 14:59 UTC
- [x] Lab notebook entry (developer 2026-05-29 15:10 UTC — design pivots + self-caught matcher bug)

