### PR TITLE
fix(pm): recheck_milestone — flag [UNSIZED] on any unsized open issue (not only at capacity 0)

### DIFF
--- a/research/lab_notebook/pm.md
+++ b/research/lab_notebook/pm.md
@@ -6,6 +6,26 @@ Format and rules unchanged from the unified notebook — see `shared/feedback_la
 
 ---
 
+## 2026-06-03
+
+### 13:42 UTC — Editor: PM
+
+#### `recheck_milestone` capacity under-read fixed — unsized-guard hoisted above the zero-check ([Issue #618](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/618), [PR #644](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/644))
+
+**Trigger.** Warm-up pull of the `recheck_milestone` proves-out dock [Issue #618](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/618). The scope verdict (keep PM-local) was already settled in [Issue #454](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/454); the live work was AC2 — "re-evaluate K and/or capacity-model accuracy," prompted by a 2026-06-01 `pm-i6` under-read.
+
+**Self-reproducing bug.** The commitment act for #618 — `gh issue edit 618 --milestone "pm-i6 …"` — *itself* fired `recheck_milestone` and reproduced the exact AC2 fault: open issues `#539 (S)` + `#527`/`#538` (unsized) → `Remaining capacity: 1.0d` → spurious `Proposed due_on: 2026-06-04 (delta -28 days) [UPDATE NEEDED]`. The dock Issue's own proves-out fire was the test case.
+
+**Root cause.** The unsized-capacity guard in `compute_recheck` was nested inside the `if remaining == 0:` branch, so a milestone with a **mix** of sized and unsized open issues bypassed it — the unsized issues were silently weighted 0d, under-reading capacity and driving a confident-but-bogus slip. Two distinct under-read causes were visible in the one fire; only the capacity-model one is in scope here:
+- **Capacity-model (this PR):** unsized issues counted as 0d when `remaining > 0`. **Fixed.**
+- **Mid-propagation membership lag:** the just-added #618 wasn't yet in the milestone's issue list (GitHub eventual-consistency). That is the separate domain of [Issue #406](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/406) — cross-referenced, not touched. It self-resolved within the session (the post-fix re-run showed #618 present).
+
+**Fix.** Hoist the unsized check above the zero-check: *any* unsized open issue now yields `[UNSIZED]` (reporting the sized subset as a floor — `sized subset 1.5d is a floor`) instead of a due-date recommendation. An unreliable read must not produce a confident proposal — the actionability principle (AWS Well-Architected OPS08-BP04) the dock Issue cites; a spurious `[UPDATE NEEDED]` is alert-fatigue noise. TDD: added direct `compute_recheck` coverage (`TestComputeRecheckUnsizedGuard` — mixed / all-unsized / no-open / all-sized); the mixed case was red pre-fix, green post-fix; full suite 39 passed, 0 regressions; live pm-i6 re-run now `[UNSIZED]`.
+
+**K unchanged.** AC2 also asked to re-evaluate K (`threshold=3`). No change: the proves-out has fired (3/3, equals-once so it won't re-fire) and the scope verdict is settled — K=3 stands; the real defect was capacity-model accuracy, not the fire threshold. Closes [Issue #618](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/618).
+
+---
+
 ## 2026-06-01
 
 ### 15:36 UTC — Editor: PM

--- a/scripts/pm/recheck_milestone.py
+++ b/scripts/pm/recheck_milestone.py
@@ -208,12 +208,21 @@ def compute_recheck(milestone_number: int) -> int:
         print(f"  - #{n} ({size_disp})")
     print(f"Remaining capacity: {remaining}d")
 
+    # Any unsized open issue makes the capacity read unreliable: the size-weighted
+    # sum silently under-counts true remaining work, which then drives a
+    # confident-but-bogus due_on proposal (the 2026-06-03 pm-i6 under-read — one
+    # sized issue + two unsized yielded 1.0d and a spurious -28d slip; Issue #618
+    # AC2). Flag and bail BEFORE computing a due date, regardless of whether the
+    # sized subset happens to be > 0 — previously this guard was nested inside the
+    # `remaining == 0` branch and so was bypassed whenever even one issue had a size.
+    unsized_count = sum(1 for n in issue_numbers if sizes.get(n) is None)
+    if unsized_count > 0:
+        floor = f"; sized subset {remaining}d is a floor" if remaining else ""
+        print(f"Proposed due_on: (cannot compute — {unsized_count} open issue(s) missing Size{floor})")
+        print("Status: [UNSIZED] — assign Size on the project board, then re-run")
+        return 2
+
     if remaining == 0:
-        unsized_count = sum(1 for n in issue_numbers if sizes.get(n) is None)
-        if unsized_count > 0:
-            print(f"Proposed due_on: (cannot compute — {unsized_count} open issue(s) missing Size)")
-            print("Status: [UNSIZED] — assign Size on the project board, then re-run")
-            return 2
         print("Proposed due_on: (no open work)")
         print("Status: [No change] — milestone has no remaining capacity")
         return 0

--- a/tools/ci/test_recheck_milestone.py
+++ b/tools/ci/test_recheck_milestone.py
@@ -253,6 +253,97 @@ class TestComputeLayeredDueDate:
         assert "standalone S7" in note
 
 
+class TestComputeRecheckUnsizedGuard:
+    """compute_recheck must flag [UNSIZED] whenever ANY open issue lacks a Size —
+    not only when total remaining capacity is exactly 0 (Issue #618 AC2).
+
+    Reproduces the 2026-06-03 pm-i6 live under-read: one sized issue (#539 S) plus
+    two unsized (#527, #538) yielded "Remaining capacity 1.0d" and a spurious
+    [UPDATE NEEDED] -28d proposal, because the unsized guard was nested inside the
+    ``remaining == 0`` branch and got bypassed when even one issue carried a size.
+    An unreliable capacity read must not produce a confident due_on recommendation.
+    """
+
+    def _patch_board(self, monkeypatch, *, title, due_on, issues, sizes):
+        monkeypatch.setattr(rm, "milestone_meta", lambda n: {"title": title, "due_on": due_on})
+        monkeypatch.setattr(rm, "open_issues_in_milestone", lambda t: list(issues))
+        monkeypatch.setattr(rm, "sizes_for_issues", lambda ns: dict(sizes))
+
+    def test_mixed_sized_and_unsized_flags_unsized_not_update(self, monkeypatch, capsys):
+        self._patch_board(
+            monkeypatch,
+            title="pm-i6 - PM Tooling, Memory & Methodology II",
+            due_on="2026-07-02T00:00:00Z",
+            issues=[527, 538, 539],
+            sizes={527: None, 538: None, 539: "S"},
+        )
+        # The due-date computation must NOT be reached when open work is unsized:
+        # if it were, the under-read 1.0d would drive a bogus proposal.
+        monkeypatch.setattr(rm, "gh", lambda *a, **k: pytest.fail(
+            "compute_layered_due_date path reached despite unsized open issues"))
+
+        rc = rm.compute_recheck(33)
+        out = capsys.readouterr().out
+
+        assert rc == 2
+        assert "[UNSIZED]" in out
+        assert "missing Size" in out
+        assert "[UPDATE NEEDED]" not in out
+        assert "delta" not in out  # no due_on proposal line emitted
+
+    def test_all_unsized_still_flags_unsized(self, monkeypatch, capsys):
+        # Pre-existing remaining==0 + unsized>0 case must be preserved.
+        self._patch_board(
+            monkeypatch,
+            title="pm-i4 - PM Tooling",
+            due_on="2026-06-03T00:00:00Z",
+            issues=[10, 11],
+            sizes={10: None, 11: None},
+        )
+        monkeypatch.setattr(rm, "gh", lambda *a, **k: pytest.fail("should not compute due date"))
+        rc = rm.compute_recheck(30)
+        out = capsys.readouterr().out
+        assert rc == 2
+        assert "[UNSIZED]" in out
+
+    def test_no_open_issues_is_no_change(self, monkeypatch, capsys):
+        self._patch_board(
+            monkeypatch,
+            title="pm-i4 - PM Tooling",
+            due_on="2026-06-03T00:00:00Z",
+            issues=[],
+            sizes={},
+        )
+        rc = rm.compute_recheck(30)
+        out = capsys.readouterr().out
+        assert rc == 0
+        assert "[No change]" in out
+        assert "[UNSIZED]" not in out
+
+    def test_all_sized_still_computes_due_date(self, monkeypatch, capsys):
+        # Regression: with every issue sized, the normal due-date path runs.
+        self._patch_board(
+            monkeypatch,
+            title="i3 - S5 - Modeling - X",
+            due_on="2026-05-10T00:00:00Z",
+            issues=[1, 2],
+            sizes={1: "L", 2: "M"},
+        )
+        monkeypatch.setattr(rm, "gh", lambda *a, **k: [])  # no other milestones
+
+        class _FakeDate(date):
+            @classmethod
+            def today(cls):
+                return date(2026, 5, 22)
+
+        monkeypatch.setattr(rm, "date", _FakeDate)
+
+        rc = rm.compute_recheck(5)
+        out = capsys.readouterr().out
+        assert "[UNSIZED]" not in out
+        assert "Proposed due_on:" in out
+
+
 @pytest.mark.live
 @REQUIRES_LIVE_GH
 class TestLiveIntegrationSmoke:


### PR DESCRIPTION
## Summary

`recheck_milestone`'s unsized-capacity guard was nested inside the `remaining == 0` branch, so a milestone with **mixed** sized + unsized open issues bypassed it — the unsized issues counted as 0d, under-reading capacity and emitting a confident-but-bogus `due_on` proposal.

**Reproduced live** while committing the dock Issue #618 to `pm-i6` (2026-06-03): `#539 (S)` + `#527`/`#538` (unsized) → `Remaining capacity: 1.0d` → spurious `Proposed due_on: 2026-06-04 (delta -28 days) [UPDATE NEEDED]`.

**Fix:** hoist the unsized check above the zero-check. Any unsized open issue now yields `[UNSIZED]` (reporting the sized subset as a floor) instead of a due-date recommendation — an unreliable read must not drive a confident slip. This is the actionability principle the dock Issue cites (a spurious proposal is alert-fatigue noise).

**Scope:** this addresses the **capacity-model** under-read (#618 AC2). The companion mid-propagation cause — a freshly-added issue not yet in the milestone's list due to GitHub eventual-consistency, also visible in the same live fire — is the separate domain of Issue #406 and is intentionally not touched here.

After the fix, the live pm-i6 re-run:

```
Remaining capacity: 1.5d
Proposed due_on: (cannot compute — 2 open issue(s) missing Size; sized subset 1.5d is a floor)
Status: [UNSIZED] — assign Size on the project board, then re-run
```

## Test plan

- [x] New `TestComputeRecheckUnsizedGuard` — mixed sized+unsized → `[UNSIZED]` with no due_on proposal (the regression), plus all-unsized / no-open-issues / all-sized cases
- [x] Full `tools/ci/test_recheck_milestone.py` suite green (39 passed, 0 regressions; live smoke deselected)
- [x] Live re-run on pm-i6 (milestone 33) emits `[UNSIZED]` instead of the spurious `-28d` proposal

Closes #618.
