### PR TITLE
feat(pm): thread issue timestamps into board_open_items.py + dormancy --stale-days sweep

### DIFF
--- a/research/lab_notebook/pm.md
+++ b/research/lab_notebook/pm.md
@@ -8,6 +8,18 @@ Format and rules unchanged from the unified notebook — see `shared/feedback_la
 
 ## 2026-06-04
 
+### 15:10 UTC — Editor: PM
+
+#### Board pull learns issue timestamps — and the cross-repo-AC overhead it surfaced pivoted personas governance ([Issue #642](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/642), [PR #671](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/671))
+
+**The tool.** Threaded content-level `createdAt/updatedAt/closedAt` into `scripts/board_open_items.py` (Issues + PRs) and added two recency modes keyed on **`Issue.updatedAt`** (not `ProjectV2Item.updatedAt` — a bare board-field nudge must not reset staleness): `--sort-updated` (momentum, Phase 1a) and `--stale-days N` (dormancy sweep, oldest-active first). Table gains an `Age` column; JSON gains the three keys (additive — `check_ready_queue.sh`'s `--json | jq length` contract preserved). Mechanizes two PM touchpoints that were on weaker substitutes (Phase 1a momentum diff; the Phase 1c milestone-health liveness check).
+
+**Verification ladder.** TDD red→green (20 unit tests) → an adversarial **4-lens** review (recency-logic / spec-fidelity / regression-compat / test-quality) that folded in real coverage gaps — the JSON-array-shape consumer contract, the inclusive `>=` stale boundary, the default no-flag ordering guard — → the `@-claude` bot review (**approve with nits**), all 5 nits folded (`--stale-days 0` foot-gun doc + test, `main()` `--stale-days` wiring test, `pytest.approx`, `now=None` fallback, JSON timestamp-key assertions). Full suite **436 passed, 0 regressions**.
+
+**AC3 (cross-repo) landed by MM.** The morning-routine wiring — Phase 1a momentum + the Phase 1c L87 liveness line — lives in personas `pm/feedback_morning_routine.md`, committed by MM (`6642d65`). That split is the interesting part:
+
+**The governance pivot #642 forced.** This one Issue's ACs spanned **two repos** — tool code (project) + a memory edit (personas, MM-committed) — so closing it needed a PM→MM→PM relay. It completed only because MM was active in a parallel session; structurally it's a per-Issue cross-session tax. Adopted as a trial ([Issue #672](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/672)): **#1** each role commits its own role-dir (`pm/`,`scientist/`,`developer/`); MM owns `shared/` + audits — because MM-sole-committer doesn't *prevent* the stranding it was created for, it *centralizes* it (edits wait longer); **#2** keep every Issue's ACs within a single repo, so the tool Issue closes on its code and memory-wiring is a cheap role-owned fast-follow. #642 is grandfathered as the **last** old-pattern cross-repo-AC Issue.
+
 ### 14:15 UTC — Editor: PM
 
 #### Morning routine — per-role Ready-queue starvation diagnosed + refilled; flow-cap recalibration ([Issue #633](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/633) (board governance), [Issue #665](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/665) (guard carve))

--- a/scripts/board_open_items.py
+++ b/scripts/board_open_items.py
@@ -275,7 +275,8 @@ def main() -> int:
     p.add_argument("--sort-updated", dest="sort_updated", action="store_true",
                    help="Sort by last activity (Issue.updatedAt), most-recent first (momentum)")
     p.add_argument("--stale-days", dest="stale_days", type=int, metavar="N",
-                   help="Keep only items idle >= N days, oldest-active first (dormancy sweep)")
+                   help="Keep only items idle >= N days, oldest-active first (dormancy sweep; "
+                        "N=0 keeps all past-dated items, it does not filter everything out)")
     p.add_argument("--json", dest="as_json", action="store_true", help="Emit JSON array instead of a table")
     args = p.parse_args()
 

--- a/scripts/board_open_items.py
+++ b/scripts/board_open_items.py
@@ -10,10 +10,17 @@ For queries that only need label + state (no Status/Priority/Size columns),
 prefer `gh issue list --label role:<role> --state open` instead — it's a one-liner
 with no pagination needed.
 
+Each item carries its issue/PR created/updated/closed timestamps; `--sort-updated`
+(momentum) and `--stale-days N` (dormancy) filter/sort on `Issue.updatedAt` — the
+content-level field, NOT the board "Updated" column (which a bare field nudge bumps;
+see Issue #642).
+
 Usage:
   scripts/board_open_items.py
   scripts/board_open_items.py --role developer
   scripts/board_open_items.py --status Ready --priority P1
+  scripts/board_open_items.py --sort-updated --role scientist   # recent momentum
+  scripts/board_open_items.py --stale-days 21                    # dormancy sweep
   scripts/board_open_items.py --json | jq '.[] | select(.size == "S")'
 """
 from __future__ import annotations
@@ -22,6 +29,7 @@ import argparse
 import json
 import subprocess
 import sys
+from datetime import datetime, timezone
 from typing import Any
 
 OWNER = "Jin-HoMLee"
@@ -38,10 +46,12 @@ query($owner: String!, $number: Int!, $after: String) {
             __typename
             ... on Issue {
               number title state url
+              createdAt updatedAt closedAt
               labels(first: 20) { nodes { name } }
             }
             ... on PullRequest {
               number title state url isDraft
+              createdAt updatedAt closedAt
               labels(first: 20) { nodes { name } }
             }
           }
@@ -142,6 +152,9 @@ def normalize(item: dict[str, Any]) -> dict[str, Any] | None:
         "size": size,
         "role": role,
         "labels": labels,
+        "created_at": content.get("createdAt"),
+        "updated_at": content.get("updatedAt"),
+        "closed_at": content.get("closedAt"),
     }
 
 
@@ -152,6 +165,70 @@ def sort_key(it: dict[str, Any]) -> tuple:
         SIZE_ORDER.get(it["size"], 99),
         it["number"] or 0,
     )
+
+
+_MIN_DT = datetime.min.replace(tzinfo=timezone.utc)
+
+
+def _parse_iso(ts: str | None) -> datetime | None:
+    """Parse a GitHub ISO-8601 timestamp (e.g. '2026-06-04T14:15:30Z')."""
+    if not ts:
+        return None
+    return datetime.fromisoformat(ts.replace("Z", "+00:00"))
+
+
+def age_days(updated_at: str | None, now: datetime) -> float | None:
+    """Days since `updated_at`; None when the timestamp is missing/empty."""
+    dt = _parse_iso(updated_at)
+    if dt is None:
+        return None
+    return (now - dt).total_seconds() / 86400.0
+
+
+def age_label(updated_at: str | None, now: datetime) -> str:
+    """Compact age-column value, e.g. '3d', or '—' when unknown.
+
+    Clamped at 0 so a server/local clock skew (a `now` slightly behind the
+    GitHub `updatedAt`) renders '0d', not a confusing negative.
+    """
+    a = age_days(updated_at, now)
+    return "—" if a is None else f"{max(0, int(a))}d"
+
+
+def _updated_key(it: dict[str, Any]) -> datetime:
+    """Sort key on Issue.updatedAt; missing timestamps sort oldest (epoch min)."""
+    return _parse_iso(it.get("updated_at")) or _MIN_DT
+
+
+def apply_recency(
+    items: list[dict[str, Any]],
+    *,
+    sort_updated: bool,
+    stale_days: int | None,
+    now: datetime,
+) -> list[dict[str, Any]]:
+    """Filter/sort open items by last activity (Issue.updatedAt).
+
+    - ``stale_days``: keep only items idle >= N days (dormancy sweep).
+    - ``sort_updated``: order most-recently-active first (momentum).
+
+    When both are set the stale filter applies and momentum (descending) ordering
+    wins; with only ``stale_days`` the result sorts oldest-active first so the most
+    dormant items float to the top. Keyed on content-level ``Issue.updatedAt`` —
+    NOT ``ProjectV2Item.updatedAt`` — so a bare board-field nudge does not reset
+    staleness (see Issue #642).
+    """
+    out = list(items)
+    if stale_days is not None:
+        out = [
+            it for it in out
+            if (a := age_days(it.get("updated_at"), now)) is not None and a >= stale_days
+        ]
+    if sort_updated:
+        out.sort(key=_updated_key, reverse=True)
+    elif stale_days is not None:
+        out.sort(key=_updated_key)
+    return out
 
 
 def matches_filter(it: dict[str, Any], args: argparse.Namespace) -> bool:
@@ -168,20 +245,23 @@ def matches_filter(it: dict[str, Any], args: argparse.Namespace) -> bool:
     return True
 
 
-def format_table(items: list[dict[str, Any]]) -> str:
+def format_table(items: list[dict[str, Any]], now: datetime | None = None) -> str:
     if not items:
         return "(no items matched)\n"
+    if now is None:
+        now = datetime.now(timezone.utc)
     lines = [
-        f"{'Status':<17} {'P':<3} {'Sz':<3} {'Role':<17} {'Kind':<5} {'#':<5} Title",
-        f"{'-' * 17} {'-' * 3} {'-' * 3} {'-' * 17} {'-' * 5} {'-' * 5} {'-' * 60}",
+        f"{'Status':<17} {'P':<3} {'Sz':<3} {'Age':<5} {'Role':<17} {'Kind':<5} {'#':<5} Title",
+        f"{'-' * 17} {'-' * 3} {'-' * 3} {'-' * 5} {'-' * 17} {'-' * 5} {'-' * 5} {'-' * 60}",
     ]
     for it in items:
         role = (it["role"] or "(none)").removeprefix("role:")[:16]
         kind = it["kind"] + ("/D" if it["is_draft"] else "")
         title = (it["title"] or "")[:60]
+        age = age_label(it.get("updated_at"), now)
         lines.append(
             f"{it['status']:<17} {it['priority'] or '?':<3} {it['size'] or '?':<3} "
-            f"{role:<17} {kind:<5} {it['number']:<5} {title}"
+            f"{age:<5} {role:<17} {kind:<5} {it['number']:<5} {title}"
         )
     return "\n".join(lines) + "\n"
 
@@ -192,13 +272,26 @@ def main() -> int:
     p.add_argument("--status", choices=list(STATUS_ORDER), help="Filter by board Status")
     p.add_argument("--priority", choices=list(PRIORITY_ORDER), help="Filter by Priority")
     p.add_argument("--size", choices=list(SIZE_ORDER), help="Filter by Size")
+    p.add_argument("--sort-updated", dest="sort_updated", action="store_true",
+                   help="Sort by last activity (Issue.updatedAt), most-recent first (momentum)")
+    p.add_argument("--stale-days", dest="stale_days", type=int, metavar="N",
+                   help="Keep only items idle >= N days, oldest-active first (dormancy sweep)")
     p.add_argument("--json", dest="as_json", action="store_true", help="Emit JSON array instead of a table")
     args = p.parse_args()
 
+    if args.stale_days is not None and args.stale_days < 0:
+        p.error("--stale-days must be a non-negative integer")
+
+    now = datetime.now(timezone.utc)
     raw = fetch_all_items()
     normalized = [n for it in raw if (n := normalize(it)) is not None]
     filtered = [it for it in normalized if matches_filter(it, args)]
-    filtered.sort(key=sort_key)
+    if args.sort_updated or args.stale_days is not None:
+        filtered = apply_recency(
+            filtered, sort_updated=args.sort_updated, stale_days=args.stale_days, now=now
+        )
+    else:
+        filtered.sort(key=sort_key)
 
     print(
         f"Total board items: {len(raw)}; open: {len(normalized)}; "
@@ -210,7 +303,7 @@ def main() -> int:
         json.dump(filtered, sys.stdout, indent=2)
         sys.stdout.write("\n")
     else:
-        sys.stdout.write(format_table(filtered))
+        sys.stdout.write(format_table(filtered, now=now))
     return 0
 
 

--- a/workflow/tests/test_board_open_items.py
+++ b/workflow/tests/test_board_open_items.py
@@ -1,0 +1,229 @@
+"""Tests for board_open_items.py timestamp threading + recency flags (Issue #642).
+
+Covers:
+  - normalize() surfaces issue created/updated/closed timestamps (AC1)
+  - --sort-updated / --stale-days recency logic, keyed on Issue.updatedAt (AC2)
+  - age helpers + the table Age column
+
+The recency logic is exercised through pure helpers with an injected `now`,
+so the tests are deterministic and never touch the network.
+"""
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+# Make top-level scripts/ importable (board_open_items.py is a standalone CLI,
+# not a Snakemake script:-invoked module under workflow/scripts/).
+_SCRIPTS_DIR = Path(__file__).resolve().parents[2] / "scripts"
+sys.path.insert(0, str(_SCRIPTS_DIR))
+
+import board_open_items as boi  # noqa: E402
+
+NOW = datetime(2026, 6, 4, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _board_item(number, *, updated="2026-06-04T00:00:00Z",
+                created="2026-05-01T00:00:00Z", closed=None, role="role:pm",
+                status="Ready", priority=None, size=None):
+    """A minimal ProjectV2 board node shaped like the GraphQL response."""
+    field_values = [{"name": status, "field": {"name": "Status"}}]
+    if priority:
+        field_values.append({"name": priority, "field": {"name": "Priority"}})
+    if size:
+        field_values.append({"name": size, "field": {"name": "Size"}})
+    return {
+        "content": {
+            "__typename": "Issue",
+            "number": number,
+            "title": f"issue {number}",
+            "state": "OPEN",
+            "url": f"https://example/{number}",
+            "createdAt": created,
+            "updatedAt": updated,
+            "closedAt": closed,
+            "labels": {"nodes": [{"name": role}]},
+        },
+        "fieldValues": {"nodes": field_values},
+    }
+
+
+def _run_main(monkeypatch, capsys, argv, raw_items):
+    """Drive main() with a stubbed board fetch; return (exit_code, stdout)."""
+    monkeypatch.setattr(boi, "fetch_all_items", lambda: raw_items)
+    monkeypatch.setattr(sys, "argv", ["board_open_items.py", *argv])
+    rc = boi.main()
+    return rc, capsys.readouterr().out
+
+
+# --- AC1: timestamps surfaced by normalize ---------------------------------
+
+def test_normalize_includes_timestamps():
+    out = boi.normalize(_board_item(642, updated="2026-06-03T09:00:00Z",
+                                    created="2026-05-15T08:00:00Z"))
+    assert out is not None
+    assert out["created_at"] == "2026-05-15T08:00:00Z"
+    assert out["updated_at"] == "2026-06-03T09:00:00Z"
+    assert out["closed_at"] is None
+
+
+# --- age helpers -----------------------------------------------------------
+
+def test_age_days_basic():
+    # 3 days, 12 hours before NOW
+    assert boi.age_days("2026-06-01T00:00:00Z", NOW) == 3.5
+
+
+def test_age_days_handles_missing():
+    assert boi.age_days(None, NOW) is None
+    assert boi.age_days("", NOW) is None
+
+
+def test_age_label():
+    assert boi.age_label("2026-06-01T00:00:00Z", NOW) == "3d"
+    assert boi.age_label(None, NOW) == "—"
+
+
+# --- AC2: --sort-updated (momentum, most-recent first) ---------------------
+
+def test_apply_recency_sort_updated_desc():
+    items = [
+        {"number": 1, "updated_at": "2026-06-01T00:00:00Z"},
+        {"number": 2, "updated_at": "2026-06-04T00:00:00Z"},
+        {"number": 3, "updated_at": "2026-05-20T00:00:00Z"},
+    ]
+    out = boi.apply_recency(items, sort_updated=True, stale_days=None, now=NOW)
+    assert [it["number"] for it in out] == [2, 1, 3]
+
+
+def test_apply_recency_missing_updated_sorts_last():
+    items = [
+        {"number": 1, "updated_at": "2026-06-01T00:00:00Z"},
+        {"number": 2, "updated_at": None},
+        {"number": 3, "updated_at": "2026-06-03T00:00:00Z"},
+    ]
+    out = boi.apply_recency(items, sort_updated=True, stale_days=None, now=NOW)
+    assert [it["number"] for it in out] == [3, 1, 2]
+
+
+# --- AC2: --stale-days (dormancy, oldest-first, filtered) ------------------
+
+def test_apply_recency_stale_filter_and_asc_sort():
+    items = [
+        {"number": 1, "updated_at": "2026-06-04T00:00:00Z"},  # 0.5d — fresh
+        {"number": 2, "updated_at": "2026-05-01T00:00:00Z"},  # ~34d — stale
+        {"number": 3, "updated_at": "2026-05-20T00:00:00Z"},  # ~15d — stale
+    ]
+    out = boi.apply_recency(items, sort_updated=False, stale_days=14, now=NOW)
+    # only the two >=14d items, oldest activity first
+    assert [it["number"] for it in out] == [2, 3]
+
+
+def test_apply_recency_stale_excludes_missing_updated():
+    items = [
+        {"number": 1, "updated_at": None},
+        {"number": 2, "updated_at": "2026-05-01T00:00:00Z"},
+    ]
+    out = boi.apply_recency(items, sort_updated=False, stale_days=14, now=NOW)
+    assert [it["number"] for it in out] == [2]
+
+
+def test_apply_recency_combined_stale_filter_with_momentum_sort():
+    # both flags: stale filter applies, but --sort-updated forces desc order
+    items = [
+        {"number": 1, "updated_at": "2026-06-04T00:00:00Z"},  # fresh, dropped
+        {"number": 2, "updated_at": "2026-05-01T00:00:00Z"},  # ~34d
+        {"number": 3, "updated_at": "2026-05-20T00:00:00Z"},  # ~15d
+    ]
+    out = boi.apply_recency(items, sort_updated=True, stale_days=14, now=NOW)
+    assert [it["number"] for it in out] == [3, 2]
+
+
+# --- AC2: exact stale boundary (inclusive >=) ------------------------------
+
+def test_apply_recency_stale_boundary_is_inclusive():
+    # NOW = 2026-06-04T12:00Z; 14 days earlier = 2026-05-21T12:00Z (exactly 14.0d)
+    items = [
+        {"number": 1, "updated_at": "2026-05-21T12:00:00Z"},  # exactly 14d → kept (>=)
+        {"number": 2, "updated_at": "2026-05-21T11:59:00Z"},  # 14d+1m  → kept
+        {"number": 3, "updated_at": "2026-05-21T12:01:00Z"},  # 13d23h59m → dropped
+    ]
+    out = boi.apply_recency(items, sort_updated=False, stale_days=14, now=NOW)
+    nums = {it["number"] for it in out}
+    assert 1 in nums          # the boundary itself is inclusive — guards >= vs > regressions
+    assert 2 in nums
+    assert 3 not in nums
+
+
+# --- normalize() -> apply_recency wiring (AC1 + AC2 in combination) ---------
+
+def test_normalize_output_feeds_apply_recency():
+    items = [
+        boi.normalize(_board_item(1, updated="2026-05-01T00:00:00Z")),
+        boi.normalize(_board_item(2, updated="2026-06-03T00:00:00Z")),
+    ]
+    out = boi.apply_recency(items, sort_updated=True, stale_days=None, now=NOW)
+    # proves normalize's "updated_at" key is the one apply_recency consumes
+    assert [it["number"] for it in out] == [2, 1]
+
+
+# --- empty input -----------------------------------------------------------
+
+def test_apply_recency_and_table_handle_empty():
+    assert boi.apply_recency([], sort_updated=True, stale_days=14, now=NOW) == []
+    assert boi.format_table([], now=NOW) == "(no items matched)\n"
+
+
+# --- main(): the check_ready_queue.sh JSON contract + default ordering ------
+
+def test_main_json_emits_flat_array(monkeypatch, capsys):
+    """check_ready_queue.sh runs `--status Ready --json | jq length` — the
+    output MUST stay a flat top-level array so `jq length` == item count."""
+    raw = [_board_item(1), _board_item(2)]
+    rc, out = _run_main(monkeypatch, capsys, ["--status", "Ready", "--json"], raw)
+    assert rc == 0
+    parsed = json.loads(out)
+    assert isinstance(parsed, list)      # not an envelope object
+    assert len(parsed) == 2              # what `jq length` would report
+    assert {it["number"] for it in parsed} == {1, 2}
+
+
+def test_main_default_no_flags_uses_sort_key(monkeypatch, capsys):
+    """No recency flags → original Status/Priority/Size sort_key ordering, not updatedAt."""
+    raw = [
+        _board_item(1, status="Ready", updated="2026-06-04T00:00:00Z"),        # recent, Status order 3
+        _board_item(2, status="In progress", updated="2026-05-01T00:00:00Z"),  # old, Status order 0
+    ]
+    _, out = _run_main(monkeypatch, capsys, ["--json"], raw)
+    # "In progress" sorts above "Ready" regardless of updatedAt
+    assert [it["number"] for it in json.loads(out)] == [2, 1]
+
+
+def test_main_sort_updated_overrides_sort_key(monkeypatch, capsys):
+    raw = [
+        _board_item(1, status="Ready", updated="2026-06-04T00:00:00Z"),
+        _board_item(2, status="In progress", updated="2026-05-01T00:00:00Z"),
+    ]
+    _, out = _run_main(monkeypatch, capsys, ["--sort-updated", "--json"], raw)
+    # momentum: most-recent first, Status ordering ignored
+    assert [it["number"] for it in json.loads(out)] == [1, 2]
+
+
+# --- table Age column ------------------------------------------------------
+
+def test_age_label_clamps_future_to_zero():
+    # clock skew: a `now` behind the GitHub timestamp must not render negative
+    assert boi.age_label("2026-06-10T00:00:00Z", NOW) == "0d"
+
+
+def test_format_table_age_column_position_and_missing_render():
+    items = [
+        boi.normalize(_board_item(1, updated="2026-06-01T00:00:00Z")),  # 3d
+        boi.normalize(_board_item(2, updated=None)),                     # missing → —
+    ]
+    table = boi.format_table(items, now=NOW)
+    header = table.splitlines()[0].split()
+    assert header.index("Age") == header.index("Sz") + 1   # Age sits right after Sz
+    assert header.index("Age") < header.index("Role")
+    assert "3d" in table
+    assert "—" in table   # missing-timestamp renders in the TABLE, not just the helper

--- a/workflow/tests/test_board_open_items.py
+++ b/workflow/tests/test_board_open_items.py
@@ -13,6 +13,8 @@ import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
+import pytest
+
 # Make top-level scripts/ importable (board_open_items.py is a standalone CLI,
 # not a Snakemake script:-invoked module under workflow/scripts/).
 _SCRIPTS_DIR = Path(__file__).resolve().parents[2] / "scripts"
@@ -71,7 +73,7 @@ def test_normalize_includes_timestamps():
 
 def test_age_days_basic():
     # 3 days, 12 hours before NOW
-    assert boi.age_days("2026-06-01T00:00:00Z", NOW) == 3.5
+    assert boi.age_days("2026-06-01T00:00:00Z", NOW) == pytest.approx(3.5)
 
 
 def test_age_days_handles_missing():
@@ -186,6 +188,8 @@ def test_main_json_emits_flat_array(monkeypatch, capsys):
     assert isinstance(parsed, list)      # not an envelope object
     assert len(parsed) == 2              # what `jq length` would report
     assert {it["number"] for it in parsed} == {1, 2}
+    # additive timestamp keys reach the JSON output (the PR-body additive-field claim)
+    assert all(k in parsed[0] for k in ("created_at", "updated_at", "closed_at"))
 
 
 def test_main_default_no_flags_uses_sort_key(monkeypatch, capsys):
@@ -209,6 +213,30 @@ def test_main_sort_updated_overrides_sort_key(monkeypatch, capsys):
     assert [it["number"] for it in json.loads(out)] == [1, 2]
 
 
+def test_main_stale_days_filters_via_main(monkeypatch, capsys):
+    """main() routes --stale-days through apply_recency. Ancient/future fixtures
+    keep this robust to the real clock (main() uses datetime.now, not NOW)."""
+    raw = [
+        _board_item(1, updated="2099-01-01T00:00:00Z"),  # future → age < 14 → dropped
+        _board_item(2, updated="2020-01-01T00:00:00Z"),  # ancient → age >= 14 → kept
+    ]
+    _, out = _run_main(monkeypatch, capsys, ["--stale-days", "14", "--json"], raw)
+    assert [it["number"] for it in json.loads(out)] == [2]
+
+
+def test_main_stale_days_zero_keeps_all_past_items(monkeypatch, capsys):
+    """--stale-days 0 (idle >= 0) keeps every past-dated item, oldest-active first —
+    it does NOT filter everything out (the documented foot-gun)."""
+    raw = [
+        _board_item(1, updated="2025-01-01T00:00:00Z"),
+        _board_item(2, updated="2020-01-01T00:00:00Z"),
+    ]
+    _, out = _run_main(monkeypatch, capsys, ["--stale-days", "0", "--json"], raw)
+    parsed = json.loads(out)
+    assert {it["number"] for it in parsed} == {1, 2}      # both kept
+    assert [it["number"] for it in parsed] == [2, 1]       # oldest-active first
+
+
 # --- table Age column ------------------------------------------------------
 
 def test_age_label_clamps_future_to_zero():
@@ -227,3 +255,12 @@ def test_format_table_age_column_position_and_missing_render():
     assert header.index("Age") < header.index("Role")
     assert "3d" in table
     assert "—" in table   # missing-timestamp renders in the TABLE, not just the helper
+
+
+def test_format_table_now_defaults_to_real_clock():
+    # the now=None fallback (datetime.now) renders without error; ancient fixture
+    # so the rendered Age is clock-independent
+    items = [boi.normalize(_board_item(1, updated="2020-01-01T00:00:00Z"))]
+    table = boi.format_table(items)  # no now= → exercises the None branch
+    assert "Age" in table.splitlines()[0]
+    assert "issue 1" in table


### PR DESCRIPTION
**Created by:** PM

Part of [Issue #642](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/642). Threads issue/PR timestamps into the canonical board pull and mechanizes two PM touchpoints that were on weaker substitutes (Phase 1a momentum; the L87 milestone-health liveness check).

## What changed (`scripts/board_open_items.py`)
- GraphQL query + `normalize()` now carry content-level `createdAt`/`updatedAt`/`closedAt` for Issues **and** PRs.
- **`--sort-updated`** — open items by last activity, most-recent first (momentum).
- **`--stale-days N`** — keep only items idle ≥ N days, oldest-active first (dormancy sweep).
- Both keyed on **`Issue.updatedAt`** (content level), **not** `ProjectV2Item.updatedAt` — per the Issue's critical note, a bare board-field nudge must not reset staleness.
- Table gains a compact `Age` column; JSON gains the three timestamp keys (**additive** — the `--json | jq length` shape `check_ready_queue.sh` depends on is unchanged).
- No new GitHub-feature dependency (AC4) — standard content-level fields only.

## Cross-repo scope (AC3 lands via MM)
AC3's morning-routine memory edits (Phase 1a + L87 in `pm/feedback_morning_routine.md`) live in the **personas** repo, which only the Memory Manager commits. They're authored and staged there, flagged to MM. This PR is linked to #642 (via its `gh issue develop` branch) and **will close it on merge** — but the merge is intentionally **held** until MM commits the AC3 edits and all ACs are ticked. The closure-ritual gate (`scripts/audit_and_merge.sh`) enforces this: it blocks merge on any unticked AC box on #642, so AC3 (memory commit) gates the close automatically.

## Test plan
- [x] 17 unit tests in `workflow/tests/test_board_open_items.py` (TDD red→green)
- [x] Inclusive `>=` stale-boundary test (guards the `>=`→`>` off-by-one)
- [x] JSON array-shape contract test via `main()` (guards the `check_ready_queue.sh` consumer)
- [x] Default no-flag path keeps the original `sort_key` ordering (regression guard)
- [x] `normalize()` → `apply_recency()` wiring + clock-skew Age clamp + empty-input
- [x] Full suite green: **433 passed, 31 skipped**, 0 regressions
- [x] Live smoke test against board #9: momentum (#633/#642 `0d` top), `--stale-days 14` (#126 `24d` oldest-first), `check_ready_queue.sh` still healthy
- [x] Adversarial multi-lens review (recency-logic / spec-fidelity / regression-compat / test-quality); findings folded in

🤖 Generated with [Claude Code](https://claude.com/claude-code)