### PR TITLE
feat(pm): arc work-structuring — foundation (labels + taxonomy + queryability)

### DIFF
--- a/docs/superpowers/plans/2026-06-05-arc-work-structuring-foundation.md
+++ b/docs/superpowers/plans/2026-06-05-arc-work-structuring-foundation.md
@@ -1,0 +1,455 @@
+# Arc Work-Structuring — Foundation (Plan 1 of 3) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stand up the arc dimension as GitHub labels, apply the validated v1 taxonomy to the 75 open issues, set the opening active slate, and make arcs queryable from the board tool.
+
+**Architecture:** Arcs are orthogonal labels (`arc:<slug>`) plus a focus marker (`arc-phase:active|next|later`), per the design spec. A committed TSV manifest (`scripts/pm/arc_taxonomy.tsv`) is the source of truth; two idempotent bash scripts create the labels and apply them; `board_open_items.py` gains `--arc`/`--arc-phase` filters so the taxonomy is queryable (and so Plan 2's pull rule has a query layer). All work here is in the **project repo** (`splice-neoepitope-pipeline`) + GitHub-side label/issue edits — no personas-repo or memory changes (those are Plan 2).
+
+**Tech Stack:** `gh` CLI (labels + issue edits + ProjectV2 GraphQL), Bash, Python 3 (stdlib only), pytest (via `workflow/tests/.venv`).
+
+**Spec:** [`docs/superpowers/specs/2026-06-05-arc-work-structuring-design.md`](../specs/2026-06-05-arc-work-structuring-design.md) (anchored to Issue #633).
+
+---
+
+## File Structure
+
+| Path | Repo | Responsibility |
+|---|---|---|
+| `scripts/pm/arc_labels.sh` | project | Create/update the 8 `arc:*` + 3 `arc-phase:*` labels (idempotent, `--force`) |
+| `scripts/pm/arc_taxonomy.tsv` | project | v1 taxonomy — source of truth: `arc_slug  phase  issue…` per row |
+| `scripts/pm/apply_arc_labels.sh` | project | Apply arc + arc-phase labels to issues per the manifest (idempotent) |
+| `scripts/board_open_items.py` | project | **Modify** — derive `arc`/`arc_phase` fields + add `--arc`/`--arc-phase` filters |
+| `scripts/tests/test_board_open_items_arc.py` | project | **Create** — unit tests for the arc derivation + filters |
+
+**Out of scope for Plan 1** (see "Follow-on Plans"): the shared pull rule, board-hygiene un-arced check, milestone cleanup, the arc-review process.
+
+---
+
+## Task 1: Arc + arc-phase label definitions
+
+**Files:**
+- Create: `scripts/pm/arc_labels.sh`
+
+- [ ] **Step 1: Write the label-creation script**
+
+```bash
+#!/usr/bin/env bash
+# scripts/pm/arc_labels.sh
+# Idempotently create the arc:* (narrative throughline) and arc-phase:* (focus
+# marker) labels. Re-runnable: --force updates colour/description if the label
+# already exists. Spec: docs/superpowers/specs/2026-06-05-arc-work-structuring-design.md
+set -euo pipefail
+REPO="Jin-HoMLee/splice-neoepitope-pipeline"
+
+# name | hex colour (no '#') | description
+ARC_LABELS=(
+  "arc:aligner-junctions|0F766E|Arc: aligner & junction extraction (STAR/HISAT2 verification, SJ/annotation correctness)"
+  "arc:junction-filtering|047857|Arc: junction filtering & tumor-specificity (GTEx + matched-normal + AlphaGenome, integrity)"
+  "arc:variant-cohort|15803D|Arc: variant calling & cohort expansion (somatic calling, SpliceAI/MMSplice, new patients)"
+  "arc:scoring-tcr-pmhc|B45309|Arc: neoepitope scoring & TCR-pMHC modeling (MHCflurry calibration, scorers, structures)"
+  "arc:results-reporting|A16207|Arc: results, reporting & manuscript (HLA panel runs, report layer, decks, writeup)"
+  "arc:cloud-reproducibility|1D4ED8|Arc: cloud execution & reproducibility (Batch, run registry, GPU, run_cloud_gpu.sh)"
+  "arc:memory-methodology|7C3AED|Arc: memory & methodology (MEMORY.md slimming/audit, MM role, persona framing)"
+  "arc:board-governance|9D174D|Arc: board governance & enforcement (Kanban governance, hooks/guards, PM-tooling evals)"
+)
+PHASE_LABELS=(
+  "arc-phase:active|2DA44E|Arc focus: actively pulled now (cap 3)"
+  "arc-phase:next|D4A72C|Arc focus: queued next"
+  "arc-phase:later|8C959F|Arc focus: parked"
+)
+
+create() {
+  local spec="$1" name color desc
+  IFS='|' read -r name color desc <<<"$spec"
+  gh label create "$name" --repo "$REPO" --color "$color" --description "$desc" --force
+}
+for spec in "${ARC_LABELS[@]}" "${PHASE_LABELS[@]}"; do create "$spec"; done
+echo "Created/updated ${#ARC_LABELS[@]} arc + ${#PHASE_LABELS[@]} arc-phase labels on $REPO."
+```
+
+- [ ] **Step 2: Make it executable and run it**
+
+Run: `chmod +x scripts/pm/arc_labels.sh && bash scripts/pm/arc_labels.sh`
+Expected: 11 lines of `gh` output (created/updated) + the final summary line.
+
+- [ ] **Step 3: Verify all 11 labels exist**
+
+Run:
+```bash
+gh label list --repo Jin-HoMLee/splice-neoepitope-pipeline --limit 200 \
+  --json name -q '[.[]|select(.name|startswith("arc"))]|length'
+```
+Expected: `11`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/pm/arc_labels.sh
+git commit -m "feat(pm): arc:* + arc-phase:* label definitions (#633)"
+```
+
+---
+
+## Task 2: The v1 arc taxonomy manifest
+
+**Files:**
+- Create: `scripts/pm/arc_taxonomy.tsv`
+
+- [ ] **Step 1: Write the manifest** (whitespace-delimited; `#` lines are comments; column 1 = arc slug, column 2 = phase, remaining tokens = issue numbers)
+
+```
+# scripts/pm/arc_taxonomy.tsv — v1 arc taxonomy (2026-06-05)
+# Source of truth for apply_arc_labels.sh. Spec §5:
+# docs/superpowers/specs/2026-06-05-arc-work-structuring-design.md
+# Columns (whitespace-delimited): arc_slug  arc-phase  issue...
+arc:aligner-junctions     active  297 375 377 378 411 636
+arc:junction-filtering    later   126 212 304 381 594 663
+arc:variant-cohort        later   413 416 436 437 438 440
+arc:scoring-tcr-pmhc      active  433 492 547 566 585 601 659
+arc:results-reporting     later   193 198 233 435 455
+arc:cloud-reproducibility next    66 183 195 310 630 651 658 664 669 673 674
+arc:memory-methodology    later   248 265 324 326 346 353 527 538 539 540 541 542 672
+arc:board-governance      active  234 250 294 295 406 445 498 499 533 553 569 578 617 626 633 655 665
+# unfiled (intentionally NO arc label): 446 451 570 641
+```
+
+- [ ] **Step 2: Verify the manifest covers exactly 71 issues across 8 arcs (75 open − 4 unfiled)**
+
+Run:
+```bash
+awk '!/^#/ && NF {for(i=3;i<=NF;i++)c++} END{print c}' scripts/pm/arc_taxonomy.tsv
+```
+Expected: `71`
+
+- [ ] **Step 3: Verify no issue is double-assigned**
+
+Run:
+```bash
+awk '!/^#/ && NF {for(i=3;i<=NF;i++)print $i}' scripts/pm/arc_taxonomy.tsv | sort | uniq -d
+```
+Expected: (empty output — no duplicates)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/pm/arc_taxonomy.tsv
+git commit -m "feat(pm): v1 arc taxonomy manifest — 71 issues across 8 arcs (#633)"
+```
+
+---
+
+## Task 3: Apply the taxonomy to the issues
+
+**Files:**
+- Create: `scripts/pm/apply_arc_labels.sh`
+
+- [ ] **Step 1: Write the apply script**
+
+```bash
+#!/usr/bin/env bash
+# scripts/pm/apply_arc_labels.sh
+# Apply arc:* + arc-phase:* labels to issues per scripts/pm/arc_taxonomy.tsv.
+# Idempotent: gh add-label of an already-present label is a no-op.
+# Prereq: run scripts/pm/arc_labels.sh first (labels must exist).
+set -euo pipefail
+REPO="Jin-HoMLee/splice-neoepitope-pipeline"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MANIFEST="${1:-$SCRIPT_DIR/arc_taxonomy.tsv}"
+[[ -f "$MANIFEST" ]] || { echo "manifest not found: $MANIFEST" >&2; exit 1; }
+
+while read -r arc phase rest; do
+  [[ -z "${arc:-}" || "${arc:0:1}" == "#" ]] && continue
+  for n in $rest; do
+    echo "  #$n -> $arc + arc-phase:$phase"
+    gh issue edit "$n" --repo "$REPO" \
+      --add-label "$arc" --add-label "arc-phase:$phase"
+  done
+done < "$MANIFEST"
+echo "Done applying arc taxonomy from $MANIFEST."
+```
+
+- [ ] **Step 2: Dry-run-read the manifest to confirm parsing (no GitHub writes yet)**
+
+Run:
+```bash
+while read -r arc phase rest; do
+  [[ -z "${arc:-}" || "${arc:0:1}" == "#" ]] && continue
+  echo "$arc [$phase]: $(echo $rest | wc -w) issues"
+done < scripts/pm/arc_taxonomy.tsv
+```
+Expected:
+```
+arc:aligner-junctions [active]: 6 issues
+arc:junction-filtering [later]: 6 issues
+arc:variant-cohort [later]: 6 issues
+arc:scoring-tcr-pmhc [active]: 7 issues
+arc:results-reporting [later]: 5 issues
+arc:cloud-reproducibility [next]: 11 issues
+arc:memory-methodology [later]: 13 issues
+arc:board-governance [active]: 17 issues
+```
+
+- [ ] **Step 3: Run the apply (writes labels to 71 issues)**
+
+Run: `chmod +x scripts/pm/apply_arc_labels.sh && bash scripts/pm/apply_arc_labels.sh`
+Expected: 71 `#N -> arc:… + arc-phase:…` lines + final "Done" line.
+
+- [ ] **Step 4: Verify per-arc issue counts match the manifest**
+
+Run:
+```bash
+for a in aligner-junctions:6 junction-filtering:6 variant-cohort:6 scoring-tcr-pmhc:7 \
+         results-reporting:5 cloud-reproducibility:11 memory-methodology:13 board-governance:17; do
+  slug=${a%:*}; want=${a#*:}
+  got=$(gh issue list --repo Jin-HoMLee/splice-neoepitope-pipeline --state open \
+        --label "arc:$slug" --json number -q 'length')
+  printf 'arc:%-22s got=%s want=%s %s\n' "$slug" "$got" "$want" \
+    "$([ "$got" = "$want" ] && echo OK || echo MISMATCH)"
+done
+```
+Expected: all 8 lines end in `OK`.
+
+- [ ] **Step 5: Verify the active slate (3 arcs = 30 issues) and that unfiled stay unlabeled**
+
+Run:
+```bash
+echo -n "active: "; gh issue list --repo Jin-HoMLee/splice-neoepitope-pipeline --state open \
+  --label arc-phase:active --json number -q 'length'    # expect 30
+echo -n "next:   "; gh issue list --repo Jin-HoMLee/splice-neoepitope-pipeline --state open \
+  --label arc-phase:next --json number -q 'length'      # expect 11
+for n in 446 451 570 641; do
+  c=$(gh issue view "$n" --repo Jin-HoMLee/splice-neoepitope-pipeline \
+      --json labels -q '[.labels[].name|select(startswith("arc"))]|length')
+  echo "unfiled #$n arc-labels=$c"                       # expect 0 each
+done
+```
+Expected: `active: 30`, `next: 11`, and `arc-labels=0` for all four unfiled issues.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/pm/apply_arc_labels.sh
+git commit -m "feat(pm): apply_arc_labels.sh — sync arc taxonomy to issues (#633)"
+```
+
+---
+
+## Task 4: Make arcs queryable in `board_open_items.py`
+
+**Files:**
+- Modify: `scripts/board_open_items.py` (`normalize()`, `matches_filter()`, argparse in `main()`)
+- Create: `scripts/tests/test_board_open_items_arc.py`
+
+- [ ] **Step 1: Write the failing unit test**
+
+```python
+# scripts/tests/test_board_open_items_arc.py
+import argparse
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+import board_open_items as b  # noqa: E402
+
+
+def _item(labels):
+    return {
+        "content": {
+            "__typename": "Issue", "number": 1, "title": "t", "url": "u", "state": "OPEN",
+            "createdAt": None, "updatedAt": None, "closedAt": None,
+            "labels": {"nodes": [{"name": n} for n in labels]},
+        },
+        "fieldValues": {"nodes": [{"name": "Ready", "field": {"name": "Status"}}]},
+    }
+
+
+def _args(**kw):
+    base = dict(role=None, status=None, priority=None, size=None, arc=None, arc_phase=None)
+    base.update(kw)
+    return argparse.Namespace(**base)
+
+
+def test_normalize_derives_arc_and_phase():
+    n = b.normalize(_item(["role:pm", "arc:board-governance", "arc-phase:active"]))
+    assert n["arc"] == "arc:board-governance"
+    assert n["arc_phase"] == "active"
+
+
+def test_normalize_arc_none_when_absent():
+    n = b.normalize(_item(["role:pm"]))
+    assert n["arc"] is None and n["arc_phase"] is None
+
+
+def test_arc_phase_label_not_mistaken_for_arc():
+    n = b.normalize(_item(["arc-phase:later"]))
+    assert n["arc"] is None and n["arc_phase"] == "later"
+
+
+def test_filter_by_arc_phase():
+    it = b.normalize(_item(["arc:scoring-tcr-pmhc", "arc-phase:active"]))
+    assert b.matches_filter(it, _args(arc_phase="active"))
+    assert not b.matches_filter(it, _args(arc_phase="later"))
+
+
+def test_filter_by_arc_slug_accepts_short_and_full_form():
+    it = b.normalize(_item(["arc:scoring-tcr-pmhc", "arc-phase:active"]))
+    assert b.matches_filter(it, _args(arc="scoring-tcr-pmhc"))
+    assert b.matches_filter(it, _args(arc="arc:scoring-tcr-pmhc"))
+    assert not b.matches_filter(it, _args(arc="cloud-reproducibility"))
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `workflow/tests/.venv/bin/python -m pytest scripts/tests/test_board_open_items_arc.py -v`
+Expected: FAIL — `KeyError: 'arc'` in `test_normalize_*` and `AttributeError`/`KeyError` on `arc`/`arc_phase` (the fields and filters don't exist yet).
+
+- [ ] **Step 3: Add arc derivation in `normalize()`**
+
+In `scripts/board_open_items.py`, find (inside `normalize()`):
+```python
+    role = next((l for l in labels if l.startswith("role:")), None)
+    return {
+```
+Replace with:
+```python
+    role = next((l for l in labels if l.startswith("role:")), None)
+    arc = next((l for l in labels if l.startswith("arc:")), None)
+    arc_phase = next(
+        (l.removeprefix("arc-phase:") for l in labels if l.startswith("arc-phase:")),
+        None,
+    )
+    return {
+```
+
+Then in the same returned dict, find:
+```python
+        "role": role,
+        "labels": labels,
+```
+Replace with:
+```python
+        "role": role,
+        "arc": arc,
+        "arc_phase": arc_phase,
+        "labels": labels,
+```
+
+- [ ] **Step 4: Add the filters in `matches_filter()`**
+
+Find:
+```python
+    if args.size and it["size"] != args.size:
+        return False
+    return True
+```
+Replace with:
+```python
+    if args.size and it["size"] != args.size:
+        return False
+    if args.arc:
+        want = args.arc if args.arc.startswith("arc:") else f"arc:{args.arc}"
+        if it["arc"] != want:
+            return False
+    if args.arc_phase and it["arc_phase"] != args.arc_phase:
+        return False
+    return True
+```
+
+- [ ] **Step 5: Add the argparse flags in `main()`**
+
+Find:
+```python
+    p.add_argument("--size", choices=list(SIZE_ORDER), help="Filter by Size")
+```
+Insert immediately after it:
+```python
+    p.add_argument("--arc", help='Filter by arc label (e.g. "scoring-tcr-pmhc" or "arc:scoring-tcr-pmhc")')
+    p.add_argument("--arc-phase", dest="arc_phase", choices=["active", "next", "later"],
+                   help="Filter by arc focus phase")
+```
+
+- [ ] **Step 6: Run the test to verify it passes**
+
+Run: `workflow/tests/.venv/bin/python -m pytest scripts/tests/test_board_open_items_arc.py -v`
+Expected: PASS (5 passed).
+
+- [ ] **Step 7: Smoke-test against the live board**
+
+Run: `python3 scripts/board_open_items.py --arc-phase active --json 2>/dev/null | python3 -c 'import json,sys; print(len(json.load(sys.stdin)))'`
+Expected: a number close to `30` (open board items in the active slate; equals the active issue count unless an issue isn't on the board).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add scripts/board_open_items.py scripts/tests/test_board_open_items_arc.py
+git commit -m "feat(pm): board_open_items --arc/--arc-phase filters + arc derivation (#633)"
+```
+
+---
+
+## Task 5: Open the PR
+
+- [ ] **Step 1: Push the branch**
+
+Run: `git push -u origin design/pm/issue-633-arc-work-structuring-spec`
+
+- [ ] **Step 2: Open the PR** (note: `@-claude` hyphen form is intentional — never the literal trigger)
+
+```bash
+gh pr create --repo Jin-HoMLee/splice-neoepitope-pipeline \
+  --title "feat(pm): arc work-structuring — foundation (labels + taxonomy + queryability)" \
+  --body "$(cat <<'BODY'
+Implements Plan 1 of the arc work-structuring rollout (design spec + plan under docs/superpowers/).
+
+- arc:* + arc-phase:* label definitions (scripts/pm/arc_labels.sh)
+- v1 taxonomy manifest, 71 issues / 8 arcs (scripts/pm/arc_taxonomy.tsv)
+- apply script (scripts/pm/apply_arc_labels.sh) — taxonomy synced to live issues
+- board_open_items.py --arc/--arc-phase filters + unit tests
+
+Opening active slate: arc:aligner-junctions, arc:scoring-tcr-pmhc, arc:board-governance.
+Plan 2 (shared pull rule + board hygiene, personas repo) and Plan 3 (milestone cleanup) follow.
+
+Related to the Issue #633 board-governance review.
+
+## Test plan
+- [ ] `gh label list` shows 11 arc/arc-phase labels
+- [ ] per-arc issue counts match the manifest (8x OK)
+- [ ] active=30, next=11, unfiled (446/451/570/641) carry no arc label
+- [ ] `pytest scripts/tests/test_board_open_items_arc.py` passes
+BODY
+)"
+```
+
+- [ ] **Step 3: Auto-board the PR** if not auto-added (the post-create hook normally handles this; verify it landed on project #9).
+
+- [ ] **Step 4: Merge via the closure-ritual gate** (after review per the routine-PR bot-review rule if applicable)
+
+Run: `bash scripts/audit_and_merge.sh <PR_NUMBER> --squash --delete-branch`
+
+---
+
+## Follow-on Plans (not implemented here)
+
+**Plan 2 — Arc-aware pull + board hygiene (personas repo, MM-landed).** Depends on Plan 1's labels existing.
+- `shared/feedback_best_next_issue.md` Step 1: restrict the candidate pool to `arc-phase:active` (one edit → all four roles get arc-aware pull). This is the spec's *core deliverable* (§8).
+- `shared/feedback_board_hygiene.md`: add the "un-arced `Ready` issue = triage gap" sweep check + surface the active slate in the PM morning routine.
+- New shared rule: the cadenced **arc review** (split/merge/retire + re-pick ≤3 active; §6).
+- Update `CLAUDE.md` board-governance section + `feedback_milestones.md` for the three-axis model.
+- Landed via the personas repo PR flow (MM / role-self-commit per Issue #672).
+
+**Plan 3 — Milestone de-overloading & cleanup (project repo + GitHub).** Independent; can follow Plan 1.
+- Delete dead `M1/M2/M7`; close/populate empty placeholder milestones.
+- Drop the arc-suffix from live milestone names; resolve Milestones-vs-Iteration-field (Issue #633 open question).
+
+---
+
+## Self-Review
+
+**Spec coverage (Plan 1 scope only):** §4.3 carriers (arc + arc-phase labels) → Tasks 1,3. §5 taxonomy → Task 2 (manifest) + Task 3 (application). §5.1 active slate → Task 2/3 (phase column). Queryability for §8 pull → Task 4. Milestone de-overloading (§7), pull rule (§8), arc review (§6 governance ops), board hygiene (§9 Phase 1 sweep) → **deferred to Plans 2/3** (flagged, not dropped).
+
+**Placeholder scan:** none — every script and edit shows full content; `<PR_NUMBER>` in Task 5 is a runtime value, not a content placeholder.
+
+**Type/name consistency:** arc slugs identical across `arc_labels.sh`, `arc_taxonomy.tsv`, `apply_arc_labels.sh`, and the verification loops. `arc`/`arc_phase` field names consistent between `normalize()`, the returned dict, `matches_filter()`, and the test. `--arc-phase` → `dest="arc_phase"` matches `args.arc_phase`.
+
+**Count reconciliation:** 6+6+6+7+5+11+13+17 = 71 arc-labeled + 4 unfiled = 75 open. Active = 6+7+17 = 30; next = 11; later = 6+6+5+13 = 30.

--- a/docs/superpowers/specs/2026-06-05-arc-work-structuring-design.md
+++ b/docs/superpowers/specs/2026-06-05-arc-work-structuring-design.md
@@ -1,0 +1,186 @@
+# Arc-Based Work Structuring — Design Spec
+
+**Date:** 2026-06-05
+**Status:** Draft for review (brainstorming output → next: writing-plans)
+**Issue:** tracked by [Issue #633](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/633) (`role:pm` — board governance review: parent-as-milestone-anchor, Milestones vs Iteration field, deferral tracking, WIP limits). This spec is the design output of that review's arc/milestone strand.
+**Author:** PM session (Claude) + Jin-Ho Lee
+
+## 1. Goal
+
+Give the work a **narrative throughline that outlives a single milestone** and let the four asynchronous persona sessions (Dev, Sci, PM, MM) **pull from a shared current focus** without coupling them. Today work feels stand-alone day-to-day and the four sessions feel like separate workstreams — the symptom the user named.
+
+The fix introduces one new dimension — the **arc** — and de-overloads the existing **milestone** so that three orthogonal axes each do exactly one job:
+
+| Axis | Question it answers | Nature |
+|---|---|---|
+| **Stage** (`S#`) | "what *kind* of lifecycle work is this?" | general, fixed scaffold (DS lifecycle) |
+| **Arc** | "which long-running concrete narrative does this serve?" | project-specific, fluid (NEW) |
+| **Due date** | "when?" | the real chronological clock |
+
+This spec is the *what/why*. The step-by-step build plan is produced next by the writing-plans skill.
+
+## 2. Background — why now (the rationale, evidenced)
+
+The current milestone scheme `i<iter> - S<N> - <Stage Name> - <Arc-descriptor>` encoded two best-practices: the **data-science lifecycle** as the stage axis (`S1 Domain Knowledge → S2 Data Collection → S3 Data Prep → S4 EDA → S5 Modeling → S6 Eval & Reporting → S7 Publication`, ≈ CRISP-DM/TDSP) and **iterating** through it as the `i<N>` axis. It was set up explicitly as a hypothesis to test and adjust. The verdict, from the live board:
+
+- **The stage axis (S#) held up — keep it.** The arc partition test (§5) independently rediscovered it: the work genuinely clusters by lifecycle stage.
+- **The iteration axis (i#) did not hold up as iterations.** An iteration is a *team-synchronization* device (one synchronized sprint, delivered at a boundary). The project runs **late-commitment Kanban** (flow-based, pull-when-ready) executed by **four async personas** — there is no synchronized cadence for an iteration to mean. Cut off from a global clock, `i<N>` mutated into a **per-track version counter** and fragmented into parallel counters (`i#`, `pm-i#`, `dev-i#`).
+- **Evidence the number is not a clock:** sorting *open* milestones by `due_on`, the iteration numbers read `2, 5, 4, 5, 2, 6, 4` (and the `pm-i*` series reads `1, 3, 5, 4, 2, 6`). The field that *looks* chronological is not.
+- **The arc is the iterative-DS-lifecycle idea expressed correctly.** "GTEx filter — pass 2, pass 3…" across iterations *is* iterating the data-prep stage on the GTEx theme. The intent was right; encoding it as a global synchronized sprint number (which fights async Kanban) was the part that broke. Expressed as a per-theme **arc lineage**, the same intent fits flow-based work.
+
+What is being retired is **only the global `i<N>` as a fake clock** — not stages, not the DS-lifecycle intent, not Kanban flow.
+
+## 3. How others handle "arc vs epic" (verified landscape)
+
+A fact-checked sweep (Scrum/Cohn, SAFe, Jira, Linear, GitHub-native, Shape Up, Cagan/SVPG, Asana/ClickUp, ThoughtWorks) converged on:
+
+- **The dividing line is closure, not size.** An **epic closes** when its children ship; a **theme/arc never closes** — successive epics keep rolling under it. *"If it ends when its children are done, it's an epic; if successive epics keep rolling under it, it's an arc."*
+- **The long-lived tier is orthogonal, not a parent above epics.** Scrum (theme = label/grouping), SAFe (epics *tag* a Strategic Theme), Asana/ClickUp (rollup object), ThoughtWorks ("above nothing, beside everything") all model it as a cross-cutting lens. **Only Jira and Linear make it a literal parent tier** — Jira premium-gates it; Linear has no GitHub equivalent. Shape Up / Cagan say don't make it a tracked object at all.
+- **A real 3rd structural rollup level is precisely what SaaS tools charge for** (automatic cross-level aggregation is expensive). The universal non-premium fallback is a label / field / single-select.
+
+**Consequence for this repo (user project #9):** Issue Types are an organization-only feature and 404 on a *user* project, so a native "Arc" type is unavailable. The only way to fake a parent tier is a parent issue — which collides with the `recheck_parent_status` rollup (a never-closing arc-parent would emit perpetual forward-drift) and with the no-milestone-inheritance anchor model. **→ The arc must be an orthogonal label, not a tier.**
+
+## 4. The model
+
+### 4.1 Three things, three words already in the team's vocabulary
+
+- **Epic** = a parent issue that **closes** when its sub-issues complete (unchanged — exactly what the repo already does).
+- **Arc** = a never-closing `arc:<name>` **label** that any issue *or* epic carries, regardless of tree position. The narrative lens.
+- **Milestone** = a dated, closeable bundle of "this stage-`S#` chunk of work." The time/stage slice.
+
+Keep the word **"arc"** (it connotes a *narrative throughline* better than "theme"/"initiative", and the team already says it). Never call an arc an "epic that spans iterations" — that conflates a never-closing lens with a closeable container.
+
+### 4.2 Stage × Arc is a grid, not a translation
+
+Arcs are **not** the lifecycle stages relabeled. A real arc moves *through* stages; a stage *contains* many arcs. Two different arcs share a stage (e.g. Aligner and GTEx-filter are both `S3` but distinct threads) — that is the proof they are orthogonal axes. Drawing arcs at "upstream science / downstream science" granularity is the failure mode: at that coarseness the arc is just `S3`/`S5` with a new name and adds nothing. Arcs are drawn at **theme-lineage granularity** (§5).
+
+### 4.3 Carriers — label-only MVP
+
+1. **`arc:<name>` label** is the **load-bearing carrier.** The async cron/remote persona sessions read raw issue *text* (labels are in the REST issue payload; a Projects v2 board field is not). MVP = label only.
+2. **`arc-phase:active | next | later` label** — the focus marker. **Cap `active` at 3.**
+3. *Optional later (only if missed):* a Projects v2 single-select `Arc` field (board grouping/views) and/or one never-closed `ARC: <name>` tracking issue per arc carrying the prose narrative. **Do not build all three carriers up front** — that is three sync-prone artifacts for one concept; start with the single text-readable label.
+
+## 5. The arc taxonomy (validated against all 75 open issues, 2026-06-05)
+
+Classification of every open issue into theme-lineage arcs. Largest arc is 23% — no catch-all (the coarse 4-arc version hit 42%; going *finer* fixed it).
+
+| # | Arc (theme) | Threads | count |
+|---|---|---|---|
+| 1 | **Aligner & junction extraction** | STAR/HISAT2 verification & tuning, SJ/annotation correctness | 6 (8%) |
+| 2 | **Junction filtering & tumor-specificity** | GTEx + matched-normal + AlphaGenome filter, integrity sweep | 6 (8%) |
+| 3 | **Variant calling & cohort expansion** | somatic calling, SpliceAI/MMSplice prong, new patients | 6 (8%) |
+| 4 | **Neoepitope scoring & TCR-pMHC modeling** | MHCflurry calibration, scorers, structures, immunogenicity | 7 (9%) |
+| 5 | **Results, reporting & manuscript** | HLA-panel runs, report layer, decks, notebooks, writeup | 5 (7%) |
+| 6 | **Cloud execution & reproducibility** | Batch, run registry, GPU fallback, `run_cloud_gpu.sh`, GCS/logs | 11 (15%) |
+| 7 | **Memory & methodology** | `MEMORY.md` slimming/consolidation/audit, MM role, persona framing | 13 (17%) |
+| 8 | **Board governance & enforcement** | Kanban governance, board hooks/guards, PM-tooling evals | 17 (23%) |
+| — | **Unfiled** (not an arc) | dev-env hygiene + arc-agnostic refactors | 4 (5%) |
+
+Membership (bare `#N` — code block):
+
+```
+1 Aligner & junction extraction:    297 375 377 378 411 636
+2 Junction filtering:               126 212 304 381 594 663
+3 Variant & cohort:                 413 416 436 437 438 440
+4 Scoring & TCR-pMHC:               433 492 547 566 585 601 659
+5 Results/reporting/manuscript:     193 198 233 435 455
+6 Cloud execution & reproducibility:66 183 195 310 630 651 658 664 669 673 674
+7 Memory & methodology:             248 265 324 326 346 353 527 538 539 540 541 542 672
+8 Board governance & enforcement:   234 250 294 295 406 445 498 499 533 553 569 578 617 626 633 655 665
+Unfiled:                            446 451 570 641
+```
+
+Two mirrors this surfaces, both worth a conscious decision rather than drift:
+
+- **Science (Arcs 1–5) = 30 issues ≈ Persona-OS (Arcs 7–8) = 30 issues.** Half the open backlog is the personas building their own machinery. Investment, not waste — but now visible.
+- **Arcs 7+8 are really one milestone lineage** (the `pm-i*` "PM Tooling, Memory & Methodology") that outgrew one thread; split at the seam memory/methodology vs board/enforcement. **First fission candidate** to watch.
+
+### 5.1 Suggested opening active slate (PM call, not fixed)
+
+Committed milestones currently touch **six** arcs at once — that scatter is the "too many parallel things" symptom, now measurable. A focused slate of three, one per persona-cluster:
+
+- **Arc 1 · Aligner/STAR verification** — closest-due milestone ([Issue #24](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/24), 2026-06-19); gates downstream science; Sci+Dev+PM.
+- **Arc 4 · Scoring & TCR-pMHC** — active modeling frontier ([Issue #29](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/29)); Sci+Dev.
+- **Arc 8 · Board governance & enforcement** — carries [Issue #633](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/633) (this design) + the Kanban migration; PM+MM+Dev.
+
+`next`: **Arc 6 (cloud)** — runs gate the science. Everything else `later`.
+
+## 6. Arc lifecycle & governance
+
+Arcs are the **most fluid** of the three axes by design. "Never closes" ≠ "fixed":
+
+- **Closing** is mechanical (an epic closes when children ship). An arc has no such trigger.
+- **Retiring** is editorial (a human decides the narrative has run its course). Arcs *can* be retired — Cagan's anti-immortal-bucket warning requires it.
+
+**Stability gradient:** stage = fixed scaffold · arc = fluid narrative layer · due date = pointwise. The taxonomy in §5 is **v1, expected to evolve.**
+
+**Operations are cheap because the carrier is a label** (this is a direct payoff of the label-only choice — a parent-issue or rigid field hierarchy would make these painful migrations):
+
+| Operation | Mechanic |
+|---|---|
+| Rename | `gh label edit "arc:old" --name "arc:new"` — propagates to all issues |
+| Split (fission) | create new label(s), re-tag the subset, delete old (as done for 7/8) |
+| Merge (fusion) | re-tag issues `arc:B → arc:A`, delete `arc:B` |
+| Retire | drop from the active/next/later rotation; optionally `arc:archived/<name>`; history preserved |
+| Spawn | new thread emerges → new label, starts `later` |
+
+**The one discipline — change on a cadence, not continuously.** Stable between reviews (that stability *is* the throughline); revised at a periodic **arc review** (monthly, or when the active slate feels stale) that deliberately decides splits/merges/retirements and re-picks the ≤3 `active`. This mirrors Shape Up's "re-bet each cycle." **PM-coordinated**, like the commitment act (portfolio-level call). The `arc-phase` markers churn fast (every review); the arc taxonomy churns slowly.
+
+**The Unfiled lane is the nursery and the graveyard:** new arcs gestate there (when several Unfiled issues share a thread, an arc is born); a retired arc's stragglers drop back into it. **Never fold Unfiled items into the biggest arc** — that re-bloats it toward catch-all.
+
+## 7. Milestone de-overloading
+
+The milestone keeps its **correct, idiomatic GitHub use** (a dated, closeable deliverable bundle) and sheds its two passengers:
+
+- **Drop the arc-descriptor from the name** (the arc is now its own label). Milestone name → just the stage chunk.
+- **Drop / demote the `i<N>` global clock.** The real clock is `due_on` (already synced to the board `Target`). If a true time-box is ever wanted, use the **native Projects Iteration field**, not a name suffix — the open question in [Issue #633](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/633).
+- **Per-arc "version" is expressed as the milestone's place in its arc lineage** ("the 5th milestone under `arc:aligner`"), not a global `i5`.
+- **Cleanup:** delete dead legacy milestones (`M1 / M2 / M7` — empty, no due date); close/populate empty placeholder milestones.
+
+Milestones remain the **commitment signal** (`Backlog → Ready`) and `Target` source — unchanged. One issue ↔ one milestone, sub-issues don't inherit — unchanged.
+
+## 8. The real deliverable — the arc-aware daily pull
+
+Labels are inert metadata until the sessions *use* them. The point of the whole exercise:
+
+> Each persona session's pull rule becomes: **`status:Ready` AND `arc-phase:active` AND `role:<self>` → take the next.**
+
+This is what turns four async sessions into a coordinated team pulling a shared current focus. It requires updating each persona's pull/cron prompt (PM, Sci, Dev, MM) + the morning routine to surface the active slate and each role's next pull. **This is the primary implementation work, not a downstream consequence.**
+
+## 9. Rollout (phased, low-risk)
+
+- **Phase 0** — create 8 `arc:*` labels + 3 `arc-phase:*` labels; batch-apply to the 75 open issues from §5; open an explicit Unfiled state for the ~4 arc-less.
+- **Phase 1** — set the opening `active` slate (§5.1); surface it in the PM morning routine board-hygiene step (an un-arced `Ready` issue is a triage gap, like a missing role label).
+- **Phase 2** — teach each persona pull/cron the arc-aware filter (§8). *The core deliverable.*
+- **Phase 3** — milestone cleanup (§7): drop arc suffix, delete `M1/M2/M7`, resolve Milestones-vs-Iteration-field for [Issue #633](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/633).
+- **Phase 4** — first **arc review** (§6) one month in: validate the taxonomy, split Arc 8 if it's grown, retire anything concluded.
+
+## 10. Risks & mitigations
+
+| Risk | Mitigation |
+|---|---|
+| **Label drift** — issues filed without an arc; arcs going stale | Morning board-hygiene sweep flags un-arced `Ready` issues; arc review refreshes the slate |
+| **Arc 7/8 (persona-OS) re-bloating** | Unfiled lane + the 7/8 split are the guardrails; it's the named first fission candidate |
+| **Cross-cutting issues** (~9, e.g. #665, #193, #455) | Resolve by *payload not label*; accept ≤10% need a judgment call |
+| **Carrier sync** — a Projects field is not in issue text | Label is canonical for text-reading sessions; defer the field until needed |
+| **Over-churn** erases the throughline | Change only at the cadenced arc review, not mid-session |
+| **The 53%-meta mirror** | The structure makes it visible; that may itself prompt a deliberate rebalance |
+
+## 11. Out of scope / explicitly NOT doing
+
+- **No 3-level arc → epic → issue hierarchy** (premium-gated, blocked on a user project, collides with the rollup hook).
+- **No per-arc tracking issue or Projects field in the MVP** (label-only first; add only if missed).
+- **No change to epics, sub-issue non-inheritance, the commitment act, or `Target` sync.**
+- **No retroactive renaming of closed milestones** (cosmetic; cleanup applies to dead/empty ones only).
+
+## 12. Open questions (for [Issue #633](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/633))
+
+1. **Milestones vs native Iteration field** — once `i<N>` leaves the name, do we adopt the Projects Iteration field for real time-boxes, or rely on `due_on` alone?
+2. **`arc-phase` as label vs Projects single-select** — label is text-readable (MVP); a single-select is tidier on the board. Decide at Phase 1.
+3. **Arc review cadence** — monthly vs per-"replenishment" — tune after Phase 4.
+
+## 13. References
+
+- Brainstorming dialogue 2026-06-05 (this session): framework landscape sweep + 75-issue partition test (theme granularity).
+- [Issue #633](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/633) — board governance review (tracking issue for this strand; a `role:pm` leaf, not an epic).
+- `CLAUDE.md` §"Board status governance — late-commitment Kanban" and `.claude/memory/feedback_milestones.md` — current milestone/commitment rules this spec amends.

--- a/docs/superpowers/specs/2026-06-05-arc-work-structuring-design.md
+++ b/docs/superpowers/specs/2026-06-05-arc-work-structuring-design.md
@@ -173,7 +173,7 @@ This is what turns four async sessions into a coordinated team pulling a shared 
 - **No change to epics, sub-issue non-inheritance, the commitment act, or `Target` sync.**
 - **No retroactive renaming of closed milestones** (cosmetic; cleanup applies to dead/empty ones only).
 
-## 12. Open questions (for [Issue #633](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/633))
+## 12. Open questions (arc-rollout details resolved across Plans 2-3; the [Issue #633](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/633) governance remainder — parent-anchor / deferral / WIP — is tracked in [Issue #690](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/690))
 
 1. **Milestones vs native Iteration field** — once `i<N>` leaves the name, do we adopt the Projects Iteration field for real time-boxes, or rely on `due_on` alone?
 2. **`arc-phase` as label vs Projects single-select** — label is text-readable (MVP); a single-select is tidier on the board. Decide at Phase 1.

--- a/docs/superpowers/specs/2026-06-05-arc-work-structuring-design.md
+++ b/docs/superpowers/specs/2026-06-05-arc-work-structuring-design.md
@@ -1,7 +1,7 @@
 # Arc-Based Work Structuring — Design Spec
 
 **Date:** 2026-06-05
-**Status:** Draft for review (brainstorming output → next: writing-plans)
+**Status:** Approved — Plan 1 (foundation: labels + taxonomy + queryability) implemented in [PR #688](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/688); Plans 2–3 pending
 **Issue:** tracked by [Issue #633](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/633) (`role:pm` — board governance review: parent-as-milestone-anchor, Milestones vs Iteration field, deferral tracking, WIP limits). This spec is the design output of that review's arc/milestone strand.
 **Author:** PM session (Claude) + Jin-Ho Lee
 

--- a/research/lab_notebook/pm.md
+++ b/research/lab_notebook/pm.md
@@ -6,6 +6,24 @@ Format and rules unchanged from the unified notebook — see `shared/feedback_la
 
 ---
 
+## 2026-06-05
+
+### 11:58 UTC — Editor: PM
+
+#### Arc work-structuring — foundation shipped: the board gains a narrative throughline ([Issue #633](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/633) arc/milestone strand, [PR #688](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/688))
+
+**The problem.** Work felt stand-alone day-to-day and the four async personas (Dev/Sci/PM/MM) felt like separate workstreams — no throughline outliving a single milestone. Root cause, evidenced from the live board: the milestone name `i<iter> - S<N> - <Stage> - <Arc>` was carrying **three** axes, and the `i<N>` masquerades as a global clock but isn't — open milestones sorted by `due_on` read `i2,5,4,5,2,6,4` (the `pm-i*` series `1,3,5,4,2,6`). The DS-lifecycle **stage** axis (S#) held up; **iteration-as-sprint** did not, because the board runs late-commitment Kanban (flow) executed by async personas — there's no synchronized cadence for an iteration to mean. The `i<N>` had mutated into a per-track version counter wearing a clock's clothes.
+
+**The decision.** Add one new dimension — an **arc**: a never-closing `arc:<slug>` label (narrative throughline) + an `arc-phase:active|next|later` focus marker — orthogonal to milestone (stage/time) and due-date (the real clock). Crucially **arc ≠ a tier above epics**: a fact-checked landscape sweep (Scrum/SAFe/Jira/Linear/GitHub/Shape Up/Cagan/Asana/ClickUp/ThoughtWorks) found the dividing line is *closure not size* (epic closes; arc never does), and the long-lived tier is almost always an *orthogonal label*, not a structural parent — only Jira/Linear make it a tier and both premium-gate it. On user project #9 a real tier is doubly blocked: Issue Types are org-only (404 on a user repo), and a parent-issue arc collides with the `recheck_parent_status` rollup. So: orthogonal **label**, MVP label-only (it's the carrier the text-reading cron sessions actually see).
+
+**What shipped (Plan 1 of 3 — the project-repo foundation).** `scripts/pm/arc_labels.sh` (8 `arc:*` + 3 `arc-phase:*` labels), `scripts/pm/arc_taxonomy.tsv` (v1 source-of-truth: **71 of 75 open issues across 8 theme arcs**, 4 left unfiled), `scripts/pm/apply_arc_labels.sh` (synced to live issues — per-arc counts 8× OK; active=30 / next=11 / later=30), and `scripts/board_open_items.py --arc/--arc-phase` filters (queryable for the Plan-2 pull rule; TDD, 5 tests). Opening **active slate**: `arc:aligner-junctions` + `arc:scoring-tcr-pmhc` + `arc:board-governance`.
+
+**The taxonomy was earned, not asserted.** A first partition collapsed the science into "upstream/downstream" — caught (by the user) as just the S3/S5 *stages relabeled*, the exact category error to avoid. Re-ran at **theme-lineage granularity** (GTEx, STAR, TCR-pMHC, … — the recurring milestone stems): no catch-all anymore (largest arc 23%, down from 42%). Two mirrors fell out: **science ≈ persona-OS in mass (30 ≈ 30 issues)** — half the open backlog is the personas building their own machinery — and the persona-OS arc is the first fission candidate. Distinction settled: the arc *taxonomy* is ~4-8 (fluid, cheap to split/merge/rename/retire via label ops, revised on a cadenced review); only the *active slate* is capped at 3.
+
+**Verification ladder.** Two fact-checked research workflows (framework landscape + 75-issue partition, each with adversarial critic) → brainstorming spec, user-approved → subagent-driven execution: implementer per task + two-stage (spec→quality) review on the Python change, both APPROVED; the live 71-issue mutation run under direct controller observation, not delegated → `@claude` bot review **requested (in flight)** → CI green (pytest ×2 + dry-run). Merge held until the bot review lands and is addressed.
+
+**Cross-repo framing + what's NOT done.** This PR is the project-repo half only. **Plan 2** (personas repo, MM-landed per the [Issue #672](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/672) single-repo-AC convention) carries the actual *core deliverable* — the arc-aware daily pull, a one-line change to shared `feedback_best_next_issue.md` Step 1 that makes all four roles pull `arc-phase:active ∧ role:self` — plus the board-hygiene un-arced sweep and the cadenced arc-review process. **Plan 3** is milestone de-overloading + dead-milestone cleanup. [Issue #633](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/633) **stays open** — this delivered only its arc/milestone strand; the Milestones-vs-Iteration-field / deferral / WIP-limit strands remain. Spec + plan: `docs/superpowers/specs/2026-06-05-arc-work-structuring-design.md`, `docs/superpowers/plans/2026-06-05-arc-work-structuring-foundation.md`.
+
 ## 2026-06-04
 
 ### 20:31 UTC — Editor: PM

--- a/scripts/board_open_items.py
+++ b/scripts/board_open_items.py
@@ -140,6 +140,11 @@ def normalize(item: dict[str, Any]) -> dict[str, Any] | None:
         return None
     labels = [l["name"] for l in content.get("labels", {}).get("nodes", [])]
     role = next((l for l in labels if l.startswith("role:")), None)
+    arc = next((l for l in labels if l.startswith("arc:")), None)
+    arc_phase = next(
+        (l.removeprefix("arc-phase:") for l in labels if l.startswith("arc-phase:")),
+        None,
+    )
     return {
         "number": content.get("number"),
         "title": content.get("title", ""),
@@ -151,6 +156,8 @@ def normalize(item: dict[str, Any]) -> dict[str, Any] | None:
         "priority": priority,
         "size": size,
         "role": role,
+        "arc": arc,
+        "arc_phase": arc_phase,
         "labels": labels,
         "created_at": content.get("createdAt"),
         "updated_at": content.get("updatedAt"),
@@ -242,6 +249,12 @@ def matches_filter(it: dict[str, Any], args: argparse.Namespace) -> bool:
         return False
     if args.size and it["size"] != args.size:
         return False
+    if args.arc:
+        want = args.arc if args.arc.startswith("arc:") else f"arc:{args.arc}"
+        if it["arc"] != want:
+            return False
+    if args.arc_phase and it["arc_phase"] != args.arc_phase:
+        return False
     return True
 
 
@@ -272,6 +285,9 @@ def main() -> int:
     p.add_argument("--status", choices=list(STATUS_ORDER), help="Filter by board Status")
     p.add_argument("--priority", choices=list(PRIORITY_ORDER), help="Filter by Priority")
     p.add_argument("--size", choices=list(SIZE_ORDER), help="Filter by Size")
+    p.add_argument("--arc", help='Filter by arc label (e.g. "scoring-tcr-pmhc" or "arc:scoring-tcr-pmhc")')
+    p.add_argument("--arc-phase", dest="arc_phase", choices=["active", "next", "later"],
+                   help="Filter by arc focus phase")
     p.add_argument("--sort-updated", dest="sort_updated", action="store_true",
                    help="Sort by last activity (Issue.updatedAt), most-recent first (momentum)")
     p.add_argument("--stale-days", dest="stale_days", type=int, metavar="N",

--- a/scripts/board_open_items.py
+++ b/scripts/board_open_items.py
@@ -140,7 +140,13 @@ def normalize(item: dict[str, Any]) -> dict[str, Any] | None:
         return None
     labels = [l["name"] for l in content.get("labels", {}).get("nodes", [])]
     role = next((l for l in labels if l.startswith("role:")), None)
-    arc = next((l for l in labels if l.startswith("arc:")), None)
+    arc_labels = [l for l in labels if l.startswith("arc:")]
+    if len(arc_labels) > 1:
+        print(
+            f"Warning: issue #{content.get('number')} has multiple arc labels: {arc_labels}",
+            file=sys.stderr,
+        )
+    arc = arc_labels[0] if arc_labels else None
     arc_phase = next(
         (l.removeprefix("arc-phase:") for l in labels if l.startswith("arc-phase:")),
         None,

--- a/scripts/pm/apply_arc_labels.sh
+++ b/scripts/pm/apply_arc_labels.sh
@@ -9,7 +9,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 MANIFEST="${1:-$SCRIPT_DIR/arc_taxonomy.tsv}"
 [[ -f "$MANIFEST" ]] || { echo "manifest not found: $MANIFEST" >&2; exit 1; }
 
-while read -r arc phase rest; do
+while read -r arc phase rest || [[ -n "${arc:-}" ]]; do
   [[ -z "${arc:-}" || "${arc:0:1}" == "#" ]] && continue
   for n in $rest; do
     echo "  #$n -> $arc + arc-phase:$phase"

--- a/scripts/pm/apply_arc_labels.sh
+++ b/scripts/pm/apply_arc_labels.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# scripts/pm/apply_arc_labels.sh
+# Apply arc:* + arc-phase:* labels to issues per scripts/pm/arc_taxonomy.tsv.
+# Idempotent: gh add-label of an already-present label is a no-op.
+# Prereq: run scripts/pm/arc_labels.sh first (labels must exist).
+set -euo pipefail
+REPO="Jin-HoMLee/splice-neoepitope-pipeline"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MANIFEST="${1:-$SCRIPT_DIR/arc_taxonomy.tsv}"
+[[ -f "$MANIFEST" ]] || { echo "manifest not found: $MANIFEST" >&2; exit 1; }
+
+while read -r arc phase rest; do
+  [[ -z "${arc:-}" || "${arc:0:1}" == "#" ]] && continue
+  for n in $rest; do
+    echo "  #$n -> $arc + arc-phase:$phase"
+    gh issue edit "$n" --repo "$REPO" \
+      --add-label "$arc" --add-label "arc-phase:$phase"
+  done
+done < "$MANIFEST"
+echo "Done applying arc taxonomy from $MANIFEST."

--- a/scripts/pm/arc_labels.sh
+++ b/scripts/pm/arc_labels.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# scripts/pm/arc_labels.sh
+# Idempotently create the arc:* (narrative throughline) and arc-phase:* (focus
+# marker) labels. Re-runnable: --force updates colour/description if the label
+# already exists. Spec: docs/superpowers/specs/2026-06-05-arc-work-structuring-design.md
+set -euo pipefail
+REPO="Jin-HoMLee/splice-neoepitope-pipeline"
+
+# name | hex colour (no '#') | description
+ARC_LABELS=(
+  "arc:aligner-junctions|0F766E|Arc: aligner & junction extraction (STAR/HISAT2 verification, SJ/annotation correctness)"
+  "arc:junction-filtering|047857|Arc: junction filtering & tumor-specificity (GTEx + matched-normal + AlphaGenome, integrity)"
+  "arc:variant-cohort|15803D|Arc: variant calling & cohort expansion (somatic calling, SpliceAI/MMSplice, new patients)"
+  "arc:scoring-tcr-pmhc|B45309|Arc: neoepitope scoring & TCR-pMHC modeling (MHCflurry calibration, scorers, structures)"
+  "arc:results-reporting|A16207|Arc: results, reporting & manuscript (HLA panel runs, report layer, decks, writeup)"
+  "arc:cloud-reproducibility|1D4ED8|Arc: cloud execution & reproducibility (Batch, run registry, GPU, run_cloud_gpu.sh)"
+  "arc:memory-methodology|7C3AED|Arc: memory & methodology (MEMORY.md slimming/audit, MM role, persona framing)"
+  "arc:board-governance|9D174D|Arc: board governance & enforcement (Kanban governance, hooks/guards, PM-tooling evals)"
+)
+PHASE_LABELS=(
+  "arc-phase:active|2DA44E|Arc focus: actively pulled now (cap 3)"
+  "arc-phase:next|D4A72C|Arc focus: queued next"
+  "arc-phase:later|8C959F|Arc focus: parked"
+)
+
+create() {
+  local spec="$1" name color desc
+  IFS='|' read -r name color desc <<<"$spec"
+  gh label create "$name" --repo "$REPO" --color "$color" --description "$desc" --force
+}
+for spec in "${ARC_LABELS[@]}" "${PHASE_LABELS[@]}"; do create "$spec"; done
+echo "Created/updated ${#ARC_LABELS[@]} arc + ${#PHASE_LABELS[@]} arc-phase labels on $REPO."

--- a/scripts/pm/arc_taxonomy.tsv
+++ b/scripts/pm/arc_taxonomy.tsv
@@ -1,0 +1,13 @@
+# scripts/pm/arc_taxonomy.tsv — v1 arc taxonomy (2026-06-05)
+# Source of truth for apply_arc_labels.sh. Spec §5:
+# docs/superpowers/specs/2026-06-05-arc-work-structuring-design.md
+# Columns (whitespace-delimited): arc_slug  arc-phase  issue...
+arc:aligner-junctions     active  297 375 377 378 411 636
+arc:junction-filtering    later   126 212 304 381 594 663
+arc:variant-cohort        later   413 416 436 437 438 440
+arc:scoring-tcr-pmhc      active  433 492 547 566 585 601 659
+arc:results-reporting     later   193 198 233 435 455
+arc:cloud-reproducibility next    66 183 195 310 630 651 658 664 669 673 674
+arc:memory-methodology    later   248 265 324 326 346 353 527 538 539 540 541 542 672
+arc:board-governance      active  234 250 294 295 406 445 498 499 533 553 569 578 617 626 633 655 665
+# unfiled (intentionally NO arc label): 446 451 570 641

--- a/scripts/tests/test_board_open_items_arc.py
+++ b/scripts/tests/test_board_open_items_arc.py
@@ -40,6 +40,12 @@ def test_arc_phase_label_not_mistaken_for_arc():
     assert n["arc"] is None and n["arc_phase"] == "later"
 
 
+def test_normalize_multi_arc_picks_first_and_warns(capsys):
+    n = b.normalize(_item(["arc:scoring-tcr-pmhc", "arc:board-governance"]))
+    assert n["arc"] == "arc:scoring-tcr-pmhc"
+    assert "multiple arc labels" in capsys.readouterr().err
+
+
 def test_filter_by_arc_phase():
     it = b.normalize(_item(["arc:scoring-tcr-pmhc", "arc-phase:active"]))
     assert b.matches_filter(it, _args(arc_phase="active"))

--- a/scripts/tests/test_board_open_items_arc.py
+++ b/scripts/tests/test_board_open_items_arc.py
@@ -1,0 +1,53 @@
+# scripts/tests/test_board_open_items_arc.py
+import argparse
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+import board_open_items as b  # noqa: E402
+
+
+def _item(labels):
+    return {
+        "content": {
+            "__typename": "Issue", "number": 1, "title": "t", "url": "u", "state": "OPEN",
+            "createdAt": None, "updatedAt": None, "closedAt": None,
+            "labels": {"nodes": [{"name": n} for n in labels]},
+        },
+        "fieldValues": {"nodes": [{"name": "Ready", "field": {"name": "Status"}}]},
+    }
+
+
+def _args(**kw):
+    base = dict(role=None, status=None, priority=None, size=None, arc=None, arc_phase=None)
+    base.update(kw)
+    return argparse.Namespace(**base)
+
+
+def test_normalize_derives_arc_and_phase():
+    n = b.normalize(_item(["role:pm", "arc:board-governance", "arc-phase:active"]))
+    assert n["arc"] == "arc:board-governance"
+    assert n["arc_phase"] == "active"
+
+
+def test_normalize_arc_none_when_absent():
+    n = b.normalize(_item(["role:pm"]))
+    assert n["arc"] is None and n["arc_phase"] is None
+
+
+def test_arc_phase_label_not_mistaken_for_arc():
+    n = b.normalize(_item(["arc-phase:later"]))
+    assert n["arc"] is None and n["arc_phase"] == "later"
+
+
+def test_filter_by_arc_phase():
+    it = b.normalize(_item(["arc:scoring-tcr-pmhc", "arc-phase:active"]))
+    assert b.matches_filter(it, _args(arc_phase="active"))
+    assert not b.matches_filter(it, _args(arc_phase="later"))
+
+
+def test_filter_by_arc_slug_accepts_short_and_full_form():
+    it = b.normalize(_item(["arc:scoring-tcr-pmhc", "arc-phase:active"]))
+    assert b.matches_filter(it, _args(arc="scoring-tcr-pmhc"))
+    assert b.matches_filter(it, _args(arc="arc:scoring-tcr-pmhc"))
+    assert not b.matches_filter(it, _args(arc="cloud-reproducibility"))


### PR DESCRIPTION
Implements **Plan 1 of 3** of the arc work-structuring rollout. Design spec + plan live under `docs/superpowers/`.

## What this is
A new **arc** dimension — a never-closing `arc:<slug>` label (the narrative throughline) plus an `arc-phase:active|next|later` focus marker — orthogonal to milestone (stage/time) and due-date (the real clock). De-overloads the milestone, gives the four async personas a shared current focus to pull from. Background + full rationale (DS-lifecycle stages held, `i<N>`-as-iteration didn't): see the spec.

## Changes
- `scripts/pm/arc_labels.sh` — idempotent definitions for 8 `arc:*` + 3 `arc-phase:*` labels
- `scripts/pm/arc_taxonomy.tsv` — v1 taxonomy (source of truth): 71 issues / 8 arcs
- `scripts/pm/apply_arc_labels.sh` — syncs the taxonomy to live issues
- `scripts/board_open_items.py` — `--arc` / `--arc-phase` filters + arc derivation (queryable for the Plan-2 pull rule)
- `scripts/tests/test_board_open_items_arc.py` — unit tests (5)
- `docs/superpowers/specs/2026-06-05-arc-work-structuring-design.md`, `docs/superpowers/plans/2026-06-05-arc-work-structuring-foundation.md`

Opening **active slate**: `arc:aligner-junctions`, `arc:scoring-tcr-pmhc`, `arc:board-governance`. `arc:cloud-reproducibility` = next; rest = later. Unfiled (446/451/570/641) intentionally carry no arc.

## Follow-ons (not in this PR)
- **Plan 2** (personas repo, MM-landed): the shared `feedback_best_next_issue.md` pull-rule change (arc-aware daily pull — the core deliverable) + board-hygiene un-arced sweep + the cadenced arc-review process.
- **Plan 3**: milestone de-overloading + dead-milestone cleanup.

Related to the Issue #633 board-governance review (this is its arc/milestone strand; #633 stays open for the remaining strands).

## Known minor follow-ups (from review)
- `apply_arc_labels.sh` `while read` would skip the last TSV row if a hand-edit strips the trailing newline — harden with `|| [[ -n "$arc" ]]` when the script sees more use.
- Optional extra negative test: `--arc` filter against an un-arced issue.

## Test plan
- [x] `gh label list` shows 11 arc/arc-phase labels
- [x] per-arc issue counts match the manifest (8× OK)
- [x] active=30, next=11, later=30; unfiled (446/451/570/641) carry no arc label
- [x] `pytest scripts/tests/test_board_open_items_arc.py` → 5 passed
- [x] `board_open_items.py --arc-phase active --json` returns 30