### PR TITLE
chore(infra): GCS bucket versioning + retention lifecycle to protect results

### DIFF
--- a/docs/google_cloud_guide.md
+++ b/docs/google_cloud_guide.md
@@ -434,6 +434,46 @@ prefetch --location GCP SRR10971381
 
 ---
 
+## Result Archiving & Versioning
+
+`run_cloud_gpu.sh` uploads results with `gcloud storage cp -r results/ gs://…/`, an
+**in-place overwrite**. To make overwrites recoverable, the bucket has **object
+versioning** enabled plus a retention **lifecycle** ([Issue #627](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/627)). Every overwrite
+leaves the previous object as a *noncurrent version*; the lifecycle expires those
+automatically so storage stays bounded.
+
+Enable / re-apply (idempotent — reads `scripts/gcs_lifecycle.json`):
+
+```bash
+bash scripts/setup_gcs_archiving.sh        # defaults to gs://splice-neoepitope-project
+```
+
+Retention policy (`scripts/gcs_lifecycle.json`):
+
+| Noncurrent versions under… | Expire after |
+|---|---|
+| `results/<patient>/alignment/` (regenerable, ~75% of footprint) | 7 days |
+| everything else (predictions, tcrdock, junctions, reports) | 90 days |
+
+**Recovery** — restore a clobbered object from a prior version:
+
+```bash
+# 1. List all versions (current + noncurrent) and copy the generation number:
+gcloud storage ls --all-versions gs://splice-neoepitope-project/results/patient_001/predictions/tcrdock/docking_scores.tsv
+# 2. Restore a specific generation over the current object:
+gcloud storage cp \
+  "gs://splice-neoepitope-project/results/patient_001/predictions/tcrdock/docking_scores.tsv#<generation>" \
+  "gs://splice-neoepitope-project/results/patient_001/predictions/tcrdock/docking_scores.tsv"
+```
+
+**Maintenance:** GCS lifecycle prefixes can't wildcard `*/alignment/`, so when a new
+patient is added, append its `results/<patient>/alignment/` prefix to the 7-day rule
+in `scripts/gcs_lifecycle.json` and re-run the setup script. Forgetting only means
+that patient's old alignment versions fall under the 90-day rule (a little extra
+storage) — never data loss.
+
+---
+
 ## Automated GPU Pipeline (TCRdock)
 
 The `scripts/run_cloud_gpu.sh` script automates the full three-phase lifecycle

--- a/scripts/gcs_lifecycle.json
+++ b/scripts/gcs_lifecycle.json
@@ -1,0 +1,20 @@
+{
+  "rule": [
+    {
+      "action": { "type": "Delete" },
+      "condition": {
+        "daysSinceNoncurrentTime": 7,
+        "matchesPrefix": [
+          "results/patient_001/alignment/",
+          "results/patient_002/alignment/"
+        ]
+      }
+    },
+    {
+      "action": { "type": "Delete" },
+      "condition": {
+        "daysSinceNoncurrentTime": 90
+      }
+    }
+  ]
+}

--- a/scripts/gcs_lifecycle.json
+++ b/scripts/gcs_lifecycle.json
@@ -6,6 +6,7 @@
         "daysSinceNoncurrentTime": 7,
         "matchesPrefix": [
           "results/patient_001/alignment/",
+          "results/patient_001_test/alignment/",
           "results/patient_002/alignment/"
         ]
       }
@@ -13,7 +14,8 @@
     {
       "action": { "type": "Delete" },
       "condition": {
-        "daysSinceNoncurrentTime": 90
+        "daysSinceNoncurrentTime": 90,
+        "isLive": false
       }
     }
   ]

--- a/scripts/run_cloud_gpu.sh
+++ b/scripts/run_cloud_gpu.sh
@@ -259,6 +259,11 @@ else
     log "Creating GCS bucket gs://${GCS_BUCKET}..."
     gcloud storage buckets create "gs://${GCS_BUCKET}" --location="${ZONE%-*}"
     log "  Bucket created."
+    # Protect the fresh bucket immediately (versioning + retention lifecycle, Issue #627)
+    # so first-deploy results aren't overwritten unrecoverably before someone runs setup.
+    log "Applying result-protection (versioning + lifecycle) to the new bucket..."
+    bash "$(dirname "$0")/setup_gcs_archiving.sh" "gs://${GCS_BUCKET}" \
+        || log "  WARNING: setup_gcs_archiving.sh failed — run it manually to protect this bucket."
 fi
 
 PROJECT_NUMBER="$(curl -sH 'Metadata-Flavor: Google' \

--- a/scripts/setup_gcs_archiving.sh
+++ b/scripts/setup_gcs_archiving.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# =============================================================================
+# setup_gcs_archiving.sh — protect GCS results from destructive overwrites
+# =============================================================================
+#
+# Issue #627. run_cloud_gpu.sh uploads results with `gcloud storage cp -r`, an
+# in-place overwrite. Without object versioning a re-run silently destroys the
+# prior results with no recovery. This script enables versioning and applies a
+# retention lifecycle so every overwrite leaves a recoverable noncurrent version.
+#
+# Idempotent: safe to re-run. Reads the policy from scripts/gcs_lifecycle.json.
+#
+# Lifecycle (see gcs_lifecycle.json):
+#   - noncurrent versions under results/<patient>/alignment/  expire after  7 days
+#     (regenerable intermediates, ~75% of the footprint)
+#   - all other noncurrent versions                           expire after 90 days
+#
+# MAINTENANCE: GCS lifecycle prefixes cannot wildcard `*/alignment/`, so each new
+# patient's `results/<patient>/alignment/` prefix must be added to the 7-day rule
+# in gcs_lifecycle.json. Forgetting only costs a little extra storage (old
+# alignment versions then fall under the 90-day rule) — never data loss.
+#
+# Recovery (restore a clobbered object from a noncurrent version):
+#   gcloud storage ls --all-versions gs://<bucket>/<path>      # find generation
+#   gcloud storage cp gs://<bucket>/<path>#<generation> gs://<bucket>/<path>
+#
+# Usage:
+#   bash scripts/setup_gcs_archiving.sh [gs://bucket-name]
+# =============================================================================
+set -euo pipefail
+
+BUCKET="${1:-gs://splice-neoepitope-project}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LIFECYCLE_FILE="${SCRIPT_DIR}/gcs_lifecycle.json"
+
+[[ -f "${LIFECYCLE_FILE}" ]] || { echo "ERROR: ${LIFECYCLE_FILE} not found." >&2; exit 1; }
+
+echo "Enabling object versioning on ${BUCKET}..."
+gcloud storage buckets update "${BUCKET}" --versioning
+
+echo "Applying retention lifecycle from ${LIFECYCLE_FILE}..."
+gcloud storage buckets update "${BUCKET}" --lifecycle-file="${LIFECYCLE_FILE}"
+
+echo "Done. Current config:"
+gcloud storage buckets describe "${BUCKET}" \
+  --format="yaml(versioning_enabled, lifecycle_config)"


### PR DESCRIPTION
## Summary

`scripts/run_cloud_gpu.sh` uploads pipeline results to GCS with `gcloud storage cp -r results/ gs://…/` — a **destructive in-place overwrite** — and the bucket had **no object versioning** (verified `versioning: null`) and no archive step. Any re-run silently destroyed prior results with **no recovery path**.

Surfaced 2026-06-01 while prepping the [Issue #205](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/205) (related) patient_001 TCRdock re-run, which would have clobbered the DMF5-baseline `docking_scores.tsv` + `top_candidate.pdb`.

Closes #627

## What changed

- **`scripts/gcs_lifecycle.json`** — retention policy: noncurrent versions under `results/<patient>/alignment/` (regenerable, ~75% of footprint) expire after **7 days**; all other noncurrent versions after **90 days**.
- **`scripts/setup_gcs_archiving.sh`** — idempotent applier: enables versioning + applies the lifecycle + prints the resulting config. Safe to re-run.
- **`docs/google_cloud_guide.md`** — new "Result Archiving & Versioning" section: recovery procedure (`ls --all-versions` + restore a generation) and the per-patient alignment-prefix maintenance note.

## Already applied

Versioning + lifecycle are **live on `gs://splice-neoepitope-project`** (this PR codifies what's already in effect):

```
versioning_enabled: true
lifecycle_config.rule:
  - Delete, daysSinceNoncurrentTime 7, matchesPrefix [results/patient_001/alignment/, results/patient_002/alignment/]
  - Delete, daysSinceNoncurrentTime 90
```

## Design note

Versioning + lifecycle was chosen over a timestamped archive step because it's bucket-wide, automatic, protects every overwrite (not just `run_cloud_gpu.sh`), and self-prunes (the archive-step alternative grows unbounded). Cost ≈ cents/month at current run cadence. The prefix-aware alignment expiry is a minor cost optimization; GCS lifecycle prefixes can't wildcard `*/alignment/`, hence the per-patient enumeration + maintenance note.

## Test plan

- [x] `scripts/setup_gcs_archiving.sh` runs idempotently (re-run produces same config, no error)
- [x] `gcs_lifecycle.json` is valid JSON
- [x] `shellcheck scripts/setup_gcs_archiving.sh` clean
- [x] Versioning enabled on the bucket — verified `versioning_enabled: true` (gsutil: "Enabled")
- [x] Lifecycle applied — verified both rules present via `buckets describe` + `gsutil lifecycle get`
- [x] Recovery procedure + maintenance note documented in `docs/google_cloud_guide.md`

<!-- skip-lab-notebook: routine -->
