### PR TITLE
fix(commands): correct /standup rule summary to canonical (re-raise/archive, never delete)

### DIFF
--- a/.claude/commands/standup.md
+++ b/.claude/commands/standup.md
@@ -1,1 +1,1 @@
-Apply the [Team standup protocol](feedback_team_standup.md) — Full standup rules: confirm with user, delete own stale messages (>7 days, Pending)
+Apply the [Team standup protocol](feedback_team_standup.md) — Full standup rules: confirm with user, re-raise own Pending >1 day, archive own Done >3 days (move, never delete)


### PR DESCRIPTION
**Created by:** Developer

## Summary

One-line correctness fix to the `/standup` slash-command body. It summarized a **non-existent** rule — *"delete own stale messages (>7 days, Pending)"* — contradicting the canonical Team standup protocol.

**Canonical** (`shared/MEMORY.md` line 55 + `feedback_team_standup.md` rules 6+7):
- own `Pending` **>1 day → re-raise**
- own `Done` **>3 days → archive (move, never delete)**

There is no "delete" operation and no 7-day threshold anywhere in the protocol — *"Archive standup messages, never delete"* is an Always-in-effect rule.

## Why it matters

The wrong summary caused a **live mis-action this session**: the morning standup-hygiene pass framed cleanup as *"no own Pending >7d to delete."* Per the `writing-skills` CSO principle, a command body that summarizes a workflow tends to get followed verbatim in place of the protocol file — so a future session could literally *delete* a stale standup message, which the protocol explicitly forbids (*"bulk-delete corrupts the journal"*). The fix makes the summary match canonical and explicitly encodes `(move, never delete)`.

## Diff

```diff
-... confirm with user, delete own stale messages (>7 days, Pending)
+... confirm with user, re-raise own Pending >1 day, archive own Done >3 days (move, never delete)
```

## Test plan

- [x] Command body matches `shared/MEMORY.md` line 55 canonical wording
- [x] Only `.claude/commands/standup.md` changed (1 insertion, 1 deletion)
- [x] No Issue closed by this PR (intentional — empty `closingIssuesReferences`)

Trivial one-line fix; bot review skippable at merge.
