### PR TITLE
docs(manuscript): land AF3 TCRdock-successor park verdict in DISCUSSIONS.md (#603)

### DIFF
--- a/research/lab_notebook/scientist.md
+++ b/research/lab_notebook/scientist.md
@@ -8,6 +8,18 @@ Format and rules unchanged from the unified notebook — see `shared/feedback_la
 
 ## 2026-05-31
 
+### 22:42 UTC — Editor: Scientist
+
+#### [Issue #603](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/603) DISCUSSION — land the AF3 TCRdock-successor park verdict (#316 / #432 follow-up). [PR #604](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/604) closes [Issue #603](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/603).
+
+**What.** Discharged the manuscript follow-up deferred from [Issue #432](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/432) onto the now-closed [Issue #316](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/316) AF3/ESMFold2 eval: replaced the "Verdict pending eval close" AF3 paragraph + the "Pending — eval in progress" per-scorer table row in [DISCUSSIONS.md](research/manuscript/DISCUSSIONS.md) with the landed verdict — AF3 parked for the shipped pipeline on **integrability** (non-redistributable / non-commercial weights), not accuracy; license-clean Chai-1/ESMFold2 GPU-blocked; CDR3-pLDDT flag declined (AF2 non-transfer). Also corrected the Synthesis sentence to separate AF3's integrability park from Boltz-2's OOD / data-availability decline — AF3 *leads* the benchmark, so the prior "AF3 pending" lumping under the data-availability constraint was wrong.
+
+**Review fixes ([PR #604](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/604), commit d20fec7).** Bot review caught four, all valid: (1) "six-scorer" → "seven-scorer" (AF3's row is now concluded, so all seven carry verdicts); (2) the *synthesis* sentence still conflated AF3's license barrier with the alternatives' GPU barrier — reworked to attribute each to the right tool (the detailed paragraph was already precise; the summary needed to match); (3) restored a dropped "as"; (4) carrier format — posted the AF3 verdict as a [close comment on Issue #316](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/316#issuecomment-4588438831) (matching the Boltz-2 / ImmSET pattern) and pointed the table carrier at it. Lesson worth recording: concluding a previously-deferred table row has ripple effects — it changes the scorer count *and* demands the same license-vs-hardware precision in the synthesis prose that the detailed paragraph already carried.
+
+**Closes the chain.** [Issue #316](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/316) (eval) → [Issue #432](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/432) (TCR-pMHC-scorer landscape) manuscript follow-up now landed; the open re-eval is parked to [Issue #601](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/601) at the next GPU refresh.
+
+---
+
 ### 22:10 UTC — Editor: Scientist
 
 #### [Issue #316](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/316) AF3 / ESMFold2 as a TCRdock successor + CDR3-pLDDT quality flag — ✅ **(c) park both prongs, coupled**; tool-primer deck shipped. [PR #602](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/602) closes [Issue #316](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/316).

--- a/research/manuscript/DISCUSSIONS.md
+++ b/research/manuscript/DISCUSSIONS.md
@@ -921,8 +921,8 @@ set. Both will be evaluated as orthogonal post-TCRdock filters.
 
 **AlphaFold3** (Abramson et al., *Nature* 2024) was evaluated as a
 TCRdock-backend successor and parked for the shipped pipeline on
-integrability rather than accuracy grounds. Lu et al. 2025 ranks AF3 the
-best-overall TCR-pMHC predictor on their 70-complex benchmark (median DockQ
+integrability rather than accuracy grounds. Lu et al. 2025 ranks AF3 as
+the best-overall TCR-pMHC predictor on their 70-complex benchmark (median DockQ
 0.636 / 0.679 for Class I / II), but its weights are released under
 non-redistributable, non-commercial terms incompatible with a pipeline whose
 TCRdock backend ships CC-BY AlphaFold2 parameters in-container; the
@@ -936,14 +936,15 @@ next GPU refresh rather than declined permanently.
 
 ### Synthesis
 
-Two patterns emerge from the six-scorer evaluation. First, **co-folding
+Two patterns emerge from the seven-scorer evaluation. First, **co-folding
 replacements for TCRdock** were not adopted, but for two distinct reasons.
 Boltz-2 (declined) faces the data-availability constraint that motivated
 TCRdock's TCR-specific fine-tuning — architectural novelty does not substitute
 for in-distribution training data, and the OOD generalization gap remains the
 operative constraint. AlphaFold3 (parked), by contrast, leads the benchmark on
-accuracy and is blocked instead by integrability: non-redistributable weights
-and the current-GPU tensor-core requirements of the co-folding model class.
+accuracy and is blocked on integrability: its weights are non-redistributable /
+non-commercial, while the license-clean alternatives (Chai-1, ESMFold2) are
+hardware-blocked on the current GPU.
 Second, **structure-based cross-checks** (HERMES and
 NetTCR-struc both integrated; t2pmhc redundant; TCRLens backbone-limited)
 are the highest-value integration angle: they slot into the existing pipeline
@@ -966,7 +967,7 @@ as the structural-QC layer matures.
 | t2pmhc | Structure-based confidence | Decline — redundant with HERMES | Issue #236 re-decision comment |
 | TCRLens | Structure-based confidence | Decline — tFold-TCR backbone framework-accuracy limit | Issue #236 re-decision comment |
 | NetTCR-struc | Structure-based confidence (GNN) | Integrate — post-TCRdock structural QC (GNN-learned) | Sub-Issue #433 (milestone 29) |
-| AlphaFold3 | End-to-end structural prediction | Park — integrability (license + current GPU), not accuracy | Issue #316 close / Issue #601 |
+| AlphaFold3 | End-to-end structural prediction | Park — integrability (license + current GPU), not accuracy | Issue #316 close comment / Issue #601 |
 
 The two integrations under the TCR-pMHC scorer integration milestone
 (HERMES, NetTCR-struc) span the physics-guided and GNN-learned axes of

--- a/research/manuscript/DISCUSSIONS.md
+++ b/research/manuscript/DISCUSSIONS.md
@@ -919,22 +919,32 @@ per-residue confidence, NetTCR-struc contributes a graph-learned
 docking-quality discriminator trained on the experimental TCR-pMHC complex
 set. Both will be evaluated as orthogonal post-TCRdock filters.
 
-**AlphaFold3** (Abramson et al., *Nature* 2024) remains under evaluation as a
-TCRdock-backend successor. Lu et al. 2025 ranks AF3 as the best-overall
-TCR-pMHC predictor on their 70-complex benchmark; the open question is
-whether AF3's general-purpose accuracy advantage holds in the specific
-patient-private-neojunction regime that this pipeline operates in, and
-whether CDR3-region pLDDT can serve as a per-prediction quality flag.
-Verdict pending eval close.
+**AlphaFold3** (Abramson et al., *Nature* 2024) was evaluated as a
+TCRdock-backend successor and parked for the shipped pipeline on
+integrability rather than accuracy grounds. Lu et al. 2025 ranks AF3 the
+best-overall TCR-pMHC predictor on their 70-complex benchmark (median DockQ
+0.636 / 0.679 for Class I / II), but its weights are released under
+non-redistributable, non-commercial terms incompatible with a pipeline whose
+TCRdock backend ships CC-BY AlphaFold2 parameters in-container; the
+license-clean co-folding alternatives surveyed alongside it (Chai-1 and
+ESMFold2) are blocked instead by the bf16/FP8 tensor-core and memory
+requirements that the production GPU lacks. The companion CDR3-region pLDDT
+quality flag was likewise not adopted — Lu et al. show that its reranking
+benefit is specific to AF3 and does not transfer to the AlphaFold2 confidence
+head that TCRdock uses. Both decisions are deferred for re-evaluation at the
+next GPU refresh rather than declined permanently.
 
 ### Synthesis
 
 Two patterns emerge from the six-scorer evaluation. First, **co-folding
-replacements for TCRdock** (Boltz-2 declined; AF3 pending) face the same
-data-availability constraint that motivated TCRdock's TCR-specific
-fine-tuning — architectural novelty does not substitute for in-distribution
-training data, and the OOD generalization gap remains the operative constraint
-on this class. Second, **structure-based cross-checks** (HERMES and
+replacements for TCRdock** were not adopted, but for two distinct reasons.
+Boltz-2 (declined) faces the data-availability constraint that motivated
+TCRdock's TCR-specific fine-tuning — architectural novelty does not substitute
+for in-distribution training data, and the OOD generalization gap remains the
+operative constraint. AlphaFold3 (parked), by contrast, leads the benchmark on
+accuracy and is blocked instead by integrability: non-redistributable weights
+and the current-GPU tensor-core requirements of the co-folding model class.
+Second, **structure-based cross-checks** (HERMES and
 NetTCR-struc both integrated; t2pmhc redundant; TCRLens backbone-limited)
 are the highest-value integration angle: they slot into the existing pipeline
 as post-TCRdock quality filters without replacing the prediction step, and a
@@ -956,7 +966,7 @@ as the structural-QC layer matures.
 | t2pmhc | Structure-based confidence | Decline — redundant with HERMES | Issue #236 re-decision comment |
 | TCRLens | Structure-based confidence | Decline — tFold-TCR backbone framework-accuracy limit | Issue #236 re-decision comment |
 | NetTCR-struc | Structure-based confidence (GNN) | Integrate — post-TCRdock structural QC (GNN-learned) | Sub-Issue #433 (milestone 29) |
-| AlphaFold3 | End-to-end structural prediction | Pending — eval in progress | Issue #316 |
+| AlphaFold3 | End-to-end structural prediction | Park — integrability (license + current GPU), not accuracy | Issue #316 close / Issue #601 |
 
 The two integrations under the TCR-pMHC scorer integration milestone
 (HERMES, NetTCR-struc) span the physics-guided and GNN-learned axes of


### PR DESCRIPTION
## Summary
Discharges the manuscript follow-up deferred from [Issue #432](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/432) (relates to) onto the [Issue #316](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/316) (relates to) AF3/ESMFold2 eval (landed in [PR #602](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/602) (relates to)). Lands the AF3 TCRdock-successor verdict in `research/manuscript/DISCUSSIONS.md`:

- **AF3 paragraph** — "Verdict pending eval close" → **parked** for the shipped pipeline on *integrability* (non-redistributable / non-commercial weights), not accuracy; license-clean Chai-1/ESMFold2 GPU-blocked on the P100; CDR3-pLDDT flag not adopted (AF3-specific; does not transfer to the AlphaFold2 head TCRdock uses).
- **Synthesis sentence** — separated AF3's integrability park from Boltz-2's OOD / data-availability decline (AF3 *leads* the benchmark; the old "AF3 pending" lumping was inaccurate).
- **Per-scorer table row** — "Pending — eval in progress" → "Park — integrability (license + current GPU), not accuracy".

Re-eval parked to [Issue #601](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/601) (relates to) at the next GPU refresh.

## Test plan
- [x] AF3 paragraph updated to the landed park verdict
- [x] Synthesis sentence corrected (AF3 integrability vs Boltz-2 OOD)
- [x] Per-scorer table row updated (Pending → Park + carrier)
- [x] American spelling verified; paragraph structure preserved
- [x] Lab-notebook entry (post-review)

Closes [Issue #603](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/603).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

