### PR TITLE
docs(manuscript): align aligner prose with shipped STAR production default

### DIFF
--- a/research/lab_notebook/scientist.md
+++ b/research/lab_notebook/scientist.md
@@ -8,6 +8,20 @@ Format and rules unchanged from the unified notebook — see `shared/feedback_la
 
 ## 2026-06-01
 
+### 14:50 UTC — Editor: Scientist
+
+#### [Issue #611](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/611) METHODS — align aligner prose with the shipped STAR production default. [PR #621](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/621) closes [Issue #611](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/611).
+
+**What.** Discharged the manuscript-stranding finding the i3-S3 milestone close surfaced this morning (see 11:02 UTC entry): live `METHODS.md` still named **HISAT2** as the production aligner though it switched to **STAR** ([Issue #17](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/17) / [PR #410](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/410)), and Known-Limitations still listed the STAR comparison as Future Work though it shipped. Scope was deliberately **expanded** beyond METHODS (Scientist-lane call) to every aligner mention so sections stop contradicting each other: METHODS §1+§2 + new *Junction coordinate handling* subsection, DISCUSSIONS aligner subsection + strand mechanism, CONCLUSIONS summary + 3 stale future-work bullets removed ([Issue #16](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/16) + [Issue #17](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/17) both shipped), INTRODUCTION toolchain table, REFERENCES (STAR Dobin 2013 / regtools Cotto 2023 / HISAT2 Kim 2019, DOIs verified).
+
+**Provenance, not a re-run.** Decision (user, 2026-06-01): name STAR as the production default + HISAT2 as the 8 GB low-memory option, with an explicit note that the **reported patient_001/002 results are HISAT2-derived**. `RESULTS.md` left untouched — it correctly records HISAT2 results. No STAR re-run is implied by the prose. Flagged the re-run question to the Developer (standup [2026-06-01 13:28 UTC]); a tracking Issue is gated on Dev's feasibility reply, not on this PR.
+
+**AC correction (the trap this Issue existed to avoid).** The original [Issue #611](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/611) AC asserted "no GTF index bias". Ground truth from the shipped rules is the opposite: the STAR genome index **is GENCODE-aware** (`--sjdbGTFfile`, `--sjdbOverhang 100`) — novel-junction sensitivity comes from two-pass + permissive `--outSJfilter*` defaults, not from an annotation-free index. Wrote the prose correctly and explicitly corrected the AC in the Issue body, commit message, and PR.
+
+**Method.** Two adversarial Workflows before any prose was written: (1) an 8-agent ground-truth pass reading `alignment.smk` / `star_sj_to_junctions.py` / `bed12_to_junctions.py` / `config/*.yaml`, (2) a 2-reviewer diff-verification pass against the shipped code. The ground-truth pass is what caught the AC error — exactly the verify-before-writing discipline that keeps falsehoods out of the manuscript.
+
+**Review.** Bot review, verdict *ready to merge*, 3 non-blocking nits — all applied: (1) split an over-long METHODS §1 sentence (semicolon + "while" run-on); (2) INTRODUCTION table cell `STAR (HISAT2 low-memory option)` → `STAR / HISAT2 (low-memory)` (the old form could read as HISAT2 being a STAR mode); (3) one pre-existing `labelled` → `labeled` in CONCLUSIONS (American-spelling convention; file already in the diff). No new gaps; the open REFERENCES citation-format sweep item is unchanged.
+
 ### 11:02 UTC — Editor: Scientist
 
 #### Morning session — milestone-closure routing (3 science milestones) + [Issue #232](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/232) epic close-out backfill

--- a/research/manuscript/CONCLUSIONS.md
+++ b/research/manuscript/CONCLUSIONS.md
@@ -8,7 +8,7 @@
 
 We present a Snakemake-based pipeline for the discovery of splice-junction-derived
 neoepitope candidates from RNA-seq data. The pipeline integrates splice junction
-extraction (regtools), junction-level normal filtering, HLA typing (OptiType), peptide
+extraction (STAR or regtools), junction-level normal filtering, HLA typing (OptiType), peptide
 translation with a junction-spanning filter, MHC class I binding prediction (MHCflurry
 2.x), and structural validation (TCRdock), producing a ranked list of neoepitope
 candidates with predicted TCR–peptide–MHC ternary complex structures.
@@ -98,8 +98,6 @@ make it feasible to process a full patient dataset within a single cloud session
 - **No proteome filter:** predicted peptides are not cross-referenced against the full
   human proteome. The junction-spanning filter removes most exonic false positives, but
   a cross-proteome BLAST check would provide a further layer of confidence.
-- **HISAT2 sensitivity:** STAR has been shown to detect more novel splice junctions in
-  benchmarks. Future runs will compare junction yield between the two aligners (issue #17).
 - **HLA validation:** no ground-truth HLA alleles are available for patient_001.
   Patient_002 (osteosarcoma) confirmed OptiType accuracy against Red Cross serology
   (A\*01:01/A\*01:11N, B\*08:01/B\*27:05, C\*01:02/C\*07:01): all six alleles were
@@ -118,12 +116,8 @@ make it feasible to process a full patient dataset within a single cloud session
   junctions, 67,935 strong presenters, HLA typing validated against serology).
   Longitudinal samples T1 and T2 are available for neoepitope evolution analysis
   during treatment.
-- **STAR aligner comparison:** benchmark STAR vs. HISAT2 junction sensitivity on the
-  same dataset (issue #17).
 - **Chimeric codon recovery:** optionally retain junction-boundary 9-mers where a
   chimeric codon introduces an amino acid change at an anchor position (P2 or P9),
   representing a small high-confidence supplementary candidate set.
 - **Proteome filter:** add a BLAST or exact-match step against the reference proteome
   to catch any peptides matching a normal protein at a different genomic locus.
-- **Pre-built HISAT2 index:** cache the GRCh38 index to reduce VM startup time from
-  ~60–90 min to near-instant (issue #16).

--- a/research/manuscript/CONCLUSIONS.md
+++ b/research/manuscript/CONCLUSIONS.md
@@ -51,7 +51,7 @@ matched RNA-seq normal, the pipeline:
    junctions (16.2%). The available normal sample was BG003082_N0_WES (whole-exome
    sequencing, DNA), which yielded valid HLA typing but contributes no junctions to
    normal subtraction — WES contains no RNA splice junctions by design — so all
-   58,914 unannotated junctions are labelled `tumor_exclusive` by default. A fraction
+   58,914 unannotated junctions are labeled `tumor_exclusive` by default. A fraction
    may reflect patient-specific non-tumor splicing rather than truly tumor-specific
    events.
 

--- a/research/manuscript/DISCUSSIONS.md
+++ b/research/manuscript/DISCUSSIONS.md
@@ -119,11 +119,12 @@ precisely those expected to harbour the most actionable neoepitopes overall.
 
 Translating both strands of each contig was considered. For strand-specific libraries
 (e.g. dUTP second-strand marking, as confirmed for patient_001's gastric cancer samples:
-KAPA RNA HyperPrep with RiboErase), only the first-strand cDNA is amplified. HISAT2
-assigns the correct strand to all canonical GT-AG junctions via the XS auxiliary tag
-(derived from splice-site dinucleotide sequence). Genuine antisense transcription then
-appears as junctions on the opposite strand and is already translated in the correct
-orientation. Antisense translation of a strand-corrected contig would correspond to the
+KAPA RNA HyperPrep with RiboErase), only the first-strand cDNA is amplified. Both aligners
+assign strand to canonical junctions from splice-site sequence — STAR from the intron-motif
+field of `SJ.out.tab` (rescuing the strand from the motif where its own call is undefined),
+and HISAT2 from the XS auxiliary tag (derived from the splice-site dinucleotide). Genuine
+antisense transcription then appears as junctions on the opposite strand and is already
+translated in the correct orientation. Antisense translation of a strand-corrected contig would correspond to the
 non-transcribed DNA strand and has no established biological basis for MHC-I presentation.
 
 For non-stranded RNA-seq libraries, strand assignment relies entirely on splice-site
@@ -281,33 +282,33 @@ against observed healthy tissue, not the reverse.
 
 ---
 
-## HISAT2 vs. STAR for novel junction detection
+## Aligner choice: STAR for production, HISAT2 for local development
 
-HISAT2 is used for local development and testing (macOS M1, 8 GB RAM). Benchmarks
-consistently show STAR to be more sensitive for novel/unannotated junction detection,
-which is the critical step for this pipeline. STAR requires ~32 GB RAM for the full
-GRCh38 index and is therefore unsuitable for local runs but appropriate for cloud
-production runs.
+The production pipeline aligns with STAR, which published benchmarks consistently show to be
+more sensitive for novel/unannotated junction detection — the critical step for a
+junction-driven neoepitope pipeline. STAR's full GRCh38 index requires ~32 GB RAM, so HISAT2
+(~8 GB) is retained as a low-memory alternative for local development and testing (macOS M1,
+8 GB RAM), selected through a single configuration switch.
 
-A planned comparison (issue #17) will run both aligners on the same gastric cancer
-samples and compare the number and quality of tumor-specific junctions detected. The
-HISAT2 production run provides a baseline.
+The patient_001 and patient_002 results reported here were generated with the HISAT2 path and
+therefore represent a conservative baseline for novel-junction recovery; STAR's higher
+sensitivity would be expected to expand the unannotated-junction set on re-analysis.
 
 ---
 
 ## Impact of missing matched normal: patient_002
 
 Patient_002 (osteosarcoma IPISRC044) has no matched RNA-seq normal sample. Blood WGS
-DNA is available but cannot substitute: `regtools junctions extract` requires reads with
-spliced CIGAR operations (`N`), which are absent from DNA-seq alignments. Running the
+DNA is available but cannot substitute: junction extraction requires spliced (gapped,
+`N`-CIGAR) alignments, which are absent from DNA-seq. Running the
 pipeline without a normal labels all unannotated junctions `tumor_exclusive`.
 
 The patient_002 T0 run completed with 364,168 raw tumor junctions; 305,254 were
 annotated (GENCODE v47) and discarded, leaving 58,914 unannotated junctions.
 BG003082_N0_WES (WES, DNA) was used as the normal input — successfully for HLA
 typing, but it contributes no junctions to normal subtraction by design (WES
-alignments yield zero spliced reads, since `regtools junctions extract` requires
-`N` CIGAR operations). All 58,914 unannotated junctions are therefore labelled
+alignments yield zero spliced reads, which junction calling — whether from STAR or
+regtools — requires). All 58,914 unannotated junctions are therefore labeled
 `tumor_exclusive` with a warning.
 
 For reference, patient_001 had an 8.9% normal-shared rate among unannotated junctions

--- a/research/manuscript/INTRODUCTION.md
+++ b/research/manuscript/INTRODUCTION.md
@@ -62,8 +62,8 @@ The reimplementation updates the toolchain to current standards:
 
 | Component | Original (2015) | Current |
 |---|---|---|
-| Aligner | TopHat | HISAT2 / STAR |
-| Junction extraction | TopHat output | regtools |
+| Aligner | TopHat | STAR (HISAT2 low-memory option) |
+| Junction extraction | TopHat output | STAR SJ.out.tab / regtools |
 | MHC binding prediction | NetMHCPan | MHCflurry 2.x |
 | Structural validation | — | TCRdock (Bradley, *eLife* 2023) |
 | Workflow management | custom scripts | Snakemake |

--- a/research/manuscript/INTRODUCTION.md
+++ b/research/manuscript/INTRODUCTION.md
@@ -62,7 +62,7 @@ The reimplementation updates the toolchain to current standards:
 
 | Component | Original (2015) | Current |
 |---|---|---|
-| Aligner | TopHat | STAR (HISAT2 low-memory option) |
+| Aligner | TopHat | STAR / HISAT2 (low-memory) |
 | Junction extraction | TopHat output | STAR SJ.out.tab / regtools |
 | MHC binding prediction | NetMHCPan | MHCflurry 2.x |
 | Structural validation | — | TCRdock (Bradley, *eLife* 2023) |

--- a/research/manuscript/METHODS.md
+++ b/research/manuscript/METHODS.md
@@ -16,23 +16,71 @@ MHC binding prediction, and structural validation.
 
 ## 1. RNA-seq Alignment
 
-Reads are aligned to the GRCh38 (hg38) reference genome using HISAT2 (v2.x), a
-splice-aware aligner. Alignments are output as coordinate-sorted BAM files using samtools.
-Single-end data uses the `-U` flag; paired-end data uses `-1`/`-2`.
+Reads are aligned to the GRCh38 (hg38) reference genome with a splice-aware aligner,
+selected via the `config.alignment.aligner` switch. The production default is **STAR**
+(Dobin et al., 2013), run in two-pass mode (`--twopassMode Basic`) so that novel junctions
+found in the first pass are incorporated into the second-pass splice-junction database. The
+genome index is built with the GENCODE v47 annotation as its splice-junction database
+(`--sjdbGTFfile`, `--sjdbOverhang 100`), so annotated junctions are known to the aligner
+while two-pass discovery recovers unannotated ones; the novel-junction output filters
+(`--outSJfilter*`) are not overridden, so STAR's permissive defaults apply and discovered
+junctions are not down-filtered, while the novel-junction insertion limit is raised
+(`--limitSjdbInsertNsj 2000000`) to retain the large set of unannotated junctions of interest. STAR is run without writing alignments (`--outSAMtype None`); splice
+junctions are taken directly from its `SJ.out.tab` output (§2).
+
+For memory-constrained environments — for example local development on a macOS M1 with 8 GB
+RAM, where STAR's ~32 GB genome index does not fit — the aligner can be switched to **HISAT2**
+(Kim et al., 2019), which writes coordinate-sorted BAM files via samtools (single-end data
+uses `-U`; paired-end `-1`/`-2`). Both aligners feed a common junction table, so all
+downstream stages are aligner-agnostic.
+
+The patient_001 and patient_002 results reported in this manuscript were generated with the
+HISAT2 path, the pipeline's earlier default; STAR is the current production default for new runs.
 
 ---
 
 ## 2. Splice Junction Extraction
 
-Splice junctions are extracted from the aligned BAM files using regtools
-(`junctions extract`), with the following parameters:
+Splice junctions are extracted in an aligner-specific manner and normalized to a common
+per-sample junction table; downstream stages do not depend on which aligner produced it.
+
+On the **STAR** path, junctions are read directly from STAR's `SJ.out.tab` output. Each
+junction carries intron donor/acceptor coordinates, an intron-motif code, and read support;
+only uniquely-mapping reads are counted toward support.
+
+On the **HISAT2** path, junctions are extracted from the coordinate-sorted BAM with regtools
+(`junctions extract`; Cotto et al., 2023):
 
 - Minimum anchor length: 8 nt (`-a 8`)
 - Minimum intron length: 50 nt (`-m 50`)
 - Maximum intron length: 500,000 nt (`-M 500000`)
 - Strand specificity inferred from the XS tag (`-s XS`)
 
-Output is a BED file of junction coordinates with read support counts.
+The resulting BED12 records are converted to the common junction table; the two coordinate
+conventions are reconciled as described below. Read support is counted slightly differently by
+the two paths — uniquely-mapping reads on the STAR path, total spliced reads on the regtools
+path — so a read-count threshold is not strictly comparable across aligners.
+
+### Junction coordinate handling
+
+The two extraction paths reach the same intron coordinates by different routes, and each
+requires a path-specific correction.
+
+regtools reports its junctions in BED12, where the start/end columns are the **outer
+boundaries of the spliced-read anchors**, not the intron donor and acceptor. The true intron
+boundaries are recovered from the block geometry (the donor is the start plus the first block
+size; the acceptor is the start plus the second block offset) rather than read from the
+start/end columns directly — which would otherwise displace every junction by the anchor
+length (typically 100–150 nt per side) and, during classification, silently fail to match any
+GENCODE-annotated junction.
+
+STAR reports intron donor/acceptor coordinates directly in `SJ.out.tab` and is not subject to
+this offset. It does, however, leave the strand undefined for junctions whose orientation it
+cannot infer; in those cases the strand is recovered from the intron-motif code (e.g. GT–AG and
+GC–AG → plus strand; CT–AC and CT–GC → minus strand). Junctions with a non-canonical motif,
+which cannot be strand-assigned, are dropped rather than carried forward with an ambiguous
+strand: an incorrect strand would yield a reverse-complemented contig and translation in the
+wrong frame at the contig-assembly stage.
 
 ---
 
@@ -273,10 +321,10 @@ visualisation via Mol\* 4.x.
 - **No proteome filter:** peptides are not cross-referenced against the full human
   proteome beyond the junction-spanning filter. A BLAST or exact-match check against
   the reference proteome would catch any remaining false positives.
-- **HISAT2 vs STAR:** STAR has been shown to detect more novel splice junctions in
-  benchmarks. Future production runs will compare results between the two aligners
-  (issue #17).
-- **Pre-built genome index:** the HISAT2 `genome_tran` index (GRCh38 + GENCODE splice sites) is downloaded from the HISAT2 S3 mirror at pipeline start rather than built from scratch, saving ~60–90 min per VM. The chr22 test configuration still builds from the local FASTA.
+- **Genome index build:** the production STAR index is built once per VM from the GRCh38
+  primary assembly and the GENCODE v47 annotation; the low-memory HISAT2 path instead
+  downloads a pre-built `genome_tran` index (GRCh38 + GENCODE splice sites) from the HISAT2 S3
+  mirror. The chr22 test configuration builds a small index from a local FASTA.
 - **HLA typing from RNA-seq:** OptiType is run on RNA-seq reads, which may have lower
   HLA coverage than WES/WGS. Low read depth (< 30 reads per locus) triggers fallback
   to configured default alleles with a warning.

--- a/research/manuscript/METHODS.md
+++ b/research/manuscript/METHODS.md
@@ -22,9 +22,9 @@ selected via the `config.alignment.aligner` switch. The production default is **
 found in the first pass are incorporated into the second-pass splice-junction database. The
 genome index is built with the GENCODE v47 annotation as its splice-junction database
 (`--sjdbGTFfile`, `--sjdbOverhang 100`), so annotated junctions are known to the aligner
-while two-pass discovery recovers unannotated ones; the novel-junction output filters
+while two-pass discovery recovers unannotated ones. The novel-junction output filters
 (`--outSJfilter*`) are not overridden, so STAR's permissive defaults apply and discovered
-junctions are not down-filtered, while the novel-junction insertion limit is raised
+junctions are not down-filtered, and the novel-junction insertion limit is raised
 (`--limitSjdbInsertNsj 2000000`) to retain the large set of unannotated junctions of interest. STAR is run without writing alignments (`--outSAMtype None`); splice
 junctions are taken directly from its `SJ.out.tab` output (§2).
 

--- a/research/manuscript/REFERENCES.md
+++ b/research/manuscript/REFERENCES.md
@@ -14,7 +14,7 @@
 → Cited in DISCUSSIONS.md (TCR–pMHC docking, future directions)
 
 **★ Avsec et al., *Nature* 2026** — Advancing regulatory variant effect prediction with AlphaGenome. *Nature* 2026. doi:10.1038/s41586-025-10014-0
-→ Cited in METHODS.md §3 (aligner comparison; AlphaGenome as candidate splice-junction predictor for predicted-normal validation); DISCUSSIONS.md (AlphaGenome predicted-normal filter NO-GO verdict per [Issue #203](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/203))
+→ Cited in METHODS.md §3 (Junction Classification; AlphaGenome as candidate splice-junction predictor for predicted-normal validation); DISCUSSIONS.md (AlphaGenome predicted-normal filter NO-GO verdict per [Issue #203](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/203))
 
 ---
 
@@ -42,6 +42,16 @@
 **Coelho et al., *Cancer Cell* 2023** — [Base-editing screens for IFN-γ pathway — title TBD]. *Cancer Cell* 2023.
 → Cited in DISCUSSIONS.md (immune-pathway gene section; JAK1/JAK2 vulnerable residues)
 
+**Cotto et al., *Nat Commun* 2023** — Integrated analysis of genomic and transcriptomic data for the discovery of splice-associated variants in cancer (RegTools). *Nat Commun* 2023;14(1):1589. doi:10.1038/s41467-023-37266-6
+→ Cited in METHODS.md §2 (regtools junction extraction; HISAT2 low-memory path)
+
+---
+
+## D
+
+**Dobin et al., *Bioinformatics* 2013** — STAR: ultrafast universal RNA-seq aligner. *Bioinformatics* 2013;29(1):15–21. doi:10.1093/bioinformatics/bts635
+→ Cited in METHODS.md §1 (RNA-seq alignment; production aligner)
+
 ---
 
 ## I
@@ -52,6 +62,9 @@
 ---
 
 ## K
+
+**Kim et al., *Nat Biotechnol* 2019** — Graph-based genome alignment and genotyping with HISAT2 and HISAT-genotype. *Nat Biotechnol* 2019;37(8):907–915. doi:10.1038/s41587-019-0201-4
+→ Cited in METHODS.md §1 (RNA-seq alignment; low-memory aligner)
 
 **★ Kim et al., *Cell* 2025** — Mis-splicing-derived neoantigens and cognate TCRs in splicing factor mutant leukemias. *Cell* 2025. doi:10.1016/j.cell.2025.03.047
 → Cited in DISCUSSIONS.md (Kwok subsection; sister paper for SF3B1/SRSF2-driven public-axis splice neoantigens)
@@ -192,7 +205,10 @@ The original 8-paper inventory plus Kwok 2025 and Kim 2025 (both added after the
 | Chen & McCluskey, *Adv Cancer Res* 2006 | ✅ | |
 | Chiappinelli et al., *Cell* 2015 | ✅ | |
 | Coelho et al., *Cancer Cell* 2023 | ✅ | |
+| Cotto et al., *Nat Commun* 2023 | ✅ | RegTools; aligner Methods citation |
+| Dobin et al., *Bioinformatics* 2013 | ✅ | STAR; aligner Methods citation |
 | Iamukova & Alferova, *Asia-Pac J Clin Oncol* 2026 | ✅ | Manuscript uses full form ("Asia-Pacific Journal of Clinical Oncology") |
+| Kim et al., *Nat Biotechnol* 2019 | ✅ | HISAT2; aligner Methods citation |
 | Kim et al., *Cell* 2025 | ✅ | |
 | Kwok et al., *Nature* 2025 | ✅ | |
 | Lang et al., *Bioinform Adv* 2024 | ✅ | |


### PR DESCRIPTION
## Summary

Aligns the manuscript's aligner / junction-extraction prose with the shipped pipeline, where the production default switched to STAR ([Issue #17](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/17) (closed) / [PR #410](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/410) (merged)) while the docs still described HISAT2 as production. Ground truth was established and adversarially verified against the actual rules / scripts / config (two workflow passes) before any prose was written.

Scope expanded beyond METHODS (Scientist-lane decision, 2026-06-01) to every aligner mention across the manuscript, so sections no longer contradict each other:

- **METHODS** — §1 (STAR production default: two-pass Basic, GENCODE-aware index, permissive novel-junction filters, `--outSAMtype None` → `SJ.out.tab`; HISAT2 as the 8 GB local-dev path; provenance note that reported results are HISAT2-derived), §2 (STAR `SJ.out.tab` vs regtools paths), new **Junction coordinate handling** subsection (BED12 anchor-outer→blockSizes per [Issue #370](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/370) + STAR strand=0 motif-rescue per [Issue #374](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/374)), Limitations cleanup
- **DISCUSSIONS** — aligner subsection reframe + strand mechanism generalized to both aligners + aligner-agnostic patient_002 phrasing
- **CONCLUSIONS** — summary tool list + removed 3 stale aligner future-work bullets ([Issue #16](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/16) + [Issue #17](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/17) both shipped)
- **INTRODUCTION** — toolchain table aligner + extraction rows
- **REFERENCES** — STAR (Dobin et al., 2013), regtools (Cotto et al., 2023), HISAT2 (Kim et al., 2019) with verified DOIs + cross-ref rows

`RESULTS.md` is intentionally unchanged — it correctly records the reported patient_001/002 results as HISAT2-derived.

**Corrects [Issue #611](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/611)'s original AC:** the STAR index is GENCODE-aware (`--sjdbGTFfile`), *not* "no GTF index bias" — novel-junction sensitivity comes from two-pass + permissive `--outSJfilter*` defaults.

## Test plan

- [x] Every factual claim in the new prose verified against shipped code (`alignment.smk`, `star_sj_to_junctions.py`, `bed12_to_junctions.py`, `config/*.yaml`) — adversarial 2-reviewer pass, no blockers
- [x] 3 new reference DOIs verified (STAR `10.1093/bioinformatics/bts635`; HISAT2 `10.1038/s41587-019-0201-4`; regtools `10.1038/s41467-023-37266-6`)
- [x] Cross-file consistency: INTRODUCTION / METHODS / DISCUSSIONS / CONCLUSIONS tell the same STAR-production / HISAT2-low-memory / HISAT2-reported-results story
- [x] American spelling + "splice-junction-derived" terminology in new prose
- [x] No stale aligner future-work framing remains in the manuscript

Closes #611

🤖 Generated with [Claude Code](https://claude.com/claude-code)
