### PR TITLE
ci(envs): conda env-solve guard — dry-run solve workflow/envs/*.yaml (#646)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -94,6 +94,9 @@ jobs:
     # only surfaces on a real `--use-conda` run on the VM (hours in). This job
     # solves every env up front. ubuntu-latest is linux-64 + Miniforge
     # (channel-priority strict), matching the GPU VM, so the solve is faithful.
+    # Native glibc is >=2.35 (Ubuntu 22.04+ runner), matching the production VM,
+    # so CONDA_OVERRIDE_GLIBC (the knob the macOS dev cross-solve needs — see
+    # star.yaml) is unnecessary here.
     # Limitation: `--dry-run` solves the conda layer only; `pip:` blocks (e.g.
     # python.yaml's torch pin) are not resolved here.
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -113,8 +113,13 @@ jobs:
         shell: bash -el {0}
         run: |
           set -uo pipefail
+          shopt -s nullglob
+          envs=( workflow/envs/*.yaml )
+          if [[ ${#envs[@]} -eq 0 ]]; then
+            echo "::error::No workflow/envs/*.yaml files found — nothing to solve"; exit 1
+          fi
           fail=0
-          for env in workflow/envs/*.yaml; do
+          for env in "${envs[@]}"; do
             echo "::group::solve ${env}"
             if conda env create --dry-run --name "probe-$(basename "${env}" .yaml)" --file "${env}"; then
               echo "OK: ${env} solves"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -86,3 +86,46 @@ jobs:
           # Secret may be absent on fork PRs — tests probe for scope at
           # collection time and skip gracefully if unavailable.
           GH_TOKEN: ${{ secrets.GH_PROJECT_TOKEN }}
+
+  pipeline-conda-env-solve:
+    # Catch conda solver regressions (e.g. the bioconda libdeflate/htslib
+    # transition that broke star.yaml — Issue #629) at PR time. The
+    # snakemake dry-run does NOT build conda envs, so an unsatisfiable spec
+    # only surfaces on a real `--use-conda` run on the VM (hours in). This job
+    # solves every env up front. ubuntu-latest is linux-64 + Miniforge
+    # (channel-priority strict), matching the GPU VM, so the solve is faithful.
+    # Limitation: `--dry-run` solves the conda layer only; `pip:` blocks (e.g.
+    # python.yaml's torch pin) are not resolved here.
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Miniforge (conda, bioconda/conda-forge, strict)
+        uses: conda-incubator/setup-miniconda@v3
+        with:
+          miniforge-version: latest
+          channels: conda-forge,bioconda
+          channel-priority: strict
+
+      - name: Dry-run solve every workflow/envs/*.yaml
+        shell: bash -el {0}
+        run: |
+          set -uo pipefail
+          fail=0
+          for env in workflow/envs/*.yaml; do
+            echo "::group::solve ${env}"
+            if conda env create --dry-run --name "probe-$(basename "${env}" .yaml)" --file "${env}"; then
+              echo "OK: ${env} solves"
+            else
+              echo "::error file=${env}::conda solver could not satisfy ${env}"
+              fail=1
+            fi
+            echo "::endgroup::"
+          done
+          if [[ "${fail}" -ne 0 ]]; then
+            echo "One or more workflow/envs/*.yaml failed to solve — see the ::error annotations above."
+            exit 1
+          fi
+          echo "All workflow/envs/*.yaml solve cleanly."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -187,7 +187,7 @@ Snakemake's `PythonScript.write_script` (`snakemake/script/__init__.py:807`) unc
 
 ### What `snakemake -n` (dry-run) does NOT catch
 `pipeline-snakemake-dry-run` in CI walks the DAG without (a) building conda envs or (b) executing scripts. Bug classes structurally invisible to dry-run:
-- **Conda solver failure** — e.g. `IMGTgeneDL>=0.7.0` pinned when PyPI max is `0.6.1`. Envs are built lazily on first execute.
+- **Conda solver failure** — e.g. `IMGTgeneDL>=0.7.0` pinned when PyPI max is `0.6.1`, or upstream channel drift (the bioconda libdeflate/htslib transition that re-broke `star.yaml`, [Issue #629](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/629)). Envs are built lazily on first execute. **Backstopped by the `pipeline-conda-env-solve` CI job ([Issue #646](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/646)), which dry-solves every `workflow/envs/*.yaml` on linux-64; it runs on *every* PR (not path-filtered) so it also catches upstream drift with no env-file change.** Watch the conda prerelease-ordering gotcha when pinning: `2.7.11b` sorts *below* `2.7.11` (a `b` suffix is a beta prerelease).
 - **Subprocess CLI typos** — e.g. `stitchr -species HUMAN` (correct flag is `-s` / `--species`). Only the real subprocess argparses the args.
 - **NaN flowing through pandas into subprocesses** — curated unit-test fixtures hide single-chain rows that the production VDJdb TSV contains.
 - **Snakemake `script:` wrapper incompat** (preceding section).

--- a/research/lab_notebook/developer.md
+++ b/research/lab_notebook/developer.md
@@ -6,6 +6,18 @@ Format and rules unchanged from the unified notebook — see `shared/feedback_la
 
 ---
 
+## 2026-06-04 — Cloud re-run robustness + CI conda env-solve guard ([PR #666](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/666) closes [Issue #658](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/658) + [Issue #664](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/664); [PR #668](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/668) closes [Issue #646](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/646))
+
+### 14:50 UTC — Editor: Developer
+
+The [Issue #212](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/212) patient validation surfaced two infra gaps in one afternoon, both now fixed.
+
+**1. CI is blind to conda solver failures → env-solve guard ([PR #668](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/668) / [Issue #646](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/646)).** The [Issue #629](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/629) STAR re-break (bioconda libdeflate/htslib drift) died at `CreateCondaEnvironmentException` on the prod VM because `snakemake -n` walks the DAG without building envs. New `pipeline-conda-env-solve` CI job dry-solves every `workflow/envs/*.yaml` on linux-64 (Miniforge, strict). **Key design call:** it runs on *every* PR, NOT path-filtered (the original AC #2) — because #629 was upstream drift with **no env-file change**, which a path filter would have skipped. (Long-term: add a scheduled run for pure-drift detection.) CLAUDE.md's "what `snakemake -n` doesn't catch" now points at it. Verified: green on all 7 current envs; red (exit 1) on an unsolvable spec.
+
+**2. `run_cloud_gpu.sh` re-run fragility ([PR #666](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/666) / [Issue #664](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/664) + [Issue #658](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/658)).** patient_002's first launch **false-completed in 2 s**: the completion poller greps `pipeline.log` for "100% done", and patient_001's *successful* run had left that string in the VM's log — matched before the new run's `tee` truncated it, so the launcher uploaded stale results + stopped the VM. Fix: `rm -f pipeline.log` before the snakemake tmux ([Issue #664](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/664)). Also added a pre-run results snapshot ([Issue #658](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/658)) so before/after comparative analyses keep a durable before-state. Filed [Issue #669](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/669) for a sibling poller bug the bot review spotted (case-sensitive `grep 'Error'` false-positives).
+
+**Learning:** a fixed + CI-green env can re-break from upstream channel churn with no repo change (#629) — so guard the *solve* in CI, on every PR. And a completion poller that reads a persistent log file must clear it per-run, or a prior success silently aborts the next run.
+
 ## 2026-06-04 — STAR env re-broke overnight from upstream bioconda churn; pinned DOWN to 2.7.10b ([PR #661](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/661) closes [Issue #629](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/629), reopened)
 
 ### 10:56 UTC — Editor: Developer


### PR DESCRIPTION
**Created by:** Developer

## Summary

Closes [Issue #646](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/646).

Adds a `pipeline-conda-env-solve` CI job that dry-run-solves every `workflow/envs/*.yaml`. The existing `pipeline-snakemake-dry-run` job walks the DAG but does **not** build conda envs, so an unsatisfiable spec only surfaces on a real `--use-conda` run on the GPU VM — hours in. That is exactly how the bioconda libdeflate/htslib transition broke `star.yaml` ([Issue #629](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/629) (closed)) and aborted a prod run ~26 s in (the [PR #653](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/653) (open) validation, 2026-06-04).

The job runs on `ubuntu-latest` with Miniforge + `channel-priority: strict` (matching the GPU VM's miniforge setup), so the solve is faithful to what snakemake's mamba/libmamba frontend does on the VM. Each env that fails to solve is annotated with `::error` and fails the job.

**Limitation:** `conda env create --dry-run` resolves the conda layer only; `pip:` blocks (e.g. `python.yaml`'s torch cu126 pin) are not exercised here — those remain validated by the real VM run / the existing P100 smoke test.

## Test plan

- [x] `tests.yml` parses (PyYAML); the new `pipeline-conda-env-solve` job + its 3 steps register
- [x] this PR's own CI run exercises the job against all 7 current envs — **PASS** (all solve on linux-64, incl. `star.yaml=2.7.10b`)

## Follow-up

- To make this a **blocking** gate, add `pipeline-conda-env-solve` to the branch-protection required checks (repo-admin action). It currently runs + reports but does not yet block merge.
