### PR TITLE
refactor(ci): property-based TestLiveIntegrationSmoke — accept milestone drift (closes #506)

### DIFF
--- a/research/lab_notebook/pm.md
+++ b/research/lab_notebook/pm.md
@@ -6,6 +6,22 @@ Format and rules unchanged from the unified notebook — see `shared/feedback_la
 
 ---
 
+## 2026-05-30
+
+### 15:20 UTC — Editor: PM
+
+#### Property-based milestone-recheck smoke test — [Issue #506](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/506) ([PR #576](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/576))
+
+**Non-obvious finding that motivated the refactor.** `recheck_milestone.py` exits **2** on `[UPDATE NEEDED]` / `[UNSIZED]` — both *legitimate* recommendations — and only **1** on error. The old `TestLiveIntegrationSmoke` conflated "non-zero exit" with "failure", so two frozen baseline lists (`[10, 11, 13, 15, 18, 24, 30]` and `[3, 5, 17, 18, 20, 21, 22, 26]`) went red the moment any pinned milestone legitimately drifted past threshold. Milestone state is **calendar-driven state, not a test invariant** — pinning it guarantees recurring false positives.
+
+**Second non-obvious finding.** Despite the `@pytest.mark.live` docstring claiming "skipped by default", `ci-tools-pytest` runs `pytest tools/ci/ -v` with **no** `-m "not live"` — so the live tests *do* execute in CI (with `GH_PROJECT_TOKEN`). That is why the drift surfaced as red CI rather than a silently-skipped test. Fixing the misleading "skipped by default" claim is out of #506's scope — noted as a possible follow-up.
+
+**Fix shape.** One property-based check: every open milestone must emit a *well-formed* report (exit ∈ {0, 2} + `Milestone:` header + a known `Status:` line); only exit 1 / missing structure fails. Non-vacuousness is proven by a separate non-live `TestRecheckOutputProperty` feeding stable + drifted + unsized + crash + missing-status snapshots — this is how the "≥2 distinct milestone-state snapshots" AC is satisfied without live access. Confirmed the live board genuinely held drifted milestones (#3, #5 = exit 2) at refactor time, so the green is real, not vacuous.
+
+#### [Issue #567](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/567) governance review ([PR #568](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/568)) — finding-resolution note
+
+Bot review surfaced 3 findings. Only **F1** (spec + plan still named three per-role `feedback_morning_routine.md` files vs. the shipped single shared-backbone Step −1) was actioned — one-line implementation notes added to each design artifact. **F2 ("`Co-Authored-By: Claude Opus 4.8` does not exist") rejected** — stale bot knowledge: Opus 4.8 *is* the current model and the standing commit trailer, and the bot also misreported `37faee8`'s trailer as "Sonnet 4.6" (it is Opus 4.8). **F3** (Sub-6 "not a #567 deliverable" framing) was a no-op — no open Sub-6 issue exists to double-count (#527's filed subs are #528, #530, #567 only). Recording the F2 rejection rationale because an unactioned bot finding is otherwise opaque to a future reader.
+
 ## 2026-05-29
 
 ### 22:16 UTC — Editor: PM

--- a/tools/ci/test_recheck_milestone.py
+++ b/tools/ci/test_recheck_milestone.py
@@ -13,6 +13,46 @@ sys.path.insert(0, str(SCRIPT_DIR))
 import recheck_milestone as rm
 
 
+# --- Property-based live-smoke helpers (Issue #506) -------------------------
+# The live smoke test validates that the recheck integration *works* on every
+# open milestone, rather than freezing which specific milestones happen to show
+# [No change] today. A milestone legitimately drifting to [UPDATE NEEDED] as the
+# calendar advances is a correct recommendation, not a test failure — the old
+# hardcoded baselines went red on exactly that drift.
+#
+# Exit codes (see recheck_milestone.py module docstring):
+#   0 = [No change]      2 = [UPDATE NEEDED] / [UNSIZED]      1 = error/crash
+WELL_FORMED_EXIT_CODES = (0, 2)
+WELL_FORMED_STATUSES = ("[No change]", "[UPDATE NEEDED]", "[UNSIZED]")
+
+
+def is_well_formed_recheck(returncode: int, stdout: str) -> bool:
+    """True if a ``recheck_milestone.py --milestone N`` run completed its
+    analysis and emitted a well-formed report.
+
+    "Completed" means exit 0 (No change) or 2 (UPDATE NEEDED / UNSIZED) — both
+    are legitimate recommendations the script is *supposed* to produce. Exit 1
+    (error/crash) is NOT well-formed. "Well-formed" means the report carries its
+    header (``Milestone:``) and a known ``Status:`` marker. This is the property
+    the live smoke test asserts, in place of a frozen which-milestones-are-stable
+    baseline list.
+    """
+    if returncode not in WELL_FORMED_EXIT_CODES:
+        return False
+    if "Milestone:" not in stdout:
+        return False
+    return any(status in stdout for status in WELL_FORMED_STATUSES)
+
+
+def open_milestone_numbers() -> list:
+    """Live: all open milestone numbers, via the script's own ``gh()`` helper."""
+    data = rm.gh(
+        "api", "--paginate",
+        f"repos/{rm.REPO}/milestones?state=open&per_page=100",
+    )
+    return [m["number"] for m in data]
+
+
 class TestParseMilestoneTitle:
     def test_standard_s_stage(self):
         assert rm.parse_milestone_title("i3 - S5 - Modeling - HLA-Matched TCR Panel") == (3, 5)
@@ -210,39 +250,105 @@ class TestComputeLayeredDueDate:
 
 
 class TestLiveIntegrationSmoke:
-    """Live API smoke tests. Skipped by default; opt-in via pytest -m live."""
+    """Live API smoke test. Skipped by default; opt-in via ``pytest -m live``.
+
+    Property-based (Issue #506). Asserts the recheck integration produces a
+    well-formed recommendation for *every* open milestone, instead of pinning a
+    hardcoded baseline of which milestones show [No change].
+
+    Why property-based beats a baseline list: as the calendar advances,
+    milestones legitimately flip between [No change] and [UPDATE NEEDED] (a
+    re-date recommendation). A frozen baseline turns red on that normal drift —
+    the old ``[10, 11, 13, 15, 18, 24, 30]`` and ``[3, 5, 17, 18, 20, 21, 22, 26]``
+    lists did exactly this, producing recurring false-positive CI failures that
+    gate nothing (the marker is ``live`` and ``ci-tools-pytest`` is not a
+    required check). The due-date *logic* is fully covered by the unit-level
+    ``TestComputeLayeredDueDate`` branch cases; this smoke test's only job is to
+    validate the live *integration* — that the script runs end-to-end against
+    the real board and emits a parseable report for whatever state it finds.
+    """
 
     @pytest.mark.live
-    def test_seven_known_sequence_bound_milestones_show_no_change(self):
-        """The 7 sequence-bound milestones from 2026-05-22 rate cascade should
-        no longer flag UPDATE NEEDED after the sequencing-aware fix.
-        """
+    def test_recheck_emits_well_formed_report_for_every_open_milestone(self):
         import subprocess
-        expected_no_change = [10, 11, 13, 15, 18, 24, 30]
-        failures = []
-        for ms in expected_no_change:
+
+        milestones = open_milestone_numbers()
+        assert milestones, "expected at least one open milestone on the board"
+
+        malformed = []
+        for ms in milestones:
             result = subprocess.run(
                 ["python3", "scripts/pm/recheck_milestone.py", "--milestone", str(ms)],
                 capture_output=True, text=True,
             )
-            if result.returncode != 0:
-                failures.append(f"M#{ms} exit={result.returncode}:\n{result.stdout}")
-        assert not failures, "Sequence-bound milestones still flagging:\n" + "\n---\n".join(failures)
+            if not is_well_formed_recheck(result.returncode, result.stdout):
+                malformed.append(
+                    f"M#{ms} exit={result.returncode}:\n{result.stdout}\n{result.stderr}"
+                )
+        assert not malformed, (
+            "recheck produced a malformed report (exit 1 / missing header or "
+            "Status line) — a crash or output-contract break, NOT a routine "
+            "[UPDATE NEEDED] drift:\n" + "\n---\n".join(malformed)
+        )
 
-    @pytest.mark.live
-    def test_eight_capacity_bound_milestones_still_no_change(self):
-        """Regression check: the 8 capacity-bound milestones from the same
-        cascade should still show [No change] after the fix.
-        """
-        import subprocess
-        expected_no_change = [3, 5, 17, 18, 20, 21, 22, 26]
-        # Note: #18 appears in both sets (capacity-bound AND prior in chain)
-        failures = []
-        for ms in expected_no_change:
-            result = subprocess.run(
-                ["python3", "scripts/pm/recheck_milestone.py", "--milestone", str(ms)],
-                capture_output=True, text=True,
-            )
-            if result.returncode != 0:
-                failures.append(f"M#{ms} exit={result.returncode}:\n{result.stdout}")
-        assert not failures, "Capacity-bound milestones regressed:\n" + "\n---\n".join(failures)
+
+class TestRecheckOutputProperty:
+    """Unit coverage proving the property-based smoke check above is not vacuous.
+
+    It must ACCEPT both a stable [No change] run and a drifted [UPDATE NEEDED]
+    run (two distinct milestone-state snapshots — Issue #506 AC), plus the
+    [UNSIZED] case, and REJECT a crash or a report missing its Status line. No
+    live API access required, so this runs in every ``ci-tools-pytest`` sweep.
+    """
+
+    NO_CHANGE_STDOUT = (
+        "Milestone: i4 - S5 - Modeling - Google Batch\n"
+        "Current due_on: 2026-06-20\n"
+        "Open issues (1):\n  - #999 (M, ~2.5d)\n"
+        "Remaining capacity: 2.5d\n"
+        "Proposed due_on: 2026-06-22 (delta +2 days) (stack after M#100 close 2026-06-20)\n"
+        "Status: [No change]\n"
+    )
+    UPDATE_NEEDED_STDOUT = (
+        "Milestone: i3 - S5 - Modeling - HLA Panel\n"
+        "Current due_on: 2026-05-10\n"
+        "Open issues (3):\n  - #1 (L, ~3.5d)\n  - #2 (M, ~2.5d)\n  - #3 (M, ~2.5d)\n"
+        "Remaining capacity: 8.5d\n"
+        "Proposed due_on: 2026-06-15 (delta +36 days) (no prior same-S milestone)\n"
+        "Status: [UPDATE NEEDED]\n"
+    )
+    UNSIZED_STDOUT = (
+        "Milestone: pm-i4 - PM Tooling, Memory & Methodology\n"
+        "Current due_on: 2026-06-03\n"
+        "Open issues (2):\n  - #10 (no size, 0d)\n  - #11 (no size, 0d)\n"
+        "Remaining capacity: 0.0d\n"
+        "Proposed due_on: (cannot compute — 2 open issue(s) missing Size)\n"
+        "Status: [UNSIZED] — assign Size on the project board, then re-run\n"
+    )
+
+    def test_stable_no_change_snapshot_is_well_formed(self):
+        assert is_well_formed_recheck(0, self.NO_CHANGE_STDOUT)
+
+    def test_drifted_update_needed_snapshot_is_well_formed(self):
+        # The exact state the old hardcoded-baseline test went red on: a
+        # milestone whose due date drifted out of threshold. It is a valid
+        # recommendation (exit 2), so the property check must ACCEPT it.
+        assert is_well_formed_recheck(2, self.UPDATE_NEEDED_STDOUT)
+
+    def test_unsized_snapshot_is_well_formed(self):
+        assert is_well_formed_recheck(2, self.UNSIZED_STDOUT)
+
+    def test_crash_is_not_well_formed(self):
+        assert not is_well_formed_recheck(
+            1, "Traceback (most recent call last):\n  ...\nKeyError: 'milestone'\n"
+        )
+
+    def test_missing_status_line_is_not_well_formed(self):
+        assert not is_well_formed_recheck(
+            0, "Milestone: i4 - S5 - Modeling\nRemaining capacity: 1.0d\n"
+        )
+
+    def test_unexpected_exit_code_is_not_well_formed(self):
+        # Even with a plausible-looking report, an exit code outside {0, 2}
+        # signals the script did not complete its contract (e.g. SIGKILL=137).
+        assert not is_well_formed_recheck(137, self.NO_CHANGE_STDOUT)

--- a/tools/ci/test_recheck_milestone.py
+++ b/tools/ci/test_recheck_milestone.py
@@ -44,7 +44,7 @@ def is_well_formed_recheck(returncode: int, stdout: str) -> bool:
     return any(status in stdout for status in WELL_FORMED_STATUSES)
 
 
-def open_milestone_numbers() -> list:
+def open_milestone_numbers() -> list[int]:
     """Live: all open milestone numbers, via the script's own ``gh()`` helper."""
     data = rm.gh(
         "api", "--paginate",
@@ -277,10 +277,17 @@ class TestLiveIntegrationSmoke:
 
         malformed = []
         for ms in milestones:
-            result = subprocess.run(
-                ["python3", "scripts/pm/recheck_milestone.py", "--milestone", str(ms)],
-                capture_output=True, text=True,
-            )
+            try:
+                result = subprocess.run(
+                    ["python3", "scripts/pm/recheck_milestone.py", "--milestone", str(ms)],
+                    capture_output=True, text=True, timeout=60,
+                )
+            except subprocess.TimeoutExpired:
+                # Bounds the blast radius now that the loop hits every open
+                # milestone: a hung gh/network call fails one milestone cleanly
+                # instead of hanging the whole suite.
+                malformed.append(f"M#{ms} timed out after 60s (hung gh/network call)")
+                continue
             if not is_well_formed_recheck(result.returncode, result.stdout):
                 malformed.append(
                     f"M#{ms} exit={result.returncode}:\n{result.stdout}\n{result.stderr}"
@@ -330,9 +337,7 @@ class TestRecheckOutputProperty:
         assert is_well_formed_recheck(0, self.NO_CHANGE_STDOUT)
 
     def test_drifted_update_needed_snapshot_is_well_formed(self):
-        # The exact state the old hardcoded-baseline test went red on: a
-        # milestone whose due date drifted out of threshold. It is a valid
-        # recommendation (exit 2), so the property check must ACCEPT it.
+        # exit 2 (UPDATE NEEDED) is a valid recommendation, not a failure.
         assert is_well_formed_recheck(2, self.UPDATE_NEEDED_STDOUT)
 
     def test_unsized_snapshot_is_well_formed(self):


### PR DESCRIPTION
**Created by:** PM

## Summary

Converts `tools/ci/test_recheck_milestone.py::TestLiveIntegrationSmoke` from frozen-baseline assertions to a **property-based** integration check ([Issue #506](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/506), carried forward from [Issue #497](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/497)).

**The bug:** the class held two hardcoded milestone lists (`expected_no_change = [10, 11, 13, 15, 18, 24, 30]` and `[3, 5, 17, 18, 20, 21, 22, 26]`), each asserting `recheck_milestone.py --milestone N` exits 0. But the script exits **2** on `[UPDATE NEEDED]`/`[UNSIZED]` — legitimate recommendations. As the calendar advances, milestones drift in and out of threshold, so the frozen baseline goes red on normal drift. Milestones **#3 and #5 flipped to `[UPDATE NEEDED]` on 2026-05-30**, turning `ci-tools-pytest` red on every PR (surfaced on [PR #575](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/575)) — recurring false-positive noise that gates nothing (`live` marker; non-required check).

**The fix:** a single property-based test asserts every **open** milestone produces a *well-formed* report — exit `0` (No change) or `2` (UPDATE NEEDED / UNSIZED), carrying its `Milestone:` header and a known `Status:` line. Only exit `1` / missing structure (a crash or output-contract break) fails. The due-date *logic* stays covered by the unit-level `TestComputeLayeredDueDate` branch cases; this smoke test validates only the live *integration*.

Adds `TestRecheckOutputProperty` — non-live unit coverage proving the property check is **not vacuous**: it accepts a stable `[No change]`, a drifted `[UPDATE NEEDED]`, and an `[UNSIZED]` snapshot, and rejects a crash / a report missing its Status line.

`recheck_milestone.py` itself is unchanged (out of scope per the Issue).

## Test plan

- [x] Non-live suite green: `pytest tools/ci/test_recheck_milestone.py -m "not live"` → 30 passed (24 existing + 6 new `TestRecheckOutputProperty`)
- [x] Live integration green against the real board: `pytest tools/ci/test_recheck_milestone.py -m live` → 1 passed (48s, all open milestones)
- [x] Non-vacuous: confirmed milestones **#3 and #5 return exit 2 `[UPDATE NEEDED]`** on the live board — the exact state that reddened the old baseline test — and the new property test accepts them
- [x] AC #2 (two distinct milestone-state snapshots) covered without live access by `TestRecheckOutputProperty` (stable + drifted + unsized)
- [x] No hardcoded milestone list remains in `TestLiveIntegrationSmoke`

Closes [Issue #506](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/506).
