### PR TITLE
chore(star): STAR sensitivity-flag benchmark sweep script (#411)

### DIFF
--- a/research/lab_notebook/developer.md
+++ b/research/lab_notebook/developer.md
@@ -6,6 +6,39 @@ Format and rules unchanged from the unified notebook — see `shared/feedback_la
 
 ---
 
+## 2026-06-12 — STAR sensitivity-flag benchmark sweep shipped ([PR #720](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/720) closes [Issue #411](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/411))
+
+### 17:11 UTC — Editor: Developer
+
+**Headline:** Landed `scripts/star_flag_sweep.sh` — the deferred Nature-recipe STAR sensitivity flags benchmarked one-at-a-time on patient_002 tumor, CPU-only on the warm prod VM. [Issue #411](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/411) is scoped to the **measurement**; the adopt/reject interpretation is delegated to [Issue #719](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/719) (Scientist) and the config change to [Issue #725](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/725) (Developer, blocked on #719).
+
+**The 8-variant run** (baseline = production STAR config; patient_002 tumor):
+
+| variant | total SJ | Δtotal | novel | Δnovel | uniq-supported | Δuniq | multi-loci % |
+|---|---|---|---|---|---|---|---|
+| baseline | 258163 | — | 531 | — | 247591 | — | 3.21 |
+| matchNmin_0.33 | 258163 | 0 | 531 | 0 | 247591 | 0 | 3.21 |
+| scoreMin_0.33 | 258338 | +175 | 540 | +9 | 247736 | +145 | 3.21 |
+| multimap_20 | 259086 | +923 | 626 | +95 | 247570 | −21 | 3.25 |
+| intronMax_500k | 258104 | −59 | 503 | −28 | 247619 | +28 | 3.22 |
+| matesGap_1M | 258937 | +774 | 553 | +22 | 248229 | +638 | 3.27 |
+| sjOverhang_1 | 272360 | +14197 | 532 | +1 | 253663 | +6072 | 3.73 |
+| noGTF_index | 244604 | −13559 | 1195 | (n/c) | 233367 | −14224 | 3.21 |
+
+Raw artifacts (per-variant `SJ.out.tab` + `Log.final.out`, `sweep_metrics.tsv`, `summary_table.md`) in GCS at `gs://splice-neoepitope-project/experiments/issue_411_star_flag_sweep/`.
+
+**Reading the numbers** (deferred to #719 for the formal call, but the dev-side observations that motivated the precision-weighted framing):
+- Ranking on **uniq-supported** (≥1 unique read = confident-recall proxy) rather than raw novel count changes the picture. `sjOverhang_1` is the biggest mover (+6072 uniq) but at a precision cost — multi-loci % jumps 3.21→3.73. `matesGap_1M` is the cleanest gain (+638 uniq, multi-loci near-flat). `multimap_20`'s headline +95 novel is **uniq −21** — i.e. the extra junctions are multi-mapper-only; exactly the precision concern #719 adjudicates.
+- `matchNmin_0.33` was **byte-identical to baseline** — matchNmin and scoreMin are ANDed and both default 0.66, so lowering matchNmin alone is inert (scoreMin stays binding). Worth a *combined* permissive variant in #719, not the single knob.
+- `noGTF_index` `novel` is **not comparable** to the GTF variants: under `--twopassMode Basic` with no GTF, STAR rebuilds the sjdb from 1st-pass discoveries, so col-6 "annotated" = "found in pass 1", not "in GENCODE". The honest read is total + uniq both drop sharply — removing the GTF reduces sensitivity.
+
+**Process notes:**
+- The sweep is idempotent + fault-tolerant (per-variant SKIP on a complete run, index-reuse sentinels, `REUSE_BASELINE_DIR` to skip re-aligning the prod baseline, atomic FASTQ download). The overnight run was interrupted after 7 variants; it resumed and completed only the missing `noGTF_index` on relaunch. Two prior fixes got it unattended-clean: `--http1.1` + retries for B2's HTTP/2 flakiness, and dropping `--sjdbOverhang` from the no-GTF index build (STAR rejects >0 overhang without annotations).
+- **Bot review** (`@claude review`) approved-to-merge with 1 Medium + 4 minor. Applied 4 in `fb7fc77`: an `align.done` completion sentinel so a SIGKILL-truncated `SJ.out.tab` isn't mistaken for a complete run on resume (the bot's literal guard would have broken `REUSE_BASELINE_DIR`, which stages a baseline with no sentinel — fixed by touching it there too); `noGTF_index` TSV flag-column label; `novel` column in the emitted table; an intent comment on the GTF-index hard-abort. Declined the `trap`-override nit (only EXIT trap, one-shot branch — no current bug).
+- **Close-out structure:** #411 re-scoped to benchmark-only (7 sensitivity flags ticked; the BAM-emission item marked out-of-scope — not a sensitivity flag, no downstream BAM consumer). The adopt decision is split across #719 (interpretation) and #725 (config change), with #725 natively `blocked_by` #719 via GitHub's dependency graph (prose-only "blocked on" creates no machine edge — caught and fixed this session).
+
+---
+
 ## 2026-06-11 — Flatten `predictions/` wrapper dir merged: tool-named sibling folders + doc-sync ([PR #650](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/650) closes [Issue #435](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/435))
 
 ### 16:05 UTC — Editor: Developer

--- a/scripts/star_flag_sweep.sh
+++ b/scripts/star_flag_sweep.sh
@@ -139,15 +139,23 @@ run_variant() {
     mkdir -p "$outdir"
     log "RUN  ${label}   extra: ${extra[*]:-<none>}"
     local t0 t1; t0=$(date +%s)
-    STAR --runMode alignReads --runThreadN "$THREADS" \
+    # Tolerate a single variant's failure: log it and skip, but keep the sweep
+    # going so one bad flag does not lose the whole unattended run. (STAR in an
+    # if-condition is exempt from set -e.)
+    if STAR --runMode alignReads --runThreadN "$THREADS" \
          --genomeDir "$index_dir" \
          --readFilesIn "$FASTQ1" "$FASTQ2" --readFilesCommand zcat \
          --outFileNamePrefix "$prefix" \
-         "${BASELINE_FLAGS[@]}" "${extra[@]}"
-    t1=$(date +%s); echo $((t1 - t0)) > "${outdir}/runtime_s.txt"
+         "${BASELINE_FLAGS[@]}" "${extra[@]}"; then
+      t1=$(date +%s); echo $((t1 - t0)) > "${outdir}/runtime_s.txt"
+    else
+      log "!! ${label} FAILED (STAR nonzero) — skipping this variant, continuing sweep"
+      return 0
+    fi
   fi
 
-  # Metrics
+  # Metrics (guard: only emit a row if an SJ.out.tab actually exists)
+  [[ -s "$sjtab" ]] || { log "!! ${label}: no SJ.out.tab — no metrics row"; return 0; }
   local secs total annot novel pct uniq multi toomany flagstr
   secs=$(cat "${outdir}/runtime_s.txt" 2>/dev/null || echo NA)
   total=$(wc -l < "$sjtab")
@@ -164,6 +172,22 @@ run_variant() {
 }
 
 # ── Step 2: baseline ─────────────────────────────────────────────────────────
+# Reuse a config-identical existing production STAR run as the baseline column
+# (set REUSE_BASELINE_DIR) rather than recomputing it. The existing run MUST be
+# the same prod star_align config: same index, same FASTQs, same 2-pass flags,
+# same STAR build. We stage its raw artifacts into the baseline outdir; run_variant
+# then sees the SJ.out.tab as "already present" and only computes the metrics row.
+if [[ -n "${REUSE_BASELINE_DIR:-}" ]]; then
+  if [[ -s "${REUSE_BASELINE_DIR}/star_SJ.out.tab" && -s "${REUSE_BASELINE_DIR}/star_Log.final.out" ]]; then
+    log "Reusing existing baseline from $REUSE_BASELINE_DIR (no recompute)"
+    mkdir -p "${OUTROOT}/baseline"
+    cp -f "${REUSE_BASELINE_DIR}/star_SJ.out.tab"    "${OUTROOT}/baseline/star_SJ.out.tab"
+    cp -f "${REUSE_BASELINE_DIR}/star_Log.final.out" "${OUTROOT}/baseline/star_Log.final.out"
+    echo "reused" > "${OUTROOT}/baseline/runtime_s.txt"
+  else
+    log "!! REUSE_BASELINE_DIR set but artifacts missing — falling back to a fresh baseline run"
+  fi
+fi
 run_variant "baseline" "$INDEX_DIR"
 
 # ── Step 3: one-flag-at-a-time variants (1–6) ────────────────────────────────
@@ -179,15 +203,22 @@ if [[ -f "${NOGTF_INDEX_DIR}/index.done" || -f "${NOGTF_INDEX_DIR}/SAindex" ]]; 
 else
   log "Building no-GTF STAR index → $NOGTF_INDEX_DIR (separate from prod cache)"
   mkdir -p "$NOGTF_INDEX_DIR"
-  STAR --runMode genomeGenerate --runThreadN "$THREADS" \
+  if STAR --runMode genomeGenerate --runThreadN "$THREADS" \
        --genomeDir "$NOGTF_INDEX_DIR" --genomeFastaFiles "$GENOME" \
-       --sjdbOverhang 100
-  touch "${NOGTF_INDEX_DIR}/index.done"
+       --sjdbOverhang 100; then
+    touch "${NOGTF_INDEX_DIR}/index.done"
+  else
+    log "!! no-GTF index build FAILED — skipping noGTF_index variant"
+  fi
 fi
 # NOTE: with no sjdb in the index, EVERY junction is reported as novel (col 6 == 0)
 # by construction — % annotated is meaningless for this variant; compare on total
 # and unique-supported counts.
-run_variant "noGTF_index" "$NOGTF_INDEX_DIR"
+if [[ -f "${NOGTF_INDEX_DIR}/SAindex" ]]; then
+  run_variant "noGTF_index" "$NOGTF_INDEX_DIR"
+else
+  log "!! skipping noGTF_index (no usable index)"
+fi
 
 # ── Step 5: summary table (markdown, ready to paste into developer.md) ────────
 log "Sweep complete. Metrics → $RESULTS_TSV"

--- a/scripts/star_flag_sweep.sh
+++ b/scripts/star_flag_sweep.sh
@@ -118,6 +118,9 @@ else
     GTF_FILE="$(mktemp)"; trap 'rm -f "$GTF_FILE"' EXIT
     gunzip -c "$GTF" > "$GTF_FILE"
   fi
+  # Abort (not skip) on failure is intentional here, unlike Step 4's no-GTF index:
+  # without the GTF index there is no sweep at all, so a hard `set -e` abort is the
+  # correct failure mode rather than the fault-tolerant `if STAR ...` skip pattern.
   STAR --runMode genomeGenerate --runThreadN "$THREADS" \
        --genomeDir "$INDEX_DIR" --genomeFastaFiles "$GENOME" \
        --sjdbGTFfile "$GTF_FILE" --sjdbOverhang 100
@@ -133,8 +136,13 @@ run_variant() {
   local sjtab="${prefix}SJ.out.tab"
   local logfinal="${prefix}Log.final.out"
 
-  if [[ -s "$sjtab" ]]; then
-    log "SKIP ${label} (SJ.out.tab already present)"
+  # Resume only on a COMPLETE run: STAR writes SJ.out.tab incrementally (not an
+  # atomic rename-on-finish), so a SIGKILL mid-alignment can leave a partial,
+  # non-empty SJ.out.tab. The align.done sentinel (touched only after STAR exits 0,
+  # and staged alongside a reused baseline below) distinguishes complete from
+  # truncated, so a resume never computes metrics off a half-written file.
+  if [[ -s "$sjtab" && -f "${outdir}/align.done" ]]; then
+    log "SKIP ${label} (complete run already present)"
   else
     mkdir -p "$outdir"
     log "RUN  ${label}   extra: ${extra[*]:-<none>}"
@@ -148,6 +156,7 @@ run_variant() {
          --outFileNamePrefix "$prefix" \
          "${BASELINE_FLAGS[@]}" "${extra[@]}"; then
       t1=$(date +%s); echo $((t1 - t0)) > "${outdir}/runtime_s.txt"
+      touch "${outdir}/align.done"   # completion sentinel (see resume guard above)
     else
       log "!! ${label} FAILED (STAR nonzero) — skipping this variant, continuing sweep"
       return 0
@@ -165,7 +174,11 @@ run_variant() {
   uniq=$(awk '$7>0' "$sjtab" | wc -l)
   multi=$(grep "% of reads mapped to multiple loci" "$logfinal" | awk '{print $NF}' | tr -d '%')
   toomany=$(grep "% of reads mapped to too many loci" "$logfinal" | awk '{print $NF}' | tr -d '%')
-  flagstr="${extra[*]:-<baseline>}"
+  if [[ "$label" == "noGTF_index" ]]; then
+    flagstr="--sjdbGTFfile removed (no-GTF index)"   # not an align flag; an index change
+  else
+    flagstr="${extra[*]:-<baseline>}"
+  fi
   printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
     "$label" "$flagstr" "$total" "$annot" "$novel" "$pct" "$uniq" "${multi:-NA}" "${toomany:-NA}" "$secs" \
     >> "$RESULTS_TSV"
@@ -184,6 +197,7 @@ if [[ -n "${REUSE_BASELINE_DIR:-}" ]]; then
     cp -f "${REUSE_BASELINE_DIR}/star_SJ.out.tab"    "${OUTROOT}/baseline/star_SJ.out.tab"
     cp -f "${REUSE_BASELINE_DIR}/star_Log.final.out" "${OUTROOT}/baseline/star_Log.final.out"
     echo "reused" > "${OUTROOT}/baseline/runtime_s.txt"
+    touch "${OUTROOT}/baseline/align.done"   # staged run is complete → satisfy the resume guard
   else
     log "!! REUSE_BASELINE_DIR set but artifacts missing — falling back to a fresh baseline run"
   fi
@@ -229,8 +243,8 @@ echo
 column -t -s $'\t' "$RESULTS_TSV"
 echo
 {
-  echo "| variant | total SJ | %annot | uniq-supported | multi-loci % | too-many % | runtime s |"
-  echo "|---|---|---|---|---|---|---|"
+  echo "| variant | total SJ | novel | %annot | uniq-supported | multi-loci % | too-many % | runtime s |"
+  echo "|---|---|---|---|---|---|---|---|"
   tail -n +2 "$RESULTS_TSV" | awk -F'\t' \
-    '{printf "| %s | %s | %s | %s | %s | %s | %s |\n",$1,$3,$6,$7,$8,$9,$10}'
+    '{printf "| %s | %s | %s | %s | %s | %s | %s | %s |\n",$1,$3,$5,$6,$7,$8,$9,$10}'
 } | tee "${OUTROOT}/summary_table.md"

--- a/scripts/star_flag_sweep.sh
+++ b/scripts/star_flag_sweep.sh
@@ -1,0 +1,195 @@
+#!/usr/bin/env bash
+#
+# star_flag_sweep.sh — STAR sensitivity-flag benchmark for Issue #411.
+#
+# Benchmarks the deferred Nature-paper STAR flags ONE AT A TIME against the
+# current production baseline (workflow/rules/alignment.smk star_align), on the
+# patient_002 tumor RNA-seq sample. Each variant is measured on:
+#   - total SJ.out.tab junction count
+#   - % annotated (SJ.out.tab col 6 == 1) vs novel (col 6 == 0)
+#   - junctions with >=1 uniquely-mapping read (col 7 > 0)
+#   - wall-clock runtime
+#   - multi-mapper utilization (Log.final.out: % mapped to multiple loci,
+#     and % mapped to too-many loci — the cap's discard bucket)
+#
+# Design notes:
+#   * CPU-only. STAR here emits SJ.out.tab only (--outSAMtype None), no BAM,
+#     no GPU. Run on the (warm) production VM with the P100 idle — Option B.
+#   * The production STAR index (indices/star/, built WITH the GTF) PERSISTS on
+#     the VM disk (it is not a Snakemake temp()); it is reused, not rebuilt.
+#   * The patient_002 FASTQs ARE temp() in the pipeline and get cleaned up after
+#     alignment — so they are re-downloaded once from the public B2 bucket and
+#     reused across every variant.
+#   * The --sjdbGTFfile-removal variant needs a SEPARATE no-GTF index. It builds
+#     to ${NOGTF_INDEX_DIR} (default indices/star_nogtf/) so it does NOT clobber
+#     the production indices/star/ cache (which is not auto-invalidated — a
+#     documented gotcha).
+#   * Idempotent: a variant whose SJ.out.tab already exists is skipped, so an
+#     interrupted sweep resumes cheaply.
+#   * --outSAMtype BAM ... (issue #411 last bullet) is intentionally NOT swept:
+#     it is only needed if a downstream rule consumes a BAM, which the
+#     junction-only pipeline does not. Out of scope for this sensitivity sweep.
+#
+# Usage:
+#   bash scripts/star_flag_sweep.sh            # full sweep (2-pass, faithful)
+#   TWOPASS=None bash scripts/star_flag_sweep.sh   # single-pass quick look (~half the time)
+#   THREADS=16 bash scripts/star_flag_sweep.sh
+#
+# Run inside tmux on the VM; it is a multi-hour unattended job.
+
+set -euo pipefail
+
+# ── Config (env-overridable) ─────────────────────────────────────────────────
+THREADS="${THREADS:-$(nproc)}"
+INDEX_DIR="${INDEX_DIR:-indices/star}"
+NOGTF_INDEX_DIR="${NOGTF_INDEX_DIR:-indices/star_nogtf}"
+GENOME="${GENOME:-references/GRCh38.primary_assembly.genome.fa}"
+GTF="${GTF:-references/gencode.v47.annotation.gtf.gz}"
+OUTROOT="${OUTROOT:-results/star_flag_sweep}"
+TWOPASS="${TWOPASS:-Basic}"   # Basic = production-faithful; None = single-pass quick look
+
+# patient_002 tumor (BG003082_T0), paired-end, from config/samples/patient_002.tsv
+FASTQ_DIR="${FASTQ_DIR:-data/patient_002/BG003082_T0}"
+FASTQ1_URL="https://b2.osteosarc.com/rna-seq/fastq/bostongene_2022/202211_bostongene_tumor_rna_BG003082_R1.fastq.gz"
+FASTQ2_URL="https://b2.osteosarc.com/rna-seq/fastq/bostongene_2022/202211_bostongene_tumor_rna_BG003082_R2.fastq.gz"
+FASTQ1="${FASTQ_DIR}/$(basename "$FASTQ1_URL")"
+FASTQ2="${FASTQ_DIR}/$(basename "$FASTQ2_URL")"
+
+# Baseline align flags = the production star_align command (alignment.smk).
+BASELINE_FLAGS=(
+  --outSAMtype None
+  --twopassMode "$TWOPASS"
+  --limitSjdbInsertNsj 2000000
+)
+
+# Variants: label → extra flag(s) layered on top of the baseline, ONE knob each.
+# (sjdbGTFfile-removal is handled separately — it is an index change, not an
+#  align flag.)
+VARIANT_LABELS=(
+  matchNmin_0.33
+  scoreMin_0.33
+  multimap_20
+  intronMax_500k
+  matesGap_1M
+  sjOverhang_1
+)
+declare -A VARIANT_FLAGS=(
+  [matchNmin_0.33]="--outFilterMatchNminOverLread 0.33"
+  [scoreMin_0.33]="--outFilterScoreMinOverLread 0.33"
+  [multimap_20]="--outFilterMultimapNmax 20"
+  [intronMax_500k]="--alignIntronMax 500000"
+  [matesGap_1M]="--alignMatesGapMax 1000000"
+  [sjOverhang_1]="--alignSJDBoverhangMin 1"
+)
+
+mkdir -p "$OUTROOT"
+RESULTS_TSV="${OUTROOT}/sweep_metrics.tsv"
+printf 'variant\tflag\ttotal_sj\tannotated\tnovel\tpct_annotated\tuniq_supported\tmultiloci_pct\ttoomany_pct\truntime_s\n' > "$RESULTS_TSV"
+
+log()  { printf '\n\033[1;34m[sweep %(%H:%M:%S)T]\033[0m %s\n' -1 "$*"; }
+
+# ── Step 0: FASTQs (download once, reuse) ────────────────────────────────────
+mkdir -p "$FASTQ_DIR"
+for pair in "$FASTQ1_URL|$FASTQ1" "$FASTQ2_URL|$FASTQ2"; do
+  url="${pair%%|*}"; dst="${pair##*|}"
+  if [[ -s "$dst" ]]; then
+    log "FASTQ cached: $dst"
+  else
+    log "Downloading $(basename "$dst") from B2 ..."
+    curl --fail -L --no-progress-meter -o "$dst" "$url"
+  fi
+done
+
+# ── Step 1: baseline index (reuse warm prod index; build only if absent) ─────
+if [[ -f "${INDEX_DIR}/index.done" || -f "${INDEX_DIR}/SAindex" ]]; then
+  log "Reusing existing STAR index: $INDEX_DIR"
+else
+  log "Building STAR index (with GTF) → $INDEX_DIR (this is the ~32 GB-RAM step)"
+  mkdir -p "$INDEX_DIR"
+  GTF_FILE="$GTF"
+  if [[ "$GTF" == *.gz ]]; then
+    GTF_FILE="$(mktemp)"; trap 'rm -f "$GTF_FILE"' EXIT
+    gunzip -c "$GTF" > "$GTF_FILE"
+  fi
+  STAR --runMode genomeGenerate --runThreadN "$THREADS" \
+       --genomeDir "$INDEX_DIR" --genomeFastaFiles "$GENOME" \
+       --sjdbGTFfile "$GTF_FILE" --sjdbOverhang 100
+  touch "${INDEX_DIR}/index.done"
+fi
+
+# ── Helper: run one STAR alignment + record metrics ──────────────────────────
+run_variant() {
+  local label="$1" index_dir="$2"; shift 2
+  local extra=("$@")
+  local outdir="${OUTROOT}/${label}"
+  local prefix="${outdir}/star_"
+  local sjtab="${prefix}SJ.out.tab"
+  local logfinal="${prefix}Log.final.out"
+
+  if [[ -s "$sjtab" ]]; then
+    log "SKIP ${label} (SJ.out.tab already present)"
+  else
+    mkdir -p "$outdir"
+    log "RUN  ${label}   extra: ${extra[*]:-<none>}"
+    local t0 t1; t0=$(date +%s)
+    STAR --runMode alignReads --runThreadN "$THREADS" \
+         --genomeDir "$index_dir" \
+         --readFilesIn "$FASTQ1" "$FASTQ2" --readFilesCommand zcat \
+         --outFileNamePrefix "$prefix" \
+         "${BASELINE_FLAGS[@]}" "${extra[@]}"
+    t1=$(date +%s); echo $((t1 - t0)) > "${outdir}/runtime_s.txt"
+  fi
+
+  # Metrics
+  local secs total annot novel pct uniq multi toomany flagstr
+  secs=$(cat "${outdir}/runtime_s.txt" 2>/dev/null || echo NA)
+  total=$(wc -l < "$sjtab")
+  annot=$(awk '$6==1' "$sjtab" | wc -l)
+  novel=$(awk '$6==0' "$sjtab" | wc -l)
+  pct=$(awk -v a="$annot" -v t="$total" 'BEGIN{printf "%.1f", t?100*a/t:0}')
+  uniq=$(awk '$7>0' "$sjtab" | wc -l)
+  multi=$(grep "% of reads mapped to multiple loci" "$logfinal" | awk '{print $NF}' | tr -d '%')
+  toomany=$(grep "% of reads mapped to too many loci" "$logfinal" | awk '{print $NF}' | tr -d '%')
+  flagstr="${extra[*]:-<baseline>}"
+  printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+    "$label" "$flagstr" "$total" "$annot" "$novel" "$pct" "$uniq" "${multi:-NA}" "${toomany:-NA}" "$secs" \
+    >> "$RESULTS_TSV"
+}
+
+# ── Step 2: baseline ─────────────────────────────────────────────────────────
+run_variant "baseline" "$INDEX_DIR"
+
+# ── Step 3: one-flag-at-a-time variants (1–6) ────────────────────────────────
+for label in "${VARIANT_LABELS[@]}"; do
+  # shellcheck disable=SC2206
+  extra=(${VARIANT_FLAGS[$label]})
+  run_variant "$label" "$INDEX_DIR" "${extra[@]}"
+done
+
+# ── Step 4: --sjdbGTFfile removal (separate no-GTF index) ─────────────────────
+if [[ -f "${NOGTF_INDEX_DIR}/index.done" || -f "${NOGTF_INDEX_DIR}/SAindex" ]]; then
+  log "Reusing existing no-GTF index: $NOGTF_INDEX_DIR"
+else
+  log "Building no-GTF STAR index → $NOGTF_INDEX_DIR (separate from prod cache)"
+  mkdir -p "$NOGTF_INDEX_DIR"
+  STAR --runMode genomeGenerate --runThreadN "$THREADS" \
+       --genomeDir "$NOGTF_INDEX_DIR" --genomeFastaFiles "$GENOME" \
+       --sjdbOverhang 100
+  touch "${NOGTF_INDEX_DIR}/index.done"
+fi
+# NOTE: with no sjdb in the index, EVERY junction is reported as novel (col 6 == 0)
+# by construction — % annotated is meaningless for this variant; compare on total
+# and unique-supported counts.
+run_variant "noGTF_index" "$NOGTF_INDEX_DIR"
+
+# ── Step 5: summary table (markdown, ready to paste into developer.md) ────────
+log "Sweep complete. Metrics → $RESULTS_TSV"
+echo
+column -t -s $'\t' "$RESULTS_TSV"
+echo
+{
+  echo "| variant | total SJ | %annot | uniq-supported | multi-loci % | too-many % | runtime s |"
+  echo "|---|---|---|---|---|---|---|"
+  tail -n +2 "$RESULTS_TSV" | awk -F'\t' \
+    '{printf "| %s | %s | %s | %s | %s | %s | %s |\n",$1,$3,$6,$7,$8,$9,$10}'
+} | tee "${OUTROOT}/summary_table.md"

--- a/scripts/star_flag_sweep.sh
+++ b/scripts/star_flag_sweep.sh
@@ -89,6 +89,11 @@ printf 'variant\tflag\ttotal_sj\tannotated\tnovel\tpct_annotated\tuniq_supported
 log()  { printf '\n\033[1;34m[sweep %(%H:%M:%S)T]\033[0m %s\n' -1 "$*"; }
 
 # ── Step 0: FASTQs (download once, reuse) ────────────────────────────────────
+# Atomic download to .part then mv, so an interrupted/partial transfer is never
+# mistaken for a complete cached file by the -s check below. --http1.1 avoids
+# B2's HTTP/2 "stream not closed cleanly" flakiness (curl 92); --retry-all-errors
+# retries transport-level failures (curl 92 is not an HTTP status code, so a
+# plain --retry would not catch it).
 mkdir -p "$FASTQ_DIR"
 for pair in "$FASTQ1_URL|$FASTQ1" "$FASTQ2_URL|$FASTQ2"; do
   url="${pair%%|*}"; dst="${pair##*|}"
@@ -96,7 +101,9 @@ for pair in "$FASTQ1_URL|$FASTQ1" "$FASTQ2_URL|$FASTQ2"; do
     log "FASTQ cached: $dst"
   else
     log "Downloading $(basename "$dst") from B2 ..."
-    curl --fail -L --no-progress-meter -o "$dst" "$url"
+    curl --fail -L --http1.1 --retry 5 --retry-delay 10 --retry-all-errors \
+         --no-progress-meter -o "${dst}.part" "$url"
+    mv "${dst}.part" "$dst"
   fi
 done
 

--- a/scripts/star_flag_sweep.sh
+++ b/scripts/star_flag_sweep.sh
@@ -203,9 +203,12 @@ if [[ -f "${NOGTF_INDEX_DIR}/index.done" || -f "${NOGTF_INDEX_DIR}/SAindex" ]]; 
 else
   log "Building no-GTF STAR index → $NOGTF_INDEX_DIR (separate from prod cache)"
   mkdir -p "$NOGTF_INDEX_DIR"
+  # No --sjdbOverhang here: STAR rejects >0 overhang when generating a genome
+  # without annotations (--sjdbGTFfile / --sjdbFileChrStartEnd). Overhang only
+  # has meaning relative to an annotated splice-junction database, which this
+  # index deliberately omits.
   if STAR --runMode genomeGenerate --runThreadN "$THREADS" \
-       --genomeDir "$NOGTF_INDEX_DIR" --genomeFastaFiles "$GENOME" \
-       --sjdbOverhang 100; then
+       --genomeDir "$NOGTF_INDEX_DIR" --genomeFastaFiles "$GENOME"; then
     touch "${NOGTF_INDEX_DIR}/index.done"
   else
     log "!! no-GTF index build FAILED — skipping noGTF_index variant"


### PR DESCRIPTION
**Created by:** Developer

Adds the STAR sensitivity-flag benchmark sweep ([`scripts/star_flag_sweep.sh`](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/blob/chore/developer/issue-411-star-flag-sweep/scripts/star_flag_sweep.sh)) and records the 8-variant run on patient_002 tumor.

Closes https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/411

## What this PR lands

[Issue #411](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/411) is the **measurement** deliverable: benchmark each deferred Nature-recipe STAR sensitivity flag one-at-a-time and record the numbers. This PR ships exactly that — the benchmark tooling + the recorded 8-variant run. It intentionally does **not** adopt any flag into the pipeline config; the adopt/reject call is delegated to the two follow-up Issues below (see "Deferred").

`scripts/star_flag_sweep.sh` benchmarks each flag against a baseline, CPU-only, on patient_002 tumor. It is idempotent and fault-tolerant for unattended overnight runs:

- per-variant SKIP on an existing `SJ.out.tab` (resume after interruption);
- index-reuse sentinel guards (no rebuild if `SAindex`/`index.done` present);
- baseline reuse via `REUSE_BASELINE_DIR` (skips re-aligning the production baseline);
- truncate+rewrite of the metrics TSV each run (full table always regenerated).

## Run results (patient_002 tumor; baseline = production STAR config)

| variant | total SJ | Δtotal | novel | Δnovel | uniq-supported | Δuniq | multi-loci % |
|---|---|---|---|---|---|---|---|
| baseline | 258163 | — | 531 | — | 247591 | — | 3.21 |
| matchNmin_0.33 | 258163 | 0 | 531 | 0 | 247591 | 0 | 3.21 |
| scoreMin_0.33 | 258338 | +175 | 540 | +9 | 247736 | +145 | 3.21 |
| multimap_20 | 259086 | +923 | 626 | +95 | 247570 | −21 | 3.25 |
| intronMax_500k | 258104 | −59 | 503 | −28 | 247619 | +28 | 3.22 |
| matesGap_1M | 258937 | +774 | 553 | +22 | 248229 | +638 | 3.27 |
| sjOverhang_1 | 272360 | +14197 | 532 | +1 | 253663 | +6072 | 3.73 |
| noGTF_index | 244604 | −13559 | 1195 | (n/c\*) | 233367 | −14224 | 3.21 |

Raw artifacts (per-variant `SJ.out.tab` + `Log.final.out`, `sweep_metrics.tsv`, `summary_table.md`) are in GCS at `gs://splice-neoepitope-project/experiments/issue_411_star_flag_sweep/`.

\* `noGTF_index` `novel` is **not comparable** to the GTF variants: under `--twopassMode Basic` with no GTF, STAR rebuilds the sjdb from 1st-pass discoveries, so col-6 "annotated" means "found in pass 1", not "in GENCODE". The meaningful read is that total and unique-supported both drop sharply — removing the GTF reduces sensitivity.

## Deferred — adopt/reject decision

The adopt/reject call (which flags' delta is meaningful) turns on a precision-weighted interpretation: does `multimap_20`'s +95 novel survive a unique-read-support filter (or is it multi-mapper-only), is the matchNmin/scoreMin AND-coupling worth a combined permissive variant, and what precision cost (multi-loci %) is `sjOverhang_1`'s +6072 uniq-supported worth. That analysis is [Issue #719](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/719) (Scientist-scoped, already filed) — it produces the recommendation and cross-links it back here. The Developer config change that lands the recommendation is [Issue #725](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/725) (blocked on #719). This PR stays interpretation-free.

## Test plan

- [x] Sweep script runs unattended to completion on the production VM — all 8 variants produced `SJ.out.tab` + `Log.final.out`
- [x] Idempotent resume verified: the interrupted overnight run resumed and completed only the missing `noGTF_index` variant on re-launch (7 variants correctly SKIPped)
- [x] `noGTF_index` fix verified: index builds without `--sjdbOverhang` and the variant completes (the bug that failed the overnight run)
- [x] Results uploaded to GCS; VM self-shut to TERMINATED
