### PR TITLE
chore(coordination): rename /standup skill → /coordination + scan all open statuses for pings

### DIFF
--- a/.claude/commands/coordination.md
+++ b/.claude/commands/coordination.md
@@ -1,6 +1,6 @@
 Scan the two team-coordination channels and surface anything addressed to or relevant to your role; confirm with the user before acting on any request.
 
-1. **Board pings** — comments `**To:** <your role>` on your `role:*` Issues + recent comment activity: `python3 scripts/board_open_items.py --role <role> --status "In progress"` (then `"Ready for review"`, `"In review"`).
+1. **Board pings** — comments `**To:** <your role>` on your `role:*` Issues + recent comment activity, across **all open statuses** (a ping can land on a Backlog / Ready / No-Status Issue, not just active work): `python3 scripts/board_open_items.py --role <role> --sort-updated` (most-recent activity first; the Status column shows per row). Closed/Done items are excluded as resolved.
 2. **Open Discussions** — Team Coordination category (open = needs attention):
    `gh api graphql -f query='{ repository(owner:"Jin-HoMLee", name:"splice-neoepitope-pipeline"){ discussions(first:30, categoryId:"DIC_kwDORwn9EM4C-Jo6", states:[OPEN]){ totalCount nodes{ number title author{login} } } } }'`
    <!-- NOTE: first:30 is unpaginated — fine at 4-role scale, but add a hasNextPage/after cursor loop if open threads ever exceed 30 (totalCount surfaces the count to check). -->

--- a/research/lab_notebook/pm.md
+++ b/research/lab_notebook/pm.md
@@ -6,6 +6,24 @@ Format and rules unchanged from the unified notebook — see `shared/feedback_la
 
 ---
 
+## 2026-06-13
+
+### 21:11 UTC — Editor: PM
+
+#### Rename `/standup` skill → `/coordination` + broaden ping scan to all open statuses ([Issue #740](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/740) / [PR #741](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/741))
+
+**Why the rename.** The `.claude/commands/standup.md` skill was misnamed: a *stand-up* is a synchronous ceremony, but this skill is an **asynchronous coordination-channel scan** (board `**To:** <role>` comments + open Team Coordination Discussions). The name overlapped with the `team_standup.md` *file* retired by [Issue #569](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/569) — a different thing — and caused a live mix-up this session. Renamed `standup.md → coordination.md` (git-tracked → propagates to all three clones on next pull; no alias kept).
+
+**The scan-scope fix (the substantive bit).** Step 1 previously scanned only `In progress` / `Ready for review` / `In review`. But a `**To:** <role>` ping can land on an Issue in *any* status — a triage question on Backlog, a commitment question on Ready, a heads-up on No-Status — so the 3-status filter silently dropped those. Replaced the three `--status` calls with one `board_open_items.py --role <role> --sort-updated` (all open statuses, freshest first; Closed/Done excluded as resolved — open-only chosen over a recently-closed sweep to bound noise).
+
+**Companion memory changes (personas repo, MM-committed).** Retired the **unused** stand-by trigger (`shared/feedback_standby_trigger.md` + the `shared/MEMORY.md` bullet + stray `/loop 4m /standup` refs) — confirmed unused by the user; its removal is what eliminates the last *automated* `/standup` invocation, making the no-alias rename safe ([claude-personas#41](https://github.com/Jin-HoMLee/claude-personas-splice-neoepitope-pipeline/issues/41)). Behavior note: *"keep an eye out" / "stay on stand-by"* phrases no longer auto-fire a watcher; the skill is run manually now.
+
+**Two side-quests this session.** (1) Migrated the ref-linking rule to `shared/` + extended it to **Discussions** (always URL-link `[Discussion #N](…/discussions/N)`, per user) — [claude-personas#40](https://github.com/Jin-HoMLee/claude-personas-splice-neoepitope-pipeline/issues/40). (2) Caught + corrected an **MM-handoff mis-routing**: I first filed the handoff as a project-repo Discussion, but Discussions are disabled on the personas repo and aren't native to MM's cwd — refiled [Discussion #739](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/discussions/739) as personas-repo Issues and saved a `reference_mm_handoff_channel.md` memory.
+
+**Review.** `@claude review` returned **LGTM, no findings** — independently verified `--sort-updated` exists (`board_open_items.py:317`), the no-`--status` all-statuses behavior, the `normalize()` Done/Closed exclusion (lines 124-140), and wording clarity. Closes [Issue #740](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/740).
+
+---
+
 ## 2026-06-12
 
 ### 18:35 UTC — Editor: PM


### PR DESCRIPTION
Closes [Issue #740](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/740).

## What
1. **Rename** `.claude/commands/standup.md` → `coordination.md`. The skill is an async coordination-channel scan, not a sync stand-up ceremony — the name overlapped with the retired `team_standup.md` *file* ([Issue #569](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/569)) and caused confusion. Git-tracked, so the rename propagates to all clones on next pull. No alias kept (nothing automated invokes it anymore — see companion memory change).
2. **Broaden the board-pings scan to all open statuses.** A `**To:** <role>` ping can land on an Issue in any status (Backlog / Ready / No-Status), but step 1 previously only checked `In progress` / `Ready for review` / `In review`. Replaced the three `--status` calls with one `--role <role> --sort-updated` (all open statuses, freshest first). Closed/Done excluded as resolved.

## Companion (separate flow — Memory Manager)
The stand-by trigger (`shared/feedback_standby_trigger.md` + `shared/MEMORY.md` bullet + stray `/loop 4m /standup` refs) is retired in the memory repo via the MM handoff — confirmed unused; its removal is what makes the no-alias rename safe.

## Test plan
- [x] `git mv` clean — only `standup.md → coordination.md` rename in the diff (no content loss)
- [x] Step 1 now uses `--role <role> --sort-updated`; verified the command returns all-open-status PM items locally
- [x] No `/standup` reference remains in the skill body
- [x] Reviewer confirms the broadened scan wording reads clearly (bot confirmed: unambiguous)

**Created by:** PM
