### PR TITLE
feat(hooks): PreToolUse guard refuses `gh issue develop` on parent Issues

### DIFF
--- a/.claude/hooks/check_gh_issue_develop_parent.py
+++ b/.claude/hooks/check_gh_issue_develop_parent.py
@@ -133,8 +133,9 @@ def deny_payload(number: int, total: int) -> dict:
                 f"Refusing `gh issue develop` on Issue #{number} — it has "
                 f"{total} sub-issue(s), so it is a parent/epic. Parents don't get "
                 "branches or PRs: the PR↔parent link auto-closes the epic on "
-                "merge and orphans its sub-issues (bit PR #543 → Issue #538, "
-                "2026-05-28). Branch off a leaf sub-issue instead, or file a "
+                "merge and orphans its sub-issues (incident: PR #543 "
+                "accidentally closed epic Issue #538 on merge, 2026-05-28). "
+                "Branch off a leaf sub-issue instead, or file a "
                 "closure sub-issue (cf. Issue #548) and develop off that. Rule: "
                 "memory/shared/feedback_parent_sub_issues.md."
             ),

--- a/.claude/hooks/check_gh_issue_develop_parent.py
+++ b/.claude/hooks/check_gh_issue_develop_parent.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python3
+"""Pre-flight hook: refuse `gh issue develop <N>` when Issue N is a parent/epic
+(has ≥1 sub-issue).
+
+Parents don't get branches or PRs: a PR opened off a branch linked to a parent
+creates a `closingIssuesReferences` edge that auto-closes the epic on merge,
+silently orphaning its sub-issues. That bit PR #543 → Issue #538 (2026-05-28) —
+the memory rule ("parents have no branches/PRs", Reference-tier in
+memory/shared/feedback_parent_sub_issues.md) didn't load at the gh-develop
+target-pick moment, so this is the mechanism-over-memory escalation.
+
+Sibling of `.claude/hooks/check_at_claude.py` (the @claude mention guard). Reads
+PreToolUse hook JSON on stdin, prints a deny decision on stdout when the guard
+fires, exits 0 silently otherwise (the harness treats no-output as allow).
+
+Fails OPEN on any parse miss, missing issue number, untokenizable command, or
+`gh` error/timeout — a guard hook must never break the user's flow on a hiccup.
+The only path that denies is a *confirmed* parent (subIssuesSummary.total > 0).
+
+See https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/549.
+"""
+from __future__ import annotations
+
+import json
+import re
+import shlex
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+LOG_PATH = Path(__file__).resolve().parent.parent.parent / ".claude" / "hook_fires.jsonl"
+
+_PUNCT = set("();<>|&")  # shell punctuation_chars → standalone separator tokens
+_DEVELOP_PREFIX = ("gh", "issue", "develop")
+# `gh issue develop` flags that consume the following token as their value.
+_VALUE_FLAGS = {"-b", "--base", "--branch-repo", "-n", "--name", "-R", "--repo"}
+_ISSUE_URL_RE = re.compile(r"/issues/(\d+)")
+
+
+# --- pure helpers (unit-tested, no I/O) ---
+
+
+def develop_args(cmd: str) -> list[str] | None:
+    """Return the token list AFTER a real `gh issue develop` invocation, or None.
+
+    Tokenizes with shlex (quotes + shell punctuation respected) so a literal
+    "gh issue develop" buried inside a quoted argument — e.g. a PR-comment body
+    discussing this very hook — does NOT match. Only a `gh issue develop` at a
+    command start (start of line or after a `&&`/`||`/`;`/`|` separator) counts.
+    Args are collected up to the next shell separator, so a trailing
+    `&& other-cmd` doesn't leak its tokens in. Untokenizable input (unbalanced
+    quotes) fails safe → None.
+    """
+    try:
+        lex = shlex.shlex(cmd or "", posix=True, punctuation_chars=True)
+        lex.whitespace_split = True
+        tokens = list(lex)
+    except ValueError:
+        return None
+    at_command_start = True
+    for i, tok in enumerate(tokens):
+        if tok and all(ch in _PUNCT for ch in tok):  # pure-punctuation = separator
+            at_command_start = True
+            continue
+        if at_command_start and tuple(tokens[i:i + 3]) == _DEVELOP_PREFIX:
+            rest = tokens[i + 3:]
+            args: list[str] = []
+            for t in rest:
+                if t and all(ch in _PUNCT for ch in t):
+                    break  # next shell command begins — stop collecting
+                args.append(t)
+            return args
+        at_command_start = False
+    return None
+
+
+def issue_number(args: list[str]) -> int | None:
+    """Extract the Issue selector (number or issue-URL) from `gh issue develop` args.
+
+    Skips value-taking flags and their values; the first positional token is the
+    selector. Accepts a bare integer or a `.../issues/N` URL. Returns None when no
+    selector is parseable (→ fail open).
+    """
+    skip_next = False
+    for tok in args:
+        if skip_next:
+            skip_next = False
+            continue
+        if tok.startswith("-"):
+            # `--name foo` consumes the next token; `--name=foo` is self-contained.
+            if tok in _VALUE_FLAGS:
+                skip_next = True
+            continue
+        if tok.isdigit():
+            return int(tok)
+        m = _ISSUE_URL_RE.search(tok)
+        if m:
+            return int(m.group(1))
+        return None  # first positional isn't a recognizable issue selector
+    return None
+
+
+def repo_from_args(args: list[str]) -> tuple[str, str] | None:
+    """Parse an explicit `-R`/`--repo [HOST/]OWNER/REPO` from the develop args.
+
+    Returns (owner, name) when present and well-formed, else None (caller then
+    falls back to the cwd repo). Strips an optional leading HOST/ segment.
+    """
+    val = None
+    for i, tok in enumerate(args):
+        if tok in ("-R", "--repo"):
+            val = args[i + 1] if i + 1 < len(args) else None
+            break
+        if tok.startswith("-R=") or tok.startswith("--repo="):
+            val = tok.split("=", 1)[1]
+            break
+    if not val:
+        return None
+    parts = val.split("/")
+    if len(parts) >= 2:
+        return parts[-2], parts[-1]
+    return None
+
+
+def deny_payload(number: int, total: int) -> dict:
+    """The PreToolUse deny decision for a confirmed parent."""
+    return {
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "deny",
+            "permissionDecisionReason": (
+                f"Refusing `gh issue develop` on Issue #{number} — it has "
+                f"{total} sub-issue(s), so it is a parent/epic. Parents don't get "
+                "branches or PRs: the PR↔parent link auto-closes the epic on "
+                "merge and orphans its sub-issues (bit PR #543 → Issue #538, "
+                "2026-05-28). Branch off a leaf sub-issue instead, or file a "
+                "closure sub-issue (cf. Issue #548) and develop off that. Rule: "
+                "memory/shared/feedback_parent_sub_issues.md."
+            ),
+        }
+    }
+
+
+# --- gh I/O (fail-open) ---
+
+
+def _gh(*args: str, timeout: int = 8) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["gh", *args], capture_output=True, text=True, timeout=timeout, check=True
+    )
+
+
+def resolve_repo(args: list[str]) -> tuple[str, str] | None:
+    """(owner, name) for the develop target: explicit `-R` wins, else cwd repo."""
+    explicit = repo_from_args(args)
+    if explicit:
+        return explicit
+    try:
+        res = _gh("repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner",
+                  timeout=6)
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired,
+            FileNotFoundError):
+        return None
+    owner, _, name = res.stdout.strip().partition("/")
+    return (owner, name) if owner and name else None
+
+
+def sub_issue_total(owner: str, name: str, number: int) -> int | None:
+    """subIssuesSummary.total for the issue, or None on any error (→ fail open)."""
+    query = (
+        "query($o:String!,$n:String!,$num:Int!){"
+        "repository(owner:$o,name:$n){issue(number:$num){"
+        "subIssuesSummary{total}}}}"
+    )
+    try:
+        res = _gh("api", "graphql", "-f", f"query={query}",
+                  "-f", f"o={owner}", "-f", f"n={name}", "-F", f"num={number}")
+        data = json.loads(res.stdout)
+        return int(data["data"]["repository"]["issue"]["subIssuesSummary"]["total"])
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired,
+            FileNotFoundError, json.JSONDecodeError, KeyError, TypeError, ValueError):
+        return None
+
+
+def _log_fire(number: int, repo: str, total: int) -> None:
+    """Append one fire-log line on a deny (Issue #453 infra). Never raises."""
+    payload = {
+        "ts": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "hook": "check_gh_issue_develop_parent",
+        "issue": number,
+        "repo": repo,
+        "action": f"refused-parent-develop:sub_total={total}",
+    }
+    line = json.dumps(payload, separators=(",", ":")) + "\n"
+    try:
+        LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+        with open(LOG_PATH, "a", encoding="utf-8") as f:
+            f.write(line)
+    except OSError:
+        pass
+
+
+# --- orchestration ---
+
+
+def main() -> int:
+    try:
+        data = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError):
+        return 0  # fail open
+
+    cmd = (data.get("tool_input") or {}).get("command", "")
+    args = develop_args(cmd)
+    if args is None:
+        return 0  # not a `gh issue develop` invocation
+
+    number = issue_number(args)
+    if number is None:
+        return 0  # no parseable issue selector → fail open
+
+    repo = resolve_repo(args)
+    if repo is None:
+        return 0  # can't resolve target repo → fail open
+    owner, name = repo
+
+    total = sub_issue_total(owner, name, number)
+    if total is None or total == 0:
+        return 0  # query failed (fail open) or a confirmed leaf → allow
+
+    _log_fire(number, f"{owner}/{name}", total)
+    print(json.dumps(deny_payload(number, total)))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -10,6 +10,12 @@
             "command": ".claude/hooks/check_at_claude.py",
             "if": "Bash(gh *)",
             "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": ".claude/hooks/check_gh_issue_develop_parent.py",
+            "if": "Bash(gh issue develop *)",
+            "timeout": 15
           }
         ]
       }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -316,6 +316,14 @@ Refuses any `gh (pr|issue) (comment|create)` whose `--body` contains a literal `
 
 **Workaround for non-trigger references:** use `@-claude` (zero-width hyphen between `@` and `claude`). The literal substring `@claude` must not appear.
 
+### `gh issue develop` parent guard ([PreToolUse hook](.claude/settings.json))
+
+Refuses any `gh issue develop <N>` (number or issue-URL form) when Issue `N` is a parent/epic — i.e. its `subIssuesSummary.total > 0`. The hook runs `.claude/hooks/check_gh_issue_develop_parent.py` on stdin-piped PreToolUse JSON and emits a `permissionDecision: deny`. It **fails open** on every uncertain path (unparseable command, no issue number, repo unresolvable, `gh`/network error) — only a *confirmed* parent denies — so a hiccup never blocks legitimate `gh issue develop`. Each deny appends one line to `.claude/hook_fires.jsonl` (gitignored, [Issue #453](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/453) fire-log infra).
+
+**Why:** branching off a parent creates a PR↔parent `closingIssuesReferences` edge that auto-closes the epic on merge, silently orphaning its sub-issues. That bit [PR #543](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/543) → [parent Issue #538](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/538) (2026-05-28). The "parents have no branches/PRs" rule was Reference-tier in `memory/shared/feedback_parent_sub_issues.md` and didn't load at the gh-develop target-pick moment — rung-3 mechanism escalation ([Issue #549](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/549)).
+
+**Workaround:** branch off a leaf sub-issue instead, or file a closure sub-issue (cf. [Issue #548](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/548)) under the epic and develop off that.
+
 ### Closure-ritual gate (`scripts/audit_and_merge.sh`)
 
 Refuses to run `gh pr merge` if any `- [ ]` remains on the PR body Test plan OR on any Issue in `closingIssuesReferences` (under that Issue's Acceptance criteria). Operational usage lives under [Merge workflow](#merge-workflow); this section captures the mechanism-over-memory rationale.

--- a/research/lab_notebook/developer.md
+++ b/research/lab_notebook/developer.md
@@ -8,6 +8,22 @@ Format and rules unchanged from the unified notebook — see `shared/feedback_la
 
 ## 2026-05-29
 
+### 20:13 UTC — Editor: Developer
+
+**Headline:** [PR #560](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/560) (closes [Issue #549](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/549)) — `PreToolUse` guard refusing `gh issue develop <N>` on parent/epic Issues (`subIssuesSummary.total > 0`). Rung-3 mechanism for the [PR #543](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/543) → [parent Issue #538](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/538) orphaning slip (2026-05-28); sibling of `check_at_claude.py`. Fails open on every uncertain path — only a *confirmed* parent denies, so a `gh`/network hiccup never blocks a legitimate develop.
+
+**Why this entry exists (non-routine) — two verification catches around the hook-matcher boundary:**
+
+#### The bot-review "gap" that wasn't — settled by docs, not assumption
+Review flagged the narrow `if: Bash(gh issue develop *)` matcher as possibly missing compound commands (`git fetch && gh issue develop N`), since `develop_args()` handles separators (and `test_after_separator` covers it) but the `if` filter "might be start-anchored." Verified against the Claude Code docs (hooks "`if` Condition" + permissions "Compound commands"): the `if` field uses permission-rule `Bash()` semantics, which are **subcommand-aware** — splits on `&&`/`||`/`;`/`|`/newlines, strips `VAR=value` prefixes, fires if *any* subcommand matches. So the compound case **does** fire; the test path is reachable, not dead code. Declined the change, pushed back with citation. Lesson: a matcher-semantics claim is verifiable from docs — don't widen a matcher defensively on an unverified premise.
+
+#### Mis-diagnosed, then verified: the sibling [PR #558](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/558) auto-board hook has a real `VAR=` bug
+The new auto-board hook didn't board PR #560. My first read (told to the user) blamed the harness `if` matcher being start-anchored — **wrong**, per the verification above. Empirically tested `matches_pr_create`: `B="x" gh pr create` and the `VAR=`-newline-`gh pr create` form both return `False`, while plain and `&&`-separated return `True`. Root cause is the hook's *own* matcher: `&&`/`;`/`|` are emitted by `shlex` as pure-punctuation separator tokens that reset command-start, but a bare `VAR=x` assignment token does not — so the trailing `gh pr create` is never recognized. Filed [Issue #561](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/561) (follow-up). Lesson: when correcting a wrong claim, verify the replacement empirically before asserting it too.
+
+**Verification:** 33 tests — pure matcher / selector-extraction / repo-parse + orchestration with monkeypatched `gh` I/O + subprocess fail-open; full `tools/ci` suite 155 green; all 3 CI checks green. **Live smoke:** parent #538 (number + URL form) refused with a self-explanatory message; leaf #549 + a non-develop `gh issue view` allowed silently; fire-log line written only on deny (`.claude/hook_fires.jsonl`, gitignored). **Bot review:** item 1 (matcher) declined with docs citation; items 3 (`--repo=HOST/owner/repo` test gap) + 5 (deny-message wording legibility) fixed in `1b7b4a3`; items 2 (`from __future__` non-issue for a standalone hook) + 4 (`-F num` typed-int) confirmations.
+
+---
+
 ### 15:10 UTC — Editor: Developer
 
 **Headline:** [PR #558](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/558) (closes [Issue #550](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/550) — `PostToolUse` hook auto-boards a created PR + sets Status). The **rung-3 mechanism** for the board-Status-flip slip that left [PR #6](https://github.com/Jin-HoMLee/claude-personas-splice-neoepitope-pipeline/pull/6) + [PR #543](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/543) at Backlog 2026-05-28 — the rule lived in `feedback_project_board.md` (memory, rung-2) and didn't fire on the create beat. Sibling of `scripts/audit_and_merge.sh` (closure-ritual gate on merge).

--- a/tools/ci/test_check_gh_issue_develop_parent.py
+++ b/tools/ci/test_check_gh_issue_develop_parent.py
@@ -114,6 +114,11 @@ class TestRepoFromArgs:
     def test_equals_form(self):
         assert h.repo_from_args(["--repo=owner/repo"]) == ("owner", "repo")
 
+    def test_equals_form_with_host_prefix(self):
+        assert h.repo_from_args(
+            ["--repo=github.com/owner/repo"]
+        ) == ("owner", "repo")
+
     def test_absent_returns_none(self):
         assert h.repo_from_args(["549"]) is None
 

--- a/tools/ci/test_check_gh_issue_develop_parent.py
+++ b/tools/ci/test_check_gh_issue_develop_parent.py
@@ -1,0 +1,215 @@
+"""Tests for `.claude/hooks/check_gh_issue_develop_parent.py` (Issue #549).
+
+Pure-function unit tests import the module directly (no network). Orchestration
+tests monkeypatch the two `gh` I/O functions (`resolve_repo`, `sub_issue_total`)
+so `main()`'s deny/allow decision is exercised without a live `gh` call. The
+subprocess fail-open tests mirror the harness invocation (pipe PreToolUse JSON to
+stdin) and only travel paths that return before any `gh` call.
+
+The full live parent-refused / leaf-allowed path is an integration check and is
+verified by smoke-testing the hook against real Issues (#538 parent, #549 leaf),
+documented in the PR Test plan — not in this suite.
+"""
+
+import io
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+HOOKS_DIR = Path(__file__).parent.parent.parent / ".claude" / "hooks"
+HOOK = HOOKS_DIR / "check_gh_issue_develop_parent.py"
+sys.path.insert(0, str(HOOKS_DIR))
+
+import check_gh_issue_develop_parent as h  # noqa: E402
+
+
+# --- develop_args: command matching ---
+
+
+class TestDevelopArgs:
+    def test_plain_invocation(self):
+        assert h.develop_args("gh issue develop 549") == ["549"]
+
+    def test_with_flags(self):
+        assert h.develop_args(
+            "gh issue develop 549 --name foo --base main"
+        ) == ["549", "--name", "foo", "--base", "main"]
+
+    def test_after_separator(self):
+        assert h.develop_args("git fetch origin && gh issue develop 538") == ["538"]
+
+    def test_trailing_separator_stops_collection(self):
+        # tokens after the `&&` belong to the next command, not develop
+        assert h.develop_args("gh issue develop 549 && echo done") == ["549"]
+
+    def test_issue_list_not_matched(self):
+        assert h.develop_args("gh issue list") is None
+
+    def test_issue_view_not_matched(self):
+        assert h.develop_args("gh issue view 549") is None
+
+    def test_develop_inside_quoted_body_not_matched(self):
+        # A PR-comment body discussing the command must NOT match.
+        cmd = 'gh pr comment 1 --body "do not run gh issue develop 538"'
+        assert h.develop_args(cmd) is None
+
+    def test_separator_inside_quoted_body_not_matched(self):
+        cmd = 'gh pr comment 1 --body "example: x && gh issue develop 538"'
+        assert h.develop_args(cmd) is None
+
+    def test_unbalanced_quotes_fail_safe(self):
+        assert h.develop_args('gh issue develop 549 --name "oops') is None
+
+
+# --- issue_number: selector extraction ---
+
+
+class TestIssueNumber:
+    def test_bare_number(self):
+        assert h.issue_number(["549"]) == 549
+
+    def test_number_after_value_flag(self):
+        assert h.issue_number(["--name", "foo", "549"]) == 549
+
+    def test_equals_form_value_flag_self_contained(self):
+        assert h.issue_number(["--name=foo", "549"]) == 549
+
+    def test_boolean_flag_not_treated_as_value_flag(self):
+        # -c/--checkout takes no value; the number is the next token
+        assert h.issue_number(["-c", "549"]) == 549
+
+    def test_mixed_flags(self):
+        assert h.issue_number(["--base", "main", "-c", "549"]) == 549
+
+    def test_issue_url(self):
+        url = "https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/538"
+        assert h.issue_number([url]) == 538
+
+    def test_no_positional_returns_none(self):
+        assert h.issue_number(["--list"]) is None
+
+    def test_empty_returns_none(self):
+        assert h.issue_number([]) is None
+
+    def test_unrecognizable_positional_returns_none(self):
+        assert h.issue_number(["not-a-number"]) is None
+
+
+# --- repo_from_args: explicit -R/--repo parsing ---
+
+
+class TestRepoFromArgs:
+    def test_short_flag(self):
+        assert h.repo_from_args(["549", "-R", "owner/repo"]) == ("owner", "repo")
+
+    def test_long_flag(self):
+        assert h.repo_from_args(["--repo", "owner/repo", "549"]) == ("owner", "repo")
+
+    def test_strips_host_segment(self):
+        assert h.repo_from_args(
+            ["--repo", "github.com/owner/repo", "549"]
+        ) == ("owner", "repo")
+
+    def test_equals_form(self):
+        assert h.repo_from_args(["--repo=owner/repo"]) == ("owner", "repo")
+
+    def test_absent_returns_none(self):
+        assert h.repo_from_args(["549"]) is None
+
+
+# --- deny_payload: shape ---
+
+
+def test_deny_payload_shape():
+    payload = h.deny_payload(538, 5)
+    out = payload["hookSpecificOutput"]
+    assert out["hookEventName"] == "PreToolUse"
+    assert out["permissionDecision"] == "deny"
+    reason = out["permissionDecisionReason"]
+    assert "#538" in reason and "5 sub-issue" in reason
+    assert "feedback_parent_sub_issues.md" in reason
+
+
+# --- main(): orchestration (monkeypatched gh I/O, no network) ---
+
+
+def _run_main(monkeypatch, capsys, cmd, *, repo=("Jin-HoMLee", "repo"), total):
+    """Drive main() with stubbed gh I/O; return (rc, parsed_stdout_or_None)."""
+    monkeypatch.setattr(h, "resolve_repo", lambda args: repo)
+    monkeypatch.setattr(h, "sub_issue_total", lambda o, n, num: total)
+    payload = json.dumps({"tool_input": {"command": cmd}})
+    monkeypatch.setattr(sys, "stdin", io.StringIO(payload))
+    rc = h.main()
+    captured = capsys.readouterr().out.strip()
+    return rc, (json.loads(captured) if captured else None)
+
+
+def test_main_denies_parent(monkeypatch, capsys, tmp_path):
+    monkeypatch.setattr(h, "LOG_PATH", tmp_path / "hook_fires.jsonl")
+    rc, out = _run_main(monkeypatch, capsys, "gh issue develop 538", total=5)
+    assert rc == 0
+    assert out["hookSpecificOutput"]["permissionDecision"] == "deny"
+    assert "#538" in out["hookSpecificOutput"]["permissionDecisionReason"]
+    # fire-log line written on deny
+    logged = (tmp_path / "hook_fires.jsonl").read_text().strip()
+    rec = json.loads(logged)
+    assert rec["hook"] == "check_gh_issue_develop_parent" and rec["issue"] == 538
+
+
+def test_main_allows_leaf(monkeypatch, capsys, tmp_path):
+    monkeypatch.setattr(h, "LOG_PATH", tmp_path / "hook_fires.jsonl")
+    rc, out = _run_main(monkeypatch, capsys, "gh issue develop 549", total=0)
+    assert rc == 0 and out is None
+    # no fire-log on allow
+    assert not (tmp_path / "hook_fires.jsonl").exists()
+
+
+def test_main_fails_open_on_query_error(monkeypatch, capsys):
+    # sub_issue_total returns None (gh/network error) → allow
+    rc, out = _run_main(monkeypatch, capsys, "gh issue develop 538", total=None)
+    assert rc == 0 and out is None
+
+
+def test_main_fails_open_on_unresolvable_repo(monkeypatch, capsys):
+    rc, out = _run_main(monkeypatch, capsys, "gh issue develop 538",
+                        repo=None, total=5)
+    assert rc == 0 and out is None
+
+
+# --- subprocess fail-open / no-op (no live gh reached) ---
+
+
+def _run_subprocess(stdin_payload: str):
+    proc = subprocess.run(
+        [sys.executable, str(HOOK)],
+        input=stdin_payload,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    return proc.returncode, proc.stdout, proc.stderr
+
+
+def _payload(command: str) -> str:
+    return json.dumps({"tool_input": {"command": command}})
+
+
+class TestSubprocessNoOp:
+    def test_empty_stdin_fail_open(self):
+        rc, out, _ = _run_subprocess("")
+        assert rc == 0 and out.strip() == ""
+
+    def test_malformed_json_fail_open(self):
+        rc, out, _ = _run_subprocess("{not valid json")
+        assert rc == 0 and out.strip() == ""
+
+    def test_non_develop_command_noop(self):
+        # returns before any gh call (develop_args is None)
+        rc, out, _ = _run_subprocess(_payload("gh issue view 549"))
+        assert rc == 0 and out.strip() == ""
+
+    def test_develop_without_number_noop(self):
+        # no parseable selector → returns before any gh call
+        rc, out, _ = _run_subprocess(_payload("gh issue develop --list"))
+        assert rc == 0 and out.strip() == ""


### PR DESCRIPTION
**Created by:** Developer

Closes [Issue #549](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/549).

## Summary

Adds a `PreToolUse` hook ([`.claude/hooks/check_gh_issue_develop_parent.py`](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/blob/549-hook-refuse-parent-issue-develop/.claude/hooks/check_gh_issue_develop_parent.py)) that refuses `gh issue develop <N>` (number **or** `.../issues/N` URL form) when Issue `N` is a parent/epic — i.e. `subIssuesSummary.total > 0`.

**Why (mechanism-over-memory rung-3):** branching off a parent creates a PR↔parent `closingIssuesReferences` edge that auto-closes the epic on merge, silently orphaning its sub-issues. That bit [PR #543](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/543) (incident) → [parent Issue #538](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/538) (orphaned epic) on 2026-05-28; cleanup needed a retroactive closure [Sub-Issue #548](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/548) (carrier). The "parents have no branches/PRs" rule was Reference-tier in `feedback_parent_sub_issues.md` and didn't load at the gh-develop target-pick moment — so memory escalates to a deterministic guard. Sibling of the existing `check_at_claude.py` [`@claude` mention guard](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/272).

**Design:**
- **Fails open** on every uncertain path (unparseable command, no issue number, repo unresolvable, `gh`/network error) — only a *confirmed* parent denies, so a hiccup never blocks a legitimate develop.
- Pure/IO split: command-matching + selector-extraction are pure (unit-tested); `gh` calls (`gh repo view`, GraphQL `subIssuesSummary`) are isolated and monkeypatched in tests.
- Narrow `if: Bash(gh issue develop *)` matcher in committed [`.claude/settings.json`](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/blob/549-hook-refuse-parent-issue-develop/.claude/settings.json) (all roles inherit, per GitHub Safety Wrappers convention).
- Each deny appends one line to `.claude/hook_fires.jsonl` (gitignored; [Issue #453](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/453) (fire-log infra)).

Companion merge-time guard for the same incident class is [Issue #559](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/559) (sibling) — a natural fast-follow.

## Test plan

- [x] 32 new tests pass — `pytest tools/ci/test_check_gh_issue_develop_parent.py` (pure helpers + orchestration with monkeypatched `gh` I/O + subprocess fail-open)
- [x] Full `tools/ci/` suite green (154 passed) — no regression
- [x] Live smoke: parent [Issue #538](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/538) (5 subs) **refused** with clear message (number + URL form); leaf [Issue #549](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/549) + a non-develop `gh issue view` **allowed** silently
- [x] Fire-log line written on deny, absent on allow
- [x] [`CLAUDE.md`](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/blob/549-hook-refuse-parent-issue-develop/CLAUDE.md) § GitHub Safety Wrappers documents the new guard + workaround

🤖 Generated with [Claude Code](https://claude.com/claude-code)