### PR TITLE
refactor(ci): thread REPO env var through pre-merge lab-notebook gate (gate 5)

### DIFF
--- a/research/lab_notebook/developer.md
+++ b/research/lab_notebook/developer.md
@@ -6,6 +6,18 @@ Format and rules unchanged from the unified notebook — see `shared/feedback_la
 
 ---
 
+## 2026-06-01 — REPO passthrough for the pre-merge lab-notebook gate ([PR #615](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/615) closes [Issue #607](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/607))
+
+### 13:47 UTC — Editor: Developer
+
+Closed the **deferred Finding 1** from the [Issue #409](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/409) gate work (see the 2026-05-31 23:09 entry below). The pre-merge lab-notebook gate — gate 5 of `scripts/audit_and_merge.sh`, via `tools/ci/lab_notebook_gate.py` — did not honor the `REPO` override its sibling gates (`stray_closers.py` / `bot_review_offer.py`) use. Running the closure-ritual gate against a fork (`REPO=fork/repo bash scripts/audit_and_merge.sh <PR>`) made gates 4/6 query the fork while gate 5 queried upstream — a composability break of the gate *as a unit*, not a bug in the documented single-repo flow (P3).
+
+**Fix.** Threaded an optional `repo` through `closure_audit`'s gh-I/O layer (`_gh` / `fetch_pr` / `fetch_issue` / `audit_pr_pre_merge`), forwarding `--repo` to `gh` **only when set**. `lab_notebook_gate.py` now reads `os.environ.get("REPO", "Jin-HoMLee/splice-neoepitope-pipeline")` and forwards it (matching the siblings); `audit_and_merge.sh` gate 5 gets the `REPO="$REPO"` prefix (matches gate 4). The #409 deferral note correctly anticipated that `_gh` is *also* used by the production post-hoc closure-audit bot (`audit_pr` / `audit_issue`) — so the change is backward-compatible: the bot passes no `repo`, and `gh` resolves from git context exactly as before (AC4, verified — both bot entry points still call the no-`repo` form).
+
+**Tests (TDD, RED→GREEN).** Subprocess-mock assertions that `--repo` is forwarded when `repo` is set and omitted when unset (`fetch_pr` / `fetch_issue`), plus a gate-level test that the `REPO` env var is read and defaults to the canonical repo. 243 `tools/ci` tests pass.
+
+**Review.** Bot review ([PR #615](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/615)) — no blocking issues. It caught one real test-quality gap: the e2e forwarding test passed *vacuously* for the `fetch_issue` path (empty-JSON mock → no closing refs → `fetch_issue` never called, assertion ran over a single call). Fixed (`cca7cfb`) — the PR fetch now returns a closing-issue ref so the per-issue fetch fires, and the test asserts both `pr view` *and* `issue view` forward `--repo`. Declined the other three notes with reasoning: the always-`--repo` resolution is the *intended* sibling-matching behavior (explicit > git-context); `post_comment` correctly stays no-`repo` (bot path only); and **gate 6** (`bot_review_offer.py`, line 196) has the *same* missing `REPO=` prefix but is out of scope for #607 (gate 5 only) — left flagged in the PR body as a follow-up candidate rather than scope-creeping this PR.
+
 ## 2026-05-31 — bot-review-offer pre-merge gate ([PR #600](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/600) closes [Issue #443](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/443))
 
 ### 23:09 UTC — Editor: Developer

--- a/scripts/audit_and_merge.sh
+++ b/scripts/audit_and_merge.sh
@@ -159,7 +159,7 @@ fi
 # PR body (same marker the post-hoc bot honors).
 if [[ -z "$PYTHON" ]]; then
     echo "⚠ lab-notebook check skipped (no python on PATH)." >&2
-elif ! NB_OUT=$("$PYTHON" "$SCRIPT_DIR/../tools/ci/lab_notebook_gate.py" "$PR" 2>&1); then
+elif ! NB_OUT=$(REPO="$REPO" "$PYTHON" "$SCRIPT_DIR/../tools/ci/lab_notebook_gate.py" "$PR" 2>&1); then
     printf '%s\n' "$NB_OUT" >&2
     FAILED=1
 elif [[ -n "$NB_OUT" ]]; then

--- a/tools/ci/closure_audit.py
+++ b/tools/ci/closure_audit.py
@@ -223,23 +223,28 @@ def _load_notebook(role: str) -> str | None:
     return path.read_text(encoding="utf-8") if path.exists() else None
 
 
-def _gh(*args: str) -> str:
+def _gh(*args: str, repo: str | None = None) -> str:
+    cmd = ["gh", *args]
+    if repo:
+        cmd += ["--repo", repo]
     return subprocess.run(
-        ["gh", *args], check=True, capture_output=True, text=True
+        cmd, check=True, capture_output=True, text=True
     ).stdout
 
 
-def fetch_pr(n: int) -> dict:
+def fetch_pr(n: int, repo: str | None = None) -> dict:
     return json.loads(_gh(
         "pr", "view", str(n),
         "--json", "mergedAt,closingIssuesReferences,files,number,body",
+        repo=repo,
     ))
 
 
-def fetch_issue(n: int) -> dict:
+def fetch_issue(n: int, repo: str | None = None) -> dict:
     return json.loads(_gh(
         "issue", "view", str(n),
         "--json", "number,body,labels,comments,closedAt",
+        repo=repo,
     ))
 
 
@@ -290,7 +295,9 @@ def audit_pr(n: int) -> None:
         post_comment("pr", n, format_comment(f"PR #{n}", ac_gaps, pr_gaps, nb_gaps))
 
 
-def audit_pr_pre_merge(n: int, today: str) -> list[tuple[str, str]]:
+def audit_pr_pre_merge(
+    n: int, today: str, repo: str | None = None
+) -> list[tuple[str, str]]:
     """Lab-notebook gaps for PR #n about to be merged on `today` (YYYY-MM-DD).
 
     Pre-merge sibling of audit_pr's notebook check (Issue #409), single-sourcing
@@ -301,18 +308,24 @@ def audit_pr_pre_merge(n: int, today: str) -> list[tuple[str, str]]:
     notebook check is mirrored; AC-checkbox + priority-rationale are already
     enforced by audit_and_merge.sh's bash checks.
 
+    `repo` (Issue #607) is forwarded to the gh I/O layer so the gate composes
+    with the `REPO` override that its sibling gates (stray_closers /
+    bot_review_offer) honor in audit_and_merge.sh. When None (the post-hoc bot
+    path, audit_pr / audit_issue), gh resolves the repo from git context — the
+    production closure-audit bot is unaffected.
+
     Notebook text is read from the working tree (_load_notebook), so the gate
     must run from the PR branch where the entry was written — the documented
     closure-ritual flow (write the entry, then merge). Reading the entry from the
     PR head ref instead is a v2 candidate. Returns [] when clear, exempt, or
     skip-marked.
     """
-    pr = fetch_pr(n)
+    pr = fetch_pr(n, repo=repo)
     refs = pr.get("closingIssuesReferences") or []
     changed = [f["path"] for f in pr.get("files", [])]
     if is_exempt(changed) or skip_lab_notebook(pr.get("body")):
         return []
-    issues = [fetch_issue(r["number"]) for r in refs]
+    issues = [fetch_issue(r["number"], repo=repo) for r in refs]
     labels_per_issue = [
         [lbl["name"] for lbl in i.get("labels", [])] for i in issues
     ]

--- a/tools/ci/lab_notebook_gate.py
+++ b/tools/ci/lab_notebook_gate.py
@@ -28,6 +28,7 @@ Usage:
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 import sys
 from datetime import datetime, timezone
@@ -46,8 +47,12 @@ def main() -> int:
         return 2
 
     today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    # Honor the REPO override so this gate composes with its sibling gates
+    # (stray_closers / bot_review_offer) when audit_and_merge.sh runs against a
+    # fork (Issue #607). Default matches them — the canonical repo.
+    repo = os.environ.get("REPO", "Jin-HoMLee/splice-neoepitope-pipeline")
     try:
-        gaps = ca.audit_pr_pre_merge(n, today)
+        gaps = ca.audit_pr_pre_merge(n, today, repo=repo)
     except (subprocess.CalledProcessError, json.JSONDecodeError, KeyError, OSError) as e:
         print(f"⚠ lab-notebook check skipped (gh error: {e})", file=sys.stderr)
         return 0  # fail open — see module docstring

--- a/tools/ci/test_closure_audit.py
+++ b/tools/ci/test_closure_audit.py
@@ -3,6 +3,70 @@
 import closure_audit as ca
 
 
+# --- #607: REPO threading through the gh I/O layer ---
+
+
+class _FakeCompleted:
+    """Stand-in for subprocess.CompletedProcess — only .stdout is read."""
+
+    def __init__(self, stdout):
+        self.stdout = stdout
+
+
+def _capture_gh(monkeypatch):
+    """Patch subprocess.run to capture each argv; return empty-JSON stdout."""
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        return _FakeCompleted("{}")
+
+    monkeypatch.setattr(ca.subprocess, "run", fake_run)
+    return calls
+
+
+def _repo_arg(cmd):
+    """The value passed to `--repo` in a gh argv, or None if absent."""
+    return cmd[cmd.index("--repo") + 1] if "--repo" in cmd else None
+
+
+def test_fetch_pr_forwards_repo_when_set(monkeypatch):
+    calls = _capture_gh(monkeypatch)
+    ca.fetch_pr(99, repo="fork/repo")
+    assert _repo_arg(calls[0]) == "fork/repo"
+
+
+def test_fetch_issue_forwards_repo_when_set(monkeypatch):
+    calls = _capture_gh(monkeypatch)
+    ca.fetch_issue(42, repo="fork/repo")
+    assert _repo_arg(calls[0]) == "fork/repo"
+
+
+def test_fetch_pr_omits_repo_when_unset(monkeypatch):
+    """Default (repo=None) → no --repo flag → gh resolves from git context.
+
+    This is what keeps the post-hoc bot (audit_pr/audit_issue) on git-context
+    resolution: they never pass a repo (AC4).
+    """
+    calls = _capture_gh(monkeypatch)
+    ca.fetch_pr(99)
+    assert "--repo" not in calls[0]
+
+
+def test_fetch_issue_omits_repo_when_unset(monkeypatch):
+    calls = _capture_gh(monkeypatch)
+    ca.fetch_issue(42)
+    assert "--repo" not in calls[0]
+
+
+def test_audit_pr_pre_merge_forwards_repo_to_gh(monkeypatch):
+    """End-to-end: the orchestration entry point forwards repo down to gh."""
+    calls = _capture_gh(monkeypatch)
+    ca.audit_pr_pre_merge(99, "2026-06-01", repo="fork/repo")
+    assert all(_repo_arg(c) == "fork/repo" for c in calls)
+    assert calls  # fetch_pr was actually called
+
+
 def test_lab_notebook_slices_block_correctly():
     """Block lookup must stop at next '## ' header — must not match later dates."""
     text = """# Lab Notebook

--- a/tools/ci/test_closure_audit.py
+++ b/tools/ci/test_closure_audit.py
@@ -1,5 +1,7 @@
 """Tests for closure_audit. Lean — focuses on parsing & format edge cases."""
 
+import json
+
 import closure_audit as ca
 
 
@@ -13,13 +15,17 @@ class _FakeCompleted:
         self.stdout = stdout
 
 
-def _capture_gh(monkeypatch):
-    """Patch subprocess.run to capture each argv; return empty-JSON stdout."""
+def _capture_gh(monkeypatch, stdout_for=None):
+    """Patch subprocess.run to capture each argv.
+
+    `stdout_for` is an optional callable (cmd argv) -> stdout str; when omitted
+    every call returns empty-JSON (`"{}"`).
+    """
     calls = []
 
     def fake_run(cmd, **kwargs):
         calls.append(cmd)
-        return _FakeCompleted("{}")
+        return _FakeCompleted(stdout_for(cmd) if stdout_for else "{}")
 
     monkeypatch.setattr(ca.subprocess, "run", fake_run)
     return calls
@@ -59,12 +65,28 @@ def test_fetch_issue_omits_repo_when_unset(monkeypatch):
     assert "--repo" not in calls[0]
 
 
-def test_audit_pr_pre_merge_forwards_repo_to_gh(monkeypatch):
-    """End-to-end: the orchestration entry point forwards repo down to gh."""
-    calls = _capture_gh(monkeypatch)
+def test_audit_pr_pre_merge_forwards_repo_to_both_gh_calls(monkeypatch):
+    """End-to-end: repo is forwarded to BOTH gh fetches (PR view + issue view).
+
+    The PR fetch returns a closing-issue reference so the per-issue fetch
+    actually fires — otherwise `refs == []` short-circuits and only `fetch_pr`
+    is exercised (the prior test passed vacuously for the fetch_issue path; PR
+    #615 review). The issue carries no role label, so the notebook check is a
+    no-op and no _load_notebook FS access happens.
+    """
+    def stdout_for(cmd):
+        if "pr" in cmd:  # `gh pr view ...`
+            return json.dumps({"closingIssuesReferences": [{"number": 42}], "files": []})
+        return json.dumps({"number": 42, "labels": []})  # `gh issue view ...`
+
+    calls = _capture_gh(monkeypatch, stdout_for)
     ca.audit_pr_pre_merge(99, "2026-06-01", repo="fork/repo")
+
+    # Both a `pr view` and an `issue view` actually happened...
+    assert any("pr" in c for c in calls), "fetch_pr was not called"
+    assert any("issue" in c for c in calls), "fetch_issue was not called"
+    # ...and every gh call forwarded --repo.
     assert all(_repo_arg(c) == "fork/repo" for c in calls)
-    assert calls  # fetch_pr was actually called
 
 
 def test_lab_notebook_slices_block_correctly():

--- a/tools/ci/test_lab_notebook_gate.py
+++ b/tools/ci/test_lab_notebook_gate.py
@@ -14,8 +14,8 @@ DATE = "2026-06-01"
 
 
 def _fake_io(monkeypatch, pr, issues_by_num, notebooks):
-    monkeypatch.setattr(ca, "fetch_pr", lambda n: pr)
-    monkeypatch.setattr(ca, "fetch_issue", lambda n: issues_by_num[n])
+    monkeypatch.setattr(ca, "fetch_pr", lambda n, repo=None: pr)
+    monkeypatch.setattr(ca, "fetch_issue", lambda n, repo=None: issues_by_num[n])
     monkeypatch.setattr(ca, "_load_notebook", lambda role: notebooks.get(role))
 
 
@@ -121,14 +121,16 @@ def _run(monkeypatch, argv):
 
 
 def test_cli_clean_returns_0(monkeypatch):
-    monkeypatch.setattr(ca, "audit_pr_pre_merge", lambda n, today: [])
+    monkeypatch.setattr(ca, "audit_pr_pre_merge", lambda n, today, repo=None: [])
     assert _run(monkeypatch, ["lab_notebook_gate.py", "99"]) == 0
 
 
 def test_cli_gap_returns_1(monkeypatch, capsys):
     monkeypatch.setattr(
         ca, "audit_pr_pre_merge",
-        lambda n, today: [("scientist", "no '## 2026-06-01' header in notebook")],
+        lambda n, today, repo=None: [
+            ("scientist", "no '## 2026-06-01' header in notebook")
+        ],
     )
     rc = _run(monkeypatch, ["lab_notebook_gate.py", "99"])
     assert rc == 1
@@ -136,7 +138,7 @@ def test_cli_gap_returns_1(monkeypatch, capsys):
 
 
 def test_cli_gh_error_fails_open(monkeypatch):
-    def boom(n, today):
+    def boom(n, today, repo=None):
         raise subprocess.CalledProcessError(1, ["gh"])
 
     monkeypatch.setattr(ca, "audit_pr_pre_merge", boom)
@@ -144,7 +146,7 @@ def test_cli_gh_error_fails_open(monkeypatch):
 
 
 def test_cli_json_error_fails_open(monkeypatch):
-    def boom(n, today):
+    def boom(n, today, repo=None):
         raise json.JSONDecodeError("bad", "doc", 0)
 
     monkeypatch.setattr(ca, "audit_pr_pre_merge", boom)
@@ -154,7 +156,7 @@ def test_cli_json_error_fails_open(monkeypatch):
 def test_cli_os_error_fails_open(monkeypatch):
     # _load_notebook can raise OSError if a notebook file is unreadable
     # (permissions). Fail open — a local FS hiccup must not block a merge.
-    def boom(n, today):
+    def boom(n, today, repo=None):
         raise OSError("permission denied")
 
     monkeypatch.setattr(ca, "audit_pr_pre_merge", boom)
@@ -164,3 +166,33 @@ def test_cli_os_error_fails_open(monkeypatch):
 def test_cli_bad_usage_returns_2(monkeypatch):
     assert _run(monkeypatch, ["lab_notebook_gate.py"]) == 2
     assert _run(monkeypatch, ["lab_notebook_gate.py", "not-a-number"]) == 2
+
+
+# --- #607: REPO env var read + forwarded to audit_pr_pre_merge ---
+
+
+def test_cli_reads_repo_env_and_forwards(monkeypatch):
+    captured = {}
+
+    def fake(n, today, repo):
+        captured["repo"] = repo
+        return []
+
+    monkeypatch.setenv("REPO", "fork/repo")
+    monkeypatch.setattr(ca, "audit_pr_pre_merge", fake)
+    assert _run(monkeypatch, ["lab_notebook_gate.py", "99"]) == 0
+    assert captured["repo"] == "fork/repo"
+
+
+def test_cli_defaults_repo_when_env_unset(monkeypatch):
+    """No REPO env → canonical repo default, matching stray_closers/bot_review_offer."""
+    captured = {}
+
+    def fake(n, today, repo):
+        captured["repo"] = repo
+        return []
+
+    monkeypatch.delenv("REPO", raising=False)
+    monkeypatch.setattr(ca, "audit_pr_pre_merge", fake)
+    assert _run(monkeypatch, ["lab_notebook_gate.py", "99"]) == 0
+    assert captured["repo"] == "Jin-HoMLee/splice-neoepitope-pipeline"


### PR DESCRIPTION
**Created by:** Developer

## Summary

Closes [Issue #607](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/607). Gate 5 of `scripts/audit_and_merge.sh` (the pre-merge lab-notebook gate, `tools/ci/lab_notebook_gate.py`) did not honor the `REPO` env override that its sibling gates use. Running the closure-ritual gate against a fork (`REPO=fork/repo bash scripts/audit_and_merge.sh <PR>`) made gates 4/6 query the fork while gate 5 queried upstream — breaking the gate's composability as a unit. It does not affect the documented single-repo flow.

This threads an optional `repo` through `closure_audit`'s gh-I/O layer so gate 5 matches the sibling gates, while keeping the production post-hoc closure-audit bot on git-context resolution.

## Changes

- `tools/ci/closure_audit.py` — `_gh` / `fetch_pr` / `fetch_issue` / `audit_pr_pre_merge` accept an optional `repo` and forward `--repo` to `gh` **only when set**.
- `tools/ci/lab_notebook_gate.py` — reads `os.environ.get("REPO", "Jin-HoMLee/splice-neoepitope-pipeline")` and forwards it, matching `stray_closers.py` / `bot_review_offer.py`.
- `scripts/audit_and_merge.sh` — gate 5 invocation gets the `REPO="$REPO"` prefix (consistent with gate 4).
- Post-hoc closure-audit bot (`audit_pr` / `audit_issue`, run by `.github/workflows/closure-audit.yml`) is **unaffected**: it passes no `repo`, so `gh` resolves from git context exactly as before.

## Test plan

- [x] `tools/ci` pytest suite green locally — 243 passed (`workflow/tests/.venv/bin/python -m pytest tools/ci/`)
- [x] New subprocess-mock tests assert `--repo` is forwarded when `repo` is set and omitted when unset (`test_closure_audit.py`), and that the gate reads `REPO` env + defaults to the canonical repo (`test_lab_notebook_gate.py`) — AC5
- [x] Existing gate fakes updated to the repo-aware signatures (still green)
- [x] `bash -n scripts/audit_and_merge.sh` clean
- [x] AC4 verified: `audit_pr` / `audit_issue` still call `fetch_pr(n)` / `fetch_issue(n)` with no repo → git-context resolution

## Note (out of scope)

Gate 6 (`bot_review_offer.py`, `scripts/audit_and_merge.sh:196`) also lacks the `REPO="$REPO"` prefix — the same latent fork-composability gap. It's outside #607's stated scope (gate 5 only), so I left it; flagging here as a candidate for a small follow-up if fork-running becomes a real workflow.
