### PR TITLE
fix(ci): closure-audit skips lab-notebook check on not_planned (superseded) Issue closes

### DIFF
--- a/research/lab_notebook/developer.md
+++ b/research/lab_notebook/developer.md
@@ -6,6 +6,22 @@ Format and rules unchanged from the unified notebook — see `shared/feedback_la
 
 ---
 
+## 2026-06-15 — closure-audit reason-awareness + two Issue-lifecycle guardrails ([PR #744](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/744) closes [Issue #743](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/743))
+
+### 14:44 UTC — Editor: Developer
+
+**Trigger chain (one morning, started from a warm-up pick).** The morning warm-up surfaced [Issue #378](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/378) (patient_002 re-run) at board `Ready`/`P1`. A freshness check before starting it showed it was stale on three axes: internally contradictory ACs (HISAT2 primary vs STAR-appended after the [PR #410](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/410) prod-aligner switch), explicitly superseded by [Issue #636](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/636) (whose blocker [Issue #629](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/629) had since closed), and orphaned (parent [Issue #370](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/370) already closed COMPLETED). Closed #378 as superseded/`not_planned` via a closing comment (descoped → comment, not a PR) — which exposed the bug fixed here.
+
+**The bug.** The closure-audit bot (`tools/ci/closure_audit.py`, `audit_issue`) fires on `issues: [closed]` and ran all three checks (AC / priority-rationale / lab-notebook) **regardless of close reason** — it never fetched `stateReason`. So the `not_planned` close of #378 drew a false-positive gap comment (`8/8 AC unticked` + missing notebook entry), both expected for descoped work that ships no code.
+
+**The fix (hybrid, user-chosen over two alternatives).** (1) `fetch_issue` now requests `stateReason`; `audit_issue` skips **only** the lab-notebook check when `NOT_PLANNED` — a descoped close's durable record is the closing comment, not a notebook entry. AC + priority-rationale checks still run. (2) New **AC-annotation convention**: on a superseded close, edit each `- [ ]` → its disposition (`- [superseded]`/`- [n/a]`/`- [deferred]`). Verified the `_UNTICKED` regex matches only a single-space `- [ ]`, so annotated forms pass cleanly *and* the annotation self-documents each AC. Applied retroactively to #378 (8/8 → `- [superseded]`). Scope is contained to the issue path: `not_planned` is unreachable via PR merge (those close COMPLETED), so `audit_pr`/`audit_pr_pre_merge` untouched.
+
+**Verification.** TDD: wrote the `not_planned`-skip test red first, then implemented to green. 42 tests pass (`workflow/tests/.venv/bin/python -m pytest tools/ci/test_closure_audit.py`) — incl. two added after `@claude review` to pin contracts (regex ignores annotated boxes; `not_planned` still flags a genuine `- [ ]`). No chr22 integration run needed (CI-tooling change, not a Snakemake rule). Bot review: no blockers.
+
+**Process memory (for MM to commit; personas repo).** Two new shared feedback rules captured from this session, both Issue-lifecycle guardrails surfaced by the user: `feedback_issue_freshness_check.md` (verify an Issue is current *before starting* it — board Status reflects triage time, not actionability) and `feedback_stall_after_filing_issue.md` (after `gh issue create`, confirm before `gh issue develop`/coding — filing ≠ committing to work now). Plus the AC-annotation convention added to `feedback_closure_ritual.md`. Both guardrails caught real slips this morning (started #378 on a stale pick; jumped straight from filing #743 into implementing it).
+
+---
+
 ## 2026-06-12 — STAR sensitivity-flag benchmark sweep shipped ([PR #720](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/720) closes [Issue #411](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/411))
 
 ### 19:10 UTC — Editor: Developer — portable Playwright path for the project-map render check ([PR #729](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/729) closes [Issue #712](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/712))

--- a/tools/ci/closure_audit.py
+++ b/tools/ci/closure_audit.py
@@ -14,6 +14,12 @@ routine single-PR-closes-single-Issue skip that #483 declared optional, so the
 bot stops coercing entries the lab-notebook rule says are unnecessary. The AC
 and Priority-rationale checks are unaffected by the marker.
 
+On the issue path, the lab-notebook check is also skipped when the Issue closed
+as `not_planned` (descoped / superseded): such a close ships no work and routes
+through a closing comment, not a notebook entry (closure ritual, #743). The AC
+and Priority-rationale checks still run — superseded ACs are annotated to their
+disposition (e.g. `- [superseded]`) rather than left as `- [ ]`.
+
 Usage (called by .github/workflows/closure-audit.yml):
     python closure_audit.py --event-type {pr|issue} --number <N>
 """
@@ -243,7 +249,7 @@ def fetch_pr(n: int, repo: str | None = None) -> dict:
 def fetch_issue(n: int, repo: str | None = None) -> dict:
     return json.loads(_gh(
         "issue", "view", str(n),
-        "--json", "number,body,labels,comments,closedAt",
+        "--json", "number,body,labels,comments,closedAt,stateReason",
         repo=repo,
     ))
 
@@ -353,11 +359,16 @@ def audit_issue(n: int) -> None:
     if d := check_priority_rationale(body):
         pr_gaps.append((n, d))
 
-    labels = [lbl["name"] for lbl in issue.get("labels", [])]
-    role_sets = resolve_roles([labels])
-    all_roles = {r for rs in role_sets for r in rs}
-    notebooks = {r: _load_notebook(r) for r in all_roles}
-    nb_gaps.extend(collect_notebook_gaps(role_sets, date, n, notebooks))
+    # A not_planned (descoped / superseded) close ships no work, so it routes
+    # through a closing comment, not a lab-notebook entry (closure ritual, #743).
+    # Skip ONLY the notebook check — AC + priority-rationale still run (the AC
+    # boxes are annotated to their disposition, e.g. `- [superseded]`).
+    if (issue.get("stateReason") or "").upper() != "NOT_PLANNED":
+        labels = [lbl["name"] for lbl in issue.get("labels", [])]
+        role_sets = resolve_roles([labels])
+        all_roles = {r for rs in role_sets for r in rs}
+        notebooks = {r: _load_notebook(r) for r in all_roles}
+        nb_gaps.extend(collect_notebook_gaps(role_sets, date, n, notebooks))
 
     if ac_gaps or pr_gaps or nb_gaps:
         post_comment("issue", n, format_comment(f"Issue #{n}", ac_gaps, pr_gaps, nb_gaps))

--- a/tools/ci/test_closure_audit.py
+++ b/tools/ci/test_closure_audit.py
@@ -348,6 +348,73 @@ def test_collect_notebook_gaps_skips_empty_role_sets():
     ) == []
 
 
+# --- #743: not_planned (superseded) closes skip only the lab-notebook check ---
+
+
+def _run_audit_issue(monkeypatch, *, state_reason, labels, notebook_text):
+    """Drive audit_issue with a controlled issue + notebook; capture any post.
+
+    Body has its AC boxes annotated to a disposition (`- [superseded]`) so the
+    AC check passes, and carries a Priority-rationale line — isolating the
+    lab-notebook check as the only thing that could post a gap. The notebook
+    text deliberately omits the Issue ref, so the notebook check WOULD fail if
+    it ran. Returns the posted comment body, or None if nothing was posted.
+    """
+    issue = {
+        "number": 743,
+        "body": "- [superseded] one\n- [superseded] two\n\n**Priority rationale:** P2 — x.\n",
+        "labels": [{"name": lbl} for lbl in labels],
+        "comments": [],
+        "closedAt": "2026-06-15T14:00:00Z",
+        "stateReason": state_reason,
+    }
+    monkeypatch.setattr(ca, "fetch_issue", lambda n: issue)
+    monkeypatch.setattr(ca, "_load_notebook", lambda role: notebook_text)
+    posted = {}
+    monkeypatch.setattr(
+        ca, "post_comment", lambda target, n, body: posted.update(body=body)
+    )
+    ca.audit_issue(743)
+    return posted.get("body")
+
+
+def test_audit_issue_not_planned_skips_notebook_check(monkeypatch):
+    """not_planned close + role label + notebook w/o ref → no notebook gap posted.
+
+    AC boxes are annotated (pass) and a rationale is present, so with the
+    notebook check skipped there are no gaps at all → nothing is posted.
+    """
+    body = _run_audit_issue(
+        monkeypatch,
+        state_reason="NOT_PLANNED",
+        labels=["role:developer"],
+        notebook_text="## 2026-06-15\n\n### 14:00 UTC — Editor: Developer\nUnrelated.\n",
+    )
+    assert body is None
+
+
+def test_audit_issue_completed_still_flags_missing_notebook(monkeypatch):
+    """Regression: COMPLETED close with no notebook ref still posts a notebook gap."""
+    body = _run_audit_issue(
+        monkeypatch,
+        state_reason="COMPLETED",
+        labels=["role:developer"],
+        notebook_text="## 2026-06-15\n\n### 14:00 UTC — Editor: Developer\nUnrelated.\n",
+    )
+    assert body is not None and "Lab notebook" in body
+
+
+def test_audit_issue_null_reason_still_flags_missing_notebook(monkeypatch):
+    """Defensive: a null/absent stateReason behaves like COMPLETED (check runs)."""
+    body = _run_audit_issue(
+        monkeypatch,
+        state_reason=None,
+        labels=["role:developer"],
+        notebook_text="## 2026-06-15\n\n### 14:00 UTC — Editor: Developer\nUnrelated.\n",
+    )
+    assert body is not None and "Lab notebook" in body
+
+
 def test_format_comment_clean_state():
     out = ca.format_comment("PR #1", [], [], [])
     assert "all clear" in out.lower()

--- a/tools/ci/test_closure_audit.py
+++ b/tools/ci/test_closure_audit.py
@@ -351,18 +351,24 @@ def test_collect_notebook_gaps_skips_empty_role_sets():
 # --- #743: not_planned (superseded) closes skip only the lab-notebook check ---
 
 
-def _run_audit_issue(monkeypatch, *, state_reason, labels, notebook_text):
+_ANNOTATED_BODY = (
+    "- [superseded] one\n- [superseded] two\n\n**Priority rationale:** P2 — x.\n"
+)
+
+
+def _run_audit_issue(monkeypatch, *, state_reason, labels, notebook_text, body=None):
     """Drive audit_issue with a controlled issue + notebook; capture any post.
 
-    Body has its AC boxes annotated to a disposition (`- [superseded]`) so the
-    AC check passes, and carries a Priority-rationale line — isolating the
+    Default body has its AC boxes annotated to a disposition (`- [superseded]`)
+    so the AC check passes, and carries a Priority-rationale line — isolating the
     lab-notebook check as the only thing that could post a gap. The notebook
     text deliberately omits the Issue ref, so the notebook check WOULD fail if
-    it ran. Returns the posted comment body, or None if nothing was posted.
+    it ran. Pass `body` to exercise the AC check (e.g. with a real `- [ ]`).
+    Returns the posted comment body, or None if nothing was posted.
     """
     issue = {
         "number": 743,
-        "body": "- [superseded] one\n- [superseded] two\n\n**Priority rationale:** P2 — x.\n",
+        "body": _ANNOTATED_BODY if body is None else body,
         "labels": [{"name": lbl} for lbl in labels],
         "comments": [],
         "closedAt": "2026-06-15T14:00:00Z",
@@ -413,6 +419,28 @@ def test_audit_issue_null_reason_still_flags_missing_notebook(monkeypatch):
         notebook_text="## 2026-06-15\n\n### 14:00 UTC — Editor: Developer\nUnrelated.\n",
     )
     assert body is not None and "Lab notebook" in body
+
+
+def test_unticked_regex_ignores_annotated_boxes():
+    """The AC-annotation convention (#743) relies on _UNTICKED matching ONLY a
+    single-space `- [ ]` — annotated dispositions must pass the AC check."""
+    for form in ("- [superseded] x\n", "- [n/a] x\n", "- [deferred] x\n"):
+        assert ca._UNTICKED.findall(form) == [], f"regex wrongly matched: {form!r}"
+    assert ca._UNTICKED.findall("- [ ] x\n"), "regex must still match a real `- [ ]`"
+
+
+def test_audit_issue_not_planned_still_flags_unticked_ac(monkeypatch):
+    """not_planned skips ONLY the notebook check — a genuinely unticked AC
+    (left as `- [ ]`, not annotated) is still flagged. Guards the skip's scope."""
+    body = _run_audit_issue(
+        monkeypatch,
+        state_reason="NOT_PLANNED",
+        labels=["role:developer"],
+        notebook_text="## 2026-06-15\n\n### 14:00 UTC — Editor: Developer\nUnrelated.\n",
+        body="- [ ] one\n- [superseded] two\n\n**Priority rationale:** P2 — x.\n",
+    )
+    assert body is not None and "AC checkboxes" in body
+    assert "Lab notebook" not in body  # notebook check still skipped
 
 
 def test_format_comment_clean_state():


### PR DESCRIPTION
Closes [Issue #743](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/743).

**Created by:** Developer

## What

The closure-audit bot (`tools/ci/closure_audit.py`, `audit_issue`) fired on every `issues: [closed]` event and ran all three checks (AC checkboxes, Priority rationale, lab-notebook entry) regardless of the close reason — it never fetched `stateReason`. So an Issue closed as **not_planned** (descoped / superseded) was audited like a COMPLETED close and produced false-positive gap comments (live instance: [Issue #378](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/378), flagged `8/8 AC unticked` + missing notebook entry).

## How (hybrid approach, agreed with user)

- `fetch_issue` now requests `stateReason`.
- `audit_issue` skips **only** the lab-notebook check when `stateReason == NOT_PLANNED`. A descoped close ships no work and routes through a **closing comment** (reason + outcome routing), not a notebook entry — per the closure ritual.
- AC + priority-rationale checks **still run**. Superseded ACs are handled by a new **annotation convention**: edit each `- [ ]` to its disposition (`- [superseded]` / `- [n/a]` / `- [deferred]`), which self-documents the AC and passes the `_UNTICKED` regex (it only matches a single-space `- [ ]`).
- Convention documented in `shared/feedback_closure_ritual.md` (memory; committed separately by MM).

Contained to the issue path — `not_planned` is unreachable via PR merge (those close as COMPLETED), so `audit_pr` / `audit_pr_pre_merge` are unaffected.

## Test plan

- [x] `workflow/tests/.venv/bin/python -m pytest tools/ci/test_closure_audit.py` — 40 passed (3 new: not_planned skip, COMPLETED regression, null-reason regression)
- [x] Verified `_UNTICKED` regex does not match `- [superseded]` (annotation convention passes the AC check)
- [x] Applied the convention to the live instance [Issue #378](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/378) (8/8 boxes → `- [superseded]`)