### PR TITLE
chore(pm): arc tooling hardening — Arc column + apply_arc_labels re-sync + recheck parent-skip (#689)

### DIFF
--- a/research/lab_notebook/pm.md
+++ b/research/lab_notebook/pm.md
@@ -8,6 +8,22 @@ Format and rules unchanged from the unified notebook — see `shared/feedback_la
 
 ## 2026-06-11
 
+### 19:27 UTC — Editor: PM
+
+#### Arc tooling hardening — Arc column + apply_arc_labels re-sync + recheck parent-skip ([Issue #689](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/689), [PR #710](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/710))
+
+**Trigger.** The capacity-recheck hook flagged `pm-i6` as `[UNSIZED]` on a milestone whose only "unsized" members were parent epics (#527/#538/#539) — which carry no Size by convention (size rolls up from sub-issues). An un-clearable false positive: sizing a parent to clear it would itself violate the no-size rule. Surfaced while sizing #527/#538 earlier this session. Folded the fix into the existing `role:pm` leaf #689 (two arc-tooling items deferred from [PR #688](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/688)) as a third item rather than minting a sub-issue — keeping #689 a leaf preserves its own PR path.
+
+**What landed (3 items).** (1) `board_open_items.py` — opt-in `--arc-columns` flag (Arc + phase columns) so an `--arc-phase active` sweep shows each issue's arc in the human table, not only `--json`. (2) `apply_arc_labels.sh` — converted from add-only to a true re-sync: removes any `arc:*`/`arc-phase:*` label not matching `arc_taxonomy.tsv` before adding the manifest pair, so a slate change (phase edit, re-tag, split/merge) leaves each *listed* issue with exactly its manifest pair; bash 3.2-portable (no `mapfile`, guarded empty-array expansion). (3) `recheck_milestone.py` — new `parent_numbers()` excludes parent epics (`subIssuesSummary.total > 0`) from both the capacity sum and the unsized-check.
+
+**Verification.** Unit: parent-skip tests (parents excluded; only-parent → `[No change]`; unsized *leaf* still flags `[UNSIZED]`); 5 stubbed-`gh` re-sync tests (full-replace / no-op / phase-flip / arc-retag / comment-skip); Arc-column render tests. Suites green (`scripts/tests` 14, `tools/ci` 261). Live: `recheck_milestone.py --milestone 33` now shows #527/#538/#539 as "parent epic — excluded", no `[UNSIZED]`, capacity 6.0d from the real leaves (#569 M + #696 L). Live `apply_arc_labels.sh` re-sync = **zero** stale removals (idempotent on the freshly-applied taxonomy). All 4 CI checks pass.
+
+**Review.** `@claude review` (non-trivial human-authored PR) returned LGTM, no bugs; 4 optional-polish observations. Folded the two wording nits (apply_arc_labels scope comment; `--arc-columns`/`--json` help note) in ce42c16; deferred the two intentional ones (merging the two GraphQL calls — kept separate for independent monkeypatching; broad `rc in (0, 2)` assert — precise invariants are checked separately).
+
+**Slip caught (recorded).** The reviewer-reply comment used `#1`-`#4` for the finding numbers, which GitHub auto-linked to unrelated Issues/PRs (user caught it). Fixed the comment to "Finding N"; inlined the positional-`#N` trap into PM Always-in-effect (the shared `feedback_hash_numbers.md` rule existed but was only an index link, so it didn't surface at comment-writing distance). Side effect of the item-3 fix worth a downstream look: `pm-i6` now reads `[UPDATE NEEDED] -13d` — a *legitimate* re-date signal, no longer the false positive. Closes [Issue #689](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/689).
+
+---
+
 ### 14:25 UTC — Editor: PM
 
 #### `docs/remote_routines.md` — remote-routine sandbox facts + hardened dispatch checklist captured as a team doc ([Issue #651](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/651), [PR #652](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/652))

--- a/scripts/board_open_items.py
+++ b/scripts/board_open_items.py
@@ -264,23 +264,39 @@ def matches_filter(it: dict[str, Any], args: argparse.Namespace) -> bool:
     return True
 
 
-def format_table(items: list[dict[str, Any]], now: datetime | None = None) -> str:
+def format_table(
+    items: list[dict[str, Any]],
+    now: datetime | None = None,
+    arc_columns: bool = False,
+) -> str:
     if not items:
         return "(no items matched)\n"
     if now is None:
         now = datetime.now(timezone.utc)
+    # Arc/phase columns are opt-in (--arc-columns): the base table is already wide,
+    # and arc only matters for an arc-scoped sweep (e.g. after --arc-phase active,
+    # where the human table otherwise can't show which arc each issue belongs to —
+    # only --json exposes it). Issue #689.
+    arc_hdr = f"{'Arc':<18} {'Ph':<7} " if arc_columns else ""
+    arc_sep = f"{'-' * 18} {'-' * 7} " if arc_columns else ""
     lines = [
-        f"{'Status':<17} {'P':<3} {'Sz':<3} {'Age':<5} {'Role':<17} {'Kind':<5} {'#':<5} Title",
-        f"{'-' * 17} {'-' * 3} {'-' * 3} {'-' * 5} {'-' * 17} {'-' * 5} {'-' * 5} {'-' * 60}",
+        f"{'Status':<17} {'P':<3} {'Sz':<3} {'Age':<5} {'Role':<17} {'Kind':<5} {'#':<5} {arc_hdr}Title",
+        f"{'-' * 17} {'-' * 3} {'-' * 3} {'-' * 5} {'-' * 17} {'-' * 5} {'-' * 5} {arc_sep}{'-' * 60}",
     ]
     for it in items:
         role = (it["role"] or "(none)").removeprefix("role:")[:16]
         kind = it["kind"] + ("/D" if it["is_draft"] else "")
         title = (it["title"] or "")[:60]
         age = age_label(it.get("updated_at"), now)
+        if arc_columns:
+            arc = (it["arc"] or "—").removeprefix("arc:")[:17]
+            phase = it["arc_phase"] or "—"  # fixed vocab: active/next/later
+            arc_cell = f"{arc:<18} {phase:<7} "
+        else:
+            arc_cell = ""
         lines.append(
             f"{it['status']:<17} {it['priority'] or '?':<3} {it['size'] or '?':<3} "
-            f"{age:<5} {role:<17} {kind:<5} {it['number']:<5} {title}"
+            f"{age:<5} {role:<17} {kind:<5} {it['number']:<5} {arc_cell}{title}"
         )
     return "\n".join(lines) + "\n"
 
@@ -294,6 +310,9 @@ def main() -> int:
     p.add_argument("--arc", help='Filter by arc label (e.g. "scoring-tcr-pmhc" or "arc:scoring-tcr-pmhc")')
     p.add_argument("--arc-phase", dest="arc_phase", choices=["active", "next", "later"],
                    help="Filter by arc focus phase")
+    p.add_argument("--arc-columns", dest="arc_columns", action="store_true",
+                   help="Add Arc + phase columns to the table (slug after 'arc:'); "
+                        "useful with --arc-phase active to see each issue's arc")
     p.add_argument("--sort-updated", dest="sort_updated", action="store_true",
                    help="Sort by last activity (Issue.updatedAt), most-recent first (momentum)")
     p.add_argument("--stale-days", dest="stale_days", type=int, metavar="N",
@@ -326,7 +345,7 @@ def main() -> int:
         json.dump(filtered, sys.stdout, indent=2)
         sys.stdout.write("\n")
     else:
-        sys.stdout.write(format_table(filtered, now=now))
+        sys.stdout.write(format_table(filtered, now=now, arc_columns=args.arc_columns))
     return 0
 
 

--- a/scripts/board_open_items.py
+++ b/scripts/board_open_items.py
@@ -312,7 +312,8 @@ def main() -> int:
                    help="Filter by arc focus phase")
     p.add_argument("--arc-columns", dest="arc_columns", action="store_true",
                    help="Add Arc + phase columns to the table (slug after 'arc:'); "
-                        "useful with --arc-phase active to see each issue's arc")
+                        "useful with --arc-phase active to see each issue's arc "
+                        "(ignored with --json, which already exposes arc/arc_phase)")
     p.add_argument("--sort-updated", dest="sort_updated", action="store_true",
                    help="Sort by last activity (Issue.updatedAt), most-recent first (momentum)")
     p.add_argument("--stale-days", dest="stale_days", type=int, metavar="N",

--- a/scripts/pm/apply_arc_labels.sh
+++ b/scripts/pm/apply_arc_labels.sh
@@ -7,9 +7,12 @@
 #   1. removes any arc:* / arc-phase:* label NOT matching the manifest pair, then
 #   2. adds the manifest-correct arc + arc-phase.
 # So after an arc-review slate change (a phase edit, a re-tag, a split/merge in
-# arc_taxonomy.tsv) a re-run leaves each issue with exactly its manifest pair —
-# the TSV stays authoritative. Idempotent: a no-op manifest re-applies the same
-# labels and removes nothing.
+# arc_taxonomy.tsv) a re-run leaves each LISTED issue with exactly its manifest
+# pair — the TSV is authoritative for every issue it lists. (Scope note: an issue
+# silently *removed* from the manifest keeps its old arc labels; de-labeling a
+# dropped issue would need a separate full `gh issue list --label arc:*` sweep,
+# out of scope here.) Idempotent: a no-op manifest re-applies the same labels and
+# removes nothing.
 #
 # Prereq: run scripts/pm/arc_labels.sh first (the labels must exist in the repo).
 set -euo pipefail

--- a/scripts/pm/apply_arc_labels.sh
+++ b/scripts/pm/apply_arc_labels.sh
@@ -1,8 +1,17 @@
 #!/usr/bin/env bash
 # scripts/pm/apply_arc_labels.sh
-# Apply arc:* + arc-phase:* labels to issues per scripts/pm/arc_taxonomy.tsv.
-# Idempotent: gh add-label of an already-present label is a no-op.
-# Prereq: run scripts/pm/arc_labels.sh first (labels must exist).
+# Re-sync arc:* + arc-phase:* labels on issues to match scripts/pm/arc_taxonomy.tsv.
+#
+# True re-sync (Issue #689), not add-only: each manifest line lists one arc, one
+# arc-phase, and the issues under it. For every listed issue this:
+#   1. removes any arc:* / arc-phase:* label NOT matching the manifest pair, then
+#   2. adds the manifest-correct arc + arc-phase.
+# So after an arc-review slate change (a phase edit, a re-tag, a split/merge in
+# arc_taxonomy.tsv) a re-run leaves each issue with exactly its manifest pair —
+# the TSV stays authoritative. Idempotent: a no-op manifest re-applies the same
+# labels and removes nothing.
+#
+# Prereq: run scripts/pm/arc_labels.sh first (the labels must exist in the repo).
 set -euo pipefail
 REPO="Jin-HoMLee/splice-neoepitope-pipeline"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -11,10 +20,27 @@ MANIFEST="${1:-$SCRIPT_DIR/arc_taxonomy.tsv}"
 
 while read -r arc phase rest || [[ -n "${arc:-}" ]]; do
   [[ -z "${arc:-}" || "${arc:0:1}" == "#" ]] && continue
+  want_phase="arc-phase:$phase"
   for n in $rest; do
-    echo "  #$n -> $arc + arc-phase:$phase"
+    # Collect the issue's current arc:* / arc-phase:* labels, then flag for removal
+    # any that aren't the manifest-correct pair. read-loop (not mapfile) + guarded
+    # array expansion keep this bash 3.2-compatible (macOS default shell).
+    remove_args=()
+    while IFS= read -r lbl; do
+      [[ -z "$lbl" ]] && continue
+      [[ "$lbl" == "$arc" || "$lbl" == "$want_phase" ]] && continue
+      remove_args+=(--remove-label "$lbl")
+    done < <(gh issue view "$n" --repo "$REPO" --json labels \
+              --jq '.labels[].name | select(startswith("arc:") or startswith("arc-phase:"))')
+
+    if [[ ${#remove_args[@]} -gt 0 ]]; then
+      echo "  #$n -> $arc + $want_phase (removing stale: ${remove_args[*]//--remove-label/})"
+    else
+      echo "  #$n -> $arc + $want_phase"
+    fi
     gh issue edit "$n" --repo "$REPO" \
-      --add-label "$arc" --add-label "arc-phase:$phase"
+      --add-label "$arc" --add-label "$want_phase" \
+      ${remove_args[@]+"${remove_args[@]}"}
   done
 done < "$MANIFEST"
-echo "Done applying arc taxonomy from $MANIFEST."
+echo "Done re-syncing arc taxonomy from $MANIFEST."

--- a/scripts/pm/recheck_milestone.py
+++ b/scripts/pm/recheck_milestone.py
@@ -184,6 +184,35 @@ def sizes_for_issues(issue_numbers: list[int]) -> dict[int, str | None]:
     return sizes
 
 
+def parent_numbers(issue_numbers: list[int]) -> set[int]:
+    """Subset of issue_numbers that are parent epics (subIssuesSummary.total > 0).
+
+    Parents carry no Size by convention — size rolls up from their sub-issues
+    (shared/feedback_parent_sub_issues.md). compute_recheck excludes them from
+    both the capacity sum and the unsized-check, so a milestone holding a parent
+    as a roadmap anchor doesn't emit a spurious, un-clearable [UNSIZED] flag
+    (Issue #689 — sizing the parent to clear it would itself violate the
+    no-size convention).
+    """
+    if not issue_numbers:
+        return set()
+    owner, name = REPO.split("/")
+    aliases = " ".join(
+        f"i{n}: issue(number: {n}) {{ subIssuesSummary {{ total }} }}"
+        for n in issue_numbers
+    )
+    query = f'query {{ repository(owner: "{owner}", name: "{name}") {{ {aliases} }} }}'
+    data = gh("api", "graphql", "-f", f"query={query}")
+    repo = data["data"]["repository"]
+    parents: set[int] = set()
+    for n in issue_numbers:
+        node = repo.get(f"i{n}") or {}
+        total = (node.get("subIssuesSummary") or {}).get("total") or 0
+        if total > 0:
+            parents.add(n)
+    return parents
+
+
 def compute_recheck(milestone_number: int) -> int:
     meta = milestone_meta(milestone_number)
     title = meta["title"]
@@ -195,12 +224,23 @@ def compute_recheck(milestone_number: int) -> int:
 
     issue_numbers = open_issues_in_milestone(title)
     sizes = sizes_for_issues(issue_numbers)
+    parents = parent_numbers(issue_numbers)
 
     print(f"Milestone: {title}")
     print(f"Current due_on: {current_due_date or '—'}")
     print(f"Open issues ({len(issue_numbers)}):")
     remaining = 0.0
+    leaf_numbers: list[int] = []
     for n in sorted(issue_numbers):
+        # Parent epics are roadmap anchors only — they carry no Size by convention
+        # (size rolls up from sub-issues, shared/feedback_parent_sub_issues.md), so
+        # exclude them from both the capacity sum and the unsized-check below. Without
+        # this a parent-anchored milestone emits an un-clearable [UNSIZED] flag
+        # (Issue #689; surfaced 2026-06-11 on pm-i6 with parents #527/#538).
+        if n in parents:
+            print(f"  - #{n} (parent epic — excluded; size rolls up from sub-issues)")
+            continue
+        leaf_numbers.append(n)
         size = sizes.get(n)
         weight = SIZE_WEIGHTS.get(size or "", 0)
         remaining += weight
@@ -208,14 +248,15 @@ def compute_recheck(milestone_number: int) -> int:
         print(f"  - #{n} ({size_disp})")
     print(f"Remaining capacity: {remaining}d")
 
-    # Any unsized open issue makes the capacity read unreliable: the size-weighted
-    # sum silently under-counts true remaining work, which then drives a
-    # confident-but-bogus due_on proposal (the 2026-06-03 pm-i6 under-read — one
+    # Any unsized open LEAF issue makes the capacity read unreliable: the
+    # size-weighted sum silently under-counts true remaining work, which then drives
+    # a confident-but-bogus due_on proposal (the 2026-06-03 pm-i6 under-read — one
     # sized issue + two unsized yielded 1.0d and a spurious -28d slip; Issue #618
     # AC2). Flag and bail BEFORE computing a due date, regardless of whether the
     # sized subset happens to be > 0 — previously this guard was nested inside the
     # `remaining == 0` branch and so was bypassed whenever even one issue had a size.
-    unsized_count = sum(1 for n in issue_numbers if sizes.get(n) is None)
+    # Parents are excluded above, so an unsized parent never trips this (Issue #689).
+    unsized_count = sum(1 for n in leaf_numbers if sizes.get(n) is None)
     if unsized_count > 0:
         floor = f"; sized subset {remaining}d is a floor" if remaining else ""
         print(f"Proposed due_on: (cannot compute — {unsized_count} open issue(s) missing Size{floor})")

--- a/scripts/tests/test_apply_arc_labels_resync.py
+++ b/scripts/tests/test_apply_arc_labels_resync.py
@@ -1,0 +1,92 @@
+"""Stubbed-gh tests for scripts/pm/apply_arc_labels.sh re-sync (Issue #689).
+
+The script is exercised with a fake ``gh`` on PATH so the re-sync logic is
+verified deterministically, with no live-board mutation:
+  - ``gh issue view N ... --json labels --jq ...`` → the canned arc/arc-phase
+    labels for issue N (from a ``LABELS_<N>`` env var), one per line.
+  - ``gh issue edit N ...``                        → the full argv, appended to
+    ``$GH_EDIT_LOG``.
+"""
+
+import os
+import subprocess
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parents[1] / "pm" / "apply_arc_labels.sh"
+
+_FAKE_GH = (
+    "#!/usr/bin/env bash\n"
+    'if [[ "$1" == "issue" && "$2" == "view" ]]; then\n'
+    '  varname="LABELS_$3"\n'
+    "  printf '%s\\n' ${!varname:-}\n"
+    "  exit 0\n"
+    "fi\n"
+    'if [[ "$1" == "issue" && "$2" == "edit" ]]; then\n'
+    '  echo "$*" >> "$GH_EDIT_LOG"\n'
+    "  exit 0\n"
+    "fi\n"
+    "exit 0\n"
+)
+
+
+def _run(tmp_path, manifest_text, labels):
+    gh = tmp_path / "gh"
+    gh.write_text(_FAKE_GH)
+    gh.chmod(0o755)
+    manifest = tmp_path / "arc_taxonomy.tsv"
+    manifest.write_text(manifest_text)
+    log = tmp_path / "edit.log"
+    env = dict(os.environ)
+    env["PATH"] = f"{tmp_path}:{env['PATH']}"
+    env["GH_EDIT_LOG"] = str(log)
+    for n, lbls in labels.items():
+        env[f"LABELS_{n}"] = lbls
+    subprocess.run(
+        ["bash", str(SCRIPT), str(manifest)],
+        env=env, check=True, capture_output=True, text=True,
+    )
+    return log.read_text() if log.exists() else ""
+
+
+def test_removes_stale_arc_and_phase(tmp_path):
+    # #5 mislabeled arc:old + arc-phase:later; manifest says board-governance/active.
+    log = _run(tmp_path, "arc:board-governance\tactive\t5\n",
+               {5: "arc:old arc-phase:later"})
+    assert "--add-label arc:board-governance" in log
+    assert "--add-label arc-phase:active" in log
+    assert "--remove-label arc:old" in log
+    assert "--remove-label arc-phase:later" in log
+
+
+def test_noop_manifest_removes_nothing(tmp_path):
+    # Already-correct issue → re-applies labels, removes nothing (idempotent).
+    log = _run(tmp_path, "arc:board-governance\tactive\t5\n",
+               {5: "arc:board-governance arc-phase:active"})
+    assert "--add-label arc:board-governance" in log
+    assert "--remove-label" not in log
+
+
+def test_phase_flip_removes_only_old_phase(tmp_path):
+    # Correct arc, stale phase (next → active): only the phase label churns.
+    log = _run(tmp_path, "arc:board-governance\tactive\t5\n",
+               {5: "arc:board-governance arc-phase:next"})
+    assert "--remove-label arc-phase:next" in log
+    assert "--remove-label arc:board-governance" not in log
+    assert "--add-label arc-phase:active" in log
+
+
+def test_retag_removes_only_old_arc(tmp_path):
+    # Re-tagged to a different arc, same phase: only the arc label churns.
+    log = _run(tmp_path, "arc:board-governance\tactive\t5\n",
+               {5: "arc:memory-methodology arc-phase:active"})
+    assert "--remove-label arc:memory-methodology" in log
+    assert "--remove-label arc-phase:active" not in log
+    assert "--add-label arc:board-governance" in log
+
+
+def test_comment_and_blank_lines_skipped(tmp_path):
+    # Only the real manifest row (#5) produces an edit; comment/blank lines don't.
+    log = _run(tmp_path, "# comment\n\narc:board-governance\tactive\t5\n", {5: ""})
+    edits = [ln for ln in log.splitlines() if ln.strip()]
+    assert len(edits) == 1
+    assert edits[0].split()[2] == "5"  # issue edit <N> ...

--- a/scripts/tests/test_board_open_items_arc.py
+++ b/scripts/tests/test_board_open_items_arc.py
@@ -57,3 +57,28 @@ def test_filter_by_arc_slug_accepts_short_and_full_form():
     assert b.matches_filter(it, _args(arc="scoring-tcr-pmhc"))
     assert b.matches_filter(it, _args(arc="arc:scoring-tcr-pmhc"))
     assert not b.matches_filter(it, _args(arc="cloud-reproducibility"))
+
+
+def test_format_table_omits_arc_columns_by_default():
+    it = b.normalize(_item(["role:pm", "arc:board-governance", "arc-phase:active"]))
+    out = b.format_table([it])
+    assert "Arc" not in out.splitlines()[0]
+    assert "board-governance" not in out
+
+
+def test_format_table_arc_columns_render_slug_and_phase():
+    it = b.normalize(_item(["role:pm", "arc:board-governance", "arc-phase:active"]))
+    out = b.format_table([it], arc_columns=True)
+    header = out.splitlines()[0]
+    assert "Arc" in header and "Ph" in header
+    # slug is shown without the "arc:" prefix
+    assert "board-governance" in out
+    assert "arc:board-governance" not in out
+    assert "active" in out
+
+
+def test_format_table_arc_columns_handle_missing_arc():
+    it = b.normalize(_item(["role:pm"]))  # no arc / phase labels
+    out = b.format_table([it], arc_columns=True)
+    assert "Arc" in out.splitlines()[0]
+    assert "—" in out  # placeholder, no crash

--- a/tools/ci/test_recheck_milestone.py
+++ b/tools/ci/test_recheck_milestone.py
@@ -264,10 +264,11 @@ class TestComputeRecheckUnsizedGuard:
     An unreliable capacity read must not produce a confident due_on recommendation.
     """
 
-    def _patch_board(self, monkeypatch, *, title, due_on, issues, sizes):
+    def _patch_board(self, monkeypatch, *, title, due_on, issues, sizes, parents=()):
         monkeypatch.setattr(rm, "milestone_meta", lambda n: {"title": title, "due_on": due_on})
         monkeypatch.setattr(rm, "open_issues_in_milestone", lambda t: list(issues))
         monkeypatch.setattr(rm, "sizes_for_issues", lambda ns: dict(sizes))
+        monkeypatch.setattr(rm, "parent_numbers", lambda ns: set(parents))
 
     def test_mixed_sized_and_unsized_flags_unsized_not_update(self, monkeypatch, capsys):
         self._patch_board(
@@ -342,6 +343,90 @@ class TestComputeRecheckUnsizedGuard:
         out = capsys.readouterr().out
         assert "[UNSIZED]" not in out
         assert "Proposed due_on:" in out
+
+
+class TestComputeRecheckParentSkip:
+    """compute_recheck must exclude parent epics (subIssuesSummary.total > 0) from
+    both the capacity sum and the unsized-check (Issue #689).
+
+    A parent carries no Size by convention (size rolls up from its sub-issues —
+    shared/feedback_parent_sub_issues.md), so a milestone holding a parent as a
+    roadmap anchor must not emit a spurious, un-clearable [UNSIZED] flag.
+    Reproduces the 2026-06-11 pm-i6 case: parents #527/#538 + sized leaf #539.
+    """
+
+    def _patch_board(self, monkeypatch, *, title, due_on, issues, sizes, parents):
+        monkeypatch.setattr(rm, "milestone_meta", lambda n: {"title": title, "due_on": due_on})
+        monkeypatch.setattr(rm, "open_issues_in_milestone", lambda t: list(issues))
+        monkeypatch.setattr(rm, "sizes_for_issues", lambda ns: dict(sizes))
+        monkeypatch.setattr(rm, "parent_numbers", lambda ns: set(parents))
+
+    def _freeze_today(self, monkeypatch, fake_today):
+        class _FakeDate(date):
+            @classmethod
+            def today(cls):
+                return fake_today
+        monkeypatch.setattr(rm, "date", _FakeDate)
+
+    def test_parents_excluded_no_unsized_flag(self, monkeypatch, capsys):
+        # pm-i6: parents #527/#538 (unsized by convention) + sized leaf #539.
+        # Pre-#689 this flagged [UNSIZED]; now the parents are excluded and the
+        # due date computes from the leaf's 1.0d alone.
+        self._patch_board(
+            monkeypatch,
+            title="pm-i6 - PM Tooling, Memory & Methodology II",
+            due_on="2026-07-02T00:00:00Z",
+            issues=[527, 538, 539],
+            sizes={527: None, 538: None, 539: "S"},
+            parents=[527, 538],
+        )
+        monkeypatch.setattr(rm, "gh", lambda *a, **k: [])  # no other milestones for layered calc
+        self._freeze_today(monkeypatch, date(2026, 6, 11))
+
+        rc = rm.compute_recheck(33)
+        out = capsys.readouterr().out
+
+        assert "[UNSIZED]" not in out
+        assert out.count("parent epic — excluded") == 2  # #527 and #538
+        assert "Remaining capacity: 1.0d" in out  # only #539 (S) counted
+        assert "Proposed due_on:" in out  # due-date path reached, not bailed
+        assert rc in (0, 2)  # a real recommendation, not a crash
+
+    def test_milestone_with_only_parent_is_no_change(self, monkeypatch, capsys):
+        # A roadmap-anchor parent alone → no countable leaf capacity, no [UNSIZED].
+        self._patch_board(
+            monkeypatch,
+            title="pm-i6 - PM Tooling, Memory & Methodology II",
+            due_on="2026-07-02T00:00:00Z",
+            issues=[538],
+            sizes={538: None},
+            parents=[538],
+        )
+        monkeypatch.setattr(rm, "gh", lambda *a, **k: pytest.fail("should not compute due date"))
+        rc = rm.compute_recheck(33)
+        out = capsys.readouterr().out
+        assert rc == 0
+        assert "[No change]" in out
+        assert "[UNSIZED]" not in out
+
+    def test_unsized_leaf_still_flagged_with_parent_present(self, monkeypatch, capsys):
+        # Parent excluded, but a genuinely unsized LEAF still trips [UNSIZED]:
+        # the convention only exempts parents, not unsized leaf/standalone work.
+        self._patch_board(
+            monkeypatch,
+            title="pm-i6 - PM Tooling, Memory & Methodology II",
+            due_on="2026-07-02T00:00:00Z",
+            issues=[538, 539, 540],
+            sizes={538: None, 539: "S", 540: None},
+            parents=[538],
+        )
+        monkeypatch.setattr(rm, "gh", lambda *a, **k: pytest.fail(
+            "should not compute due date while a leaf is unsized"))
+        rc = rm.compute_recheck(33)
+        out = capsys.readouterr().out
+        assert rc == 2
+        assert "[UNSIZED]" in out
+        assert "1 open issue(s) missing Size" in out  # only #540, not the parent #538
 
 
 @pytest.mark.live


### PR DESCRIPTION
Closes #689.

Three deferred/surfaced PM-tooling items from the arc work-structuring strand (the #633 arc/milestone follow-ups + the 2026-06-11 pm-i6 false-positive).

## Items
1. **`board_open_items.py` — `--arc-columns` flag.** Opt-in Arc + phase columns (slug after `arc:`). The base table is already wide, so it's behind a flag; most useful paired with `--arc-phase active`, where the human table otherwise can't show which arc each issue belongs to (only `--json` did).
2. **`apply_arc_labels.sh` — true re-sync, not add-only.** Removes any `arc:*` / `arc-phase:*` label not matching `arc_taxonomy.tsv` before adding the manifest-correct pair, so a re-run after a slate change (phase edit, re-tag, split/merge) leaves each issue with exactly its manifest pair — the TSV stays authoritative. Portable to bash 3.2 (no `mapfile`; guarded empty-array expansion under `set -u`).
3. **`recheck_milestone.py` — skip parent epics in the capacity sum.** Parents (`subIssuesSummary.total > 0`) carry no Size by convention (size rolls up from sub-issues), so a milestone holding a parent as a roadmap anchor emitted a spurious, un-clearable `[UNSIZED]` flag. Now excluded from both the capacity sum and the unsized-check.

## Test plan
- [x] `recheck_milestone.py` parent-skip unit tests pass (parents excluded; only-parent → `[No change]`; unsized leaf still flags `[UNSIZED]`) — `tools/ci/test_recheck_milestone.py`, 42 passed.
- [x] Existing `#618` unsized-guard tests still pass unchanged (parents default-empty in the patched board helper).
- [x] Live-verified against `pm-i6`: `#527/#538/#539` now show "parent epic — excluded", no `[UNSIZED]`; capacity reads `6.0d` from the real leaves (`#569 M + #696 L`).
- [x] `apply_arc_labels.sh` re-sync verified via stubbed-`gh` tests (removes stale arc, removes stale phase only on flip, removes stale arc only on retag, no-op manifest removes nothing, comment/blank lines skipped) — `scripts/tests/test_apply_arc_labels_resync.py`.
- [x] `bash -n` syntax check passes on `apply_arc_labels.sh`.
- [x] `board_open_items.py` Arc-column render tests pass (omitted by default; slug+phase shown with `--arc-columns`; missing-arc placeholder) — `scripts/tests/test_board_open_items_arc.py`; live smoke confirms rendering.
- [x] Full suites green: `scripts/tests/` 14 passed, `tools/ci/` 261 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
