### PR TITLE
research(evals): OpenFold3 TCR-pMHC backend eval — (b) decline-for-now (#552)

### DIFF
--- a/research/evals/issue_552_openfold3/refs.bib
+++ b/research/evals/issue_552_openfold3/refs.bib
@@ -1,0 +1,45 @@
+@misc{openfold3_2026,
+	title = {{OpenFold3}-preview: an open, {Apache}-2.0 {AlphaFold3}-class all-atom co-folding model},
+	howpublished = {AlQuraishi Lab (Columbia University) \& OpenFold Consortium. Code: \url{https://github.com/aqlaboratory/openfold-3}; weights (model card): \url{https://huggingface.co/OpenFold/OpenFold3}; training data: \url{https://registry.opendata.aws/openfold3/}; NVIDIA NIM: \url{https://build.nvidia.com/openfold/openfold3/modelcard}},
+	note = {Research preview, tag 0.4.1 (2026-04-09); preview first released 2025-10-28, training-data release update 2026-03-13. Final model in development (full multi-modality parity with AlphaFold3 and improved antibody-antigen performance on the 2026 roadmap). Code + weights Apache-2.0; training data CC BY 4.0. Accessed 2026-06-03.},
+	year = {2026},
+	author = {{AlQuraishi Lab and OpenFold Consortium}},
+}
+
+@article{lu_benchmarking_2025,
+	title = {Benchmarking {TCR}-{pMHC} structure prediction: a unified evaluation and {CDR3}-based functional insights},
+	url = {http://biorxiv.org/content/early/2025/12/02/2025.11.30.691400.abstract},
+	doi = {10.64898/2025.11.30.691400},
+	journal = {bioRxiv},
+	author = {Lu, Jiadong and Zhu, Xinyuan and Hu, Xinting and Zhang, Cheng and Feng, Fuli},
+	month = dec,
+	year = {2025},
+	pages = {2025.11.30.691400},
+}
+
+@article{abramson_accurate_2024,
+	title = {Accurate structure prediction of biomolecular interactions with {AlphaFold} 3},
+	author = {Abramson, Josh and Adler, Jonas and Dunger, Jack and Evans, Richard and Green, Tim and Pritzel, Alexander and others},
+	journal = {Nature},
+	volume = {630},
+	pages = {493--500},
+	year = {2024},
+	doi = {10.1038/s41586-024-07487-w},
+}
+
+@article{chai_2024,
+	title = {Chai-1: {Decoding} the molecular interactions of life},
+	author = {{Chai Discovery Team}},
+	journal = {bioRxiv},
+	year = {2024},
+	doi = {10.1101/2024.10.10.615955},
+}
+
+@techreport{candido_language_2026,
+	title = {Language {Modeling} {Materializes} a {World} {Model} of {Protein} {Biology}},
+	url = {https://biohub.ai/papers/esm_protein.pdf},
+	institution = {Chan Zuckerberg Biohub},
+	author = {Candido, Salvatore and Hayes, Thomas and Derry, Alexander and Rao, Roshan and Lin, Zeming and Rives, Alexander and others},
+	month = may,
+	year = {2026},
+}

--- a/research/evals/issue_552_openfold3/slides.qmd
+++ b/research/evals/issue_552_openfold3/slides.qmd
@@ -144,7 +144,7 @@ If/when the hardware clears, the plumbing our issue worried about is **favorable
 :::
 ::: {.column width="46%"}
 ::: {.callout-important appearance="simple"}
-**No transfer, two ways.** (1) The AF3 *family* tops TCR-pMHC (Lu et al.: median DockQ 0.64/0.68 [@lu_benchmarking_2025]) — but **OpenFold3, Boltz, and TCRdock are not in that 10-model roster**, so AF3's win is *not* OpenFold3's. (2) Antibody–antigen — the closest immune analogue — is the AF3 family's **weakest** category and an explicit **2026 roadmap** item, *not* done.
+**No transfer, two ways.** (1) The AF3 *family* tops TCR-pMHC (Lu et al.: median DockQ 0.64/0.68 [@lu_benchmarking_2025]) — but **OpenFold3 and Boltz are absent from that 10-model roster** (TCRdock is represented only by its **AF2** backbone, the roster's 2nd-best entry), so AF3's win is *not* OpenFold3's. (2) Antibody–antigen — the closest immune analogue — is the AF3 family's **weakest** category and an explicit **2026 roadmap** item, *not* done.
 :::
 :::
 :::

--- a/research/evals/issue_552_openfold3/slides.qmd
+++ b/research/evals/issue_552_openfold3/slides.qmd
@@ -1,0 +1,194 @@
+---
+title: "OpenFold3 as a TCR-pMHC structure backend — the open AF3-class candidate #316 was hunting for"
+subtitle: "Tool evaluation · Issue #552 · 2026-06-03"
+author: "Jin-Ho Lee"
+institute: "Splice Neoepitope Pipeline · JH M Lee Lab"
+date: 2026-06-03
+date-format: "YYYY-MM-DD"
+format:
+  revealjs:
+    theme: [simple, ../../slides/custom.scss]
+    footer: "Splice Neoepitope Pipeline · JH M Lee Lab"
+    incremental: false
+    slide-number: c/t
+    progress: true
+    chalkboard: false
+    code-line-numbers: false
+    fig-align: center
+    fig-cap-location: bottom
+    transition: fade
+    background-transition: fade
+    width: 1280
+    height: 720
+# PDF (beamer) render disabled — same Quarto/pandoc longtable issue as the pilot deck.
+# HTML reveal.js is the primary delivery; "Print → Save as PDF" in Chrome for handouts.
+bibliography: refs.bib
+csl: ../../slides/nature.csl
+execute:
+  echo: false
+  warning: false
+---
+
+## The question
+
+::: {style="text-align: center; font-size: 2.0em; font-weight: bold; line-height: 1.2; margin-top: 0.4em;"}
+Should OpenFold3 replace\
+TCRdock's AF2 backend for\
+TCR-pMHC structure prediction?
+:::
+
+. . .
+
+::: {.callout-note appearance="simple"}
+**Scope:** TCR-pMHC **structure prediction** (DockQ / pLDDT), *upstream* of MHC-presentation scoring — distinct vocabularies. Decision-only ([Issue #552](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/552)); no integration here. This **extends [Issue #316](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/316)** (the AF3-class / ESMFold2 verdict) rather than re-opening it — OpenFold3 is the *next candidate* in that same survey.
+:::
+
+---
+
+## Tool primer — what OpenFold3 actually is {.smaller}
+
+::: {.incremental}
+- An **AlphaFold3-class, all-atom co-folding model** — a PyTorch reimplementation of DeepMind's AF3, explicitly aiming for a *bitwise reproduction* (Pairformer + diffusion module; folds proteins, RNA, DNA, ligands jointly). From the **AlQuraishi Lab (Columbia) + OpenFold Consortium** [@openfold3_2026].
+- **Architecturally distinct from "OpenFold."** The original `aqlaboratory/openfold` is an **AF2** protein-only reproduction; OpenFold3 lives in a separate repo (`aqlaboratory/openfold-3`) and is the AF2→AF3 generational jump.
+- **It is a research preview, not a finished model.** Latest tag **0.4.1 (Apr 9 2026)**; preview first shipped **2025-10-28**, with the **2026-03-13** update adding the public training-data release. The repo states verbatim *"the final OpenFold3 model is still in development,"* with **"full parity with AlphaFold3 on all modalities"** and improved **antibody–antigen** performance still on the 2026 roadmap.
+:::
+
+::: {.callout-note appearance="simple"}
+**Premise correction:** the issue's "March 2026 release" is the *training-data-release update* — the preview itself is from Oct 2025, and it remains a *preview*.
+:::
+
+---
+
+## The openness story — genuinely better than AF3 {.smaller}
+
+This is OpenFold3's real differentiator, and it is **the exact blocker that killed AF3 in [Issue #316](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/316)** (non-redistributable weights).
+
+| Layer | OpenFold3 | vs AlphaFold3 |
+|---|---|---|
+| Inference code | **Apache-2.0** | AF3 code restricted |
+| Model weights | **Apache-2.0** (HF/portal, *registration*-gated — an access gate, not a license restriction) | AF3 weights non-commercial, manual grant |
+| Training data | **CC BY 4.0**, open on AWS Registry of Open Data (`openfold3-data`, `--no-sign-request`) | AF3 training data not released |
+| Output usage | **no restriction** | AF3 ships an output-terms-of-use |
+
+::: {.callout-important appearance="simple"}
+**Correction to the issue premise:** it's a **code+weights = Apache-2.0 / training-data = CC BY 4.0** split (not "weights on AWS under Apache-2.0"). **Separate qualifier:** the *NVIDIA NIM* path is governed by the **NVIDIA Open Model License + API Trial ToS**, *not* pure Apache-2.0 — the bare GitHub/HF weights are the Apache route.
+:::
+
+---
+
+## Where it sits vs the #316 candidates {.smaller}
+
+OpenFold3 slots straight into the [Issue #316](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/316) survey as the **next license-clean AF3-class backend**:
+
+| Tool | License / weights | P100 16 GB? | TCR-pMHC accuracy | Ship here? |
+|---|---|---|---|---|
+| **TCRdock-AF2** *(incumbent)* | MIT + CC-BY AF2 params — **ships legally** | ✅ today | 2nd-best, AF3-complementary | **Keep** |
+| **AlphaFold3** [@abramson_accurate_2024] | non-redistributable, non-commercial | *moot* | **best** (0.64 / 0.68) | ❌ license |
+| **Chai-1 / Protenix** [@chai_2024] | Apache-2.0 ✅ | ❌ bf16 + ≥24 GB | competitive | ❌ HW |
+| **ESMFold2** [@candido_language_2026] | MIT ✅ | ❌ FP8 + bf16 | **none for TCR-pMHC** | ❌ no evidence + HW |
+| **OpenFold3** *(this eval)* | **Apache + CC-BY data ✅✅** | ❌ **≥48 GB + CUDA 13.x** | **none reported** | ❌ HW + no evidence |
+
+::: {.callout-important appearance="simple"}
+**OpenFold3 fixes #316's license half and reproduces its hardware half — at an even higher floor.** It is the cleanest-licensed AF3-class option yet (open *training data* too), but it is **hardware-blocked on the P100** like Chai-1/ESMFold2, and reports **no TCR-pMHC accuracy** like ESMFold2.
+:::
+
+---
+
+## The hardware wall — higher than #316's L4 plan {.smaller}
+
+```{mermaid}
+%%| fig-width: 11
+flowchart LR
+    A["Top neoepitope<br/>candidate"] --> B["TCRdock<br/>(AF2 / CC-BY)<br/>P100 ✅"]
+    F["VDJdb TCR panel"] --> B
+    B --> C["PDB + pLDDT, PAE, ipTM"]
+    B -. "OpenFold3 swap?" .-> X["OpenFold3 NIM<br/>(Apache / open data)"]
+    X -. "blocked" .-> W["CUDA 13.x · Ampere+ · ≥48 GB"]
+    C --> I["candidate retained / dropped"]
+
+    style B fill:#a3e6a3,stroke:#2a8a2a,stroke-width:2px
+    style X fill:#ffe6a3,stroke:#b8860b,stroke-width:3px
+    style W fill:#ffb3b3,stroke:#b81e1e,stroke-width:2px
+```
+
+The official OpenFold3 **NVIDIA NIM** floor: **CUDA 13.1 / driver ≥590**, an **Ampere/Ada-or-newer** GPU, **≥48 GB VRAM (L40S-class)**. CUDA 13.x **drops Pascal entirely** (Turing SM 7.5 is the new compile floor) — our **P100 (SM 6.0, 16 GB, driver 550.90.07)** is *structurally* excluded.
+
+| Wall | P100 | T4 | **L4 (Ada)** | L40S / A100 |
+|---|---|---|---|---|
+| Modern arch (CUDA 13.x) | ✗ | ✅ | ✅ | ✅ |
+| ≥48 GB VRAM | ✗ (16) | ✗ (16) | ✗ **(24)** | ✅ |
+
+::: {.callout-important appearance="simple"}
+**Refines [Issue #601](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/601):** the **L4-class refresh #601 targets (≥24 GB) clears Chai-1/ESMFold2 but *not* the OpenFold3 NIM (≥48 GB).** Open escape hatch: a *self-hosted* OpenFold3 from the bare Apache-2.0 weights, outside the NIM, *might* relax the 48 GB / CUDA-13.x floor — **unverified**, to pin at re-eval.
+:::
+
+---
+
+## Integration mechanics — the good news {.smaller}
+
+If/when the hardware clears, the plumbing our issue worried about is **favorable** — these are *not* blockers:
+
+::: {.incremental}
+- **Output format:** the NIM emits **both mmCIF and PDB** (`output_format='pdb'`). So `relabel_pdb_chains()` (A=MHC / B=peptide / C=TCR-α / D=TCR-β, driving the Mol* report panel) would **not** need an mmCIF rewrite — the original integration concern dissolves.
+- **Confidence metrics:** emits **pLDDT, pTM, ipTM, PDE** (NIM: `complex_plddt_score`, `ptm_score`, `iptm_score`, `complex_pde_score`; PAE in the UI) — directly usable the way we consume TCRdock's `docking_scores.tsv`.
+- **CDR3-pLDDT reranking is portable.** The [Issue #316](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/316) recipe (mean per-residue pLDDT over CDR3-α+β; +4.3% Top-1 on AF3-class) needs per-residue pLDDT + ipTM — **both of which OpenFold3 emits.** Banked on [Issue #601](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/601), ready to fire.
+:::
+
+---
+
+## The validation gap — no TCR-pMHC number {.smaller}
+
+::: {.columns}
+::: {.column width="54%"}
+**What OpenFold3 reports:** competitive on protein/RNA **monomers** (CASP16), **protein–protein** (CASP16, FoldBench), **protein–ligand** (Runs N' Poses); *"the only model to match AF3 on monomeric RNA."* **No TCR-pMHC / immune-ternary accuracy** is asserted, and **no DockQ/TM/RMSD numbers** appear on any official page — only **speed** (≤1.8× faster).
+:::
+::: {.column width="46%"}
+::: {.callout-important appearance="simple"}
+**No transfer, two ways.** (1) The AF3 *family* tops TCR-pMHC (Lu et al.: median DockQ 0.64/0.68 [@lu_benchmarking_2025]) — but **OpenFold3, Boltz, and TCRdock are not in that 10-model roster**, so AF3's win is *not* OpenFold3's. (2) Antibody–antigen — the closest immune analogue — is the AF3 family's **weakest** category and an explicit **2026 roadmap** item, *not* done.
+:::
+:::
+:::
+
+So OpenFold3's TCR-pMHC capability today is **assumed from architecture, not demonstrated** — the same posture that held back ESMFold2 in [Issue #316](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/316).
+
+---
+
+## Decision
+
+::: {style="text-align: center; font-size: 2.6em; font-weight: bold; margin-top: 0.4em;"}
+\(b\) Decline — *for now*
+:::
+
+::: {style="text-align: center; font-size: 1.25em; margin-top: 0.4em;"}
+keep TCRdock-AF2; fold the OpenFold3 re-eval into [Issue #601](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/601)
+:::
+
+. . .
+
+::: {.callout-note appearance="simple"}
+**Why not (a) integrate:** structurally cannot run on the P100, and no validated TCR-pMHC accuracy. **Why not (c) skip:** OpenFold3 is the **best license posture yet** for an AF3-class backend (open weights *and* open training data) — a genuine future candidate the moment the hardware constraint lifts. So it is a *deferred yes-candidate*, not a dead end — tracked, not re-litigated.
+:::
+
+---
+
+## Open questions + re-eval triggers {.smaller}
+
+Folded into [Issue #601](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/601) (the AF3-class parking lot) — re-fire when the pipeline leaves the P100:
+
+::: {.incremental}
+1. **GPU target, refined** *(Developer)* — OpenFold3's NIM needs **≥48 GB (L40S-class)**, *above* #601's L4 (24 GB) plan; an L4 refresh clears Chai-1/ESMFold2 but **not** the OpenFold3 NIM. Reconcile with [Issue #310](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/310).
+2. **Self-hosted vs NIM floor** — does a bare Apache-2.0 OpenFold3 install (no NIM) relax the CUDA-13.x / 48 GB / Ampere floor? Decides whether OpenFold3 is reachable on a cheaper card *and* off the NVIDIA license path.
+3. **OpenFold3-specific TCR-pMHC validation** — run the Lu et al. 70-complex set against OpenFold3 (it's absent from the published benchmark) before any adoption.
+4. **Watch the roadmap** — re-evaluate when OpenFold3 reaches "full parity on all modalities" (antibody–antigen closes) and a finalized, non-preview release ships.
+:::
+
+::: {.callout-tip appearance="simple"}
+**Verification note:** all OpenFold3 facts confirmed against primary sources (GitHub repo, HF model card, AWS Open Data registry, NVIDIA NIM docs). The exact NIM supported-GPU roster did **not** fully survive adversarial verification — the load-bearing, high-confidence fact is that **CUDA 13.x structurally excludes Pascal/P100**, which is sufficient for the verdict.
+:::
+
+---
+
+## References {.smaller}
+
+::: {#refs}
+:::

--- a/research/lab_notebook/scientist.md
+++ b/research/lab_notebook/scientist.md
@@ -8,6 +8,22 @@ Format and rules unchanged from the unified notebook — see `shared/feedback_la
 
 ## 2026-06-03
 
+### 20:24 UTC — Editor: Scientist
+
+#### [Issue #552](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/552) evaluate OpenFold3 as the TCR-pMHC structure-prediction backend. [PR #654](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/654) closes [Issue #552](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/552).
+
+**What.** Decision-only tool eval; verdict **(b) decline-for-now**. Standalone tool-primer deck (`research/evals/issue_552_openfold3/`, title + 9 content + refs, HERMES [Issue #218](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/218) format) **extending the [Issue #316](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/316) AF3-class verdict** — OpenFold3 is the next license-clean AF3-class candidate in that survey. No pipeline/integration changes.
+
+**Why it matters.** OpenFold3 **fixes the exact blocker that killed AlphaFold3 in #316** (non-redistributable weights): code + weights are **Apache-2.0**, training data **CC BY 4.0** on AWS Open Data — the cleanest AF3-class license posture yet. But it **reproduces #316's hardware blocker at a higher floor**, so it is a *deferred yes-candidate*, not a dead end. Re-eval folds into the existing [Issue #601](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/601) parking lot, not a new track.
+
+**Two decisive blockers (vs a P100 backend).** (1) **Structural P100 incompatibility** — the official OpenFold3 NVIDIA NIM needs CUDA 13.1 / driver ≥590 / Ampere-or-newer / ≥48 GB VRAM (L40S-class); CUDA 13.x drops Pascal entirely (Turing SM 7.5 floor). This is *higher* than the L4-class (≥24 GB) refresh #601 targets — an L4 clears Chai-1/ESMFold2 but **not** the OpenFold3 NIM. (2) **No TCR-pMHC validation** — OpenFold3 reports no immune-ternary accuracy and is absent from the Lu et al. 10-model benchmark; antibody-antigen (closest immune analogue) is the AF3 family's weakest, roadmap-2026 modality.
+
+**Verification.** Backed by a 99-agent fact-checked deep-research run (17 primary sources; 79 claims → 25 adversarially verified → 23 confirmed). All OpenFold3 facts confirmed against the GitHub repo, HF model card, AWS Open Data registry, and NVIDIA NIM docs. **Premise corrections caught:** the preview is **Oct-2025** (the issue's "March 2026 release" is the training-data-release update); license is **code+weights Apache-2.0 / training-data CC-BY-4.0** (not "weights on AWS under Apache-2.0"). The exact NIM supported-GPU roster did not fully survive adversarial verification — the load-bearing, high-confidence fact (CUDA 13.x structurally excludes Pascal/P100) is sufficient for the verdict.
+
+**Review.** @-claude review — **DOI flag was a false alarm, pushed back with evidence:** the reviewer assumed `lu_benchmarking_2025` should be bioRxiv `10.1101`, but CrossRef returns **200** for `10.64898/2025.11.30.691400` (publisher *openRxiv*) and **404** for `10.1101/...` — the deck DOI is correct (and matches the merged #316 deck), no change. **TCRdock-roster wording fixed** (commit `1cacaa8`): "OpenFold3, Boltz, and TCRdock are not in that roster" → "OpenFold3 and Boltz are absent … (TCRdock is represented only by its **AF2** backbone, the roster's 2nd-best entry)", since TCRdock's AF2 backbone *is* in the roster. Section-(iii) why-it-works adaptation (no standalone mechanism slide for a hardware-blocked decline) accepted by the reviewer as non-blocking.
+
+**Routing + AC discharge.** [Issue #601](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/601) updated with OpenFold3 as a tracked candidate + the ≥48 GB-vs-L4 refinement + self-hosted-vs-NIM and OpenFold3-specific-TCR-pMHC-validation open questions (so no slide-only state). #552 verdict comment discharges AC1 + AC4; **AC2** (Developer, P100/Pascal NIM gating) answered from NVIDIA's published docs — P100 structurally excluded, empirical benchmark moot + parked to #601; the stale "blocked by #310" edge cleared. Milestone left to PM (uncommitted; candidate = a new i6-S1 *Tool Landscape Evaluations III*).
+
 ### 14:19 UTC — Editor: Scientist
 
 #### [Issue #599](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/599) integrate 2025-26 splice-neoepitope validation cohorts (POSTN, RCAN1-4, JAseC) into INTRODUCTION + DISCUSSION. [PR #643](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/643) closes [Issue #599](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/599).


### PR DESCRIPTION
## Summary

Tool-evaluation of **OpenFold3** as a candidate TCR-pMHC structure-prediction backend (would replace TCRdock's AF2 backend). **Decision-only** eval; verdict **(b) decline-for-now**. This **extends the [Issue #316](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/316) AF3-class verdict** — OpenFold3 is the next license-clean AF3-class candidate — and **routes its re-eval into the [Issue #601](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/601) parking lot**. No pipeline or integration changes.

## What landed
- `research/evals/issue_552_openfold3/slides.qmd` — tool-primer deck (title + 9 content + references, HERMES [Issue #218](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/218) format): the question · tool primer · openness story · candidates-vs-#316 · hardware wall · integration mechanics · validation gap · decision · open questions.
- `research/evals/issue_552_openfold3/refs.bib` — deck bibliography (OpenFold3 + reused #316 keys).
- Rendered `slides.html` / `slides_files/` are gitignored (kept locally per the render-artifacts convention).

## Verdict — (b) decline-for-now
Two decisive blockers as a P100 backend: (1) **structural P100 incompatibility** — the OpenFold3 NVIDIA NIM needs CUDA 13.1 / Ampere+ / ≥48 GB (L40S); CUDA 13.x drops Pascal entirely; (2) **no TCR-pMHC validation** — OpenFold3 reports no immune-ternary accuracy and is absent from the Lu et al. benchmark. **Not (c) skip:** its Apache-2.0 code+weights + CC-BY open-training-data posture is the cleanest AF3-class license story yet — a deferred yes-candidate once hardware lifts.

## Verification (claims confirmed against primary sources)
Backed by a 99-agent fact-checked deep-research run (17 primary sources; 79 claims → 25 adversarially verified → 23 confirmed). All OpenFold3 facts confirmed against the GitHub repo, HF model card, AWS Open Data registry, and NVIDIA NIM docs. **Premise corrections caught:** the preview is Oct-2025 (the "March 2026 release" is the training-data update); license is code+weights Apache-2.0 / training-data CC-BY-4.0 (not "weights on AWS under Apache-2.0"). The exact NIM supported-GPU roster did **not** fully survive adversarial verification — the load-bearing, high-confidence fact (CUDA 13.x structurally excludes Pascal) is sufficient for the verdict.

## Test plan
- [x] AC1 — Scientist recommendation recorded ((b) decline-for-now) — [#552 verdict comment](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/552#issuecomment-4616242310)
- [x] AC2 (Dev, P100/Pascal NIM gating) — answered from NVIDIA docs: P100 **structurally excluded** (CUDA 13.x); empirical benchmark moot + parked to [Issue #601](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/601)
- [x] AC3 (if integrate) — N/A (decline; no integration sub-issue filed)
- [x] AC4 — decline-with-rationale recorded so it is not re-litigated — [#552 verdict comment](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/552#issuecomment-4616242310)
- [x] AC5 — tool-primer Quarto deck shipped + visually verified (11 slides rendered, no overflow)
- [x] AC6 — lab-notebook entry (post-review, pre-merge) — `research/lab_notebook/scientist.md` 2026-06-03 20:24 UTC (commit `11a57a3`)
- [x] Forward-looking slide items backed on the board before merge — [#601 candidate update](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/601#issuecomment-4616242151) (OpenFold3 candidate + ≥48 GB-vs-L4 refinement + self-hosted / TCR-pMHC-validation open questions)

Closes #552

🤖 Generated with [Claude Code](https://claude.com/claude-code)

