### PR TITLE
fix(hooks): post_gh_pr_create matches `gh pr create` after a VAR=value prefix

### DIFF
--- a/.claude/hooks/post_gh_pr_create.py
+++ b/.claude/hooks/post_gh_pr_create.py
@@ -54,6 +54,10 @@ LOG_PATH = Path(__file__).resolve().parent.parent.parent / ".claude" / "hook_fir
 _PR_URL_RE = re.compile(r"https://github\.com/([\w.-]+)/([\w.-]+)/pull/(\d+)")
 _PR_CREATE_PREFIX = ("gh", "pr", "create")
 _PUNCT = set("();<>|&")  # shell punctuation_chars → standalone separator tokens
+# A leading `VAR=value` assignment at a command-start position (shlex strips the
+# quotes in posix mode, so `B="x"` arrives as the token `B=x`). Mirrors the
+# harness's subcommand-aware Bash matcher, which strips such prefixes.
+_ASSIGNMENT_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
 
 
 # --- pure helpers (unit-tested) ---
@@ -70,6 +74,9 @@ def matches_pr_create(cmd: str) -> bool:
 
     Compound commands are handled: a `gh pr create` segment after a real shell
     separator (`&&`, `||`, `;`, `|`) matches; one buried in quotes does not.
+    Leading `VAR=value` environment-assignment prefixes are skipped so the
+    command start is found after them (the harness Bash matcher does the same) —
+    `B="x" gh pr create …` and its `VAR=…`-newline-`gh pr create` form both match.
     Untokenizable input (unbalanced quotes) fails safe → no match.
     """
     try:
@@ -83,6 +90,8 @@ def matches_pr_create(cmd: str) -> bool:
         if tok and all(ch in _PUNCT for ch in tok):  # pure-punctuation = separator
             at_command_start = True
             continue
+        if at_command_start and _ASSIGNMENT_RE.match(tok):
+            continue  # leading `VAR=value` prefix → command starts after it
         if at_command_start and tuple(tokens[i:i + 3]) == _PR_CREATE_PREFIX:
             return True
         at_command_start = False

--- a/research/lab_notebook/developer.md
+++ b/research/lab_notebook/developer.md
@@ -6,6 +6,17 @@ Format and rules unchanged from the unified notebook — see `shared/feedback_la
 
 ---
 
+## 2026-05-30 — post_gh_pr_create matches `gh pr create` after a `VAR=value` prefix ([PR #575](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/575) closes [Issue #561](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/561))
+
+**What:** `matches_pr_create()` in [post_gh_pr_create.py](../../.claude/hooks/post_gh_pr_create.py) skipped the auto-board when `gh pr create` was preceded by a shell env-assignment (`VAR=x gh pr create`, or a `VAR=x` line then `gh pr create`). The fix skips leading `VAR=value` assignment tokens (regex `^[A-Za-z_][A-Za-z0-9_]*=`) at each command-start position, mirroring the harness's subcommand-aware `Bash(gh *)` matcher. `shlex` (posix mode) strips the quotes (`B="x"` → `B=x`) and consumes newlines as whitespace, so the single fix covers both the same-line and newline forms. +5 unit tests.
+
+**Why:** root cause — `shlex` emits `&&`/`;`/`|` as pure-punctuation separator tokens that reset `at_command_start`, but a bare `VAR=x` assignment token does not, so the following `gh pr create` was never seen as a command start. [PR #560](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/560) hit this and had to be boarded by hand.
+
+**What I learned / notes:**
+- **Dogfooded in production:** opened [PR #575](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/575) via `DOGFOOD=1 gh pr create …` — the exact previously-broken form — and the hook auto-boarded it + set Status "Ready for review", confirming the fix end-to-end (fire-log line `pr:575 board-add+status:Ready for review`).
+- Bot review approved; per its note, added a one-line comment that an `export VAR=x` builtin prefix is deliberately **not** stripped (rare for `gh pr create`, out of scope).
+- CI `ci-tools-pytest` is red on an **unrelated** stale live-test (`test_recheck_milestone.py::TestLiveIntegrationSmoke`): milestones #3/#5 legitimately flipped to `[UPDATE NEEDED]` as the calendar advanced (#5 due 2026-05-31). Non-required check; required checks (`pipeline-pytest`, `pipeline-snakemake-dry-run`) pass. Flagged the live recurrence on [Issue #506](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/506) (already P2; the property-based-refactor fix lives there).
+
 ## 2026-05-29
 
 ### 21:30 UTC — Editor: Developer

--- a/tools/ci/test_post_gh_pr_create.py
+++ b/tools/ci/test_post_gh_pr_create.py
@@ -27,6 +27,29 @@ class TestMatchesPrCreate:
     def test_after_separator(self):
         assert h.matches_pr_create("git push -u origin br && gh pr create --fill") is True
 
+    def test_var_prefix_same_line_matched(self):
+        # `VAR=value gh pr create` — the harness Bash matcher is subcommand-aware
+        # and strips the assignment prefix; the hook must mirror that (Issue #561).
+        assert h.matches_pr_create('B="x" gh pr create --fill') is True
+
+    def test_var_prefix_newline_matched(self):
+        # `VAR=value` then `gh pr create` on the next line — PR #560's actual form,
+        # which silently failed to auto-board (Issue #561).
+        assert h.matches_pr_create('B="x"\ngh pr create --fill') is True
+
+    def test_multiple_var_prefixes_matched(self):
+        # Several leading assignments are all skipped before the command start.
+        assert h.matches_pr_create("A=1 B=2 gh pr create --fill") is True
+
+    def test_var_assignment_only_not_matched(self):
+        # A bare assignment with no following `gh pr create` must not match.
+        assert h.matches_pr_create('B="x"') is False
+
+    def test_var_prefix_before_other_subcommand_not_matched(self):
+        # The assignment prefix is stripped, but the command is `gh pr view`, not
+        # `gh pr create` — must not match.
+        assert h.matches_pr_create('B="x" gh pr view 1') is False
+
     def test_pr_view_not_matched(self):
         assert h.matches_pr_create("gh pr view 1") is False
 


### PR DESCRIPTION
**Created by:** Developer

## Summary

The `PostToolUse` auto-board hook [`post_gh_pr_create.py`](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/blob/main/.claude/hooks/post_gh_pr_create.py) silently failed to board a created PR when the `gh pr create` invocation was preceded by a shell variable assignment (`VAR=value gh pr create …`, or a `VAR=…` line followed by `gh pr create`). [PR #560](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/560) hit this and had to be boarded by hand. closes [Issue #561](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/561).

## Root cause

`&&`/`;`/`|` are emitted by `shlex` as pure-punctuation separator tokens that reset `at_command_start`, but a bare `VAR=x` assignment token does **not** — so the following `gh pr create` was never recognized as a command start. The harness's own `Bash(gh *)` matcher is subcommand-aware and strips such prefixes; the hook's `matches_pr_create()` did not mirror that.

## Fix

In `matches_pr_create`, skip leading `VAR=value` assignment tokens (regex `^[A-Za-z_][A-Za-z0-9_]*=`) at each command-start position before testing the `gh pr create` prefix. `shlex` strips the quotes in posix mode (`B="x"` → `B=x`) and consumes newlines as whitespace, so both the same-line and `VAR=…`-newline forms are handled by the single fix. Fail-open behavior on untokenizable input is unchanged.

## Test plan

- [x] `pytest tools/ci/test_post_gh_pr_create.py` is green (5 new `VAR=` cases + all pre-existing) — verified locally with `workflow/tests/.venv` (25 passed)
- [x] New tests cover: same-line `VAR=x gh pr create`, the `VAR=x`-newline form, multiple leading assignments, bare-assignment-no-match, and `VAR=x gh pr view` no-match
- [x] Existing True/False cases (plain, `&&`-separated, quoted-body no-match, unbalanced-quote fail-safe) still hold
- [x] Fail-open preserved (untokenizable input still no-ops)
- [x] Full `tools/ci` suite green (188 passed, 2 live-only deselected)
- [x] This PR was opened via a `VAR=value`-prefixed `gh pr create` to dogfood the fix end-to-end (the hook auto-boards this PR + sets Status)

## Out of scope

- Newline-as-separator handling beyond what the `VAR=` fix needs (per the Issue).
- The same matcher pattern in other hooks — to be audited separately if it recurs.

