### PR TITLE
design+feat(pm): personas-repo governance Phase 1 (closes #567)

### DIFF
--- a/docs/superpowers/plans/2026-05-30-personas-repo-governance-phase1.md
+++ b/docs/superpowers/plans/2026-05-30-personas-repo-governance-phase1.md
@@ -145,6 +145,8 @@ Expected: `OK: index link resolves`.
 
 ## Task 3: Add the session-start git-status scan to each role's morning routine
 
+> ⚠️ **Implementation note (as shipped):** This task was executed as **one shared step in `shared/feedback_morning_routine.md` Step −1**, not as three per-role file edits as written below — the shared backbone avoids 3-way drift across the role copies. The Steps below are retained as the original plan; the deviation and rationale are recorded in the 2026-05-29 PM lab-notebook entry.
+
 **Files:**
 - Modify: `$PERSONAS/pm/feedback_morning_routine.md`
 - Modify: `$PERSONAS/scientist/feedback_morning_routine.md`

--- a/docs/superpowers/plans/2026-05-30-personas-repo-governance-phase1.md
+++ b/docs/superpowers/plans/2026-05-30-personas-repo-governance-phase1.md
@@ -1,0 +1,351 @@
+# Personas-Repo Governance — Phase 1 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking. **Caveat for THIS plan:** it edits the personas repo, and dispatching parallel subagents to edit it would re-create the "too many sessions touching it" problem — execute **inline** (executing-plans), in one PM-caretaker session.
+
+**Goal:** Land Phase 1 of the personas-repo governance ([Issue #567](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/567), sub of [#527](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/527)): the access/lifecycle policy as memory rules, the session-start git-status scan (= #527 Sub 6), and the PM-caretaker interim commit convention.
+
+**Architecture:** Pure memory-doc edits in the personas repo (`claude-personas-splice-neoepitope-pipeline`): one new shared feedback file holding the full policy, a concise Always-in-effect pointer replacing the obsolete rule in `shared/MEMORY.md`, and a session-start scan step added to each role's morning-routine file. Committed by PM-as-caretaker under the bootstrap exception (MM not yet onboarded), with the user's push gate. The project repo carries only the spec, this plan, and the lab-notebook entry on the #567 branch.
+
+**Tech Stack:** Markdown memory files; `git -C` against the personas repo; `gh` for the project-repo PR. No code, no test harness — "tests" here are `grep` verifications that the right text is present/absent.
+
+**Personas repo path (used throughout):** `~/dev/GitHub/Jin-HoMLee/claude-personas-splice-neoepitope-pipeline` (referenced below as `$PERSONAS`).
+
+---
+
+## File Structure
+
+**Personas repo (`claude-personas-splice-neoepitope-pipeline`):**
+- **Create** `shared/feedback_personas_governance.md` — the full governance policy (edit/commit matrix, propose-flows, commit ownership, interim caretaker, the "Memory edits — for MM to commit" flag, Phase-2 roadmap).
+- **Modify** `shared/MEMORY.md` — replace the Always-in-effect "Personas-repo git state is not your responsibility" line with a concise new-model pointer; add the new file to the Reference index.
+- **Modify** `pm/feedback_morning_routine.md` — add a session-start personas git-status scan step (PM = caretaker committer variant).
+- **Modify** `scientist/feedback_morning_routine.md` — add the scan step (surface-and-flag variant).
+- **Modify** `developer/feedback_morning_routine.md` — add the scan step (surface-and-flag variant).
+
+**Project repo (`splice-neoepitope-pipeline`, branch `design/pm/issue-567-personas-repo-governance`):**
+- **Modify** `research/lab_notebook/pm.md` — non-routine governance-session entry.
+- Spec + this plan already committed on the branch.
+
+**Decision baked in:** the policy lives in `shared/` only (auto-loaded by every role), **not** copied into each role's `MEMORY.md`. This diverges from #527 Sub 6's original "per-role MEMORY.md copy" step on purpose — per-role duplication fights the slimming epic ([#538](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/538)); one shared rule covers all roles.
+
+---
+
+## Task 1: Create the governance policy file
+
+**Files:**
+- Create: `$PERSONAS/shared/feedback_personas_governance.md`
+
+- [ ] **Step 1: Write the file**
+
+Write to `$PERSONAS/shared/feedback_personas_governance.md`:
+
+```markdown
+---
+name: personas-repo-governance
+description: Who may edit what in the personas memory repo and who commits/pushes. Own-dir edits free; shared/ + cross-role go through MM (propose); MM owns all commits. Interim: PM-caretaker commits with the user push gate + a session-start git-status scan.
+metadata:
+  type: feedback
+---
+
+Governance for the `claude-personas-splice-neoepitope-pipeline` memory repo. Decided 2026-05-29 ([Issue #567](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/567), sub of [Issue #527](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/527)); supersedes the 2026-05-26 "personas-repo git state is not your responsibility" rule. Full design: `docs/superpowers/specs/2026-05-29-personas-repo-governance-design.md` (project repo).
+
+## Edit + commit matrix (steady state — once MM is onboarded)
+
+| Zone | Who may edit | Non-owner change request | Commit / push |
+|---|---|---|---|
+| Own `<role>/` dir | that role, freely | n/a | MM only |
+| `shared/` | MM only | role proposes (role-labeled issue / standup) -> MM edits | MM only |
+| Another role's `<role>/` dir | nobody | file a request (issue / standup) | MM only |
+| `team_standup.md` + archives | append-only (existing rule) | n/a | MM only |
+
+**Your only direct write is your own `<role>/` dir.** Cross-cutting (`shared/`) and cross-role changes route through MM so they get a second set of eyes before reaching every session.
+
+## Proposing a change you cannot make directly
+
+- **`shared/` rule change** -> file a role-labeled issue OR a standup note describing it; MM makes the edit. (Interim: PM-caretaker makes it.)
+- **Another role's memory** (dead link, correction, etc.) -> file a request (issue / standup); the owner role or MM handles it. Example: the dead-link handoff [claude-personas#12](https://github.com/Jin-HoMLee/claude-personas-splice-neoepitope-pipeline/issues/12).
+
+## Own-dir edits: flag them for the committer
+
+After editing your own `<role>/` memory in a session, add a **"Memory edits — for MM to commit"** bullet to your lab-notebook / standup entry listing the touched files. That bullet is the structural handoff so the next committer lands them.
+
+## Commit / push ownership
+
+- **Steady state:** MM is the sole committer/pusher for the entire personas repo.
+- **Interim (MM not yet onboarded):** **PM-as-caretaker** commits/pushes, in-session, **with the user's push gate** — never chain commit -> push without the user OK. Caretaker work is journaled in `pm.md` tagged `(MM caretaker)`. This replaces the failed "user commits outside the session" assumption that produced the 2026-05-29 stranding incident.
+
+## Anti-stranding: session-start scan
+
+Every PM / Sci / Dev session runs a `git -C <personas-repo> status` scan at session start (see each role's `feedback_morning_routine.md`) and surfaces any uncommitted / stranded state immediately, so edits cannot silently pile up on a stale branch. This is [Issue #527](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/527) Sub 6.
+
+## Enforcement roadmap (Phase 2 — gated on MM onboarding)
+
+Once MM is onboarded ([Issue #527](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/527) Subs 3–9), two mechanisms make this deterministic (filed as #527 subs): (1) per-role `.claude/settings.json` denying `git commit`/`push` on personas to non-MM sessions; (2) a PreToolUse hook blocking `Write`/`Edit` on `shared/**` and other roles' dirs unless the session is MM. Until then, this file is the convention.
+```
+
+- [ ] **Step 2: Verify the file exists and is well-formed**
+
+Run:
+```bash
+PERSONAS=~/dev/GitHub/Jin-HoMLee/claude-personas-splice-neoepitope-pipeline
+test -f "$PERSONAS/shared/feedback_personas_governance.md" && head -4 "$PERSONAS/shared/feedback_personas_governance.md"
+```
+Expected: file exists; frontmatter `---` / `name: personas-repo-governance` printed.
+
+- [ ] **Step 3: Verify no dead self-links**
+
+Run:
+```bash
+grep -c "feedback_personas_governance" "$PERSONAS/shared/feedback_personas_governance.md"
+```
+Expected: `0` (the file does not reference itself).
+
+---
+
+## Task 2: Rewrite the obsolete Always-in-effect rule + index it
+
+**Files:**
+- Modify: `$PERSONAS/shared/MEMORY.md` (the "Personas-repo git state is not your responsibility" Always-in-effect line + the Reference index)
+
+- [ ] **Step 1: Replace the obsolete rule line**
+
+In `$PERSONAS/shared/MEMORY.md`, replace the entire Always-in-effect bullet that begins `- **Personas-repo git state is not your responsibility:**` (currently one long line) with:
+
+```markdown
+- **Personas-repo edits — own dir only; `shared/` + cross-role go through MM; MM commits:** Edit your own `<role>/` memory freely. **Never directly edit `shared/` or another role's dir** — *propose* instead (`shared/` rule -> role-labeled issue/standup; other-role -> file a request). All commits/pushes are **MM's**. **Interim (MM not yet onboarded):** PM-as-caretaker commits/pushes with the **user's push gate**, after a session-start `git -C <personas> status` scan; flag your own-dir edits with a "Memory edits — for MM to commit" bullet. Supersedes the 2026-05-26 "not your responsibility" rule (which produced the 2026-05-29 stranding incident). Full policy: `shared/feedback_personas_governance.md`; design: [Issue #567](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/567) / [Issue #527](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/527). <!-- src: shared/feedback_personas_governance.md -->
+```
+
+- [ ] **Step 2: Verify the old rule is gone and the new one is present**
+
+Run:
+```bash
+PERSONAS=~/dev/GitHub/Jin-HoMLee/claude-personas-splice-neoepitope-pipeline
+grep -c "not your responsibility" "$PERSONAS/shared/MEMORY.md"   # expect 0
+grep -c "own dir only.*go through MM" "$PERSONAS/shared/MEMORY.md" # expect 1
+```
+Expected: first `0`, second `1`.
+
+- [ ] **Step 3: Add the new file to the Reference index**
+
+In `$PERSONAS/shared/MEMORY.md`, find the Reference-section list (the bullets near the bottom linking `feedback_*.md` files) and add:
+
+```markdown
+- [Personas-repo governance](feedback_personas_governance.md) — who edits what (own dir only; shared/ + cross-role via MM) + who commits (MM; interim PM-caretaker with user gate) + session-start git-status scan
+```
+
+- [ ] **Step 4: Verify the index entry resolves**
+
+Run:
+```bash
+PERSONAS=~/dev/GitHub/Jin-HoMLee/claude-personas-splice-neoepitope-pipeline
+grep -q "(feedback_personas_governance.md)" "$PERSONAS/shared/MEMORY.md" && test -f "$PERSONAS/shared/feedback_personas_governance.md" && echo "OK: index link resolves"
+```
+Expected: `OK: index link resolves`.
+
+---
+
+## Task 3: Add the session-start git-status scan to each role's morning routine
+
+**Files:**
+- Modify: `$PERSONAS/pm/feedback_morning_routine.md`
+- Modify: `$PERSONAS/scientist/feedback_morning_routine.md`
+- Modify: `$PERSONAS/developer/feedback_morning_routine.md`
+
+- [ ] **Step 1: Add the PM (caretaker) variant**
+
+In `$PERSONAS/pm/feedback_morning_routine.md`, add as a new bullet at the end of the session-start / first-phase step list (the earliest "at session start" steps, before the news/status phases):
+
+```markdown
+- **Personas-repo uncommitted-state scan (session start).** Run `git -C ~/dev/GitHub/Jin-HoMLee/claude-personas-splice-neoepitope-pipeline status` and surface any uncommitted / stranded state in chat (one line per touched file). As **caretaker committer** (interim, until MM onboards), land legitimate stranded edits with the user's push gate; stage specific files, never `git add -A`. Prevents the silent pile-up that caused the 2026-05-29 incident. Per [Issue #527](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/527) Sub 6 / [Issue #567](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/567) governance.
+```
+
+- [ ] **Step 2: Add the Scientist (surface-and-flag) variant**
+
+In `$PERSONAS/scientist/feedback_morning_routine.md`, add at the end of the session-start step list:
+
+```markdown
+- **Personas-repo uncommitted-state scan (session start).** Run `git -C ~/dev/GitHub/Jin-HoMLee/claude-personas-splice-neoepitope-pipeline status` and surface any uncommitted / stranded state in chat. **Do not commit** — surface it and (if it's your own edit) flag it with a "Memory edits — for MM to commit" bullet; PM-caretaker / MM lands it. Per [Issue #527](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/527) Sub 6 / [Issue #567](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/567) governance.
+```
+
+- [ ] **Step 3: Add the Developer (surface-and-flag) variant**
+
+In `$PERSONAS/developer/feedback_morning_routine.md`, add the **same bullet as Step 2** (Developer is also surface-and-flag, not a committer).
+
+- [ ] **Step 4: Verify all three files carry the scan**
+
+Run:
+```bash
+PERSONAS=~/dev/GitHub/Jin-HoMLee/claude-personas-splice-neoepitope-pipeline
+for r in pm scientist developer; do
+  printf "%s: " "$r"; grep -c "Personas-repo uncommitted-state scan" "$PERSONAS/$r/feedback_morning_routine.md"
+done
+```
+Expected: each prints `1`.
+
+---
+
+## Task 4: PM-caretaker commit + push the personas edits (user-gated)
+
+**Files:** all five personas files from Tasks 1–3.
+
+> ⚠️ The working tree may contain **unrelated** stranded edits (e.g. `developer/MEMORY.md`, `developer/hooks-inactive-after-midsession-settings-edit.md`). **Stage only the governance files by exact path** — never `git add -A` / `git add .`. Surface the unrelated edits separately (see Task 6 notes).
+
+- [ ] **Step 1: Stage only the governance files**
+
+Run:
+```bash
+PERSONAS=~/dev/GitHub/Jin-HoMLee/claude-personas-splice-neoepitope-pipeline
+git -C "$PERSONAS" add \
+  shared/feedback_personas_governance.md \
+  shared/MEMORY.md \
+  pm/feedback_morning_routine.md \
+  scientist/feedback_morning_routine.md \
+  developer/feedback_morning_routine.md
+git -C "$PERSONAS" status --short
+```
+Expected: exactly those 5 paths staged (one `A`, four `M`); any unrelated edits remain unstaged.
+
+- [ ] **Step 2: Commit (do NOT push yet)**
+
+Run:
+```bash
+PERSONAS=~/dev/GitHub/Jin-HoMLee/claude-personas-splice-neoepitope-pipeline
+git -C "$PERSONAS" commit -m "$(cat <<'EOF'
+feat(governance): personas-repo edit/commit policy + session-start git-status scan
+
+Phase 1 of project-repo Issue #567 (sub of #527). Lands the access/lifecycle
+policy as memory rules:
+
+- shared/feedback_personas_governance.md (new): edit/commit matrix (own-dir
+  edits free; shared/ + cross-role go through MM; MM commits), propose-flows,
+  PM-caretaker interim convention, "Memory edits — for MM to commit" flag,
+  Phase-2 enforcement roadmap.
+- shared/MEMORY.md: replace the 2026-05-26 "not your responsibility" Always-in-
+  effect rule with the new model + index the new file.
+- pm/scientist/developer/feedback_morning_routine.md: session-start
+  `git -C <personas> status` scan (= #527 Sub 6); PM caretaker-commits, Sci/Dev
+  surface-and-flag.
+
+Committed by PM-as-caretaker under the bootstrap exception (MM not yet onboarded).
+EOF
+)"
+git -C "$PERSONAS" log -1 --stat
+```
+Expected: commit created; the stat lists exactly the 5 governance files.
+
+- [ ] **Step 3: Surface the diff and push ONLY after the user confirms**
+
+Run (show the diff, then gate):
+```bash
+PERSONAS=~/dev/GitHub/Jin-HoMLee/claude-personas-splice-neoepitope-pipeline
+git -C "$PERSONAS" show --stat HEAD
+```
+Then ask the user to confirm. On their OK:
+```bash
+git -C "$PERSONAS" push origin main
+```
+Expected: push to personas `origin/main` succeeds. Per the commit/push-separate rule, the push is a distinct, user-gated step.
+
+---
+
+## Task 5: Project-repo lab notebook entry
+
+**Files:**
+- Modify: `research/lab_notebook/pm.md` (project repo, on branch `design/pm/issue-567-personas-repo-governance`)
+
+- [ ] **Step 1: Add the entry**
+
+Run `date -u +"%H:%M UTC"` for the timestamp, then add a new time-entry at the TOP of the current date block in `research/lab_notebook/pm.md`:
+
+```markdown
+### HH:MM UTC — Editor: PM
+
+#### Personas-repo governance Phase 1 — [Issue #567](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/567) (sub of [#527](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/527))
+
+**Trigger.** User flagged "too many people touching the personas repo" after a stranding incident. Brainstormed → spec → this Phase-1 landing.
+
+**Decisions captured (not in the Issue body).** MM-curated `shared/` was chosen as the *strict* reading (roles cannot inline-edit `shared/`, must propose) over the looser edit-with-flag — accepted the day-to-day friction for the second-set-of-eyes guarantee on cross-cutting rules. #567 was restructured from a parallel parent into a native sub of #527 after the user caught the duplication (scan = #527 Sub 6; Phase-2 mechanisms = new #527 subs). Per-role MEMORY.md copies of the rule were deliberately *not* made (slimming) — the shared rule covers all roles.
+
+**What landed (personas main, PM-caretaker commit).** `shared/feedback_personas_governance.md` (policy), `shared/MEMORY.md` rule rewrite + index, session-start git-status scan in all three role morning routines.
+
+**Followups.** Phase 2 (per-role git-permission split + edit-boundary PreToolUse hook) filed as #527 subs, gated on MM onboarding (Subs 3–9).
+```
+
+- [ ] **Step 2: Commit + push the entry on the #567 branch**
+
+Run:
+```bash
+cd ~/dev/GitHub/Jin-HoMLee/splice-neoepitope-pipeline-pm
+git add research/lab_notebook/pm.md
+git commit -m "docs(lab-notebook): PM — personas-repo governance Phase 1 (advances #567)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+git push origin design/pm/issue-567-personas-repo-governance
+```
+Expected: entry committed + pushed on the branch.
+
+---
+
+## Task 6: Open the PR, tick #567 ACs, merge
+
+**Files:** none (GitHub state).
+
+- [ ] **Step 1: Open the PR for #567 (if not already open)**
+
+Run:
+```bash
+gh pr create --repo Jin-HoMLee/splice-neoepitope-pipeline \
+  --project "JH M Lee Lab" \
+  --title "design+feat(pm): personas-repo governance Phase 1 (closes #567)" \
+  --body "$(cat <<'EOF'
+**Created by:** PM
+
+## Summary
+
+Personas-repo governance ([Issue #567](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/567), sub of [#527](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/527)). This PR carries the spec, the Phase-1 plan, and the lab-notebook entry. The policy content itself landed in the personas repo (PM-caretaker commit; SHA recorded in the lab notebook).
+
+Closes [Issue #567](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/567).
+
+## Test plan
+
+- [x] shared/feedback_personas_governance.md created (policy matrix + propose-flows + caretaker convention + Phase-2 roadmap)
+- [x] shared/MEMORY.md "not your responsibility" rule replaced + new file indexed
+- [x] session-start git-status scan added to pm/scientist/developer morning routines
+- [x] personas edits committed by PM-caretaker + pushed (user-gated)
+- [x] spec + plan committed on this branch
+EOF
+)"
+```
+Then flip board Status to "Ready for review" (option `8bf9192f`) per the PR-open checklist.
+
+- [ ] **Step 2: Tick all #567 acceptance criteria**
+
+Run `gh issue view 567 --repo Jin-HoMLee/splice-neoepitope-pipeline --json body`, edit each `- [ ]` whose work is done to `- [x]` (design doc ✓, plan ✓, rule rewrite ✓, caretaker convention ✓, Sub 6 scan ✓), and `gh issue edit 567 --body-file`.
+
+- [ ] **Step 3: Merge via the closure-ritual gate**
+
+Run:
+```bash
+cd ~/dev/GitHub/Jin-HoMLee/splice-neoepitope-pipeline-pm
+bash scripts/audit_and_merge.sh <PR_NUMBER>
+```
+Expected: audit passes (no unticked boxes on PR Test plan or #567 ACs); squash-merge; #567 auto-closes. Then `git checkout main && git pull`.
+
+- [ ] **Step 4: Handle the unrelated stranded Developer edits (separate caretaker action)**
+
+The `developer/MEMORY.md` + `developer/hooks-inactive-after-midsession-settings-edit.md` edits found during this work are **Developer's own-dir content**, not part of #567. Per the new policy, surface them to the user and either (a) land them as a separate PM-caretaker commit attributed to Developer (user-gated push), or (b) flag for the next Developer/MM session. Do NOT fold them into the governance commit.
+
+---
+
+## Self-Review
+
+**1. Spec coverage:**
+- §1 model → Task 1 (the matrix + propose-flows in the policy file) + Task 2 (the Always-in-effect summary). ✓
+- §2.1 rule rewrite → Task 2. ✓
+- §2.2 git-status scan (= #527 Sub 6) → Task 3. ✓
+- §2.3 PM-caretaker interim commit → Task 1 (policy section) + Task 4 (the actual caretaker commit + user gate). ✓
+- §3 Phase 2 → out of scope for Phase 1 by design; captured as roadmap text (Task 1) + tracked as #527 subs (not built here). ✓
+- §"Rule / file changes" table → Tasks 1–3 cover every Phase-1 row. ✓
+
+**2. Placeholder scan:** No TBD/TODO. The only `<PR_NUMBER>` token (Task 6.3) is a runtime value filled from `gh pr create` output — standard, not a content gap.
+
+**3. Type/identifier consistency:** File paths consistent throughout (`shared/feedback_personas_governance.md`, the three `feedback_morning_routine.md` paths). The "Memory edits — for MM to commit" flag string is used identically in Task 1, Task 2, and Task 3. The scan-bullet heading "Personas-repo uncommitted-state scan" matches across Task 3 Steps 1–3 and the verification grep in Step 4.

--- a/docs/superpowers/specs/2026-05-29-personas-repo-governance-design.md
+++ b/docs/superpowers/specs/2026-05-29-personas-repo-governance-design.md
@@ -78,7 +78,7 @@ This Issue (#567) is a **native sub of #527**. It refines and extends the rollou
 | File | Change |
 |---|---|
 | `shared/MEMORY.md` | Replace Always-in-effect "Personas-repo git state is not your responsibility" with the §1 model (own-dir-edit; `shared/` + cross-role = propose to MM; MM commits; interim = PM-caretaker commits) + the git-status-scan rule. |
-| `pm/`, `scientist/`, `developer/feedback_morning_routine.md` | Add the session-start `git -C <personas> status` scan step. |
+| `pm/`, `scientist/`, `developer/feedback_morning_routine.md` | Add the session-start `git -C <personas> status` scan step. ⚠️ **Implementation note (Phase 1):** delivered instead as one shared step in `shared/feedback_morning_routine.md` Step −1 (avoids 3-way drift across role copies), not three per-role files — see the 2026-05-29 PM lab-notebook entry. |
 | (Phase 2) personas `.claude/settings.json` (per-role), new `.claude/hooks/` PreToolUse edit-boundary guard | Created during MM onboarding. |
 
 ## Open questions / risks

--- a/docs/superpowers/specs/2026-05-29-personas-repo-governance-design.md
+++ b/docs/superpowers/specs/2026-05-29-personas-repo-governance-design.md
@@ -1,0 +1,89 @@
+# Personas-Repo Governance — Edit Boundaries + MM-Owned Commit Lifecycle
+
+> **Status:** approved design (2026-05-29) · **Issue:** [#567](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/567) · **Extends:** [#527](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/527) (Memory Manager rollout)
+
+## Problem
+
+The `claude-personas-splice-neoepitope-pipeline` repo (the memory repo backing the PM / Scientist / Developer / Memory-Manager workflow on `splice-neoepitope-pipeline`) has no enforced governance for *who may edit what* and *who lands changes*. The result, observed 2026-05-29: morning-routine memory edits from multiple role sessions piled up **uncommitted** on a checked-out feature branch (`infra/add-to-project-workflow`), behind `main`, at risk of loss — 10 modified + 4 untracked files with no clear committer. Recovery took a full backup → stash → fast-forward → re-apply → commit cycle.
+
+Root cause is a **governance interregnum**:
+
+- The only *live* rule (`shared/MEMORY.md`, 2026-05-26) is **"Personas-repo git state is not your responsibility"**: roles may edit memory files in-session, but the commit/push lifecycle happens *"outside the session, managed by the user."* In practice nobody committed, so edits stranded.
+- The **Memory Manager (MM)** model from [#527](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/527) — roles edit, MM commits — was *designed* (Subs 1–2) but **not onboarded** (Subs 3–9 unshipped; `memory_manager/` dir, personas `CLAUDE.md`, and `.claude/settings.json` do not exist).
+
+So neither model is actually operating, and any role session edits anything with no committer of record.
+
+## Goals
+
+- One coherent, **end-to-end** policy: who may edit which areas **and** who commits/pushes.
+- **Prevent stranding** — uncommitted edits must surface immediately, not accumulate invisibly.
+- Realize it **without blocking on the stalled MM onboarding**, while still committing to the MM model long-term.
+- Prefer **mechanism over memory** where a rule has already proven fragile (this gap recurred despite documented rules).
+
+## Non-goals
+
+- Re-litigating whether MM should exist (decided: yes — it is the committer).
+- Memory *content* quality / slimming (tracked separately under the memory-slim epic [#538](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/538)).
+- Project-repo (`splice-neoepitope-pipeline`) git workflow — unchanged.
+
+## Decisions (brainstormed + approved 2026-05-29)
+
+1. **Scope:** end-to-end (edit boundaries AND commit/push lifecycle).
+2. **Commit owner:** dedicated Memory Manager — roles edit, MM commits/pushes.
+3. **`shared/` edits:** MM-curated — roles *propose*, MM is the one who edits + commits `shared/`.
+4. **Realization:** phased (rules + scan now; mechanism enforcement once MM onboards).
+
+## §1 — Steady-state model (once MM is onboarded)
+
+| Zone | Edit rights | Non-owner change request | Commit / push |
+|---|---|---|---|
+| Own `<role>/` dir | that role edits freely | n/a | **MM only** |
+| `shared/` (rules all sessions load) | **MM only** | role *proposes* via role-labeled issue / standup note → MM edits | **MM only** |
+| Another role's `<role>/` dir | nobody | file a request (issue/standup), e.g. the [#12 dead-link handoff](https://github.com/Jin-HoMLee/claude-personas-splice-neoepitope-pipeline/issues/12) | **MM only** |
+| `team_standup.md` + archives | append-only (existing rule, unchanged) | n/a | **MM only** |
+
+**Key consequence (approved):** a role's only *direct* write is to its **own dir**. A role **cannot directly edit `shared/`** even inline — it proposes and MM makes the edit. This is the strict reading of decision 3 and the largest day-to-day friction point; accepted deliberately so cross-cutting rules get a second set of eyes (MM's) before they reach every session.
+
+**Own-dir hand-off:** after editing its own dir, a role leaves the existing **"Memory edits — for MM to commit"** bullet in its lab-notebook/standup entry, listing touched files, so the next MM session lands them.
+
+**Session model assumption (confirmed):** PM / Scientist / Developer / MM each run as *distinct* Claude sessions (separate `claude` invocations, distinct cwd / role identity). Phase 2's per-role permission split depends on this.
+
+## §2 — Phase 1: interim (now — MM not yet onboarded)
+
+1. **Land the policy as rules.** Rewrite the live `shared/MEMORY.md` rule *"Personas-repo git state is not your responsibility"* into the §1 model. Because this is itself a `shared/` edit and MM does not yet exist, **PM-as-caretaker makes this edit under a documented bootstrap exception** (this design authorizes it).
+2. **Anti-stranding mechanism that works today.** A mandatory **session-start `git -C <personas> status` scan** in each role's morning routine — surfaces uncommitted / stranded state on the first message instead of letting it accumulate. This *is* [#527](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/527) **Sub 6**; it needs no MM and directly prevents the 2026-05-29 incident class.
+3. **Interim committer = PM-as-caretaker**, committing/pushing in-session **with the user's push gate**, replacing the failed "user commits outside the session" assumption. Caretaker work is journaled in `pm.md` tagged `(MM caretaker)` per the existing convention.
+
+## §3 — Phase 2: enforcement (after [#527](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/527) Subs 3–9 onboard MM)
+
+1. **Per-role `.claude/settings.json` on the personas repo** — `git commit` / `git push` (and personas-write `git -C`) **denied** in PM / Sci / Dev sessions, **allowed** only in the MM session. Mechanically enforces "MM commits."
+2. **PreToolUse hook** — blocks `Write` / `Edit` whose target path is under `shared/**` or another role's `<role>/**` **unless the session is MM**. Each role keeps free write to its own dir; MM may write anywhere. Mechanically enforces the §1 edit boundaries.
+3. **PM-caretaker commit role ends**; MM assumes it. The git-status scan (§2.2) stays permanently.
+
+## §4 — Relationship to [#527](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/527)
+
+This design **refines and extends** the MM rollout:
+
+- §2.2's git-status scan **is** #527 Sub 6 — landing it here satisfies that sub.
+- §3 **adds two mechanisms #527 never had.** The original #527 design relied on memory rules alone for "MM commits" + edit boundaries — exactly the adherence model that just proved fragile. Phase 2 makes them deterministic.
+- §1 **tightens** #527's edit model: the original was "active roles may edit personas memory (MM commits)"; this restricts `shared/` to MM-only.
+- Phase 2 is **gated on MM onboarding** (#527 Subs 3–9), so this Issue and #527 are explicitly coupled.
+
+## Rule changes (Phase 1 deliverables)
+
+| File | Change |
+|---|---|
+| `shared/MEMORY.md` | Replace Always-in-effect "Personas-repo git state is not your responsibility" with the §1 model (own-dir-edit; `shared/` + cross-role = propose to MM; MM commits; interim = PM-caretaker commits) + the git-status-scan rule. |
+| `pm/`, `scientist/`, `developer/feedback_morning_routine.md` | Add the session-start `git -C <personas> status` scan step. |
+| (Phase 2) personas `.claude/settings.json` (per-role), new `.claude/hooks/` PreToolUse edit-boundary guard | Created during MM onboarding. |
+
+## Open questions / risks
+
+- **`shared/` friction in the interim.** Until MM is onboarded, `shared/` changes route through PM-caretaker (standing in for MM). This is acceptable but means cross-cutting rule changes are PM-gated in the window.
+- **Phase 2 hook path-matching.** The edit-boundary hook must reliably know "the session's role." Mechanism: derive from cwd (each role's clone path) or an explicit env/setting — to be settled in the implementation plan.
+- **Coupling risk.** If MM onboarding (#527) stalls indefinitely, Phase 2 never lands and we run on Phase 1 (rules + scan + PM-caretaker) permanently. That is a *safe* degraded state (the scan prevents stranding), not a failure — but full edit-boundary enforcement waits.
+
+## Sequencing
+
+1. **Phase 1** (this Issue): rule rewrite + git-status scan + PM-caretaker commit convention. Independent; lands now.
+2. **Phase 2** (folded into #527 Subs 3–9 + new mechanism sub-tasks): permission split + edit-boundary hook. Gated on MM onboarding.

--- a/docs/superpowers/specs/2026-05-29-personas-repo-governance-design.md
+++ b/docs/superpowers/specs/2026-05-29-personas-repo-governance-design.md
@@ -1,6 +1,8 @@
 # Personas-Repo Governance — Edit Boundaries + MM-Owned Commit Lifecycle
 
-> **Status:** approved design (2026-05-29) · **Issue:** [#567](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/567) · **Extends:** [#527](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/527) (Memory Manager rollout)
+> **Status:** approved design (2026-05-29) · **Issue:** [#567](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/567) — **sub-issue of [#527](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/527)** (Memory Manager rollout)
+>
+> **Source-of-truth split:** the [#527 design doc](2026-05-27-memory-manager-role-design.md) owns the MM *role* (rationale, rollout phases); this doc owns the personas-repo *access/lifecycle policy + enforcement mechanisms* and **refines** that doc's ownership model where they overlap. Deliverables already tracked under #527 are referenced here, not re-tracked (see §4).
 
 ## Problem
 
@@ -51,10 +53,12 @@ So neither model is actually operating, and any role session edits anything with
 ## §2 — Phase 1: interim (now — MM not yet onboarded)
 
 1. **Land the policy as rules.** Rewrite the live `shared/MEMORY.md` rule *"Personas-repo git state is not your responsibility"* into the §1 model. Because this is itself a `shared/` edit and MM does not yet exist, **PM-as-caretaker makes this edit under a documented bootstrap exception** (this design authorizes it).
-2. **Anti-stranding mechanism that works today.** A mandatory **session-start `git -C <personas> status` scan** in each role's morning routine — surfaces uncommitted / stranded state on the first message instead of letting it accumulate. This *is* [#527](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/527) **Sub 6**; it needs no MM and directly prevents the 2026-05-29 incident class.
+2. **Anti-stranding mechanism = [#527](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/527) Sub 6 (referenced, not re-delivered here).** A mandatory **session-start `git -C <personas> status` scan** in each role's morning routine surfaces uncommitted / stranded state on message 1 instead of letting it accumulate. It needs no MM and directly prevents the 2026-05-29 incident class — so this design's contribution is to **pull Sub 6 forward** (already recommended in the [#527 incident comment](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/527#issuecomment-4579516000)). The scan ships under Sub 6, **not** as a #567 deliverable.
 3. **Interim committer = PM-as-caretaker**, committing/pushing in-session **with the user's push gate**, replacing the failed "user commits outside the session" assumption. Caretaker work is journaled in `pm.md` tagged `(MM caretaker)` per the existing convention.
 
 ## §3 — Phase 2: enforcement (after [#527](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/527) Subs 3–9 onboard MM)
+
+Both mechanisms below are **filed as new subs of [#527](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/527)** when the rollout reaches its onboarding phase — they are *not* #567 deliverables (they're meaningless until MM exists to enforce *for*). This design specifies them; #527 tracks and ships them.
 
 1. **Per-role `.claude/settings.json` on the personas repo** — `git commit` / `git push` (and personas-write `git -C`) **denied** in PM / Sci / Dev sessions, **allowed** only in the MM session. Mechanically enforces "MM commits."
 2. **PreToolUse hook** — blocks `Write` / `Edit` whose target path is under `shared/**` or another role's `<role>/**` **unless the session is MM**. Each role keeps free write to its own dir; MM may write anywhere. Mechanically enforces the §1 edit boundaries.
@@ -62,14 +66,14 @@ So neither model is actually operating, and any role session edits anything with
 
 ## §4 — Relationship to [#527](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/527)
 
-This design **refines and extends** the MM rollout:
+This Issue (#567) is a **native sub of #527**. It refines and extends the rollout, and is explicitly de-duplicated against it:
 
-- §2.2's git-status scan **is** #527 Sub 6 — landing it here satisfies that sub.
-- §3 **adds two mechanisms #527 never had.** The original #527 design relied on memory rules alone for "MM commits" + edit boundaries — exactly the adherence model that just proved fragile. Phase 2 makes them deterministic.
-- §1 **tightens** #527's edit model: the original was "active roles may edit personas memory (MM commits)"; this restricts `shared/` to MM-only.
-- Phase 2 is **gated on MM onboarding** (#527 Subs 3–9), so this Issue and #527 are explicitly coupled.
+- **No double-tracking of the scan.** §2.2's git-status scan ships under #527 **Sub 6** (this doc references it and pulls it forward; it is not re-tracked as a #567 deliverable).
+- **Phase 2 mechanisms → new #527 subs.** §3's per-role permission split + edit-boundary hook are *new* (the original #527 design relied on memory rules alone for "MM commits" + edit boundaries — the adherence model that just proved fragile). This doc *specifies* them; they're *filed and shipped* as #527 subs, not #567 deliverables.
+- **Refines, not competes with, the #527 design doc.** §1 tightens #527's edit model (original: "active roles may edit personas memory"; new: `shared/` is MM-only). The [#527 design doc](2026-05-27-memory-manager-role-design.md) remains source-of-truth for the MM role; this doc is source-of-truth for the access/lifecycle policy + mechanisms.
+- **#567's own deliverables** are therefore narrow: this design doc, the Phase-1 `shared/MEMORY.md` rule rewrite, and the PM-caretaker interim convention. Everything mechanism-shaped lives in #527's orbit.
 
-## Rule changes (Phase 1 deliverables)
+## Rule / file changes
 
 | File | Change |
 |---|---|
@@ -85,5 +89,5 @@ This design **refines and extends** the MM rollout:
 
 ## Sequencing
 
-1. **Phase 1** (this Issue): rule rewrite + git-status scan + PM-caretaker commit convention. Independent; lands now.
-2. **Phase 2** (folded into #527 Subs 3–9 + new mechanism sub-tasks): permission split + edit-boundary hook. Gated on MM onboarding.
+1. **Phase 1** (#567's own deliverables): `shared/MEMORY.md` rule rewrite + PM-caretaker interim commit convention, **plus** pulling #527 **Sub 6** (git-status scan) forward. Independent of MM; lands now.
+2. **Phase 2** (filed as new #527 subs): per-role permission split + edit-boundary hook. Gated on MM onboarding (#527 Subs 3–9).

--- a/research/lab_notebook/pm.md
+++ b/research/lab_notebook/pm.md
@@ -8,6 +8,25 @@ Format and rules unchanged from the unified notebook — see `shared/feedback_la
 
 ## 2026-05-29
 
+### 22:16 UTC — Editor: PM
+
+#### Personas-repo governance Phase 1 — [Issue #567](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/567) (sub of [Issue #527](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/527))
+
+**Trigger.** User flagged "too many people touching the personas repo" after a stranding incident (morning-routine memory edits from multiple roles piling up uncommitted on a stale feature branch). Brainstormed → spec → Phase-1 landing this session.
+
+**Decisions captured (not in the Issue body).**
+- **MM-curated `shared/` — strict reading.** Roles cannot inline-edit `shared/`; they propose, MM edits. Chose this over the looser edit-with-flag, accepting day-to-day friction for a second-set-of-eyes guarantee on cross-cutting rules.
+- **#567 restructured from a parallel parent → native sub of #527** after the user caught the duplication (scan = #527 Sub 6; Phase-2 mechanisms = new #527 subs; explicit source-of-truth split between the two design docs).
+- **Scan landed in `shared/feedback_morning_routine.md` Step −1, NOT 3 role files** (deliberate plan deviation) — the shared backbone exists precisely to prevent the 3-way role-file drift its own "Why a shared backbone" section warns about. One place, all roles.
+
+**What landed (personas main, PM-caretaker commit `00fd8be`).** `shared/feedback_personas_governance.md` (policy: edit/commit matrix, propose-flows, caretaker convention, Phase-2 roadmap); `shared/MEMORY.md` rule rewrite + index + narrowed line-15 git-`-C` clause; session-start git-status scan in shared Step −1.
+
+**Why PM-caretaker committed (bootstrap exception).** MM not yet onboarded; the new rule itself authorizes PM-caretaker to commit personas edits with the user's push gate during the interim. Pushed on user OK.
+
+**Followups.** Phase 2 (per-role git-permission split + edit-boundary PreToolUse hook) = new #527 subs, gated on MM onboarding (#527 Subs 3–9). Unrelated stranded Developer edits (`developer/MEMORY.md` + new `developer/hooks-inactive-after-midsession-settings-edit.md`) found during the scan — surfaced to user, to be landed as a separate Dev-attributed caretaker commit or flagged to Dev (NOT folded into the governance commit).
+
+**Entry vehicle:** [PR #568](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/568) (closes #567).
+
 ### 14:39 UTC — Editor: PM
 
 PM morning routine (Friday, run post-lunch). No code/data PR — this entry is the durable artifact for a board-hygiene + methodology session. Issues touched are not closed by this entry; the closure-audit pass and triage/milestone edits below carry their own audit trail on GitHub.


### PR DESCRIPTION
**Created by:** PM

## Summary

Personas-repo governance ([Issue #567](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/567), sub of [#527](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/527)). This PR carries the **spec**, the **Phase-1 plan**, and the **lab-notebook entry**. The policy content itself landed in the **personas repo** via a PM-caretaker commit (`00fd8be`) under the bootstrap exception (MM not yet onboarded); SHA recorded in the lab notebook.

Phase 2 (per-role git-permission split + PreToolUse edit-boundary hook) is **not** in this PR — it's filed as new #527 subs, gated on MM onboarding.

Closes [Issue #567](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/567).

## Test plan

- [x] `shared/feedback_personas_governance.md` created (edit/commit matrix + propose-flows + caretaker convention + Phase-2 roadmap)
- [x] `shared/MEMORY.md` "not your responsibility" rule replaced + new file indexed + line-15 git-C clause narrowed
- [x] session-start git-status scan added to `shared/feedback_morning_routine.md` Step −1 (one shared step, not 3 role copies)
- [x] personas edits committed by PM-caretaker (`00fd8be`) + pushed on user gate
- [x] spec + plan committed on this branch