### PR TITLE
docs(results): flatten TCRdock output paths to match PR #650 layout

### DIFF
--- a/research/manuscript/RESULTS.md
+++ b/research/manuscript/RESULTS.md
@@ -160,7 +160,7 @@ stronger tumor-exclusivity claim than patient_002's WES-only normal.
 TCRdock was run on SQIPRTHSY / HLA-C\*07:01, the top GPS-ranked candidate, on a GCP
 Spot GPU VM (NVIDIA P100, 16 GB VRAM). The predicted TCR–peptide–MHC ternary complex
 structure was successfully generated (`pdb_available: true` in `report.tsv`) and is
-available in `results/patient_001/predictions/tcrdock/`, rendered interactively using
+available in `results/patient_001/tcrdock/`, rendered interactively using
 Mol\* 4.x in the pipeline HTML report with chain labels A=MHC, B=peptide, C=TCR-α,
 D=TCR-β.
 
@@ -298,7 +298,7 @@ absent from healthy osteoblasts or mesenchymal stem cells.
 
 TCRdock was run on FADLRPLLL / HLA-C\*01:02, the top GPS-ranked candidate.
 The predicted TCR–peptide–MHC ternary complex structure was successfully generated
-and is available in `results/patient_002/predictions/tcrdock/`.
+and is available in `results/patient_002/tcrdock/`.
 
 *Structural interpretation (pLDDT, CDR3 contacts) to be added after Developer
 review of the PDB output.*


### PR DESCRIPTION
**Created by:** Developer

## What

Corrects two stale TCRdock output-path references in `RESULTS.md` to match the current code layout. [PR #650](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/650) flattened `results/{patient}/predictions/<tool>/` → `results/{patient}/<tool>/`, but the manuscript prose still pointed at the old `predictions/tcrdock/` path.

- `research/manuscript/RESULTS.md:163` — `results/patient_001/predictions/tcrdock/` → `results/patient_001/tcrdock/`
- `research/manuscript/RESULTS.md:301` — `results/patient_002/predictions/tcrdock/` → `results/patient_002/tcrdock/`

Verified against current code: `workflow/rules/structure.smk` documents the output at `results/{patient_id}/tcrdock/top_candidate.pdb`.

## Scope

This is the **RESULTS.md prose portion** of the AC8 path-flatten sync on [Issue #636](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/636). It leaves Issue #636 open — the science-side ACs (STAR comparability gate, RESULTS number refresh, notebook refresh) remain to be done and are Scientist-owned. The **notebook GCS-fetch cells** (the other half of AC8) are deliberately held: the harvested #653 data on GCS is still in the *old* `predictions/` layout, so the cell fix direction (point-at-old-paths vs migrate-GCS-then-new-paths) depends on the Scientist's harvest decision — see [the verification handoff](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/636#issuecomment-4722257370).

## Test plan

- [x] `grep -n "predictions/" research/manuscript/RESULTS.md` returns no matches (both refs corrected)
- [x] Path matches current pipeline output (`structure.smk` → `results/{patient_id}/tcrdock/`)
- [x] Docs-only change; no code/CI surface touched
