### PR TITLE
chore(pm): wire recheck_milestone/recheck_parent_status dock Issues into HOOK_CONFIG

### DIFF
--- a/.claude/hooks/recheck_dispatch.py
+++ b/.claude/hooks/recheck_dispatch.py
@@ -84,8 +84,8 @@ HOOK_CONFIG: dict[str, dict] = {
     # scope: "shared" → runs in all role sessions (committed settings.json);
     #        "pm"     → PM-local only (settings.local.json).
     "target_sync_check":     {"threshold": 3, "dock": 454, "scope": "shared"},   # re-sync actionable by whoever moved the milestone (any role)
-    "recheck_milestone":     {"threshold": 3, "dock": None, "scope": "pm"},      # capacity rebalance is PM-coordinated + fires on every close → noise for Sci/Dev
-    "recheck_parent_status": {"threshold": 3, "dock": None, "scope": "pm"},      # shared-leaning but unproven (2/3); flip scope to "shared" to promote once proven
+    "recheck_milestone":     {"threshold": 3, "dock": 618, "scope": "pm"},      # PM-local by design (dock #618); capacity rebalance is PM-coordinated + fires on every close → noise for Sci/Dev
+    "recheck_parent_status": {"threshold": 3, "dock": 617, "scope": "pm"},      # shared-leaning but unproven (2/3); dock #617 — flip scope to "shared" to promote once proven
 }
 
 

--- a/scripts/check_hook_health.sh
+++ b/scripts/check_hook_health.sh
@@ -13,10 +13,10 @@ get_dock_issue() {
             echo "Issue #454"
             ;;
         recheck_milestone)
-            echo "(no dock Issue filed yet)"
+            echo "Issue #618"
             ;;
         recheck_parent_status)
-            echo "(no dock Issue filed yet)"
+            echo "Issue #617"
             ;;
         *)
             echo "(unknown hook)"


### PR DESCRIPTION
## Summary

Wires the `dock` field for the two PM-local dispatcher checks to their freshly-filed tracking Issues, so each check's K-fire threshold prompt points at a real home instead of "(no dock Issue filed yet)":

- `recheck_milestone` → Issue #618 (PM-local standing + capacity right-sizing)
- `recheck_parent_status` → Issue #617 (shared-promotion candidate)

The functionally-meaningful one is **#617** — `recheck_parent_status` is still at 2/3 fires, so when it crosses K=3 the `🎯` prompt will now reference #617. (`recheck_milestone` already passed K=3, equals-once, so its wiring is record-only.)

Also syncs the **hardcoded duplicate** `get_dock_issue()` in `scripts/check_hook_health.sh` — the script self-documents as a keep-in-sync mirror of `HOOK_CONFIG` (3 entries), and was still printing "(no dock filed)" for both.

Intentionally leaves Issues #617 / #618 **open** — they remain the proves-out review trackers; this PR only ticks their "wire the dock" acceptance item (neutral phrasing here on purpose, to avoid an accidental closing-keyword link).

## Test plan

- [x] `bash scripts/check_hook_health.sh` resolves all three docks: `#454` / `#618` / `#617`
- [x] `recheck_dispatch` suite green (16 passed) — dock change doesn't affect threshold tests (they monkeypatch `HOOK_CONFIG`)
- [x] Both dock sources (`HOOK_CONFIG` + `get_dock_issue()`) confirmed in sync

<!-- skip-lab-notebook: routine -->
