### PR TITLE
fix(ci): thread REPO env var through gate 6 (bot-review-offer) in audit_and_merge.sh

### DIFF
--- a/scripts/audit_and_merge.sh
+++ b/scripts/audit_and_merge.sh
@@ -193,7 +193,7 @@ elif [[ -z "$PYTHON" ]]; then
     # before this block if either is ever refactored.
     echo "⚠ bot-review-offer check skipped (no python on PATH)." >&2
 else
-    REVIEW_STATUS="$("$PYTHON" "$SCRIPT_DIR/../tools/ci/bot_review_offer.py" "$PR")" || REVIEW_STATUS="OFFERED"
+    REVIEW_STATUS="$(REPO="$REPO" "$PYTHON" "$SCRIPT_DIR/../tools/ci/bot_review_offer.py" "$PR")" || REVIEW_STATUS="OFFERED"
     if [[ "$REVIEW_STATUS" == "NOT_OFFERED" ]]; then
         if [[ -t 0 && -t 1 ]]; then
             echo "" >&2


### PR DESCRIPTION
## Summary

Threads the `REPO` env override through **gate 6** (the bot-review-offer gate, [`tools/ci/bot_review_offer.py`](tools/ci/bot_review_offer.py)) in `scripts/audit_and_merge.sh`, completing the closure-ritual gate's fork composability. Direct sibling of the gate-5 fix shipped in [PR #615](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/615) (which addressed [Issue #607](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/607)); this gap was flagged during that review.

Closes #619.

**One-line change** — `scripts/audit_and_merge.sh:196`:

```diff
-    REVIEW_STATUS="$("$PYTHON" "$SCRIPT_DIR/../tools/ci/bot_review_offer.py" "$PR")" || REVIEW_STATUS="OFFERED"
+    REVIEW_STATUS="$(REPO="$REPO" "$PYTHON" "$SCRIPT_DIR/../tools/ci/bot_review_offer.py" "$PR")" || REVIEW_STATUS="OFFERED"
```

`REPO` is a shell var (set at line 48) but **not exported**, so without the inline prefix the child never sees it and `bot_review_offer.py` falls back to the upstream default. The Python side already reads `os.environ.get("REPO", "Jin-HoMLee/splice-neoepitope-pipeline")` and forwards `--repo` to `gh` — no Python change needed.

All three Python-backed gates now carry the prefix consistently:

| Gate | Script | Line |
|------|--------|------|
| 4 | `stray_closers.py` | 142 |
| 5 | `lab_notebook_gate.py` | 162 |
| 6 | `bot_review_offer.py` | **196 (this PR)** |

**Impact:** low (P3) — no difference in the documented single-repo flow. The gap only bites against a fork (`REPO=fork/repo bash scripts/audit_and_merge.sh <PR>`), where gates 4/5 query the fork while gate 6 queried upstream.

## Test plan

- [x] `bash -n scripts/audit_and_merge.sh` clean
- [x] grep confirms gates 4/5/6 all carry the `REPO="$REPO"` prefix (consistency)
- [x] No change to `tools/ci/bot_review_offer.py` (already honors `REPO` + forwards `--repo`; covered by its existing tests)

<!-- skip-lab-notebook: routine -->
