### PR TITLE
chore(pm): scope-aware split of recheck_dispatch hook — promote target_sync to shared

### DIFF
--- a/.claude/hooks/recheck_dispatch.py
+++ b/.claude/hooks/recheck_dispatch.py
@@ -164,7 +164,7 @@ def _is_fire(hook_name: str, output: str) -> bool:
 def _wrap_warning(hook_name: str, issue: int | None, warning: str, outputs: list[str]) -> None:
     """Append warning to outputs; if it's a real fire, log it + append threshold prompt."""
     if not _in_scope(hook_name):
-        return  # out of active scope — suppress entirely (defensive; dispatch() also guards before the costly subprocess)
+        return  # out of scope — suppress output (the dispatch() guard prevents the subprocess before reaching here; this is a defensive backstop)
     outputs.append(warning)  # always emit so user sees recheck context
     if not _is_fire(hook_name, warning):
         return

--- a/.claude/hooks/recheck_dispatch.py
+++ b/.claude/hooks/recheck_dispatch.py
@@ -10,6 +10,13 @@ Watches Bash commands for trigger shapes:
 
 For each match, invokes the relevant script and emits its output as
 `additionalContext` so it appears in the next prompt.
+
+Scope filter (Issue #454): each check declares a "scope" in HOOK_CONFIG and
+runs only when that scope is active for this invocation (`--scope shared|pm|all`).
+Committed `.claude/settings.json` invokes `--scope shared`; the PM-local
+`.claude/settings.local.json` invokes `--scope pm`. So Scientist/Developer
+sessions get only the shared, broadly-actionable checks, while PM-only checks
+(e.g. capacity rechecks) stay local. A flagless invocation runs everything.
 """
 from __future__ import annotations
 
@@ -74,10 +81,40 @@ def _count_fires(hook_name: str) -> int:
 
 
 HOOK_CONFIG: dict[str, dict] = {
-    "target_sync_check":     {"threshold": 3, "dock": 454},
-    "recheck_milestone":     {"threshold": 3, "dock": None},   # dock Issue to be filed when promotion is sought
-    "recheck_parent_status": {"threshold": 3, "dock": None},   # dock Issue to be filed when promotion is sought
+    # scope: "shared" → runs in all role sessions (committed settings.json);
+    #        "pm"     → PM-local only (settings.local.json).
+    "target_sync_check":     {"threshold": 3, "dock": 454, "scope": "shared"},   # re-sync actionable by whoever moved the milestone (any role)
+    "recheck_milestone":     {"threshold": 3, "dock": None, "scope": "pm"},      # capacity rebalance is PM-coordinated + fires on every close → noise for Sci/Dev
+    "recheck_parent_status": {"threshold": 3, "dock": None, "scope": "pm"},      # shared-leaning but unproven (2/3); flip scope to "shared" to promote once proven
 }
+
+
+# ---------------------------------------------------------------------------
+# Scope filter (Issue #454)
+# ---------------------------------------------------------------------------
+ACTIVE_SCOPES: set[str] = {"shared", "pm"}  # default: run everything (flagless / --scope all)
+
+
+def _parse_scope(argv: list[str]) -> set[str]:
+    """Map a --scope {shared,pm,all} CLI arg to the active-scope set. Unknown/absent → all (fail-open)."""
+    scope = "all"
+    for i, arg in enumerate(argv):
+        if arg == "--scope" and i + 1 < len(argv):
+            scope = argv[i + 1]
+        elif arg.startswith("--scope="):
+            scope = arg.split("=", 1)[1]
+    if scope == "shared":
+        return {"shared"}
+    if scope == "pm":
+        return {"pm"}
+    return {"shared", "pm"}
+
+
+def _in_scope(hook_name: str) -> bool:
+    """True if hook_name's scope is active this invocation. No scope key → always (fail-open)."""
+    cfg = HOOK_CONFIG.get(hook_name)
+    scope = cfg.get("scope") if cfg else None
+    return scope is None or scope in ACTIVE_SCOPES
 
 
 def _threshold_prompt(hook_name: str) -> str | None:
@@ -126,6 +163,8 @@ def _is_fire(hook_name: str, output: str) -> bool:
 
 def _wrap_warning(hook_name: str, issue: int | None, warning: str, outputs: list[str]) -> None:
     """Append warning to outputs; if it's a real fire, log it + append threshold prompt."""
+    if not _in_scope(hook_name):
+        return  # out of active scope — suppress entirely (defensive; dispatch() also guards before the costly subprocess)
     outputs.append(warning)  # always emit so user sees recheck context
     if not _is_fire(hook_name, warning):
         return
@@ -316,47 +355,51 @@ def dispatch(cmd: str) -> list[str]:
     m = PATTERN_CLOSE.search(cmd)
     if m:
         issue_n = int(m.group(1))
-        _wrap_warning(
-            "recheck_milestone",
-            issue_n,
-            f"[milestone recheck — close #{issue_n}]\n{run_recheck('--issue', str(issue_n))}",
-            outputs,
-        )
-        _wrap_warning(
-            "recheck_parent_status",
-            issue_n,
-            f"[parent-status recheck — close #{issue_n}]\n"
-            f"{run_parent_status_recheck('--issue', str(issue_n))}",
-            outputs,
-        )
+        if _in_scope("recheck_milestone"):
+            _wrap_warning(
+                "recheck_milestone",
+                issue_n,
+                f"[milestone recheck — close #{issue_n}]\n{run_recheck('--issue', str(issue_n))}",
+                outputs,
+            )
+        if _in_scope("recheck_parent_status"):
+            _wrap_warning(
+                "recheck_parent_status",
+                issue_n,
+                f"[parent-status recheck — close #{issue_n}]\n"
+                f"{run_parent_status_recheck('--issue', str(issue_n))}",
+                outputs,
+            )
 
     m = PATTERN_MOVE.search(cmd)
     if m:
         issue = int(m.group(1))
-        ms_numbers = prior_milestones_for_issue(issue)
-        if not ms_numbers:
-            _wrap_warning(
-                "recheck_milestone",
-                issue,
-                f"[milestone recheck — move on #{issue} "
-                f"(milestone history empty; rechecking current only)]\n"
-                f"{run_recheck('--issue', str(issue))}",
-                outputs,
-            )
-        else:
-            for ms in ms_numbers:
+        if _in_scope("recheck_milestone"):
+            ms_numbers = prior_milestones_for_issue(issue)
+            if not ms_numbers:
                 _wrap_warning(
                     "recheck_milestone",
                     issue,
-                    f"[milestone recheck — move on #{issue}, milestone {ms}]\n"
-                    f"{run_recheck('--milestone', str(ms))}",
+                    f"[milestone recheck — move on #{issue} "
+                    f"(milestone history empty; rechecking current only)]\n"
+                    f"{run_recheck('--issue', str(issue))}",
                     outputs,
                 )
-        sync_warn = target_sync_check(issue)
-        if sync_warn:
-            _wrap_warning("target_sync_check", issue, sync_warn, outputs)
+            else:
+                for ms in ms_numbers:
+                    _wrap_warning(
+                        "recheck_milestone",
+                        issue,
+                        f"[milestone recheck — move on #{issue}, milestone {ms}]\n"
+                        f"{run_recheck('--milestone', str(ms))}",
+                        outputs,
+                    )
+        if _in_scope("target_sync_check"):
+            sync_warn = target_sync_check(issue)
+            if sync_warn:
+                _wrap_warning("target_sync_check", issue, sync_warn, outputs)
 
-    if SIZE_FIELD_ID in cmd:
+    if SIZE_FIELD_ID in cmd and _in_scope("recheck_milestone"):
         item_match = PATTERN_ITEMID.search(cmd)
         if item_match:
             issue = lookup_issue_for_item(item_match.group(1))
@@ -369,7 +412,7 @@ def dispatch(cmd: str) -> list[str]:
                     outputs,
                 )
 
-    if STATUS_FIELD_ID in cmd:
+    if STATUS_FIELD_ID in cmd and _in_scope("recheck_parent_status"):
         item_match = PATTERN_ITEMID.search(cmd)
         if item_match:
             issue = lookup_issue_for_item(item_match.group(1))
@@ -382,7 +425,7 @@ def dispatch(cmd: str) -> list[str]:
                     outputs,
                 )
 
-    if PATTERN_GH_API.search(cmd) and PATTERN_PATCH_METHOD.search(cmd):
+    if PATTERN_GH_API.search(cmd) and PATTERN_PATCH_METHOD.search(cmd) and _in_scope("recheck_milestone"):
         m = PATTERN_MILESTONE_PATH.search(cmd)
         if m:
             _wrap_warning(
@@ -397,6 +440,8 @@ def dispatch(cmd: str) -> list[str]:
 
 
 def main() -> int:
+    global ACTIVE_SCOPES
+    ACTIVE_SCOPES = _parse_scope(sys.argv[1:])
     try:
         payload = json.load(sys.stdin)
     except (json.JSONDecodeError, ValueError):

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -29,6 +29,12 @@
             "command": ".claude/hooks/post_gh_pr_create.py",
             "if": "Bash(gh *)",
             "timeout": 35
+          },
+          {
+            "type": "command",
+            "command": ".claude/hooks/recheck_dispatch.py --scope shared",
+            "if": "Bash(gh *)",
+            "timeout": 30
           }
         ]
       }

--- a/research/lab_notebook/pm.md
+++ b/research/lab_notebook/pm.md
@@ -8,6 +8,31 @@ Format and rules unchanged from the unified notebook — see `shared/feedback_la
 
 ## 2026-06-01
 
+### 13:35 UTC — Editor: PM
+
+#### Hook promotion as a *scope-aware split*, not a file move — target-date sync → shared, capacity recheck stays PM-local ([Issue #454](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/454); [PR #616](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/616))
+
+**Trigger.** The proves-out signal from this morning ([target_sync_check](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/454) hit its K=3 review threshold). Picked up as the warm-up to promote the target-date sync hook from PM-local `settings.local.json` → committed `settings.json` so Sci/Dev sessions benefit too.
+
+**Proves-out review (the readiness gate).** `target_sync_check` had **5 fires** (#524, #514, #582, #583, #584). Verified each by re-running the hook's own `target_sync_check()` against current state: all 5 now **in-sync** (board Target == milestone `due_on`) → **5/5 real stale-Target catches, 0 spurious, all re-synced**. By construction the check only fires on a genuine mismatch, so the review is "were these acted on?" — yes, uniformly. K=3 confirmed appropriate (no noise at 5 either).
+
+**The premise the original ACs rested on was false — caught by inspecting the wiring before the "mechanical move."** The ACs said "move *only* the target-sync entry; settings.local.json retains its *other* local-only hooks." But `recheck_dispatch.py` is a **single dispatcher** behind **one** settings entry, bundling three checks (`target_sync_check`, `recheck_milestone`, `recheck_parent_status`). There is no separable entry and no "other" local hooks. A binary file-move would have promoted all three to Sci/Dev at once. Same verify-before-mutate reflex as this morning's OBE catch — read the actual artifact before executing the described action.
+
+**Best-practice grounding (the user pushed for this, and it inverted the naive call).** Applied the **actionability principle** (*a warning is only worth emitting to a recipient who can act on it*; AWS Well-Architected OPS08-BP04, PagerDuty, Datadog) + Claude Code hook-scope guidance (commit team-wide hooks; keep role-specific automation local). Per-check verdict:
+- `target_sync_check` → **shared**: the Target re-sync is actionable by whoever moved the milestone, any role.
+- `recheck_milestone` → **PM-local**: the prompted action is a *capacity rebalance* (PM-coordinated, cross-portfolio) **and** it fires on every `gh issue close` — high-frequency × non-actionable for Sci/Dev = textbook alert fatigue. The naive "promote the proven dispatcher" would have shipped exactly this noise.
+- `recheck_parent_status` → **PM-local (defer)**: shared-leaning (sub-issue closer is well-placed to notice epic rollup) but **unproven** (2/3 fires, PM-only) — promote later via a 1-line scope flip.
+
+**Implementation.** `recheck_dispatch.py` gains `--scope {shared,pm,all}` + a `scope` field per check in `HOOK_CONFIG`; `dispatch()` gates each check before its subprocess (no wasted `gh` out of scope), `_wrap_warning` re-checks defensively. Committed `settings.json` runs `--scope shared`; PM-local `settings.local.json` runs `--scope pm`. Net: PM = shared ∪ pm (all 3), Sci/Dev = shared only. Flagless = `all` (backward-compat → existing tests unchanged). Tests: `_parse_scope`/`_in_scope` units + hermetic shared-scope-suppression-on-close integration; full suite **16 passed**; 5/5 scope-routing smoke cases pass.
+
+**Two mechanism notes.** (a) *Hooks didn't deactivate this session.* The CLAUDE.md "editing settings.json kills hooks until restart" caveat did **not** fire here — the `recheck_dispatch` hook ran on my subsequent `gh issue edit`. Live config is presumably pre-edit (flagless), but the script on disk is the new one. (b) *Why `target_sync_check` didn't fire on my own #454 commitment move:* the PostToolUse hook fires once per **Bash tool-call**, after the whole script runs — my call did `edit --milestone` → set Target in one block, so by hook time the Target was already synced → no drift → no fire (count stayed a clean 5, unpolluted). Worth remembering: bundling the fix into the same Bash call as the trigger self-resolves the warning before it can fire.
+
+**Governance + follow-up.** Committed #454 to `pm-i6` (commitment act: milestone + Target 2026-07-02, in-sync). The `recheck_milestone` advisory that fired on that move flagged **pm-i6 capacity** (1.0d open vs a 2026-07-02 date → proposed pull-in to 2026-06-02) — *not acted on*: tangential to #454, and the 1.0d count under-reads (mid-propagation + recently-closed #582–584). *Follow-up candidate:* a pm-i6 due_on right-sizing pass, and file dock Issues for `recheck_milestone`/`recheck_parent_status` if/when their promotion is sought.
+
+**Bot review: LGTM**, one doc-accuracy nit applied — the `_wrap_warning` defensive guard suppresses *output*, not the subprocess: `run_recheck()` is evaluated while building the f-string argument, *before* `_wrap_warning` is entered, so `dispatch()`'s per-check guard is the actual subprocess gate (the inner guard is a backstop). Reworded the comment to say so. Reviewer also confirmed all five trigger branches are scope-gated and the `PATTERN_MOVE` early-out correctly skips the live `prior_milestones_for_issue()` `gh` call when `recheck_milestone` is out of scope.
+
+---
+
 ### 10:19 UTC — Editor: PM
 
 #### Monday morning routine — weekend-batch closure audit (21-agent workflow), milestone-health closes, parked-arc re-dating, triage + caretaker commit

--- a/tools/ci/test_recheck_dispatch.py
+++ b/tools/ci/test_recheck_dispatch.py
@@ -21,10 +21,10 @@ from _live_gh import REQUIRES_LIVE_GH
 HOOK = Path(__file__).parent.parent.parent / ".claude" / "hooks" / "recheck_dispatch.py"
 
 
-def _run(cmd: str) -> tuple[int, str, str]:
+def _run(cmd: str, *args: str) -> tuple[int, str, str]:
     payload = json.dumps({"tool_input": {"command": cmd}})
     proc = subprocess.run(
-        [sys.executable, str(HOOK)],
+        [sys.executable, str(HOOK), *args],
         input=payload,
         capture_output=True,
         text=True,
@@ -47,6 +47,28 @@ class TestDispatcherSilent:
 
     def test_non_matching_gh_command_silent(self):
         rc, out, _ = _run("gh pr status")
+        assert rc == 0
+        assert out.strip() == ""
+
+
+class TestScopeFilter:
+    """Issue #454 scope-aware split: --scope shared (Sci/Dev) runs only shared checks.
+
+    Hermetic — the pm-scope checks (recheck_milestone, recheck_parent_status) are
+    skipped *before* any `gh` subprocess on a `gh issue close`, so no live auth is
+    needed to prove the suppression.
+    """
+
+    def test_shared_scope_suppresses_pm_checks_on_close(self):
+        # gh issue close → only pm-scope checks; under --scope shared they are
+        # gated out before run_recheck / run_parent_status_recheck run → silent.
+        rc, out, _ = _run("gh issue close 123456", "--scope", "shared")
+        assert rc == 0
+        assert out.strip() == ""
+
+    def test_non_gh_command_silent_with_scope_flag(self):
+        # Scope flag must not change the non-matching-command silent contract.
+        rc, out, _ = _run("ls -la", "--scope", "shared")
         assert rc == 0
         assert out.strip() == ""
 

--- a/workflow/tests/test_recheck_dispatch.py
+++ b/workflow/tests/test_recheck_dispatch.py
@@ -126,3 +126,46 @@ def test_is_fire_unknown_hook_returns_false():
     """Unknown hook names default to no-fire (safe-by-default)."""
     import recheck_dispatch
     assert recheck_dispatch._is_fire("unknown_hook", "any text") is False
+
+
+# ---------------------------------------------------------------------------
+# Scope filter (Issue #454)
+# ---------------------------------------------------------------------------
+
+def test_parse_scope_mappings():
+    """--scope {shared,pm} narrow the active set; absent/all/unknown fail open to everything."""
+    import recheck_dispatch as rd
+    assert rd._parse_scope([]) == {"shared", "pm"}                  # flagless → all (backward-compat)
+    assert rd._parse_scope(["--scope", "all"]) == {"shared", "pm"}
+    assert rd._parse_scope(["--scope", "shared"]) == {"shared"}
+    assert rd._parse_scope(["--scope", "pm"]) == {"pm"}
+    assert rd._parse_scope(["--scope=shared"]) == {"shared"}        # = form
+    assert rd._parse_scope(["--scope", "bogus"]) == {"shared", "pm"}  # unknown → fail open
+
+
+def test_in_scope_honors_active_scopes(monkeypatch):
+    """_in_scope gates each check by its HOOK_CONFIG scope against ACTIVE_SCOPES."""
+    import recheck_dispatch as rd
+
+    monkeypatch.setattr(rd, "ACTIVE_SCOPES", {"shared"})
+    assert rd._in_scope("target_sync_check") is True          # shared check runs in shared session
+    assert rd._in_scope("recheck_milestone") is False         # pm check suppressed for Sci/Dev
+    assert rd._in_scope("recheck_parent_status") is False
+
+    monkeypatch.setattr(rd, "ACTIVE_SCOPES", {"pm"})
+    assert rd._in_scope("target_sync_check") is False
+    assert rd._in_scope("recheck_milestone") is True
+    assert rd._in_scope("recheck_parent_status") is True
+
+    monkeypatch.setattr(rd, "ACTIVE_SCOPES", {"shared", "pm"})  # PM session sees both
+    assert rd._in_scope("target_sync_check") is True
+    assert rd._in_scope("recheck_milestone") is True
+
+
+def test_in_scope_unknown_hook_fails_open(monkeypatch):
+    """A check with no 'scope' key (or unknown name) runs everywhere (fail-open)."""
+    import recheck_dispatch as rd
+    monkeypatch.setattr(rd, "ACTIVE_SCOPES", {"shared"})
+    monkeypatch.setattr(rd, "HOOK_CONFIG", {"scopeless": {"threshold": 1, "dock": None}})
+    assert rd._in_scope("scopeless") is True       # no scope key → always in scope
+    assert rd._in_scope("never_configured") is True  # unknown name → always in scope


### PR DESCRIPTION
## Summary

Promotes the proven **target-date sync** check to committed config so Scientist/Developer sessions get it too — but as a **scope-aware split**, not a binary file move.

`recheck_dispatch.py` is a single dispatcher bundling three checks behind one settings entry. Moving the entry wholesale would have promoted all three to Sci/Dev. A per-check actionability review (*a warning is only worth emitting to a recipient who can act on it* — AWS Well-Architected OPS08-BP04, PagerDuty, Datadog) split them by audience:

| Check | Fires on | Sci/Dev can act on it? | Scope |
|---|---|---|---|
| `target_sync_check` | milestone edit | **yes** — fixes their own stale Target | **shared** (committed) |
| `recheck_milestone` | every issue close + milestone edit | **no** — capacity rebalance is PM-coordinated; every-close noise | **PM-local** |
| `recheck_parent_status` | sub-issue close | yes-ish, but **unproven (2/3)** | **PM-local (defer)** |

## Changes

- `recheck_dispatch.py`: add `--scope {shared,pm,all}` + per-check `scope` in `HOOK_CONFIG`. `dispatch()` gates each check before its subprocess (no wasted `gh` calls out of scope); `_wrap_warning` re-checks defensively. Flagless = `all` (backward-compatible).
- `.claude/settings.json` (committed): `recheck_dispatch.py --scope shared` → `target_sync_check` for all roles.
- `.claude/settings.local.json` (PM-local, gitignored — **not in this PR**): `--scope pm`, keeping the two PM-only checks for PM.
- Tests: `_parse_scope` / `_in_scope` unit tests + hermetic shared-scope suppression integration test.

Promoting `recheck_parent_status` later is a one-line `scope: "pm" → "shared"` flip once it proves out.

## Readiness gate (the proves-out review)

`target_sync_check`: **5 fires** (#524, #514, #582, #583, #584), all **real** stale-Target catches, **0 spurious**, all re-synced to current milestone `due_on`. K=3 confirmed appropriate.

## Test plan

- [x] `workflow/tests/.venv/bin/python -m pytest workflow/tests/test_recheck_dispatch.py tools/ci/test_recheck_dispatch.py` → **16 passed** (existing tests unchanged via flagless=all)
- [x] Scope routing smoke-tested across `shared`/`pm` × `move`/`close` (hermetic, stale-Target simulated) — shared emits only target_sync; pm emits only the two PM checks; shared-on-close fully silent
- [x] `settings.json` + `settings.local.json` validate via `jq -e`; `settings.local.json` permissions block intact (48 rules) + confirmed gitignored
- [x] Operator review of all 5 logged fires (real + re-synced + 0 spurious)

## Hook-reload caveat

Editing `.claude/settings.json` deactivates this session's hooks until restart (no hot-reload), so the live `--scope shared` wiring takes effect next session; behavior is proven here via the hermetic suite + `jq -e` validation.

Closes #454
