### PR TITLE
docs(CLAUDE.md): note hooks deactivate after mid-session settings.json edit

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -308,6 +308,8 @@ snakemake --cores 4 --use-conda --configfile config/test_config.yaml
 
 Mechanisms that fire automatically to enforce GitHub-related discipline rules that have broken repeatedly despite being documented in memory. Per the mechanism-over-memory ladder (memory → inline Always-in-effect → mechanism), these are the rung-3 escalation when a rule has slipped ≥2× on the same shape.
 
+> **⚠️ Hook loading — restart after editing `.claude/settings.json`.** Editing `.claude/settings.json` mid-session **silently deactivates ALL the hooks below** (every PreToolUse + PostToolUse) for the rest of that session — they do **not** hot-reload. So wiring a new hook (or changing one) also kills the *existing* guards (e.g. the `@claude` blocker) until you **restart the session**. Verify what's actually live with `/hooks`. Verified 2026-05-29: the committed `post_gh_pr_create` hook fired in a fresh session (trace probe) but was dead in the session that had edited `settings.json` mid-session — silently causing [PR #560](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/560) + [PR #562](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/562) to miss auto-boarding. Also: hooks fire only on **Claude's tool calls**, not on commands a human runs in a terminal — so a firing test must be driven by a Claude session.
+
 ### `@claude` mention guard ([PreToolUse hook](.claude/settings.json))
 
 Refuses any `gh (pr|issue) (comment|create)` whose `--body` contains a literal `@claude` substring, except the exact canonical review-trigger `--body "@claude review"` (and the single-quoted variant). The hook runs `.claude/hooks/check_at_claude.py` on stdin-piped PreToolUse JSON and emits a `permissionDecision: deny` when the guard fires.

--- a/research/lab_notebook/developer.md
+++ b/research/lab_notebook/developer.md
@@ -8,6 +8,16 @@ Format and rules unchanged from the unified notebook — see `shared/feedback_la
 
 ## 2026-05-29
 
+### 21:30 UTC — Editor: Developer
+
+**Headline:** [PR #564-vehicle](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/564) — documented a **confirmed Claude Code hook-loading gotcha** in CLAUDE.md § GitHub Safety Wrappers, resolving the auto-board-miss investigation from the 20:45 entry.
+
+**Root cause (systematic debugging, evidence-first):** the `post_gh_pr_create` auto-board hook missed both [PR #560](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/560) and [PR #562](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/562). A trace probe (unconditional line at `main()` entry + a read-only `gh pr view` tool call) proved the hook **never fired in this session** — even though `settings.json` is valid and the matcher correct. A fresh session ran the identical probe and the hook **fired** (`/tmp/pgpc.log` written). The only difference: this session had **edited `.claude/settings.json` mid-session** (wired `check_gh_issue_develop_parent` during PR #560). Conclusion: editing `settings.json` mid-session silently deactivates ALL hooks until restart — no hot-reload. So the misses were a session-loading artifact, **not** a code defect; [Issue #561](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/561)'s `VAR=` matcher bug stays scoped as a separate latent fix (deferred to a fresh session).
+
+**Why doc-worthy:** it silently disables *existing* safety guards too (the `@claude` blocker was dead in this session after my edit). Anyone wiring a hook hits this. Captured as a ⚠️ callout + a role memory. Two doc-process notes: hooks fire only on Claude tool calls (not human terminal commands), and the `/hooks` menu's "create" screen is just its entry UI, not proof of absence.
+
+---
+
 ### 20:45 UTC — Editor: Developer
 
 **Headline:** [PR #562](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/562) (closes [Issue #559](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/559)) — merge-time **stray-closing-keyword gate**, the companion to the 20:13 `gh issue develop` guard. Together they close the [PR #543](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/543) → [parent Issue #538](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/538) incident class from both ends: create-time (don't branch off a parent) + merge-time (don't let a stray `close|fix|resolve` + `#N` in the squash body silently shut an unintended Issue).


### PR DESCRIPTION
**Created by:** Developer

Closes [Issue #564](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/564).

## Summary

Documents a confirmed Claude Code **hook-loading gotcha** in CLAUDE.md § GitHub Safety Wrappers: editing `.claude/settings.json` mid-session silently deactivates **all** hooks (every PreToolUse + PostToolUse) until the session is restarted — no hot-reload.

**Why it matters:** wiring a new hook also kills the *existing* guards (e.g. the `@claude` blocker) until restart — silently. This is the root cause of the [PR #560](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/560) + [PR #562](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/562) auto-board misses, root-caused during the [Issue #561](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/561) investigation: the committed `post_gh_pr_create` hook fired in a fresh session (trace probe) but was dead in the session that had edited `settings.json` mid-session.

Separate from [Issue #561](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/561)'s `VAR=value` matcher code bug — that's a distinct latent fix, deferred to a fresh session.

## Test plan

- [x] CLAUDE.md callout covers: mid-session edit → all hooks inactive until restart; mitigation (restart + `/hooks`); the fresh-vs-edited verification evidence; hooks fire on Claude's tool calls, not human terminal commands
- [x] Doc-only change — no code or tests affected
- [x] Lab-notebook entry (21:30 UTC) resolves the auto-board-miss investigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
