### PR TITLE
chore(pm): register arc:immunogenicity-benchmark + tag #680 registry family

### DIFF
--- a/scripts/pm/arc_labels.sh
+++ b/scripts/pm/arc_labels.sh
@@ -16,7 +16,7 @@ ARC_LABELS=(
   "arc:cloud-reproducibility|1D4ED8|Arc: cloud execution & reproducibility (Batch, run registry, GPU, run_cloud_gpu.sh)"
   "arc:memory-methodology|7C3AED|Arc: memory & methodology (MEMORY.md slimming/audit, MM role, persona framing)"
   "arc:board-governance|9D174D|Arc: board governance & enforcement (Kanban governance, hooks/guards, PM-tooling evals)"
-  "arc:immunogenicity-benchmark|0E7490|Arc: splice-neoantigen immunogenicity benchmark (functional-validation registry, ground-truth labels, scoring harness)"
+  "arc:immunogenicity-benchmark|DB2777|Arc: splice-neoantigen immunogenicity benchmark (functional-validation registry, ground-truth labels, scoring harness)"
 )
 PHASE_LABELS=(
   "arc-phase:active|2DA44E|Arc focus: actively pulled now (cap 3)"

--- a/scripts/pm/arc_labels.sh
+++ b/scripts/pm/arc_labels.sh
@@ -16,7 +16,7 @@ ARC_LABELS=(
   "arc:cloud-reproducibility|1D4ED8|Arc: cloud execution & reproducibility (Batch, run registry, GPU, run_cloud_gpu.sh)"
   "arc:memory-methodology|7C3AED|Arc: memory & methodology (MEMORY.md slimming/audit, MM role, persona framing)"
   "arc:board-governance|9D174D|Arc: board governance & enforcement (Kanban governance, hooks/guards, PM-tooling evals)"
-  "arc:immunogenicity-benchmark|DB2777|Arc: splice-neoantigen immunogenicity benchmark (functional-validation registry, ground-truth labels, scoring harness)"
+  "arc:immunogenicity-benchmark|DB2777|Arc: splice-neoantigen immunogenicity benchmark (registry, labels, scoring harness)"
 )
 PHASE_LABELS=(
   "arc-phase:active|2DA44E|Arc focus: actively pulled now (cap 3)"

--- a/scripts/pm/arc_labels.sh
+++ b/scripts/pm/arc_labels.sh
@@ -16,6 +16,7 @@ ARC_LABELS=(
   "arc:cloud-reproducibility|1D4ED8|Arc: cloud execution & reproducibility (Batch, run registry, GPU, run_cloud_gpu.sh)"
   "arc:memory-methodology|7C3AED|Arc: memory & methodology (MEMORY.md slimming/audit, MM role, persona framing)"
   "arc:board-governance|9D174D|Arc: board governance & enforcement (Kanban governance, hooks/guards, PM-tooling evals)"
+  "arc:immunogenicity-benchmark|0E7490|Arc: splice-neoantigen immunogenicity benchmark (functional-validation registry, ground-truth labels, scoring harness)"
 )
 PHASE_LABELS=(
   "arc-phase:active|2DA44E|Arc focus: actively pulled now (cap 3)"

--- a/scripts/pm/arc_taxonomy.tsv
+++ b/scripts/pm/arc_taxonomy.tsv
@@ -10,4 +10,5 @@ arc:results-reporting     later   193 198 233 435 455
 arc:cloud-reproducibility next    66 183 195 310 630 651 658 664 669 673 674
 arc:memory-methodology    later   248 265 324 326 346 353 527 538 539 540 541 542 672
 arc:board-governance      active  234 250 294 295 406 445 498 499 533 553 569 578 617 626 633 655 665
+arc:immunogenicity-benchmark next 680 732 733 734 735 736 737
 # unfiled (intentionally NO arc label): 446 451 570 641


### PR DESCRIPTION
**Created by:** Scientist

Registers the PM-approved **`arc:immunogenicity-benchmark`** narrative arc and tags the splice-neoantigen immunogenicity registry family. Closes #758 — a governance sub-issue under epic [Issue #680](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/680).

## What
- `scripts/pm/arc_labels.sh`: new label definition (`#DB2777`, 83-char description).
- `scripts/pm/arc_taxonomy.tsv`: new arc row — `arc:immunogenicity-benchmark next 680 732 733 734 735 736 737`.

Enters at focus-phase **`next`**, so the ≤3-active cap is unaffected (active stays `arc:aligner-junctions` / `arc:scoring-tcr-pmhc` / `arc:board-governance`). #732 is the closed seed issue, included as the arc's historical throughline.

## Review follow-ups
- Color switched `0E7490` → `DB2777` (vivid pink) per the @claude color-proximity nit — distinct from the teal `arc:aligner-junctions`. TSV column-alignment nit consciously declined (re-padding all rows = diff churn; parser is whitespace-indifferent).
- Description trimmed 117 → 83 chars after the apply run hit GitHub's 100-char label-description limit (HTTP 422) — a latent bug in the original `arc_labels.sh` entry.

## Test plan (applied pre-merge from the branch so #758's ACs close truthfully)
- [x] `bash -n scripts/pm/arc_labels.sh` clean.
- [x] New TSV row parses correctly under `apply_arc_labels.sh`'s `read -r arc phase rest` loop.
- [x] Label `arc:immunogenicity-benchmark` (`#DB2777`) created in the repo from the `arc_labels.sh` definition.
- [x] `apply_arc_labels.sh` run with a **scoped manifest** applied `arc:immunogenicity-benchmark` + `arc-phase:next` to 680 + 732–737 (no full-board re-sync).
- [x] Confirmed all 7 family issues carry both labels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- skip-lab-notebook: routine -->
