### PR TITLE
fix(envs): pin star=2.7.10b — bioconda htslib/libdeflate transition broke 2.7.11 (#629)

### DIFF
--- a/research/lab_notebook/developer.md
+++ b/research/lab_notebook/developer.md
@@ -6,6 +6,24 @@ Format and rules unchanged from the unified notebook — see `shared/feedback_la
 
 ---
 
+## 2026-06-04 — STAR env re-broke overnight from upstream bioconda churn; pinned DOWN to 2.7.10b ([PR #661](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/661) closes [Issue #629](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/629), reopened)
+
+### 10:56 UTC — Editor: Developer
+
+[Issue #629](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/629) was closed yesterday via [PR #645](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/645) (env verified solving on a `ubuntu-latest` CI probe: `star 2.7.11b / htslib 1.23.1 / libdeflate 1.25`). It **re-broke ~18h later**, surfacing when the first real prod STAR run — the [Issue #212](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/212) / [PR #653](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/653) GTEx validation — died at `CreateCondaEnvironmentException` ~26s in, before any GTEx code executed. Non-routine incident + durable learnings, so its own entry (the #645 entry stays immutable).
+
+**Root cause — a fresh upstream regression, not an incomplete fix.** bioconda's `libdeflate` ABI migration advanced overnight (1.25 → 1.26 now forced; htslib hasn't caught up), so modern `htslib` (≥1.17) is no longer co-installable on linux-64 — `htslib` alone now falls back to the 2018-era 1.9. STAR 2.7.11a/2.7.11b both *require* modern htslib, so the (correct-yesterday) `>=2.7.11a` pin stopped solving. I first reopened #629 framing this as "#645 was insufficient" — **wrong, and I corrected it on the Issue**: #645 was right at merge; bioconda regressed a day later.
+
+**Fix — pin DOWN past the churning subtree.** `star=2.7.10b` is the newest STAR with **no htslib dependency at all**, so it's structurally immune to the htslib/libdeflate transition — more durable than chasing a transient-stable 2.7.11 build that re-breaks on the next repodata shift. Functionally equivalent here: the pipeline uses STAR only for `SJ.out.tab`, never BAM (samtools already omitted for the same reason).
+
+**Learning 1 — "fixed + CI-green" conda envs can silently re-break from upstream ABI churn within a day.** A solve verified on CI is a point-in-time fact, not a durable guarantee; repodata drifts. The env-solve guard ([Issue #646](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/646)) catches regressions *at CI-run time*, not against future drift. **During an active bioconda ABI transition, pin DOWN past the churning subtree (here: a STAR build with no htslib dep) rather than re-pinning the newest transient-stable build.**
+
+**Learning 2 — read the actual error; don't ship the plausible fix.** The failure *looked* like the new GTEx code (first cloud exercise of `download_gtex_pan_tissue_bed`). I held two specific hypotheses — H1 `gsutil` not on the rule-shell PATH, H2 SHA256 mismatch — both plausible, both **wrong**. The VM log showed the GTEx rule never ran (`references/gtex/` absent, `gsutil` *is* on PATH); the pipeline died upstream at STAR env-create. Had I "fixed" the download rule on H1/H2, the next P100 run would have failed identically. Reading the authoritative log (worth a brief P100 restart) beat guessing.
+
+**Verification note.** macOS cross-solve (`--platform linux-64`, even with `CONDA_OVERRIDE_GLIBC`) is documented-unreliable in the htslib subtree (the #645 entry, Learning 2) — but `2.7.10b` doesn't touch that subtree (no htslib), so the verdict holds; the [PR #653](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/653) re-validation is the faithful linux-64 *build* confirmation (fast-fails ~minutes at env-create if wrong, so no multi-hour-run risk). Local Docker (the ideal faithful probe) wasn't available this session.
+
+**Session-adjacent (not this PR):** the same GTEx validation drove a GCS before/after-snapshot audit — versioning is on but lifecycle prunes noncurrent (alignment 7d / all 90d) and `run_cloud_gpu.sh` doesn't auto-archive — so I snapshotted `results/patient_00X` → `_archive/..._pre_issue212_2026-06-04` and filed [Issue #658](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/658) (pre-run auto-snapshot). Re-validation resumes once this lands.
+
 ## 2026-06-03 — GTEx pan-tissue novel-junction blacklist (Snaptron gtexv2) ([PR #598](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/598) closes [Issue #211](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/211))
 
 ### 18:51 UTC — Editor: Developer

--- a/workflow/envs/star.yaml
+++ b/workflow/envs/star.yaml
@@ -4,11 +4,19 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  # >=2.7.11a, NOT >=2.7.11: conda orders a trailing-letter build as a *prerelease*,
-  # so 2.7.11b < 2.7.11. bioconda ships no plain `2.7.11` build (only 2.7.11a/2.7.11b),
-  # so `>=2.7.11` matched ZERO builds and poisoned the whole solve with a misleading
-  # samtools/htslib error (Issue #629). `>=2.7.11a` matches the 2.7.11 series (→ 2.7.11b).
-  - star >=2.7.11a
+  # star =2.7.10b (pinned DOWN from 2.7.11): bioconda's in-flight libdeflate ABI
+  # migration has made modern htslib (>=1.17) unsolvable on linux-64 — `htslib` alone
+  # falls back to the 2018-era 1.9 — and STAR 2.7.11a/2.7.11b both *require* modern
+  # htslib, so the prior `>=2.7.11a` pin raised CreateCondaEnvironmentException on a
+  # from-scratch build (Issue #629; surfaced on the first prod STAR run, 2026-06-04).
+  # 2.7.10b is the newest STAR that solves cleanly — it pulls no htslib at all, which
+  # is fine here since star_align only emits SJ.out.tab, never a BAM (samtools note
+  # below). Same libdeflate conflict class CLAUDE.md documents for hisat2.yaml/regtools.
+  # TODO(#629): bump back to >=2.7.11 once bioconda's htslib/libdeflate transition
+  # settles — re-test before bumping with:
+  #   CONDA_OVERRIDE_GLIBC=2.35 conda create --dry-run --platform linux-64 \
+  #     -c bioconda -c conda-forge star=2.7.11b   # must SOLVE
+  - star=2.7.10b
   # samtools intentionally omitted: the star_align rule runs with `--outSAMtype None`
   # (workflow/rules/alignment.smk) — it emits only SJ.out.tab, never a BAM — so samtools
   # is never invoked on the STAR path. (It was unused dead weight, not the #629 blocker:


### PR DESCRIPTION
**Created by:** Developer

## Summary

Pins `star=2.7.10b` in `workflow/envs/star.yaml`, replacing the `>=2.7.11a` pin from [PR #645](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/645).

**Root cause:** bioconda's in-flight `libdeflate` ABI migration has made modern `htslib` (≥1.17) unsolvable on `linux-64` — `htslib` alone falls back to the 2018-era 1.9. STAR 2.7.11a/2.7.11b both *require* modern htslib, so the `>=2.7.11a` pin raised `CreateCondaEnvironmentException` on a from-scratch build. It surfaced ~26s into the first real prod STAR run — the [Issue #212](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/212) / [PR #653](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/653) GTEx validation (2026-06-04) — before any GTEx code executed (so PR #653's code is unaffected).

`2.7.10b` is the newest STAR that solves cleanly: it pulls **no htslib at all**, which is functionally fine since the pipeline uses STAR only for `SJ.out.tab` (never BAM — samtools is already omitted for the same reason). The [PR #645](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/645) pin corrected only the prerelease-ordering error, not this deeper htslib layer.

Closes #629.

## Test plan

- [x] Root cause confirmed from the pipeline VM log (`CreateCondaEnvironmentException` → `LibMambaUnsatisfiableError` on `star.yaml`)
- [x] Faithful linux-64 dry-solve (`CONDA_OVERRIDE_GLIBC=2.35`): `star=2.7.10b` + `python>=3.11` + `pandas` solves cleanly (star 2.7.10b, no htslib pulled)
- [x] Confirmed 2.7.10b is the newest installable STAR (nothing exists between it and the broken 2.7.11a)
- [x] STAR usage unaffected — the pipeline consumes only `SJ.out.tab`; 2.7.10b ↔ 2.7.11b are functionally equivalent for junction extraction

The full from-scratch env **build** (vs. solve) is exercised by the [PR #653](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/653) GTEx re-validation this unblocks; it fails fast (~minutes, at env-create) if anything's still wrong, so there's no multi-hour-run risk.

## Follow-ups
- Bump back to `>=2.7.11` once bioconda's htslib/libdeflate transition settles (TODO + re-test recipe inline in `star.yaml`).
- [Issue #646](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/646) (CI env-solve guard) would have caught this pre-merge — strong case to prioritize.
- Heads-up for [Issue #611](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/611) (Scientist, METHODS aligner): prod STAR is now 2.7.10b (transient workaround); no existing STAR results affected (RESULTS.md is HISAT2).
