### PR TITLE
docs(manuscript): DISCUSSION subsection — neoantigen-generator + immunogenicity-scorer eval landscape (#610)

### DIFF
--- a/research/lab_notebook/scientist.md
+++ b/research/lab_notebook/scientist.md
@@ -6,6 +6,24 @@ Format and rules unchanged from the unified notebook — see `shared/feedback_la
 
 ---
 
+## 2026-06-04
+
+### 10:31 UTC — Editor: Scientist
+
+#### [Issue #610](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/610) DISCUSSION subsection — splice-generator + immunogenicity-scorer eval landscape (NeoGuider / ASNEO / NeoPrecis / Łuksza). [PR #660](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/660) closes [Issue #610](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/610).
+
+**What.** Consolidating manuscript DISCUSSION subsection (`DISCUSSIONS.md`, ~125 lines) mirroring the [Issue #432](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/432) TCR-pMHC scoring-landscape subsection's 4-part shape (taxonomy → per-tool verdicts → synthesis → carrier table). Lands the i3-S1 generator / immunogenicity-scorer eval arm that was evaluated but never written up — the TCR-pMHC arm already had its subsection ([Issue #432](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/432)), this arm had zero `DISCUSSIONS.md` coverage. Six references reconciled in `REFERENCES.md` (new `## G` / `## W` sections + `L`/`Z` inserts + tracking-table rows). No pipeline / method changes.
+
+**Why it matters (the payload).** The immunogenicity-beyond-presentation family encodes immunogenicity as a mutant-vs-wild-type **self-contrast** — NeoPrecis's cross-reactivity distance (needs an aligned WT peptide) and the Łuksza amplitude term (`A = Kd_WT/Kd_MT`, needs the paired WT peptide for its reference MHC binding affinity) — which **splice-junction-derived neoepitopes lack by construction** (novel reading frames over exon-exon joins / retained introns, no aligned germline self). So the family does not transfer; NeoPrecis's missing-value-on-junction-peptides is the explicit failure. Łuksza foreignness is the lone WT-free exception (structurally runs) but was declined on signal strength. Per-tool verdicts: ASNEO → component reuse (GTEx normal-junction filter, design reference); NeoGuider → component reuse (KDE + centered-isotonic calibration); NeoPrecis → decline; Łuksza foreignness → decline.
+
+**Forward-pointer + board-backing.** The Synthesis closes by pointing to **structure-aware** scorers as the WT-free frontier — ImmunoStruct (Givechian et al., *Nat Mach Intell* 2026). Filed as eval [Issue #659](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/659) so the manuscript actionable is backed on board #9 before merge (slides-for-humans / board-for-actionables rule). Carrier column in the summary table points each verdict at its board provenance, mirroring the TCR-pMHC table.
+
+**Verification (citations vs Zotero `Z38GTJNW`).** All six references cited from the curated Zotero records rather than the eval decks — which caught two errors: NeoGuider's first author is **Zhao** (the eval deck's `refs.bib` had "Wei", the 2nd author); the ASNEO DOI is **10.18632/aging.103516** ([Issue #546](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/546)'s body has the wrong `…103581`). Wells / TESLA DOI verified via CrossRef. AC scan clean: "splice-junction-derived" terminology (no bare "splice peptide"), American spelling, presentation vocabulary (no "binder / binding affinity" for the pipeline's own scoring).
+
+**Review.** @-claude review: 11 confirmations clean + 3 findings. **Finding 1 (substantive) — pushed back with the source.** The reviewer characterized the Łuksza amplitude term as VAF / clonal-dynamics and proposed a VAF-based rewrite; our eval deck (`research/evals/issue_572_foreignness/slides.qmd`) shows `A = Kd_WT/Kd_MT` is a peptide–MHC *binding* ratio needing the paired WT peptide — so the original framing was accurate and the per-tool Łuksza entry already introduced the amplitude term, i.e. the per-tool↔Synthesis loop was already closed. Took the valid kernel: the Synthesis now distinguishes the two peptide-level WT dependencies precisely (commit `b7ebd78`). **Finding 2 (adopted):** sharpened the ASNEO carrier cell to separate GTEx-filter ([Issue #212](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/212)) from cross-check ([Issue #566](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/566)). **Finding 3 (kept):** the NeoGuider "delegates to ASNEO" provenance is its carrier cell ([Issue #258](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/258)) per the mirror's design (no inline issue numbers in prose, consistent with the TCR-pMHC subsection).
+
+**Process.** Brainstormed the design first (the ImmunoStruct forward-pointer + eval-Issue scoping was a user-confirmed scoping call) before writing; section-by-section manuscript edit, no deletions (154 insertions / 0 deletions on the first commit). Commits `4dd3e07` (subsection + references) + `b7ebd78` (review response).
+
 ## 2026-06-03
 
 ### 20:24 UTC — Editor: Scientist

--- a/research/manuscript/DISCUSSIONS.md
+++ b/research/manuscript/DISCUSSIONS.md
@@ -1008,3 +1008,125 @@ structural quality scoring respectively, providing the redundancy on the
 calibration axis described above; integration outcomes will inform whether
 further cross-checks from the sequence-based or end-to-end classes are
 warranted in subsequent iterations.
+
+---
+
+## Neoantigen-generator and immunogenicity-scorer landscape: self-contrast dependence and per-tool verdicts
+
+The MHCflurry composite predictor ranks tumor-exclusive junction candidates by
+presentation likelihood (see *MHC binding prediction* above), and the TCR-pMHC
+scoring landscape above surveys the scorers that act once a candidate TCR
+engages the presented peptide. Between those two layers sits the immunogenicity
+question: among presented peptides, which are likely to be recognized as foreign
+by a T cell? Four tools spanning two layers — end-to-end neoantigen generators /
+rankers and immunogenicity-beyond-presentation scorers — were evaluated across
+the i3-S1 tool-landscape sprint to determine which, if any, transfer to
+splice-junction-derived neoepitopes. The organizing finding is that the
+immunogenicity layer's dominant design — contrasting a mutant peptide against
+its wild-type self — has no counterpart for novel junction sequences, which
+arise from exon-exon joins and retained introns rather than point substitutions
+and so carry no aligned germline self.
+
+### Scoring-layer taxonomy
+
+- **End-to-end generators and rankers.** Tools that reconstruct neoepitope
+  candidates from sequencing data and rank them (ASNEO, NeoGuider).
+  Architectural peers to this pipeline; evaluated for whole-pipeline replacement
+  or component reuse, not as add-on scorers.
+- **Immunogenicity-beyond-presentation scorers.** Models that score the
+  likelihood that a presented peptide is recognized by a T cell, layered above
+  MHC presentation (NeoPrecis, Łuksza foreignness). This is the layer where the
+  wild-type-self-contrast assumption lives.
+
+### Per-tool evaluation outcomes
+
+**ASNEO** (Zhang et al., *Aging* 2020) was evaluated as an end-to-end splice
+neoantigen generator — our closest published peer (RNA-seq → splice junctions →
+neoepitopes). The decision was component reuse. Its population-level GTEx
+normal-junction filter is direct prior art for our planned pan-tissue filter and
+is adopted as a design reference; full replacement was declined — ASNEO is
+unmaintained since 2019, hg19-only against our GRCh38, uses one-frame translation
+against our three-frame junction-spanning approach, and wraps a license-gated
+NetMHCpan / NetCTLpan backend rather than a presentation predictor. A head-to-head
+cross-check on our own candidates is parked as a possible manuscript-validation
+experiment.
+
+**NeoGuider** (Zhao et al., *Genome Med* 2025) was evaluated as an end-to-end
+ranker whose novel contribution is feature calibration rather than architecture.
+The decision was component reuse. Its kernel-density-estimate plus
+centered-isotonic-regression rank calibration — which maps raw per-feature scores
+to immunogenicity log-odds — is adoptable as a calibration module downstream of
+MHCflurry presentation scoring, while its variant-calling and splice branches are
+redundant with ours (its splice branch in fact delegates to ASNEO). One caveat
+carries forward: the calibration was learned on single-nucleotide-variant
+neoantigens, and whether it transfers to novel junction peptides is itself an
+open question.
+
+**NeoPrecis** (Lee et al., *Nat Commun* 2026) was evaluated as an immunogenicity
+re-scorer built on a cross-reactivity-distance recognition model. The decision
+was decline. The recognition score is a distance between a mutant peptide and its
+equal-length, position-aligned wild-type counterpart; the implementation returns
+a missing value when the two differ in length, and the authors state it is not
+applicable to indels or frameshift mutations. Splice-junction-derived neoepitopes
+are exactly that excluded case — novel sequences with no aligned germline self —
+so the recognition score cannot be computed for our junction candidates, and
+constructing a pseudo-wild-type from the canonical isoform would be arbitrary and
+would violate the model's premise.
+
+**Łuksza foreignness** (Łuksza et al., *Nature* 2017) was evaluated as the
+recognition term of the neoantigen fitness model, which scores TCR-recognition
+potential from sequence similarity to known immunogenic epitopes. The decision
+was decline. Unlike the cross-reactivity-distance and amplitude terms,
+foreignness is wild-type-free — it needs no germline counterpart and so
+structurally runs on junction peptides, the lone exception in this family. It was
+declined nonetheless on signal strength: independent TESLA-consortium
+benchmarking (Wells et al., *Cell* 2020) found that prioritizing foreignness
+without accounting for presentation does not improve — and can worsen — candidate
+ranking, and this pipeline already ranks by presentation; its fitted parameters
+were calibrated on 9-mer missense neoantigens against a fixed IEDB snapshot and
+may not transfer to our 8–11-mer novel-frame peptides; and no ground-truth
+immunogenicity labels are available to validate added signal. A conditional
+revival is parked on the acquisition of such labels.
+
+### Synthesis
+
+One pattern dominates. The immunogenicity-beyond-presentation scorers encode
+immunogenicity as a contrast between a mutant peptide and its wild-type self:
+NeoPrecis's cross-reactivity distance and the Łuksza amplitude term both require
+an equal-length, aligned germline counterpart. Splice-junction-derived
+neoepitopes have no such counterpart by construction — they are novel reading
+frames spanning exon-exon joins and retained introns, not single substitutions of
+a germline residue — so the family does not transfer to this setting, and
+NeoPrecis's missing-value behavior on junction peptides is the explicit form of
+that failure. The two generators / rankers (ASNEO, NeoGuider) sit at a different
+layer and yielded component reuse — a normal-junction filter and a calibration
+module — rather than whole-tool adoption.
+
+The lone wild-type-free signal in the family, Łuksza foreignness, escapes the
+contrast trap structurally but proved too weak and uncalibratable to bank. That
+leaves an open question the sequence-based family cannot answer: whether a
+wild-type-free immunogenicity signal can add over presentation for junction
+peptides at all. Structure-aware scorers are the natural next probe — ImmunoStruct
+(Givechian et al., *Nat Mach Intell* 2026) scores immunogenicity from the
+peptide-MHC structure rather than from a mutant-versus-wild-type comparison, and
+so is wild-type-free by design; its evaluation for the splice setting is the
+natural next target in this landscape.
+
+### Per-tool evaluation summary
+
+| Tool | Layer / axis | Verdict | Carrier |
+|------|--------------|---------|---------|
+| ASNEO | End-to-end splice generator | Component reuse — GTEx normal-junction filter (design reference) | Issue #546 close comment / Issue #212, #566 |
+| NeoGuider | End-to-end ranker | Component reuse — KDE + centered-isotonic calibration module | Issue #258 close comment / Issue #547 |
+| NeoPrecis | Immunogenicity beyond presentation (cross-reactivity distance) | Decline — requires a wild-type counterpart (missing value on junctions) | Issue #551 close comment |
+| Łuksza foreignness | Immunogenicity beyond presentation (foreignness) | Decline — wild-type-free but weak / uncalibratable | Issue #572 close comment / Issue #585 |
+| ImmunoStruct | Immunogenicity beyond presentation (structure-aware) | Evaluation pending — wild-type-free escape candidate | Issue #659 |
+
+As with the TCR-pMHC scoring landscape above, the highest-value outcomes are not
+whole-tool replacements but the components that survive scrutiny — there,
+orthogonal structural cross-checks; here, a normal-junction filter and a
+calibration module — together with a sharpened design constraint: any
+immunogenicity signal adopted downstream of presentation must be computable
+without a wild-type self. That constraint is what makes the structure-aware,
+wild-type-free class the next evaluation target rather than a further
+sequence-based contrast model.

--- a/research/manuscript/DISCUSSIONS.md
+++ b/research/manuscript/DISCUSSIONS.md
@@ -1092,8 +1092,10 @@ revival is parked on the acquisition of such labels.
 
 One pattern dominates. The immunogenicity-beyond-presentation scorers encode
 immunogenicity as a contrast between a mutant peptide and its wild-type self:
-NeoPrecis's cross-reactivity distance and the Łuksza amplitude term both require
-an equal-length, aligned germline counterpart. Splice-junction-derived
+NeoPrecis's cross-reactivity distance is computed against an equal-length,
+position-aligned wild-type peptide, and the Łuksza amplitude term (A =
+Kd_WT/Kd_MT) requires that same paired wild-type peptide to supply its reference
+MHC binding affinity. Splice-junction-derived
 neoepitopes have no such counterpart by construction — they are novel reading
 frames spanning exon-exon joins and retained introns, not single substitutions of
 a germline residue — so the family does not transfer to this setting, and
@@ -1116,7 +1118,7 @@ natural next target in this landscape.
 
 | Tool | Layer / axis | Verdict | Carrier |
 |------|--------------|---------|---------|
-| ASNEO | End-to-end splice generator | Component reuse — GTEx normal-junction filter (design reference) | Issue #546 close comment / Issue #212, #566 |
+| ASNEO | End-to-end splice generator | Component reuse — GTEx normal-junction filter (design reference) | Issue #546 close comment; GTEx filter → Issue #212; cross-check → Issue #566 |
 | NeoGuider | End-to-end ranker | Component reuse — KDE + centered-isotonic calibration module | Issue #258 close comment / Issue #547 |
 | NeoPrecis | Immunogenicity beyond presentation (cross-reactivity distance) | Decline — requires a wild-type counterpart (missing value on junctions) | Issue #551 close comment |
 | Łuksza foreignness | Immunogenicity beyond presentation (foreignness) | Decline — wild-type-free but weak / uncalibratable | Issue #572 close comment / Issue #585 |

--- a/research/manuscript/REFERENCES.md
+++ b/research/manuscript/REFERENCES.md
@@ -54,6 +54,13 @@
 
 ---
 
+## G
+
+**Givechian et al., *Nat Mach Intell* 2026** — ImmunoStruct enables multimodal deep learning for immunogenicity prediction. *Nature Machine Intelligence* 2026. doi:10.1038/s42256-025-01163-y
+→ Cited in DISCUSSIONS.md (neoantigen-generator + immunogenicity-scorer landscape; structure-aware, wild-type-free escape candidate — [Issue #659](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/659))
+
+---
+
 ## I
 
 **★ Iamukova & Alferova, *Asia-Pac J Clin Oncol* 2026** — Personalized Cancer Vaccines in the Clinical Trial Pipeline. *Asia-Pac J Clin Oncol* 2026. doi:10.1111/ajco.70006
@@ -78,6 +85,12 @@
 
 **★ Lang et al., *Bioinform Adv* 2024** — Prediction of tumor-specific splicing from somatic mutations as a source of neoantigens. *Bioinform Adv* 2024;4(1):vbae080. doi:10.1093/bioadv/vbae080
 → Cited in METHODS.md §2-3 (variant-driven splice-neoantigen tooling; closest published methodological analog)
+
+**Lee et al., *Nat Commun* 2026** — NeoPrecis: enhancing immunotherapy response prediction through integration of qualified immunogenicity and clonality-aware neoantigen landscapes. *Nature Communications* 2026. doi:10.1038/s41467-026-68651-6
+→ Cited in DISCUSSIONS.md (immunogenicity-scorer landscape; cross-reactivity-distance recognition model declined — requires a wild-type counterpart)
+
+**Łuksza et al., *Nature* 2017** — A neoantigen fitness model predicts tumour response to checkpoint blockade immunotherapy. *Nature* 2017. doi:10.1038/nature24473
+→ Cited in DISCUSSIONS.md (immunogenicity-scorer landscape; foreignness recognition term — wild-type-free but declined on signal strength)
 
 ---
 
@@ -157,6 +170,13 @@
 
 ---
 
+## W
+
+**Wells et al., *Cell* 2020** — Key Parameters of Tumor Epitope Immunogenicity Revealed Through a Consortium Approach Improve Neoantigen Prediction. *Cell* 2020. doi:10.1016/j.cell.2020.09.015
+→ Cited in DISCUSSIONS.md (immunogenicity-scorer landscape; TESLA-consortium benchmark — foreignness adds value only when layered on presentation)
+
+---
+
 ## X
 
 **Xiong (Zujian) et al., *Genes Immun* 2025** — Transcript-targeted antigen mapping reveals the potential of POSTN splicing junction epitopes in glioblastoma immunotherapy. *Genes Immun* 2025. doi:10.1038/s41435-025-00326-6
@@ -184,6 +204,12 @@
 
 **Zemmour & Parham 1992** — [HLA-C surface expression — title and journal TBD]. 1992.
 → Cited in INTRODUCTION.md (HLA-C ~10–50% surface density relative to HLA-A/B)
+
+**Zhang et al., *Aging* 2020** — ASNEO: Identification of personalized alternative splicing based neoantigens with RNA-seq. *Aging* 2020. doi:10.18632/aging.103516
+→ Cited in DISCUSSIONS.md (immunogenicity-scorer landscape; closest published splice-neoantigen peer — GTEx normal-junction filter adopted as design reference)
+
+**Zhao et al., *Genome Med* 2025** — NeoGuider: neoepitope prediction using advanced feature engineering. *Genome Medicine* 2025. doi:10.1186/s13073-025-01592-9
+→ Cited in DISCUSSIONS.md (immunogenicity-scorer landscape; KDE + centered-isotonic calibration module adopted)
 
 ---
 
@@ -220,11 +246,14 @@ The original 8-paper inventory plus Kwok 2025 and Kim 2025 (both added after the
 | Coelho et al., *Cancer Cell* 2023 | ✅ | |
 | Cotto et al., *Nat Commun* 2023 | ✅ | RegTools; aligner Methods citation |
 | Dobin et al., *Bioinformatics* 2013 | ✅ | STAR; aligner Methods citation |
+| Givechian et al., *Nat Mach Intell* 2026 | ✅ | ImmunoStruct; DISCUSSIONS immunogenicity-scorer landscape ([Issue #659](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/659)) |
 | Iamukova & Alferova, *Asia-Pac J Clin Oncol* 2026 | ✅ | Manuscript uses full form ("Asia-Pacific Journal of Clinical Oncology") |
 | Kim et al., *Nat Biotechnol* 2019 | ✅ | HISAT2; aligner Methods citation |
 | Kim et al., *Cell* 2025 | ✅ | |
 | Kwok et al., *Nature* 2025 | ✅ | |
 | Lang et al., *Bioinform Adv* 2024 | ✅ | |
+| Lee et al., *Nat Commun* 2026 | ✅ | NeoPrecis; DISCUSSIONS immunogenicity-scorer landscape |
+| Łuksza et al., *Nature* 2017 | ✅ | Foreignness term; DISCUSSIONS immunogenicity-scorer landscape |
 | McKeithan, *PNAS* 1995 | ✅ | |
 | O'Donnell et al., *Cell Syst* 2020 | ✅ | Manuscript uses full form ("Cell Systems"); also year-before-journal ordering |
 | Onkar et al., *Cell Rep Med* 2026 | ✅ | |
@@ -241,12 +270,15 @@ The original 8-paper inventory plus Kwok 2025 and Kim 2025 (both added after the
 | Trolle et al. 2016 | ✅ | Journal TBD — no journal given in-text |
 | Valitutti et al., *Nature* 1995 | ✅ | |
 | van Bergen et al. 2004 | ✅ | Journal TBD — no journal given in-text |
+| Wells et al., *Cell* 2020 | ✅ | TESLA consortium benchmark; DISCUSSIONS immunogenicity-scorer landscape |
 | Xiong (Zujian) et al., *Genes Immun* 2025 | ✅ | POSTN; Issue #599. Same first author as the Cell Mol Immunol 2025 entry |
 | Xiong (Zujian) et al., *Cell Mol Immunol* 2025 | ✅ | RCAN1-4; Issue #599 |
 | Xiong (Jieyi) et al., *Nucleic Acids Res* 2025 | ✅ | JAseC; Issue #599. Distinct first author (Jieyi) from the Zujian Xiong entries |
 | Yewdell & Bennink, *Annu Rev Immunol* 1999 | ✅ | |
 | Zaretsky et al., *N Engl J Med* 2016 | ✅ | Manuscript uses "NEJM" abbreviation rather than "N Engl J Med" |
 | Zemmour & Parham 1992 | ✅ | Journal TBD — no journal given in-text |
+| Zhang et al., *Aging* 2020 | ✅ | ASNEO; DISCUSSIONS immunogenicity-scorer landscape |
+| Zhao et al., *Genome Med* 2025 | ✅ | NeoGuider; DISCUSSIONS immunogenicity-scorer landscape |
 
 ### Open items before submission
 


### PR DESCRIPTION
**Created by:** Scientist

Closes #610.

## Summary
Adds a consolidating DISCUSSION subsection — **Neoantigen-generator and immunogenicity-scorer landscape** — to `research/manuscript/DISCUSSIONS.md`, mirroring the existing TCR-pMHC scoring landscape subsection (Issue #432) for landscape symmetry. It lands the manuscript-grade finding that the i3-S1 generator / immunogenicity-scorer evals produced but never wrote up (the TCR-pMHC arm already had its subsection; this arm had zero coverage).

**Central finding:** the immunogenicity-beyond-presentation family encodes immunogenicity as a mutant-vs-wild-type *self-contrast* (NeoPrecis cross-reactivity distance, Łuksza amplitude) that splice-junction-derived neoepitopes lack by construction — so it does not transfer; NeoPrecis's missing-value-on-junction-peptides is the explicit failure. Łuksza foreignness is the lone wild-type-free exception (declined on signal strength). Structure-aware scorers — ImmunoStruct (Issue #659, filed) — are the wild-type-free frontier.

Per-tool verdicts consolidated: ASNEO → component reuse (GTEx normal-junction filter); NeoGuider → component reuse (KDE + centered-isotonic calibration); NeoPrecis → decline; Łuksza foreignness → decline.

## References
Six entries reconciled in REFERENCES.md (DOI-only, verified against Zotero `Z38GTJNW`): Givechian (ImmunoStruct), Lee (NeoPrecis), Łuksza (foreignness), Wells (TESLA), Zhang (ASNEO), Zhao (NeoGuider). Two corrections caught against the curated records: NeoGuider's first author is **Zhao** (not Wei, as the eval deck's refs had it); the ASNEO DOI is `10.18632/aging.103516` (Issue #546's body has the wrong `…103581`).

## Test plan
- [x] AC scan clean — "splice-junction-derived" terminology (no bare "splice peptide"), American spelling, presentation vocabulary (no "binder / binding affinity" for the pipeline's own scoring)
- [x] References reconciled against Zotero `Z38GTJNW` + REFERENCES.md; all six DOIs verified (CrossRef for Wells; curated Zotero records for the rest)
- [x] Subsection renders cleanly (summary table well-formed), mirrors the TCR-pMHC 4-part structure, and cross-links Issue #432 twice (AC3)
- [x] ImmunoStruct synthesis forward-pointer board-backed (Issue #659 filed on board #9)
- [x] Reviewer pass (`@-claude`) addressed — Findings 1–3 dispositioned (1 pushed back with eval-deck source + precision edit, 2 adopted, 3 kept per mirror design)
- [x] Scientist lab-notebook entry written (post-review, pre-merge) — `research/lab_notebook/scientist.md`, 2026-06-04 10:31 UTC
