### PR TITLE
docs(pm): CLAUDE.md board-governance section — late-commitment model

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -320,7 +320,7 @@ The GitHub project board (user project #9, "JH M Lee Lab") runs **late-commitmen
 
 Left-side transitions: **intake-triage** (`No Status → Backlog`) → **commitment** (`Backlog → Ready`, PM-coordinated) → **pull** (`Ready → In progress`). The **right side** (`In progress → Ready for review → In review → Done`) is unchanged. Giving `Ready` a distinct job structurally kills the JIT-Ready anti-pattern: you cannot reach In progress without first crossing the commitment act.
 
-Full rules: `.claude/memory/shared/feedback_board_hygiene.md` (sweep cadence, DoR, commitment-act mechanics) and `pm/feedback_milestones.md` (milestone naming, the capacity decision tree).
+Full rules: `.claude/memory/shared/feedback_board_hygiene.md` (sweep cadence, DoR, commitment-act mechanics) and `.claude/memory/feedback_milestones.md` (milestone naming, the capacity decision tree).
 
 ## GitHub Safety Wrappers
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -304,6 +304,24 @@ snakemake --cores 4 --use-conda --configfile config/test_config.yaml
 - All test outputs go to `results/test/` and `logs/test/`
 - **STAR is not usable for local development** — its genome index build requires >8 GB RAM, exceeding the M1 8 GB limit. HISAT2 was chosen for local testing specifically because its index fits within available memory.
 
+## Board status governance — late-commitment Kanban (left side)
+
+The GitHub project board (user project #9, "JH M Lee Lab") runs **late-commitment Kanban**: the commitment point — where an option becomes committed work — sits at the **`Backlog → Ready` boundary**, not at intake triage. The three left-side statuses:
+
+| Status | Meaning | Milestone / Target |
+|--------|---------|--------------------|
+| **No Status** | Untriaged intake inbox — newly filed, not yet categorized. | none |
+| **Backlog** | Triaged but **uncommitted** options: stage S#, priority, size, role label(s), priority rationale set — but not yet committed to an iteration. | **none** — a Backlog item legitimately has no milestone/Target (not a drift finding) |
+| **Ready** | **Committed** + Definition-of-Ready pull queue: an iteration milestone is assigned and the issue is refined enough to start. | milestone + Target, set at the commitment act |
+
+**The commitment act (`Backlog → Ready`)** bundles two things: (1) confirm the issue meets the **Definition of Ready** (scope clear, blockers cleared), and (2) **assign the iteration milestone** via the capacity decision tree. The `gh issue edit N --milestone "<full name>"` edit drives **Target-date sync** (`Target = milestone.due_on`) + a capacity recheck via the `recheck_dispatch.py` hook. Commitment is **PM-coordinated** (the capacity call needs the cross-cutting portfolio view); DoR-readiness is usually confirmed by the implementing role.
+
+**Milestone is the commitment signal, NOT a triage field.** A freshly-triaged issue — including a new sub-issue — enters Backlog with no milestone and takes one individually at its own `Backlog → Ready` commitment. Sub-issues do **not** inherit a parent's milestone; the parent milestone is a roadmap anchor (see `.claude/memory/shared/feedback_parent_sub_issues.md` §Inheritance).
+
+Left-side transitions: **intake-triage** (`No Status → Backlog`) → **commitment** (`Backlog → Ready`, PM-coordinated) → **pull** (`Ready → In progress`). The **right side** (`In progress → Ready for review → In review → Done`) is unchanged. Giving `Ready` a distinct job structurally kills the JIT-Ready anti-pattern: you cannot reach In progress without first crossing the commitment act.
+
+Full rules: `.claude/memory/shared/feedback_board_hygiene.md` (sweep cadence, DoR, commitment-act mechanics) and `pm/feedback_milestones.md` (milestone naming, the capacity decision tree).
+
 ## GitHub Safety Wrappers
 
 Mechanisms that fire automatically to enforce GitHub-related discipline rules that have broken repeatedly despite being documented in memory. Per the mechanism-over-memory ladder (memory → inline Always-in-effect → mechanism), these are the rung-3 escalation when a rule has slipped ≥2× on the same shape.

--- a/research/lab_notebook/pm.md
+++ b/research/lab_notebook/pm.md
@@ -8,6 +8,20 @@ Format and rules unchanged from the unified notebook — see `shared/feedback_la
 
 ## 2026-05-31
 
+### 14:43 UTC — Editor: PM
+
+#### Board left-side governance Phase 2d — CLAUDE.md board-governance section ([Issue #584](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/584) under epic [Issue #580](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/580); [PR #591](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/591))
+
+**Context.** Promotes the late-commitment model from memory-only into the always-loaded `CLAUDE.md` — load-bearing, less drift-prone. New `## Board status governance` section placed in the board/PR-governance cluster (before GitHub Safety Wrappers): a 3-status table (No Status / Backlog / Ready), the `Backlog → Ready` commitment act, the milestone-as-commitment-signal rule + a one-line sub-issue non-inheritance tie-in to Phase 2a, the three left-side transitions, and cross-links. Deliberately a **summary + pointer** to `feedback_board_hygiene.md` + `feedback_milestones.md`, not a re-statement (reinforcement, P2).
+
+**Review — the non-obvious trap.** Bot flagged the `pm/feedback_milestones.md` cross-link as inconsistent (every other memory ref uses the `.claude/memory/` prefix) — a valid catch, but its proposed fix `.claude/memory/pm/feedback_milestones.md` is **broken**: `.claude/memory` is itself a symlink to the `pm/` role dir (`readlink` → `…/claude-personas…/pm`), so inserting `pm/` resolves to a non-existent `pm/pm/…`. The resolvable consistent path is `.claude/memory/feedback_milestones.md` (verified both ways before applying). Worth recording because the "obvious" consistency fix is exactly the wrong one here — the symlink topology will re-trap any future reader or reviewer. (The §Inheritance fragment the bot also queried checks out — `feedback_parent_sub_issues.md:19`.)
+
+**Dogfooding + hook clarification.** Committed #584 through the new model — assigned `pm-i6` at its own `Backlog → Ready` boundary. This run **resolves last session's #581 "Target hook didn't fire" worry**: the `recheck_dispatch.py` hook *did* fire — it ran the capacity recheck (no change, 23 d free) and surfaced the exact `updateProjectV2ItemFieldValue` command, which I then executed. So it is a **notifier, not a silent auto-executor**; the Phase 1 entry's "auto-fires … mechanical, not a separate manual step" framing is slightly off — the Target sync IS a Claude-run step, just a fully-guided one. (Possible follow-up: soften that wording in `feedback_board_hygiene.md` during 2c.) The hook also reported `target_sync_check` has now fired 3× → a mechanism-promotion candidate per [Issue #454](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/454).
+
+**Closure.** This entry is #584's final AC box; [PR #591](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/591) (from this `gh issue develop` branch) closes #584. Epic #580 stays open tracking the last two leaves — [Issue #582](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/582) (morning-routine split + replenishment nudge) and [Issue #583](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/583) (residual retimes).
+
+---
+
 ### 14:18 UTC — Editor: PM (MM caretaker)
 
 #### Board left-side governance Phase 2a — sub-issue milestone inheritance under late commitment ([Issue #581](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/581) under epic [Issue #580](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/580); personas [PR #14](https://github.com/Jin-HoMLee/claude-personas-splice-neoepitope-pipeline/pull/14))


### PR DESCRIPTION
Phase 2d of the board-governance epic ([Issue #580](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/580)). Adds a **Board status governance** section to `CLAUDE.md`, codifying the left-side late-commitment Kanban model as load-bearing, always-loaded convention (less drift-prone than memory-only).

## What lands

A new `## Board status governance — late-commitment Kanban (left side)` section, placed in the board/PR-governance cluster (before GitHub Safety Wrappers), documenting:

- The three left-side statuses as a table — **No Status** (untriaged inbox) / **Backlog** (triaged, uncommitted, **no** milestone/Target) / **Ready** (committed + Definition-of-Ready pull queue).
- The **commitment act** at `Backlog → Ready` — DoR + capacity-tree milestone assignment → Target-date sync + capacity recheck via the `recheck_dispatch.py` hook; PM-coordinated.
- **Milestone = commitment signal, not a triage field** + the sub-issue non-inheritance rule (ties in Phase 2a, [Issue #581](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/581)).
- The three left-side transitions; right side unchanged; the structural kill of the JIT-Ready anti-pattern.
- Cross-links to `shared/feedback_board_hygiene.md`, `pm/feedback_milestones.md`, and (+1) `shared/feedback_parent_sub_issues.md`.

Reinforcement, not the primary carrier — the section summarizes and points to the memory files rather than duplicating them.

Closes [Issue #584](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/584).

## Test plan

- [x] Section renders; table + markdown valid
- [x] Cross-link paths resolve (`shared/feedback_board_hygiene.md`, `pm/feedback_milestones.md`, `shared/feedback_parent_sub_issues.md`)
- [x] [Issue #584](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/584) AC boxes ticked before merge
- [x] No memory content duplicated verbatim — summary + pointer only

🤖 Generated with [Claude Code](https://claude.com/claude-code)