### PR TITLE
research(eval): ASNEO splice-neoepitope candidate generator — desk eval (#546)

### DIFF
--- a/docs/superpowers/plans/2026-05-29-issue-546-asneo-eval.md
+++ b/docs/superpowers/plans/2026-05-29-issue-546-asneo-eval.md
@@ -20,7 +20,7 @@
 |---|---|---|
 | `research/evals/issue_546_asneo/slides.qmd` | Tool-primer deck source (title + 9 content slides) | Create |
 | `research/evals/issue_546_asneo/refs.bib` | Deck bibliography (ASNEO + any cited comparators) | Create |
-| `research/evals/issue_546_asneo/slides.html` + `slides_files/` | Rendered deck (kept in tree, gitignored from *commit*? no — committed per HERMES precedent) | Create (rendered) |
+| `research/evals/issue_546_asneo/slides.html` + `slides_files/` | Rendered deck — **gitignored** (`research/evals/**/*.html`, `**/*_files/`); kept on disk, NOT committed (HERMES precedent: only `slides.qmd` + `refs.bib` are tracked) | Create (rendered, local-only) |
 | `research/lab_notebook/scientist.md` | Dated lab-notebook entry (after review) | Modify (append) |
 | Zotero collection `Z38GTJNW` (external) | 3-section HTML note on DOI `10.18632/aging.103581` | Create (via API) |
 | Issue #546 (external) | 5-mode decision comment + AC ticks | Modify |
@@ -316,14 +316,9 @@ Read each PNG; confirm no clipped text/tables. `.check_shots/` is a throwaway de
 
 If a slide clips, add `{.smaller}` / split content / trim bullets in `slides.qmd`, re-render (Step 1), re-check (Step 2). Repeat until clean.
 
-- [ ] **Step 4: Commit the rendered deck**
+- [ ] **Step 4: Keep the rendered deck locally — do NOT commit**
 
-```bash
-git add research/evals/issue_546_asneo/slides.html research/evals/issue_546_asneo/slides_files
-git commit -m "research(eval): render ASNEO deck (Issue #546)"
-```
-
-Keep `slides.html` + `slides_files/` in the tree (`feedback_keep_render_artifacts.md`). Delete only `.check_shots/`.
+`slides.html` + `slides_files/` are **gitignored** (`research/evals/**/*.html`, `**/*_files/`) — `git add` on them silently no-ops. Only the source (`slides.qmd` + `refs.bib`, committed in Task 3) is tracked, per HERMES precedent. Keep the rendered artifacts in the working tree for local browsing (`feedback_keep_render_artifacts.md`); delete only the throwaway `.check_shots/`. **Nothing to commit at this step.**
 
 ---
 

--- a/docs/superpowers/plans/2026-05-29-issue-546-asneo-eval.md
+++ b/docs/superpowers/plans/2026-05-29-issue-546-asneo-eval.md
@@ -1,0 +1,434 @@
+# ASNEO Eval Implementation Plan (Issue #546)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship a desk-eval verdict on ASNEO (Zhang et al., *Aging* 2020) as a splice-neoepitope candidate generator peer to our pipeline — a verified Zotero note, a 5-mode pipeline-fit decision on #546, and a tool-primer Quarto deck.
+
+**Architecture:** A multi-agent research Workflow (gather → adversarial-verify → return structured findings) feeds a single-author synthesis pass that writes the Zotero note, the deck, and the decision comment. No code execution / no ASNEO run (desk eval).
+
+**Tech Stack:** Claude Workflow tool (research engine); Quarto reveal.js (deck); `research/scripts/zotero_add.py` (Zotero); `gh` CLI + GraphQL (board/PR); `quarto` + headless Chrome (render + visual verify).
+
+**Domain note — there is no unit-test loop here.** This plan produces research + documentation artifacts, not testable code. The TDD "red/green" gates are replaced by **verification gates**: (1) the Workflow's adversarial-verify phase rejects unsourced claims, (2) a headless per-slide overflow check, (3) the AC closure-ritual audit. Each is called out explicitly in its task.
+
+**Spec:** [docs/superpowers/specs/2026-05-29-issue-546-asneo-eval-design.md](../specs/2026-05-29-issue-546-asneo-eval-design.md)
+
+---
+
+## File Structure
+
+| Path | Responsibility | Action |
+|---|---|---|
+| `research/evals/issue_546_asneo/slides.qmd` | Tool-primer deck source (title + 9 content slides) | Create |
+| `research/evals/issue_546_asneo/refs.bib` | Deck bibliography (ASNEO + any cited comparators) | Create |
+| `research/evals/issue_546_asneo/slides.html` + `slides_files/` | Rendered deck (kept in tree, gitignored from *commit*? no — committed per HERMES precedent) | Create (rendered) |
+| `research/lab_notebook/scientist.md` | Dated lab-notebook entry (after review) | Modify (append) |
+| Zotero collection `Z38GTJNW` (external) | 3-section HTML note on DOI `10.18632/aging.103581` | Create (via API) |
+| Issue #546 (external) | 5-mode decision comment + AC ticks | Modify |
+| Issue #258 (external) | Verdict-comment update *iff* calculus changes | Conditionally modify |
+
+Already done (pre-plan): #546 → In progress (`47fc9ee4`); branch `research/scientist/issue-546-asneo-eval` checked out; spec committed (`6c9ad06`).
+
+---
+
+## Task 1: Research Workflow → verified structured findings
+
+**Files:** none committed (findings live in-context for the synthesis tasks).
+
+This is the **gather + adversarial-verify** engine (spec approach C). It returns ONE validated object the rest of the plan consumes. The schema field names defined here are referenced verbatim in Task 3 — keep them consistent.
+
+- [ ] **Step 1: Author the Workflow script**
+
+Save inline via the Workflow tool (it persists to the session dir). Script:
+
+```javascript
+export const meta = {
+  name: 'asneo-eval-research',
+  description: 'Gather + adversarially verify ASNEO facts and our-pipeline backbone for the Issue #546 desk eval',
+  phases: [
+    { title: 'Gather' },
+    { title: 'Verify' },
+  ],
+}
+
+const FINDINGS = {
+  type: 'object',
+  required: ['asneo', 'ours', 'modes', 'open_questions', 'caveats'],
+  properties: {
+    asneo: {
+      type: 'object',
+      required: ['citation','license','repo_url','repo_last_activity','language',
+                 'code_available','weights_available','junction_backbone',
+                 'normal_filtering','peptide_assembly','frame_handling',
+                 'mhc_predictor','validation_cohort','validation_n'],
+      properties: {
+        citation: {type:'string'}, license: {type:'string'},
+        repo_url: {type:'string'}, repo_last_activity: {type:'string'},
+        language: {type:'string'}, code_available: {type:'string'},
+        weights_available: {type:'string'}, junction_backbone: {type:'string'},
+        normal_filtering: {type:'string'}, peptide_assembly: {type:'string'},
+        frame_handling: {type:'string'}, mhc_predictor: {type:'string'},
+        validation_cohort: {type:'string'}, validation_n: {type:'string'},
+      },
+    },
+    ours: {
+      type: 'object',
+      required: ['junction_backbone','normal_filtering','peptide_assembly','frame_handling','mhc_predictor'],
+      properties: {
+        junction_backbone: {type:'string'}, normal_filtering: {type:'string'},
+        peptide_assembly: {type:'string'}, frame_handling: {type:'string'},
+        mhc_predictor: {type:'string'},
+      },
+    },
+    modes: {
+      type: 'object',
+      required: ['triage','replacement','cross_check','component_reuse','reject'],
+      properties: {
+        triage: {type:'object', required:['verdict','rationale'], properties:{verdict:{type:'string'},rationale:{type:'string'}}},
+        replacement: {type:'object', required:['verdict','rationale'], properties:{verdict:{type:'string'},rationale:{type:'string'}}},
+        cross_check: {type:'object', required:['verdict','rationale'], properties:{verdict:{type:'string'},rationale:{type:'string'}}},
+        component_reuse: {type:'object', required:['verdict','rationale'], properties:{verdict:{type:'string'},rationale:{type:'string'}}},
+        reject: {type:'object', required:['verdict','rationale'], properties:{verdict:{type:'string'},rationale:{type:'string'}}},
+      },
+    },
+    verified_claims: {
+      type: 'array',
+      items: {type:'object', required:['claim','sources','status'],
+        properties:{claim:{type:'string'}, sources:{type:'array',items:{type:'string'}}, status:{type:'string'}}},
+    },
+    open_questions: {type:'array', items:{type:'string'}},
+    caveats: {type:'array', items:{type:'string'}},
+  },
+}
+
+const CLAIM = {
+  type:'object', required:['claim','status','sources','confidence'],
+  properties:{ claim:{type:'string'}, status:{type:'string'},
+    sources:{type:'array',items:{type:'string'}}, confidence:{type:'string'} },
+}
+
+phase('Gather')
+const [asneoPaper, asneoRepo, ours] = await parallel([
+  () => agent(`Read the ASNEO paper (Zhang et al., Aging 2020, DOI 10.18632/aging.103581) and any accessible mirrors. Extract, with source URLs: junction-calling backbone (STAR-only? extra filtering/motif selection?), normal-junction filtering (matched-normal? GTEx panel? both?), peptide assembly + flank handling + frameshift detection, MHC presentation predictor (netMHCpan / MHCflurry / in-house?), validation cohort + N. Mark any value you cannot source as "UNVERIFIED".`,
+        {label:'asneo-paper', phase:'Gather', schema: FINDINGS.properties.asneo}),
+  () => agent(`Survey the ASNEO GitHub/code repository. Report with URLs: repo URL, last commit/activity date, language (Python 2 vs 3), whether code is available, whether trained weights/models are available, and the license (verify against the actual LICENSE file, not just the README). Mark unsourced values "UNVERIFIED".`,
+        {label:'asneo-repo', phase:'Gather', schema: {type:'object', required:['repo_url','repo_last_activity','language','code_available','weights_available','license'], properties:{repo_url:{type:'string'},repo_last_activity:{type:'string'},language:{type:'string'},code_available:{type:'string'},weights_available:{type:'string'},license:{type:'string'}}}}),
+  () => agent(`Read these files in the current repo and summarize OUR splice-neoepitope backbone per axis: workflow/scripts/bed12_to_junctions.py, workflow/scripts/star_sj_to_junctions.py, workflow/scripts/filter_junctions.py, workflow/scripts/assemble_contigs.py, workflow/scripts/translate_peptides.py, workflow/scripts/run_mhcflurry.py. Axes: junction_backbone, normal_filtering, peptide_assembly, frame_handling, mhc_predictor. Quote file:line for each claim.`,
+        {label:'our-backbone', phase:'Gather', agentType:'Explore', schema: FINDINGS.properties.ours}),
+])
+
+phase('Verify')
+const loadBearing = [
+  `ASNEO MHC predictor identity: claimed "${asneoPaper.mhc_predictor}"`,
+  `ASNEO validation cohort: claimed "${asneoPaper.validation_cohort}" (N=${asneoPaper.validation_n})`,
+  `ASNEO license: claimed "${asneoRepo.license}"`,
+  `ASNEO normal-junction filtering: claimed "${asneoPaper.normal_filtering}"`,
+]
+const verdicts = await parallel(loadBearing.map(c => () =>
+  agent(`Adversarially verify this claim against >=2 INDEPENDENT sources (paper text, repo, third-party). Default to status="unverified" if you cannot find >=2 concordant sources. Claim: ${c}`,
+        {label:`verify`, phase:'Verify', schema: CLAIM})))
+
+return {
+  asneo: { citation: asneoPaper.citation || 'Zhang et al., Aging 2020, 10.18632/aging.103581', ...asneoPaper, ...asneoRepo },
+  ours,
+  modes: {
+    triage: {verdict:'', rationale:''},
+    replacement: {verdict:'', rationale:''},
+    cross_check: {verdict:'', rationale:''},
+    component_reuse: {verdict:'', rationale:''},
+    reject: {verdict:'', rationale:''},
+  },
+  verified_claims: verdicts.filter(Boolean),
+  open_questions: [],
+  caveats: [],
+}
+```
+
+- [ ] **Step 2: Run the Workflow**
+
+Invoke the Workflow tool with the script above. It runs in the background and notifies on completion.
+
+- [ ] **Step 3 (VERIFICATION GATE): Audit the returned findings**
+
+Read the returned object. For EVERY field used in the deck (Task 3), confirm it is NOT the literal string `UNVERIFIED` and that any numeric/cohort claim appears in `verified_claims` with `status:"verified"` and ≥2 `sources`. The `modes` verdicts come back empty by design — the Scientist fills them in synthesis (Step 4), they are not delegated.
+
+Expected: a populated `asneo` + `ours` object; `verified_claims` with the four load-bearing claims each `verified` or `unverified`.
+
+- [ ] **Step 4: Synthesize the 5-mode verdicts + decision (Scientist, in main loop)**
+
+Using ONLY verified findings, fill `modes.{triage,replacement,cross_check,component_reuse,reject}` (verdict ∈ {✅,⚠️,❌} + one-line rationale), pick the headline decision mode, and draft `open_questions` + `caveats`. Hedge or drop any `unverified` claim (memory: never quote unreachable sources). No commit — these feed Tasks 2/3/5.
+
+---
+
+## Task 2: Zotero entry (dedup-check → 3-section note)
+
+**Files:** Zotero collection `Z38GTJNW` (external; no git change). `.env` at repo root holds creds.
+
+- [ ] **Step 1 (GATE): Dedup pre-check the DOI**
+
+`zotero_add.py` does not dedup. Query existing items first:
+
+```bash
+cd /Users/jin-holee/dev/GitHub/Jin-HoMLee/splice-neoepitope-pipeline-scientist
+python - <<'PY'
+import os, requests
+from dotenv import load_dotenv
+load_dotenv()
+uid=os.environ["ZOTERO_USER_ID"]; key=os.environ["ZOTERO_API_KEY"]
+r=requests.get(f"https://api.zotero.org/users/{uid}/items/top",
+    headers={"Zotero-API-Key":key}, params={"q":"10.18632/aging.103581","qmode":"everything","limit":50})
+hits=[(i["key"], i["data"].get("DOI",""), i["data"].get("title","")) for i in r.json()
+      if "aging.103581" in (i["data"].get("DOI","") or "")]
+print("EXISTING:", hits or "none")
+PY
+```
+
+Expected: `EXISTING: none` (then add) or a `(KEY, doi, title)` tuple (then `--update-note KEY`).
+
+- [ ] **Step 2: Surface the entry to the user before adding**
+
+Per `feedback_zotero_surface_extras.md`: show the user the title + the drafted 3-section note and confirm before writing to Zotero. Do not silently add.
+
+- [ ] **Step 3: Add (or update) with the 3-section HTML note**
+
+Note format = **Findings / Methods / vs. our pipeline**, bold-keyword leads, telegraphic bullets (`feedback_zotero_note_format.md`). Tags are **space-separated**:
+
+```bash
+python research/scripts/zotero_add.py 10.18632/aging.103581 \
+  --tags splice-neoepitope alternative-splicing rna-seq tool-eval \
+  --note '<p><b>Findings.</b></p><ul><li>...</li></ul><p><b>Methods.</b></p><ul><li>...</li></ul><p><b>vs. our pipeline.</b></p><ul><li>...</li></ul>'
+# If Step 1 found an existing key K:  ... --update-note K --note '<...>'
+```
+
+- [ ] **Step 4 (VERIFICATION GATE): Confirm the entry + capture its Zotero key**
+
+Re-query `items/top` for the DOI; record the returned item key for `refs.bib` (`note = {Zotero: KEY}`).
+
+---
+
+## Task 3: Scaffold the deck (`slides.qmd` + `refs.bib`)
+
+**Files:**
+- Create: `research/evals/issue_546_asneo/refs.bib`
+- Create: `research/evals/issue_546_asneo/slides.qmd`
+
+- [ ] **Step 1: Write `refs.bib`**
+
+```bibtex
+@article{zhang2020asneo,
+  title = {{ASNEO}: Identification of personalized alternative splicing based neoantigens with {RNA}-seq},
+  author = {Zhang, Zhanbo and others},
+  journal = {Aging},
+  year = {2020},
+  doi = {10.18632/aging.103581},
+  note = {Zotero: <KEY from Task 2 Step 4>},
+}
+```
+
+Add a second `@article`/`@misc` entry only for any comparator actually cited on a slide (e.g. the #258 NeoGuider paper, Zotero `Z8FJSDVT`).
+
+- [ ] **Step 2: Write `slides.qmd` — front matter (mirror HERMES verbatim except title/date)**
+
+```yaml
+---
+title: "ASNEO as a splice-neoepitope candidate generator — peer or upgrade?"
+subtitle: "Tool evaluation · Issue #546 · 2026-05-29"
+author: "Jin-Ho Lee"
+institute: "Splice Neoepitope Pipeline · JH M Lee Lab"
+date: 2026-05-29
+date-format: "YYYY-MM-DD"
+format:
+  revealjs:
+    theme: [simple, ../../slides/custom.scss]
+    footer: "Splice Neoepitope Pipeline · JH M Lee Lab"
+    incremental: false
+    slide-number: c/t
+    progress: true
+    chalkboard: false
+    code-line-numbers: false
+    fig-align: center
+    fig-cap-location: bottom
+    transition: fade
+    background-transition: fade
+    width: 1280
+    height: 720
+# PDF (beamer) render disabled — Quarto/pandoc longtable issue (per CLAUDE.md).
+bibliography: refs.bib
+csl: ../../slides/nature.csl
+execute:
+  echo: false
+  warning: false
+---
+```
+
+- [ ] **Step 3: Write the 9 content slides**
+
+Each `## Heading` + `---` separator. Fill bracketed `<from findings.*>` slots from the Task 1 object (these are data-dependent values, NOT deferred decisions). Slide map:
+
+1. **The question** — centered: *"Should ASNEO change how we generate splice neoepitopes?"* + a `callout-note` "Why now": surfaced from the #258 NeoGuider eval as the actual splice tool it delegates to.
+2. **ASNEO at a glance** `{.smaller}` — `<findings.asneo.citation>`, `<license>`, `<repo_url>` + `<repo_last_activity>` + `<language>`, code/weights status. `callout-tip` one-liner of its CLI if known.
+3. **How it works** — STAR → `SJ.out.tab` → `<junction_backbone>` filtering → `<peptide_assembly>` / `<frame_handling>` → `<mhc_predictor>` → ranking. Use an `.incremental` list.
+4. **Head-to-head** `{.smaller}` — a 5-row table, columns *Axis | ASNEO | Ours*, rows = junction calling / normal filtering / peptide+frame / MHC predictor / validation. Values from `findings.asneo.*` and `findings.ours.*`.
+5. **Where it would plug in** — a `{mermaid}` flowchart showing our DAG (junction extract → filter → assemble → translate → MHCflurry) with the candidate ASNEO insertion point(s) highlighted per the surviving mode(s).
+6. **Reasons by mode** `{.smaller}` — table: *Mode | Verdict | Rationale* for Triage/Replacement/Cross-check/Component-reuse/Reject, from `findings.modes.*`.
+7. **Decision** — centered big text = the headline mode + one-line framing; `. . .` then the sub-issue title (if integrate) or decline-note (if not); `callout-note` on whether the #258 calculus changed.
+8. **Open questions & caveats** `{.smaller}` — `.incremental` list from `findings.open_questions` + `findings.caveats`.
+9. **References** — `::: {#refs}\n:::` and cite entries inline elsewhere with `[@zhang2020asneo]`.
+
+- [ ] **Step 4: Commit the source**
+
+```bash
+git add research/evals/issue_546_asneo/slides.qmd research/evals/issue_546_asneo/refs.bib
+git commit -m "research(eval): ASNEO tool-primer deck source (Issue #546)"
+```
+
+(Commit only — surface SHA, do not push yet.)
+
+---
+
+## Task 4: Render + visual-verify the deck
+
+**Files:** Create `research/evals/issue_546_asneo/slides.html` + `slides_files/`.
+
+- [ ] **Step 1: Render**
+
+```bash
+cd /Users/jin-holee/dev/GitHub/Jin-HoMLee/splice-neoepitope-pipeline-scientist/research/evals/issue_546_asneo
+quarto render slides.qmd
+```
+
+Expected: `slides.html` written, exit 0, no unresolved-citation warnings.
+
+- [ ] **Step 2 (VERIFICATION GATE): Headless per-slide overflow check**
+
+reveal.js silently lets content overflow the 1280×720 canvas (`feedback_slide_visual_check.md`). Screenshot each slide index in a throwaway `.check_shots/` dir and page through:
+
+```bash
+for i in $(seq 0 9); do
+  "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" \
+    --headless --screenshot=".check_shots/slide_$i.png" --window-size=1280,720 \
+    "file://$PWD/slides.html#/$i" 2>/dev/null
+done
+```
+
+Read each PNG; confirm no clipped text/tables. `.check_shots/` is a throwaway debug dir — safe to delete after (the *exception* in `feedback_keep_render_artifacts.md`).
+
+- [ ] **Step 3: Fix any overflow**
+
+If a slide clips, add `{.smaller}` / split content / trim bullets in `slides.qmd`, re-render (Step 1), re-check (Step 2). Repeat until clean.
+
+- [ ] **Step 4: Commit the rendered deck**
+
+```bash
+git add research/evals/issue_546_asneo/slides.html research/evals/issue_546_asneo/slides_files
+git commit -m "research(eval): render ASNEO deck (Issue #546)"
+```
+
+Keep `slides.html` + `slides_files/` in the tree (`feedback_keep_render_artifacts.md`). Delete only `.check_shots/`.
+
+---
+
+## Task 5: Record the 5-mode decision + board-back the actionables
+
+**Files:** Issue #546 (comment + AC ticks); Issue #258 (conditional); board #9 (any new follow-up Issues).
+
+- [ ] **Step 1: Post the decision comment on #546**
+
+Render-for-humans: a `Mode | Verdict | Rationale` table + the headline decision + the verified-claims provenance. End with **Created by: Scientist**. Use the link+prefix+keyword ref style for every Issue/PR mention.
+
+```bash
+gh issue comment 546 --body-file <(cat <<'MD'
+## Verdict — <headline mode>
+... 5-mode table + rationale + verified-claims list ...
+**Created by:** Scientist
+MD
+)
+```
+
+- [ ] **Step 2: Conditionally update the #258 verdict comment**
+
+If the ASNEO eval changes the NeoGuider component-reuse calculus (#546 AC), append a note to the #258 verdict; otherwise state explicitly in the #546 comment that #258 is unaffected (so it is not re-litigated).
+
+- [ ] **Step 3 (GATE): Board-back every slide-surfaced actionable**
+
+Per `feedback_slide_findings_on_board.md`: each item on the Decision/Open-questions/Caveats slides that is actionable (a promised follow-up, an open scientific question, a forward-looking caveat) must exist as an Issue or an Issue comment on board #9 BEFORE the deck PR merges. File them now; capture their #numbers for the PR Test plan.
+
+---
+
+## Task 6: Open the PR + request review
+
+**Files:** none (git + GitHub).
+
+- [ ] **Step 1: Push the branch (after surfacing)**
+
+Surface the full commit list + diffstat, get the user's OK, THEN:
+
+```bash
+git push -u origin research/scientist/issue-546-asneo-eval
+```
+
+- [ ] **Step 2: Create the PR**
+
+Body includes a **Test plan** with checkboxes: deck renders clean / per-slide overflow verified / Zotero note added / 5-mode decision posted on #546 / slide actionables board-backed (list the #s from Task 5 Step 3). Reference `closes #546` is wrong for a desk eval that stays open until merge — use `advances #546` or link without auto-close, matching the #258 pattern.
+
+```bash
+gh pr create --title "research(eval): ASNEO splice-neoepitope candidate generator — desk eval (#546)" --body-file <path>
+```
+
+- [ ] **Step 3: Flip PR Status → Ready for review**
+
+A PostToolUse hook (#558) may auto-board the new PR and set Status. VERIFY the PR's board Status; only set `8bf9192f` (`Ready for review`) via GraphQL if the hook did not.
+
+- [ ] **Step 4: Offer `@claude review`**
+
+Per `feedback_github_workflow.md`, offer the review pass. On approval only: `gh pr comment <N> --body "@claude review"` (the exact canonical trigger the hook allows).
+
+---
+
+## Task 7: Lab notebook + close ritual + merge
+
+**Files:** Modify `research/lab_notebook/scientist.md`; Issue #546 + PR (AC/Test-plan ticks).
+
+- [ ] **Step 1: Write the lab-notebook entry (AFTER review, before merge)**
+
+Append a dated entry (`## 2026-05-29` / `### HH:MM UTC — Editor: Scientist` / `#### [Issue #546](url) ASNEO desk eval`) capturing the decision + rationale + deck path + Zotero key + that it reflects the post-review final state. Reference the PR # (closure-audit bot checks for it). Commit:
+
+```bash
+git add research/lab_notebook/scientist.md
+git commit -m "research(notebook): ASNEO eval decision entry (Issue #546)"
+git push
+```
+
+- [ ] **Step 2 (GATE): Tick the closure checklists**
+
+Verify each #546 AC and each PR Test-plan box, then tick `- [x]` (or comment-defer with a link). Never leave aspirational unchecked boxes.
+
+- [ ] **Step 3: Merge via the closure-ritual gate**
+
+```bash
+bash scripts/audit_and_merge.sh <PR_NUMBER> --squash --delete-branch
+```
+
+The script blocks the merge if any `- [ ]` remains on the PR Test plan or any linked Issue's ACs. On clean audit it forwards to `gh pr merge`.
+
+- [ ] **Step 4: Confirm board auto-flip**
+
+#546 + the PR should auto-flip to **Done** on merge (never set manually). If #546 used `advances` (no auto-close), tick-with-defer-link or close manually per the #258 closure path.
+
+---
+
+## Self-Review (against the spec)
+
+**Spec coverage:**
+- Zotero verified 3-section note → Task 2. ✅
+- Repo state (maintenance/lang/weights/license) → Task 1 Step 1 (asneo-repo agent). ✅
+- Head-to-head across 5 axes → Task 1 (gather) + Task 3 slide 4. ✅
+- 5-mode decision recorded → Task 1 Step 4 + Task 5 Step 1. ✅
+- Tool-primer deck, visually verified → Tasks 3 + 4. ✅
+- #258 conditional update → Task 5 Step 2. ✅
+- Lab-notebook entry → Task 7 Step 1. ✅
+- Board-backed actionables → Task 5 Step 3. ✅
+- Lifecycle (status/branch/commit-push-separate/PR/@claude/close) → Tasks 6 + 7. ✅
+
+**Placeholder scan:** The `<from findings.*>` slots in Task 3 are data-dependent values resolved by Task 1 (legitimate, not deferred decisions); the schema field names are concrete and defined in Task 1. The `<KEY>`, `<N>`, `<path>` slots are values captured by an explicit earlier step. No "TBD"/"add error handling"-class deferrals.
+
+**Type consistency:** Deck slots in Task 3 reference `findings.asneo.{citation,license,repo_url,repo_last_activity,language,junction_backbone,normal_filtering,peptide_assembly,frame_handling,mhc_predictor,validation_cohort,validation_n}`, `findings.ours.{junction_backbone,normal_filtering,peptide_assembly,frame_handling,mhc_predictor}`, and `findings.modes.{triage,replacement,cross_check,component_reuse,reject}` — all defined in the Task 1 `FINDINGS` schema. Consistent.

--- a/docs/superpowers/specs/2026-05-29-issue-546-asneo-eval-design.md
+++ b/docs/superpowers/specs/2026-05-29-issue-546-asneo-eval-design.md
@@ -5,15 +5,17 @@
 **Parent Issue:** [#546](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/546) — *research: evaluate ASNEO as splice-neoepitope candidate generator (peer to our HISAT2/regtools + STAR/SJ.out.tab paths)*
 **Source eval:** [#258](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/258) (NeoGuider) — ASNEO surfaced as the actual splice tool NeoGuider delegates to.
 
+> ⚠️ **DOI corrected during the eval:** the Issue #546 body and this spec's first draft cited `10.18632/aging.103581`; the verified DOI is **`10.18632/aging.103516`** (PubMed PMID 32697765 / PMC7425491 / Aging / GitHub). The references below are corrected.
+
 ## Goal
 
-Decide whether **ASNEO** (Zhang et al., *Aging* 2020, DOI `10.18632/aging.103581`) — our closest published peer (personalized alternative-splicing neoepitopes from RNA-seq) — should change our pipeline. The decision is framed as the five pipeline-fit modes from the Issue body: **Triage / Replacement / Cross-check / Component reuse / Reject**.
+Decide whether **ASNEO** (Zhang et al., *Aging* 2020, DOI `10.18632/aging.103516`) — our closest published peer (personalized alternative-splicing neoepitopes from RNA-seq) — should change our pipeline. The decision is framed as the five pipeline-fit modes from the Issue body: **Triage / Replacement / Cross-check / Component reuse / Reject**.
 
 This is a **desk eval** (decision-only), consistent with the sibling evals [#218](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/218) (HERMES), [#201](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/201) (ImmSET), [#188](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/188) (Boltz-2), [#258](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/258) (NeoGuider). **No code execution / no ASNEO run** — the multi-day Python2-era dependency archaeology is not justified for a P3 informational eval.
 
 ## Success criteria (maps to #546 ACs)
 
-- Verified Zotero entry on DOI `10.18632/aging.103581` with a 3-section HTML note (**Findings / Methods / vs. our pipeline**), added after a dedup pre-check.
+- Verified Zotero entry on DOI `10.18632/aging.103516` with a 3-section HTML note (**Findings / Methods / vs. our pipeline**), added after a dedup pre-check.
 - ASNEO repo state verified: maintenance status, language (Py2 vs Py3), code + weights availability, license.
 - Head-to-head comparison of ASNEO's junction-calling backbone vs. ours documented across five axes (below).
 - A 5-mode pipeline-fit decision recorded with rationale on #546.

--- a/docs/superpowers/specs/2026-05-29-issue-546-asneo-eval-design.md
+++ b/docs/superpowers/specs/2026-05-29-issue-546-asneo-eval-design.md
@@ -1,0 +1,92 @@
+# ASNEO eval — design spec (Issue #546)
+
+**Date:** 2026-05-29
+**Author:** Scientist
+**Parent Issue:** [#546](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/546) — *research: evaluate ASNEO as splice-neoepitope candidate generator (peer to our HISAT2/regtools + STAR/SJ.out.tab paths)*
+**Source eval:** [#258](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/258) (NeoGuider) — ASNEO surfaced as the actual splice tool NeoGuider delegates to.
+
+## Goal
+
+Decide whether **ASNEO** (Zhang et al., *Aging* 2020, DOI `10.18632/aging.103581`) — our closest published peer (personalized alternative-splicing neoepitopes from RNA-seq) — should change our pipeline. The decision is framed as the five pipeline-fit modes from the Issue body: **Triage / Replacement / Cross-check / Component reuse / Reject**.
+
+This is a **desk eval** (decision-only), consistent with the sibling evals [#218](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/218) (HERMES), [#201](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/201) (ImmSET), [#188](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/188) (Boltz-2), [#258](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/258) (NeoGuider). **No code execution / no ASNEO run** — the multi-day Python2-era dependency archaeology is not justified for a P3 informational eval.
+
+## Success criteria (maps to #546 ACs)
+
+- Verified Zotero entry on DOI `10.18632/aging.103581` with a 3-section HTML note (**Findings / Methods / vs. our pipeline**), added after a dedup pre-check.
+- ASNEO repo state verified: maintenance status, language (Py2 vs Py3), code + weights availability, license.
+- Head-to-head comparison of ASNEO's junction-calling backbone vs. ours documented across five axes (below).
+- A 5-mode pipeline-fit decision recorded with rationale on #546.
+- Tool-primer Quarto deck shipped at `research/evals/issue_546_asneo/slides.qmd`, visually verified.
+- #258 verdict comment updated *if* the ASNEO eval changes the NeoGuider component-reuse calculus.
+- Lab-notebook entry capturing the decision and rationale.
+
+## Execution — Workflow (approach C)
+
+Multi-agent Workflow because (i) ultracode is on and (ii) two memory rules bite hardest on tool evals: *never quote numerical findings from unreachable sources* (caught on PR #518) and the head-to-head needs **our-side** facts a general research harness won't have.
+
+**Phase 1 — Gather (parallel, schema'd):**
+1. ASNEO *paper claims* — junction backbone, normal-junction filtering, peptide assembly + frame logic, MHC predictor, validation cohort.
+2. ASNEO *repo state* — last commit, Py2 vs Py3, code + weights availability, license.
+3. *Our backbone* facts read from source — `workflow/scripts/bed12_to_junctions.py`, `star_sj_to_junctions.py`, `filter_junctions.py`, `assemble_contigs.py`, `translate_peptides.py`, `run_mhcflurry.py`.
+
+**Phase 2 — Adversarial verify:** each load-bearing claim (validation cohort + N, any reported AUROC/performance, MHC-predictor identity, license) refuted-by-default against ≥2 independent sources. Anything unverifiable is hedged or dropped — no quoting from unreachable sources.
+
+**Phase 3 — Synthesize (main loop, not an agent):** Scientist writes the 5-mode decision, Zotero note, and deck from verified findings only. Repo writes stay under direct control.
+
+## Head-to-head comparison axes (slide 5 + Zotero "vs. our pipeline")
+
+| Axis | ASNEO | Our pipeline |
+|---|---|---|
+| Junction calling | STAR → `SJ.out.tab` (+ any ASNEO filtering/motif selection — to verify) | HISAT2/regtools → `bed12_to_junctions.py`; STAR → `star_sj_to_junctions.py` (strand rescue from intron motif) |
+| Normal-junction filtering | matched-normal / GTEx panel / both — to verify | matched-normal at junction level (annotated → normal_shared → tumor_exclusive); GTEx pan-tissue planned (#212) |
+| Peptide assembly + frame | flank handling + frameshift detection — to verify | `assemble_contigs.py` (`bedtools getfasta -s`) → `translate_peptides.py` |
+| MHC predictor | netMHCpan / MHCflurry / in-house — to verify | MHCflurry `Class1PresentationPredictor` (presentation likelihood) |
+| Validation cohort | TESLA-like / self-curated — to verify | n/a (we are the pipeline under comparison) |
+
+## Deliverables
+
+Deck-only family at `research/evals/issue_546_asneo/`:
+- `slides.qmd` + `refs.bib` (theme `[simple, ../../slides/custom.scss]`; `csl: ../../slides/nature.csl`); rendered `slides.html` + `slides_files/` kept in the working tree.
+- Zotero 3-section HTML note (post dedup-check).
+- 5-mode decision comment on #546; conditional #258 verdict update.
+- Lab-notebook entry (written *after* review, before merge).
+
+## Deck slide map (title + 9, mirrors HERMES `issue_218_hermes/`)
+
+1. Title
+2. The question — *"Should ASNEO change how we generate splice neoepitopes?"*
+3. ASNEO at a glance — Zhang 2020, license, repo state, key facts
+4. How it works — STAR → `SJ.out.tab` → filtering → peptide assembly → MHC predictor → ranking
+5. Head-to-head — ASNEO vs. our backbone across the five axes above
+6. Integration map (mermaid) — where ASNEO or a component would plug into our DAG
+7. Reasons by mode — Triage / Replacement / Cross-check / Component reuse / Reject table
+8. Decision — verdict + rationale (+ sub-issue if integrate / decline-note if not)
+9. Open questions & caveats
+10. References
+
+## Lifecycle
+
+1. #546 → **In progress** (`47fc9ee4`) — done before branching.
+2. Branch `research/scientist/issue-546-asneo-eval` via `gh issue develop` — done.
+3. Build deliverables (Workflow → synthesis → deck + Zotero + decision).
+4. `quarto render` + **visually verify every slide** (reveal.js silently overflows; headless screenshots per slide).
+5. Commit (separate from push); surface SHA + diff and wait for OK before pushing.
+6. PR → flip PR **Ready for review** (`8bf9192f`) — note: a PostToolUse hook (#558) may auto-board the PR + set Status; verify, don't double-set.
+7. Offer `@claude review`.
+8. Lab-notebook entry (after review, before merge).
+9. Slide-surfaced actionables (open questions, follow-ups) filed on the board *before* the PR merges.
+10. Tick ACs via `scripts/audit_and_merge.sh <PR>`.
+
+## Out of scope
+
+- Any code execution / ASNEO run (desk eval only).
+- #547 (KDE + centered isotonic calibration) — already spun off from #258; not re-litigated here.
+- MHC-II support.
+- Re-running sibling evals; cite them for cohesion only.
+
+## Risks / open questions
+
+- ASNEO repo may be Python2-era and unmaintained — affects the "code + weights available" AC and the Replacement/Cross-check feasibility verdict.
+- Some paper claims (specific PSR/normal-filter thresholds, per-cohort AUROC) may be unverifiable from accessible sources — hedge or defer rather than quote, per the unreachable-source rule.
+- If ASNEO's normal-junction filtering meaningfully overlaps the planned GTEx pan-tissue filter (#212), the decision may surface a cross-reference to #212 rather than a standalone integration.

--- a/research/evals/issue_546_asneo/refs.bib
+++ b/research/evals/issue_546_asneo/refs.bib
@@ -1,0 +1,12 @@
+@article{zhang2020asneo,
+  title = {{ASNEO}: Identification of personalized alternative splicing based neoantigens with {RNA}-seq},
+  author = {Zhang, Zhanbing and Zhou, Chi and Tang, Lihua and Gong, Yukang and Wei, Zhiting and Zhang, Gongchen and Wang, Feng and Liu, Qi and Yu, Jing},
+  journal = {Aging},
+  volume = {12},
+  number = {14},
+  pages = {14633--14648},
+  year = {2020},
+  month = jul,
+  doi = {10.18632/aging.103516},
+  note = {Zotero: SZIRVGX4. Repo: github.com/bm2-lab/ASNEO (Apache-2.0).},
+}

--- a/research/evals/issue_546_asneo/slides.qmd
+++ b/research/evals/issue_546_asneo/slides.qmd
@@ -1,0 +1,180 @@
+---
+title: "ASNEO as a splice-neoepitope candidate generator — peer or upgrade?"
+subtitle: "Tool evaluation · Issue #546 · 2026-05-29"
+author: "Jin-Ho Lee"
+institute: "Splice Neoepitope Pipeline · JH M Lee Lab"
+date: 2026-05-29
+date-format: "YYYY-MM-DD"
+format:
+  revealjs:
+    theme: [simple, ../../slides/custom.scss]
+    footer: "Splice Neoepitope Pipeline · JH M Lee Lab"
+    incremental: false
+    slide-number: c/t
+    progress: true
+    chalkboard: false
+    code-line-numbers: false
+    fig-align: center
+    fig-cap-location: bottom
+    transition: fade
+    background-transition: fade
+    width: 1280
+    height: 720
+# PDF (beamer) render disabled — Quarto/pandoc longtable + footnotehyper LaTeX
+# interaction (per CLAUDE.md "Render tooling"). HTML reveal.js is primary;
+# "Print → Save as PDF" from Chrome for a handout.
+bibliography: refs.bib
+csl: ../../slides/nature.csl
+execute:
+  echo: false
+  warning: false
+---
+
+## The question
+
+::: {style="text-align: center; font-size: 2.2em; font-weight: bold; line-height: 1.2; margin-top: 0.4em;"}
+Should ASNEO change\
+how *we* generate\
+splice neoepitopes?
+:::
+
+. . .
+
+::: {.callout-note appearance="simple"}
+**Why now:** ASNEO surfaced from the [Issue #258](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/258) (NeoGuider eval) as the actual splice tool NeoGuider delegates to (STAR → `SJ.out.tab` → ASNEO). It is our **closest published peer** — RNA-seq → splice junctions → neoepitopes — so the head-to-head is the comparison a manuscript reviewer would expect.
+:::
+
+---
+
+## ASNEO at a glance {.smaller}
+
+**ASNEO** — *Identification of personalized **A**lternative **S**plicing based **NEO**antigens with RNA-seq* — Zhang et al., **Aging** 2020 [@zhang2020asneo] (DOI `10.18632/aging.103516`).
+
+::: {.incremental}
+- **Architecture:** STAR-based alternative-splicing neoantigen caller from tumor RNA-seq; ranks novel-junction peptides by an immunogenicity score.
+- **Code:** [`bm2-lab/ASNEO`](https://github.com/bm2-lab/ASNEO) — **Apache-2.0**, Python 3 (with Py2 shims). **Dormant**: last code change 2019, README-only edit 2021.
+- **Bundled weights:** three XGBoost immunogenicity models (9/10/11-mer) + reference panels `Norm_SJ.tab`, `Norm_Protein.fasta`, `iRefSeq.bed`, `iedb.fasta`.
+- **External deps (license-gated, user-obtained):** NetMHCpan-4.0 + NetCTLpan-1.1; plus STAR, bedtools.
+:::
+
+. . .
+
+::: {.callout-important appearance="simple"}
+**Provenance caveat:** the [Issue #546](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/546) body cited DOI `…/aging.103581` — **incorrect**. PubMed (PMID 32697765), PMC7425491, Aging, and GitHub all confirm `…/aging.103516`.
+:::
+
+---
+
+## How ASNEO works {.smaller}
+
+::: {.incremental}
+1. **Align** — STAR 2.5 → `SJ.out.tab` (hg19, `--sjdbOverhang 100`).
+2. **Filter junctions** — keep > 10 unique reads **and** psi5/psi3 > 0.1 (via `sj2psi`).
+3. **Remove normal** — drop junctions in **GTEx** (≥ 2 reads in ≥ 1% of samples) **or** the **UCSC hg19** reference annotation. *Population-level — no matched normal.*
+4. **Assemble + translate** — insert novel junction into the reference isoform → **one-frame** translation (start → stop) → proteins > 30 aa → chop to 8–11-mers.
+5. **Score** — NetMHCpan-4.0 %rank < 2 → combine NetCTLpan cleavage/TAP + hydrophobicity + XGBoost + T-cell-recognition into one immune score.
+:::
+
+. . .
+
+::: {.callout-note appearance="simple"}
+One-frame translation was a **deliberate low-false-positive choice** by the authors (vs. three- or six-frame).
+:::
+
+---
+
+## Head-to-head {.smaller}
+
+| Axis | **ASNEO** | **Ours** |
+|---|---|---|
+| Junction calling | STAR 2.5 → `SJ.out.tab` only; filter reads > 10, psi > 0.1 | Dual-path: HISAT2/regtools BED12 **+** STAR `SJ.out.tab` (strand rescue from motif) |
+| Normal filtering | **GTEx panel + UCSC annotation** (population-level) | **Matched-normal** at junction level (annotated → shared → tumor-exclusive); GTEx pan-tissue *planned* [Issue #212](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/212) |
+| Peptide / frame | **One-frame** (start→stop), > 30 aa → 8–11-mers | **Three-frame** w/ GENCODE CDS phase + junction-spanning condition |
+| MHC predictor | **NetMHCpan-4.0** affinity %rank + NetCTLpan | **MHCflurry** `Class1PresentationPredictor` (presentation) |
+| Validation | Schuster ovarian (n=14, **2 MS-confirmed**); Van Allen (n=39); Hugo (n=25) | — |
+
+. . .
+
+**Maintenance / portability:** ASNEO is hg19-only, dormant since 2019, needs Biopython < 1.80, and wraps license-gated binaries — *not* a maintained GRCh38 drop-in.
+
+---
+
+## Where it would plug in {.smaller}
+
+```{mermaid}
+%%| fig-width: 11
+flowchart LR
+    R["Tumor RNA-seq"] --> AL["HISAT2 / STAR<br/>alignment"]
+    AL --> JX["Junction extraction<br/>(bed12 / star_sj)"]
+    JX --> FILT["filter_junctions.py<br/>matched-normal<br/>3-tier hierarchy"]
+    FILT --> ASM["assemble_contigs +<br/>translate_peptides<br/>(3-frame)"]
+    ASM --> MHC["MHCflurry<br/>presentation"]
+    GTEX["ASNEO GTEx-panel<br/>normal-junction ref<br/>(Norm_SJ.tab)"] -.->|"design ref · #212"| FILT
+
+    style GTEX fill:#ffe6a3,stroke:#b8860b,stroke-width:3px
+    style FILT fill:#a3d8ff,stroke:#1e5ba8,stroke-width:2px
+```
+
+The one genuinely adoptable element is ASNEO's **population-level GTEx normal-junction reference** — it slots in *beside* our matched-normal filter, exactly the [Issue #212](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/212) GTEx pan-tissue enhancement. Full **replacement** would swap the entire highlighted chain — rejected (next slide).
+
+---
+
+## Reasons by mode {.smaller}
+
+| Mode | Verdict | Rationale |
+|---|:---:|---|
+| Triage | ❌ | ASNEO's junction filters sit at the **same stage** as ours — no upstream pre-filter advantage |
+| Replacement | ❌ | Unmaintained, **hg19-only** (we're GRCh38), stale Biopython dep, wraps license-gated NetMHCpan/NetCTLpan — regressive swap |
+| Cross-check | ⚠️ | Attractive (closest peer, orthogonal 2nd opinion) but costly: hg19 liftover + NetMHCpan license + old env. **Park as future manuscript-validation experiment** |
+| **Component reuse** | **✅** | ASNEO's **GTEx-panel normal-junction filter** (`Norm_SJ.tab`; "≥ 2 reads in ≥ 1% of GTEx samples") = direct **prior art** for our planned [Issue #212](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/212) filter |
+| Reject | ❌ | Not a reject — our closest published peer; yields a #212 design reference + a manuscript comparison point |
+
+---
+
+## Decision
+
+::: {style="text-align: center; font-size: 3em; font-weight: bold; margin-top: 0.4em;"}
+(✅) Component reuse
+:::
+
+::: {style="text-align: center; font-size: 1.3em; margin-top: 0.4em;"}
+ASNEO's GTEx-panel normal-junction filter\
+= design reference for [Issue #212](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/212)
+:::
+
+. . .
+
+**No new integration sub-issue** — this is a **design-reference note on [Issue #212](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/212)** (already-planned GTEx pan-tissue filter), not a fresh build. Decline Replacement + Triage; park Cross-check.
+
+. . .
+
+::: {.callout-note appearance="simple"}
+**[Issue #258](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/258) calculus unaffected:** the NeoGuider component-reuse take-home (KDE + isotonic calibration, [Issue #547](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/547)) is a **downstream ranker-calibration layer** — orthogonal to ASNEO's upstream junction filtering.
+:::
+
+---
+
+## Open questions & caveats {.smaller}
+
+**Open scientific questions** *(board-backed on [Issue #212](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/212)):*
+
+::: {.incremental}
+1. Should [Issue #212](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/212) adopt ASNEO's exact thresholds (≥ 2 reads in ≥ 1% of GTEx samples), and which GTEx version / tissue set to match?
+2. **One-frame** (ASNEO, low-FP) vs. our **three-frame** (higher sensitivity) — worth quantifying the FP/sensitivity tradeoff on the chr22 PoC?
+:::
+
+. . .
+
+**Caveats:**
+
+::: {.incremental}
+- ASNEO's immunogenicity stack (NetCTLpan + XGBoost + T-cell recognition) overlaps [Issue #551](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/551) (NeoPrecis) + [Issue #547](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/547) (NeoGuider calibration) already under eval — **no new action**.
+- Cross-check needs hg19 liftover + a NetMHCpan license — out of scope here.
+:::
+
+---
+
+## References {.smaller}
+
+::: {#refs}
+:::

--- a/research/lab_notebook/scientist.md
+++ b/research/lab_notebook/scientist.md
@@ -8,6 +8,30 @@ Format and rules unchanged from the unified notebook — see `shared/feedback_la
 
 ## 2026-05-29
 
+### 21:19 UTC — Editor: Scientist
+
+#### [Issue #546](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/546) ASNEO desk eval — ✅ Component reuse verdict; tool-primer deck shipped. [PR #563](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/563) closes [Issue #546](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/546).
+
+**Verdict.** ASNEO (Zhang et al., *Aging* 2020) — our closest published peer (RNA-seq → splice junctions → neoepitopes), surfaced from the [Issue #258](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/258) (NeoGuider eval) as the splice tool NeoGuider delegates to — lands at **Component reuse** on the 5-mode scale (Triage / Replacement / Cross-check / Component reuse / Reject). The one adoptable element is ASNEO's population-level **GTEx normal-junction filter** (`Norm_SJ.tab`; "≥2 reads in ≥1% of GTEx samples" + UCSC hg19 annotation) — direct prior art for our planned GTEx pan-tissue filter ([Issue #212](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/212) (consume)). Declined Replacement + Triage; parked Cross-check as a possible future manuscript-validation experiment.
+
+**Why not Replacement.** ASNEO is **unmaintained** (last code change 2019, README-only edit 2021), **hg19-only** (we're GRCh38), needs Biopython < 1.80 (imports the removed `Bio.SubsMat`), and wraps license-gated NetMHCpan-4.0 / NetCTLpan — swapping our maintained GRCh38 + MHCflurry stack for it would be regressive, not an upgrade.
+
+**Head-to-head divergences (all adversarially verified vs ≥2 sources).** Four substantive differences from our pipeline: (1) **normal filtering** — ASNEO GTEx-panel + reference annotation (population-level) vs. our matched-normal at junction level (annotated → shared → tumor-exclusive); (2) **frame** — ASNEO one-frame translation (a deliberate low-false-positive choice) vs. our three-frame with GENCODE CDS phase + junction-spanning condition; (3) **MHC** — ASNEO NetMHCpan-4.0 affinity %rank + NetCTLpan/XGBoost/T-cell immune score vs. our MHCflurry `Class1PresentationPredictor` (presentation likelihood); (4) **junction calling** — ASNEO STAR-only + read/psi filters vs. our dual HISAT2/regtools BED12 + STAR `SJ.out.tab` paths.
+
+**Method (approach C, ultracode).** A gather → adversarial-verify Workflow (8 agents): three parallel gather agents (ASNEO paper, ASNEO repo, our backbone read from `workflow/scripts/*.py`) + five refute-by-default verifiers on the load-bearing claims. All five (MHC predictor, validation cohort/N, license, normal filtering, junction backbone) returned **verified** with 3–4 concordant independent sources — zero unverified fields. Validation cohorts confirmed: Schuster ovarian n=14 (2 MS-confirmed peptides: MKANPALTM, IHFLSLLNF), Van Allen melanoma n=39, Hugo melanoma n=25.
+
+**DOI correction.** The [Issue #546](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/546) body cited `10.18632/aging.103581` — incorrect. Verified DOI is **`10.18632/aging.103516`** (PubMed PMID 32697765 / PMC7425491 / Aging / GitHub all concordant). Corrected in the deck + Zotero (`SZIRVGX4`); the design spec carries a correction note (review fix).
+
+**Deliverables.** Tool-primer deck [`research/evals/issue_546_asneo/slides.qmd`](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/blob/main/research/evals/issue_546_asneo/slides.qmd) (title + 9 content slides, mirrors the HERMES eval-deck spec), all 10 slides headless-PDF overflow-checked clean per [`feedback_slide_visual_check.md`](feedback_slide_visual_check.md). Zotero `SZIRVGX4` (3-section note). Board-backed actionables: [Issue #212](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/212) (consume) carries the design-reference + two open questions (threshold/GTEx-version adoption; one-frame-vs-three-frame FP/sensitivity check on the chr22 PoC); [Issue #258](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/258) (cross-link) notes its calculus is unaffected — the NeoGuider KDE+isotonic take-home ([Issue #547](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/547) (downstream)) is a downstream ranker-calibration layer, orthogonal to ASNEO's upstream junction filtering.
+
+**Review.** [PR #563](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/563) automated review clean bar two doc-accuracy findings, both valid and fixed in `4aad617`: (a) a stale `…103581` DOI in the design spec (the deliverables were already correct); (b) plan Task 4 Step 4's `git add slides.html slides_files` would silently no-op (`research/evals/**` HTML + `_files/` are gitignored) — also corrected the File Structure table's wrong "committed per HERMES precedent" annotation.
+
+**Hook bug flagged.** The [PR #558](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/558) PostToolUse auto-board hook wrongly flipped the *linked Issue* ([Issue #546](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/546)) to Ready-for-review on PR creation — it should touch only the PR and leave the Issue at In progress. Corrected manually; a hook-fix follow-up is pending a decision.
+
+**Commits.** `6c9ad06` (spec), `18da469` (plan), `837e0d2` (deck source), `4aad617` (review fixes).
+
+---
+
 ### 14:36 UTC — Editor: Scientist
 
 #### [Issue #258](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/258) NeoGuider deck — added a visual KDE + centered-isotonic backup appendix + two matplotlib diagrams; 2nd automated review pass clean; diagram-tool convention documented. [PR #544](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/544) ready to merge — closes [Issue #258](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/258).


### PR DESCRIPTION
## Summary

Desk eval ([Issue #546](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/546)) of **ASNEO** (Zhang et al., *Aging* 2020) as a splice-neoepitope candidate generator — our **closest published peer** (RNA-seq → splice junctions → neoepitopes). Surfaced from the [Issue #258](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/258) (NeoGuider eval) as the splice tool NeoGuider delegates to.

**Verdict: ✅ Component reuse** — ASNEO's population-level **GTEx normal-junction filter** (`Norm_SJ.tab`) is direct prior art for our planned GTEx pan-tissue filter ([Issue #212](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/212) (design reference)). Decline **Replacement** (unmaintained, hg19-only, license-gated NetMHCpan) + **Triage**; park **Cross-check** as a possible future manuscript-validation experiment.

All facts adversarially verified vs ≥2 independent sources via a gather → verify Workflow. **DOI corrected** along the way: Issue body cited `…/aging.103581` → actual is `…/aging.103516`.

## Files
- `research/evals/issue_546_asneo/slides.qmd` + `refs.bib` — tool-primer deck (title + 9 content slides)
- `docs/superpowers/specs/2026-05-29-issue-546-asneo-eval-design.md` — design spec
- `docs/superpowers/plans/2026-05-29-issue-546-asneo-eval.md` — implementation plan

## Test plan
- [x] Deck renders clean (`quarto render`, exit 0)
- [x] Per-slide overflow verified — 10/10 slides via reveal `?print-pdf`, no clipping
- [x] Zotero note added — key `SZIRVGX4`, corrected DOI `10.18632/aging.103516`
- [x] 5-mode decision recorded on [Issue #546](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/546)
- [x] Slide actionables board-backed — [Issue #212](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/212) (design ref + open Qs), [Issue #258](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/258) (calculus unaffected)
- [x] Lab-notebook entry (after review, before merge)

Closes #546.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

