### PR TITLE
feat(pm): prose-dependency reconciler — verify native blockedBy graph (#722)

### DIFF
--- a/docs/superpowers/plans/2026-06-16-prose-dependency-reconciler.md
+++ b/docs/superpowers/plans/2026-06-16-prose-dependency-reconciler.md
@@ -1,0 +1,655 @@
+# Prose-Dependency Reconciler Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build `scripts/pm/scan_prose_deps.py` — a reconciler that finds prose-stated Issue dependencies ("depends on #M") and wires the corresponding native GitHub `blockedBy` edges — then run it to backfill the existing graph.
+
+**Architecture:** Four thin layers — *fetch* (open issues via `gh issue list`), *parse* (pure regex: body → `(dependent, blocker)` pairs), *reconcile* (diff prose pairs vs the native graph, classify each), *act* (report / wire / exit-code). The parse layer is pure and carries the test coverage; the gh-backed layers are monkeypatched in tests. Mirrors `scripts/pm/recheck_milestone.py` (the `gh()` subprocess helper) and `scripts/board_open_items.py` (the inject-the-fetch test style).
+
+**Tech Stack:** Python 3 (stdlib only: `argparse`, `re`, `subprocess`, `json`), `gh` CLI, pytest (`workflow/tests/.venv`).
+
+**Spec:** `docs/superpowers/specs/2026-06-16-prose-dependency-reconciler-design.md`
+**Issue:** [#722](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/722) — branch `design/pm/issue-722-prose-dependency-reconciler` (already checked out).
+
+---
+
+## File Structure
+
+- **Create:** `scripts/pm/scan_prose_deps.py` — the reconciler CLI + library functions.
+- **Create:** `workflow/tests/test_scan_prose_deps.py` — pytest (parse layer = bulk; reconcile/act = mocked gh).
+- **Modify (personas memory, MM-committed):** `memory/shared/feedback_dependency_tracking.md` — cross-ref the scanner. Flagged for MM, not part of the code PR.
+
+**Module API (locked here so later tasks match):**
+
+```python
+REPO = "Jin-HoMLee/splice-neoepitope-pipeline"
+
+# fetch
+def gh(*args, parse_json=True): ...                      # subprocess wrapper (mirror recheck_milestone.py)
+def fetch_open_issues() -> list[dict]: ...               # [{number, title, body, state}, ...]
+
+# parse (PURE — no I/O)
+BLOCKER_RE: "re.Pattern"                                 # matches a blocker phrase + #<digits>
+def parse_dependencies(number: int, body: str) -> list[tuple[int, int]]: ...   # [(dependent, blocker)]
+
+# reconcile (gh-backed)
+def issue_meta(number: int) -> dict: ...                 # {"state": "open"|"closed", "is_pr": bool}
+def native_blockers(number: int) -> set[int]: ...        # existing blockedBy edge targets
+def classify(dependent: int, blocker: int, *, blocker_meta: dict, existing: set[int]) -> str: ...
+    # -> "needs-wiring" | "already-wired" | "closed-blocker" | "un-wireable-pr" | "self-ref"
+def reconcile(pairs: list[tuple[int, int]]) -> list[dict]: ...   # [{dependent, blocker, state, action}]
+
+# act
+def render_report(records: list[dict]) -> str: ...
+def wire(records: list[dict]) -> list[tuple[int, int]]: ...      # POSTs edges for needs-wiring; returns wired
+def main() -> int: ...                                   # argparse: --report/--apply/--check/--issue/--only
+```
+
+---
+
+## Task 1: Scaffold + fetch layer
+
+**Files:**
+- Create: `scripts/pm/scan_prose_deps.py`
+- Test: `workflow/tests/test_scan_prose_deps.py`
+
+- [ ] **Step 1: Write the failing test for the import + REPO constant**
+
+```python
+# workflow/tests/test_scan_prose_deps.py
+"""Tests for scripts/pm/scan_prose_deps.py — the prose-dependency reconciler (Issue #722).
+
+Parse layer is pure and gets the bulk of coverage; reconcile/act monkeypatch the
+gh-backed helpers so nothing touches the network.
+"""
+import sys
+from pathlib import Path
+
+import pytest
+
+_PM_DIR = Path(__file__).resolve().parents[2] / "scripts" / "pm"
+sys.path.insert(0, str(_PM_DIR))
+
+import scan_prose_deps as spd  # noqa: E402
+
+
+def test_repo_constant():
+    assert spd.REPO == "Jin-HoMLee/splice-neoepitope-pipeline"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `workflow/tests/.venv/bin/python -m pytest workflow/tests/test_scan_prose_deps.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'scan_prose_deps'`
+
+- [ ] **Step 3: Create the script skeleton with the fetch layer**
+
+```python
+#!/usr/bin/env python3
+"""Reconcile prose-stated Issue dependencies into native GitHub blockedBy edges.
+
+Finds bodies saying "depends on #M" / "blocked on #M" etc., diffs them against
+the native blockedBy graph, and reports or wires the missing edges.
+
+Usage:
+  scripts/pm/scan_prose_deps.py                 # --report (default): drift table
+  scripts/pm/scan_prose_deps.py --issue N       # single-issue scope
+  scripts/pm/scan_prose_deps.py --check         # exit 2 if any drift
+  scripts/pm/scan_prose_deps.py --apply         # wire all needs-wiring records
+  scripts/pm/scan_prose_deps.py --apply --only 745 594   # wire only these dependents
+
+Exits 0 clean / 2 drift-present (--check) / 1 on error.
+"""
+import argparse
+import json
+import re
+import subprocess
+import sys
+
+REPO = "Jin-HoMLee/splice-neoepitope-pipeline"
+
+
+def gh(*args, parse_json=True):
+    """Run a gh command; return parsed JSON (default) or raw stdout text."""
+    result = subprocess.run(["gh", *args], capture_output=True, text=True, check=True)
+    return json.loads(result.stdout) if parse_json else result.stdout
+
+
+def fetch_open_issues():
+    """All open issues with bodies. Uses the issue list (NOT the project board),
+    so the board's Done-first pagination trap does not apply."""
+    return gh(
+        "issue", "list", "--repo", REPO, "--state", "open", "--limit", "1000",
+        "--json", "number,title,body,state",
+    )
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `workflow/tests/.venv/bin/python -m pytest workflow/tests/test_scan_prose_deps.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/pm/scan_prose_deps.py workflow/tests/test_scan_prose_deps.py
+git commit -m "feat(pm): scan_prose_deps scaffold + fetch layer (#722)"
+```
+
+---
+
+## Task 2: Parse layer (the core — heavy TDD)
+
+**Files:**
+- Modify: `scripts/pm/scan_prose_deps.py`
+- Test: `workflow/tests/test_scan_prose_deps.py`
+
+- [ ] **Step 1: Write failing tests — allowlist hits, narrative excludes, multi-blocker, self-ref, dedupe**
+
+```python
+# append to workflow/tests/test_scan_prose_deps.py
+
+@pytest.mark.parametrize("phrase", [
+    "depends on #722", "blocked by #722", "blocked on #722",
+    "blocked-by:722", "gated on #722", "requires #722",
+])
+def test_parse_allowlist_phrases_match(phrase):
+    body = f"Some context. This {phrase} to proceed."
+    assert spd.parse_dependencies(745, body) == [(745, 722)]
+
+
+@pytest.mark.parametrize("phrase", [
+    "informs #722", "consumes #722", "relates to #722", "related to #722",
+    "follow-up to #722", "supersedes #722", "superseded by #722",
+    "see #722", "cf. #722", "fixes #722",
+])
+def test_parse_narrative_phrases_excluded(phrase):
+    # Narrative cross-refs are *why*-context, never blockers — must yield nothing.
+    body = f"This PR {phrase}."
+    assert spd.parse_dependencies(745, body) == []
+
+
+def test_parse_multiple_blockers_deduped_and_sorted():
+    body = "Depends on #708 and blocked by #707. Also depends on #708 again."
+    assert spd.parse_dependencies(709, body) == [(709, 707), (709, 708)]
+
+
+def test_parse_self_reference_dropped():
+    body = "This depends on #745 (itself, nonsensically)."
+    assert spd.parse_dependencies(745, body) == []
+
+
+def test_parse_empty_or_none_body():
+    assert spd.parse_dependencies(1, "") == []
+    assert spd.parse_dependencies(1, None) == []
+
+
+def test_parse_case_insensitive():
+    assert spd.parse_dependencies(2, "DEPENDS ON #5") == [(2, 5)]
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `workflow/tests/.venv/bin/python -m pytest workflow/tests/test_scan_prose_deps.py -k parse -v`
+Expected: FAIL — `AttributeError: module 'scan_prose_deps' has no attribute 'parse_dependencies'`
+
+- [ ] **Step 3: Implement the parse layer**
+
+```python
+# add to scan_prose_deps.py (after fetch layer)
+
+# Blocker-phrase allowlist — deliberately narrow: only verbs that mean "this is
+# blocked until #M". Narrative verbs (informs/consumes/relates to/see/fixes/...)
+# are NOT listed, so they never match — that IS the exclude mechanism (a narrow
+# allowlist), proven by test_parse_narrative_phrases_excluded.
+_BLOCKER_PHRASES = [
+    r"depends on",
+    r"blocked by",
+    r"blocked on",
+    r"blocked-by:",
+    r"gated on",
+    r"requires",
+]
+BLOCKER_RE = re.compile(
+    r"(?:" + "|".join(_BLOCKER_PHRASES) + r")\s*#(\d+)",
+    re.IGNORECASE,
+)
+
+
+def parse_dependencies(number, body):
+    """Return sorted, deduped (dependent, blocker) pairs from one issue body.
+
+    Pure: no I/O. Matches only the blocker-phrase allowlist; drops self-references.
+    Blocker open/closed and PR-vs-issue filtering happen later, in reconcile().
+    """
+    if not body:
+        return []
+    blockers = {int(m.group(1)) for m in BLOCKER_RE.finditer(body)}
+    blockers.discard(number)  # self-reference
+    return [(number, b) for b in sorted(blockers)]
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `workflow/tests/.venv/bin/python -m pytest workflow/tests/test_scan_prose_deps.py -k parse -v`
+Expected: PASS (all parametrized cases)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/pm/scan_prose_deps.py workflow/tests/test_scan_prose_deps.py
+git commit -m "feat(pm): scan_prose_deps parse layer — allowlist phrase extraction (#722)"
+```
+
+---
+
+## Task 3: Reconcile layer (classify + gh-backed lookups)
+
+**Files:**
+- Modify: `scripts/pm/scan_prose_deps.py`
+- Test: `workflow/tests/test_scan_prose_deps.py`
+
+- [ ] **Step 1: Write failing tests for `classify()` (pure given inputs)**
+
+```python
+# append to workflow/tests/test_scan_prose_deps.py
+
+def test_classify_needs_wiring():
+    r = spd.classify(745, 722, blocker_meta={"state": "open", "is_pr": False}, existing=set())
+    assert r == "needs-wiring"
+
+def test_classify_already_wired():
+    r = spd.classify(745, 722, blocker_meta={"state": "open", "is_pr": False}, existing={722})
+    assert r == "already-wired"
+
+def test_classify_closed_blocker():
+    r = spd.classify(594, 211, blocker_meta={"state": "closed", "is_pr": False}, existing=set())
+    assert r == "closed-blocker"
+
+def test_classify_un_wireable_pr():
+    r = spd.classify(680, 714, blocker_meta={"state": "open", "is_pr": True}, existing=set())
+    assert r == "un-wireable-pr"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `workflow/tests/.venv/bin/python -m pytest workflow/tests/test_scan_prose_deps.py -k classify -v`
+Expected: FAIL — `AttributeError: ... 'classify'`
+
+- [ ] **Step 3: Implement `classify` + the gh-backed lookups**
+
+```python
+# add to scan_prose_deps.py
+
+def classify(dependent, blocker, *, blocker_meta, existing):
+    """Classify one (dependent, blocker) pair. Pure given resolved inputs."""
+    if dependent == blocker:
+        return "self-ref"
+    if blocker in existing:
+        return "already-wired"
+    if blocker_meta["state"] == "closed":
+        return "closed-blocker"  # convention: only wire currently-open blockers
+    if blocker_meta["is_pr"]:
+        return "un-wireable-pr"  # native deps are issue<->issue
+    return "needs-wiring"
+
+
+def issue_meta(number):
+    """{'state': 'open'|'closed', 'is_pr': bool} via the REST issues endpoint
+    (which serves both issues and PRs; a PR carries a 'pull_request' key)."""
+    obj = gh("api", f"repos/{REPO}/issues/{number}")
+    return {"state": obj["state"], "is_pr": "pull_request" in obj}
+
+
+def native_blockers(number):
+    """Set of issue numbers this issue is already natively blockedBy."""
+    q = (
+        'query { repository(owner: "Jin-HoMLee", name: "splice-neoepitope-pipeline") {'
+        f"  issue(number: {number}) {{ blockedBy(first: 50) {{ nodes {{ number }} }} }}"
+        "}}"
+    )
+    data = gh("api", "graphql", "-f", f"query={q}")
+    nodes = data["data"]["repository"]["issue"]["blockedBy"]["nodes"]
+    return {n["number"] for n in nodes}
+```
+
+- [ ] **Step 4: Write failing test for `reconcile()` with monkeypatched gh lookups**
+
+```python
+# append to workflow/tests/test_scan_prose_deps.py
+
+def test_reconcile_classifies_each_pair(monkeypatch):
+    meta = {
+        722: {"state": "open", "is_pr": False},   # needs-wiring
+        211: {"state": "closed", "is_pr": False}, # closed-blocker
+        714: {"state": "open", "is_pr": True},    # un-wireable-pr
+        708: {"state": "open", "is_pr": False},   # already-wired (in existing)
+    }
+    monkeypatch.setattr(spd, "issue_meta", lambda n: meta[n])
+    monkeypatch.setattr(spd, "native_blockers", lambda n: {708} if n == 709 else set())
+
+    pairs = [(745, 722), (594, 211), (680, 714), (709, 708)]
+    records = spd.reconcile(pairs)
+    actions = {(r["dependent"], r["blocker"]): r["action"] for r in records}
+    assert actions == {
+        (745, 722): "needs-wiring",
+        (594, 211): "closed-blocker",
+        (680, 714): "un-wireable-pr",
+        (709, 708): "already-wired",
+    }
+```
+
+- [ ] **Step 5: Run to verify it fails**
+
+Run: `workflow/tests/.venv/bin/python -m pytest workflow/tests/test_scan_prose_deps.py -k reconcile -v`
+Expected: FAIL — `AttributeError: ... 'reconcile'`
+
+- [ ] **Step 6: Implement `reconcile()`**
+
+```python
+# add to scan_prose_deps.py
+
+def reconcile(pairs):
+    """Resolve + classify each (dependent, blocker) pair into a record dict.
+    Caches per-issue lookups so each blocker/dependent is fetched once."""
+    meta_cache = {}
+    edges_cache = {}
+
+    def meta(n):
+        if n not in meta_cache:
+            meta_cache[n] = issue_meta(n)
+        return meta_cache[n]
+
+    def edges(n):
+        if n not in edges_cache:
+            edges_cache[n] = native_blockers(n)
+        return edges_cache[n]
+
+    records = []
+    for dependent, blocker in pairs:
+        bmeta = meta(blocker)
+        action = classify(dependent, blocker, blocker_meta=bmeta, existing=edges(dependent))
+        records.append({
+            "dependent": dependent,
+            "blocker": blocker,
+            "state": bmeta["state"],
+            "action": action,
+        })
+    return records
+```
+
+- [ ] **Step 7: Run all tests to verify pass**
+
+Run: `workflow/tests/.venv/bin/python -m pytest workflow/tests/test_scan_prose_deps.py -v`
+Expected: PASS (all)
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add scripts/pm/scan_prose_deps.py workflow/tests/test_scan_prose_deps.py
+git commit -m "feat(pm): scan_prose_deps reconcile layer — classify + native-graph diff (#722)"
+```
+
+---
+
+## Task 4: Act layer (report + wire) + `main()` CLI
+
+**Files:**
+- Modify: `scripts/pm/scan_prose_deps.py`
+- Test: `workflow/tests/test_scan_prose_deps.py`
+
+- [ ] **Step 1: Write failing tests for `render_report` and `main` wiring**
+
+```python
+# append to workflow/tests/test_scan_prose_deps.py
+
+def _records():
+    return [
+        {"dependent": 745, "blocker": 722, "state": "open", "action": "needs-wiring"},
+        {"dependent": 594, "blocker": 211, "state": "closed", "action": "closed-blocker"},
+    ]
+
+def test_render_report_lists_each_record():
+    out = spd.render_report(_records())
+    assert "745" in out and "722" in out and "needs-wiring" in out
+    assert "594" in out and "closed-blocker" in out
+
+def test_render_report_empty():
+    assert "no prose-dependency drift" in spd.render_report([]).lower()
+
+def _run_main(monkeypatch, capsys, argv, pairs, records):
+    monkeypatch.setattr(spd, "fetch_open_issues",
+                        lambda: [{"number": 745, "title": "x", "body": "depends on #722", "state": "OPEN"}])
+    monkeypatch.setattr(spd, "parse_dependencies", lambda n, b: pairs)
+    monkeypatch.setattr(spd, "reconcile", lambda p: records)
+    monkeypatch.setattr(sys, "argv", ["scan_prose_deps.py", *argv])
+    rc = spd.main()
+    return rc, capsys.readouterr().out
+
+def test_main_report_default_exit_zero(monkeypatch, capsys):
+    rc, out = _run_main(monkeypatch, capsys, [], [(745, 722)], _records())
+    assert rc == 0 and "needs-wiring" in out
+
+def test_main_check_exits_2_on_drift(monkeypatch, capsys):
+    rc, _ = _run_main(monkeypatch, capsys, ["--check"], [(745, 722)], _records())
+    assert rc == 2  # a needs-wiring record is present
+
+def test_main_check_exits_0_when_clean(monkeypatch, capsys):
+    clean = [{"dependent": 594, "blocker": 211, "state": "closed", "action": "closed-blocker"}]
+    rc, _ = _run_main(monkeypatch, capsys, ["--check"], [(594, 211)], clean)
+    assert rc == 0  # no needs-wiring
+
+def test_main_apply_wires_only_needs_wiring(monkeypatch, capsys):
+    wired = []
+    monkeypatch.setattr(spd, "wire", lambda recs: wired.extend((r["dependent"], r["blocker"]) for r in recs) or [])
+    rc, _ = _run_main(monkeypatch, capsys, ["--apply"], [(745, 722)], _records())
+    # wire() is handed only the needs-wiring subset
+    assert rc == 0 and wired == [(745, 722)]
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `workflow/tests/.venv/bin/python -m pytest workflow/tests/test_scan_prose_deps.py -k "report or main" -v`
+Expected: FAIL — `AttributeError: ... 'render_report'` / `'main'`
+
+- [ ] **Step 3: Implement act layer + `main()`**
+
+```python
+# add to scan_prose_deps.py
+
+_ACTION_ORDER = ["needs-wiring", "un-wireable-pr", "already-wired", "closed-blocker", "self-ref"]
+
+
+def render_report(records):
+    if not records:
+        return "scan_prose_deps: no prose-dependency drift found.\n"
+    lines = [f"{'DEPENDENT':>9}  {'BLOCKER':>7}  {'STATE':<7}  ACTION",
+             "-" * 44]
+    key = lambda r: (_ACTION_ORDER.index(r["action"]), r["dependent"], r["blocker"])
+    for r in sorted(records, key=key):
+        lines.append(f"#{r['dependent']:<8} #{r['blocker']:<6} {r['state']:<7}  {r['action']}")
+    return "\n".join(lines) + "\n"
+
+
+def wire(records):
+    """POST a native blockedBy edge for each record (must be needs-wiring).
+    Uses the REST dependencies endpoint, which takes the blocker's numeric DB id."""
+    wired = []
+    for r in records:
+        dependent, blocker = r["dependent"], r["blocker"]
+        blocker_db_id = gh("api", f"repos/{REPO}/issues/{blocker}", parse_json=True)["id"]
+        gh("api", "--method", "POST",
+           f"repos/{REPO}/issues/{dependent}/dependencies/blocked_by",
+           "-F", f"issue_id={blocker_db_id}", parse_json=False)
+        print(f"  wired: #{dependent} blocked_by #{blocker}")
+        wired.append((dependent, blocker))
+    return wired
+
+
+def _scan(issue_number=None):
+    """Fetch -> parse -> reconcile. Single-issue if issue_number given."""
+    if issue_number is not None:
+        issues = [i for i in fetch_open_issues() if i["number"] == issue_number]
+    else:
+        issues = fetch_open_issues()
+    pairs = []
+    for i in issues:
+        pairs.extend(parse_dependencies(i["number"], i.get("body")))
+    return reconcile(pairs)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--issue", type=int, help="restrict scan to a single dependent issue")
+    parser.add_argument("--check", action="store_true", help="exit 2 if any needs-wiring drift")
+    parser.add_argument("--apply", action="store_true", help="wire the needs-wiring edges")
+    parser.add_argument("--only", type=int, nargs="*", default=None,
+                        help="with --apply: wire only these dependent issue numbers")
+    args = parser.parse_args()
+
+    records = _scan(args.issue)
+    needs = [r for r in records if r["action"] == "needs-wiring"]
+
+    if args.apply:
+        subset = needs if args.only is None else [r for r in needs if r["dependent"] in args.only]
+        if not subset:
+            print("scan_prose_deps: nothing to wire.")
+            return 0
+        wire(subset)
+        return 0
+
+    print(render_report(records), end="")
+    if args.check:
+        return 2 if needs else 0
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+- [ ] **Step 4: Run all tests to verify pass**
+
+Run: `workflow/tests/.venv/bin/python -m pytest workflow/tests/test_scan_prose_deps.py -v`
+Expected: PASS (all)
+
+- [ ] **Step 5: Make the script executable + commit**
+
+```bash
+chmod +x scripts/pm/scan_prose_deps.py
+git add scripts/pm/scan_prose_deps.py workflow/tests/test_scan_prose_deps.py
+git commit -m "feat(pm): scan_prose_deps act layer (report/wire) + CLI (#722)"
+```
+
+---
+
+## Task 5: Live smoke test (read-only)
+
+**Files:** none (operational verification).
+
+- [ ] **Step 1: Run `--report` against the live board**
+
+Run: `scripts/pm/scan_prose_deps.py --report`
+Expected: a drift table. Sanity-check that the known #745→#722 pair appears as `needs-wiring`, and a known closed chain (e.g. #594→#211) shows `closed-blocker`.
+
+- [ ] **Step 2: Run single-issue mode on #745**
+
+Run: `scripts/pm/scan_prose_deps.py --issue 745`
+Expected: exactly the #745→#722 `needs-wiring` row (this is the call-site the DoR/best-next backstop uses).
+
+- [ ] **Step 3: Confirm `--check` reflects drift**
+
+Run: `scripts/pm/scan_prose_deps.py --check; echo "exit=$?"`
+Expected: `exit=2` (needs-wiring drift present at this point).
+
+No commit (read-only).
+
+---
+
+## Task 6: Execute the backfill (AC items 1 + 2)
+
+**Files:** none (board mutations + verification).
+
+- [ ] **Step 1: Capture the review set**
+
+Run: `scripts/pm/scan_prose_deps.py --report | tee /tmp/prose_dep_report.txt`
+**PM review gate (non-negotiable):** read every `needs-wiring` row. Strike any false positive (a blocker phrase in negated/historical context) by noting its dependent number for exclusion. PR-blockers and closed-blockers are already excluded by classification.
+
+- [ ] **Step 2: Wire the reviewed set**
+
+If the full `needs-wiring` set is correct:
+Run: `scripts/pm/scan_prose_deps.py --apply`
+If excluding reviewed-out false positives, wire the rest explicitly:
+Run: `scripts/pm/scan_prose_deps.py --apply --only <good dependent numbers…>`
+Expected: one `wired: #N blocked_by #M` line per edge.
+
+- [ ] **Step 3: Verify the native graph now answers `is:blocked` (AC item 2)**
+
+Run: `gh search issues "is:open is:blocked" --repo Jin-HoMLee/splice-neoepitope-pipeline --json number,title`
+Expected: the real blocked set (≥ the rows just wired), not ~0.
+
+- [ ] **Step 4: Confirm `--check` is now clean**
+
+Run: `scripts/pm/scan_prose_deps.py --check; echo "exit=$?"`
+Expected: `exit=0` (no remaining needs-wiring drift).
+
+No commit (board state only — there is no code change in this task).
+
+---
+
+## Task 7: Convention cross-ref (memory) + PR
+
+**Files:**
+- Modify (personas memory, MM-committed): `memory/shared/feedback_dependency_tracking.md`
+
+- [ ] **Step 1: Add the scanner cross-ref to the dependency-tracking memory**
+
+Under "How to apply", append a bullet:
+
+```markdown
+- **Reconcile prose → native in bulk / on demand:** `scripts/pm/scan_prose_deps.py` finds prose-stated dependencies (the blocker-phrase allowlist) and diffs them against the native graph. `--report` lists drift; `--apply` wires the missing edges (after a human review of the report); `--check` exits non-zero on drift (board-hygiene sweep); `--issue N` scopes to one candidate — the call the DoR commitment-act check (`feedback_board_hygiene.md`) and the best-next backstop (`feedback_best_next_issue.md` Step 1) use. Built for [Issue #722](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/722).
+```
+
+Flag for MM in the PR description (memory file → MM commits separately).
+
+- [ ] **Step 2: Push the branch + open the PR**
+
+```bash
+git push -u origin design/pm/issue-722-prose-dependency-reconciler
+gh pr create --repo Jin-HoMLee/splice-neoepitope-pipeline \
+  --title "feat(pm): prose-dependency reconciler — backfill native blockedBy (#722)" \
+  --body "$(cat <<'EOF'
+Closes #722.
+
+Builds `scripts/pm/scan_prose_deps.py` (fetch → parse → reconcile → act) and backfills the existing prose dependencies into native `blockedBy` edges.
+
+## Test plan
+- [ ] `workflow/tests/.venv/bin/python -m pytest workflow/tests/test_scan_prose_deps.py -v` green
+- [ ] `--report` lists drift; `--issue 745` returns the #745→#722 row
+- [ ] backfill applied; `gh search issues "is:blocked"` returns the real set
+- [ ] `--check` exits 0 after backfill
+
+## Memory edits — for MM to commit
+- `shared/feedback_dependency_tracking.md` — scanner cross-ref under "How to apply".
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 3: Offer a bot review, write the lab-notebook entry post-review, then merge via the gate**
+
+Per the closure ritual: offer `@claude review` on this non-trivial PR, write the `research/lab_notebook/pm.md` entry referencing the PR after review, then:
+Run: `bash scripts/audit_and_merge.sh <PR_NUMBER> --squash --delete-branch`
+
+---
+
+## Self-Review (completed during authoring)
+
+**Spec coverage:** §3 deliverable → Tasks 1-4. §4 four layers → Tasks 1 (fetch), 2 (parse), 3 (reconcile), 4 (act). §5 false-positive control → Task 2 (narrow allowlist + negative tests). §6 four modes → Task 4 (`main`). §7 backfill flow → Task 6. §8 integration → Task 7 cross-ref. §9 testing → Tasks 2-4. §10 doc update → Task 7. §11 AC → Tasks 4 (script+modes+tests), 6 (backfill+verify), 7 (convention doc). All covered.
+
+**Placeholder scan:** none — every code step shows complete code; the `--only <numbers>` in Task 6 is an operational argument the PM fills from the live report, not a code placeholder.
+
+**Type consistency:** `parse_dependencies(number, body)`, `classify(dependent, blocker, *, blocker_meta, existing)`, `reconcile(pairs) -> [{dependent, blocker, state, action}]`, `wire(records)`, `render_report(records)`, `main()` — names + signatures match across Tasks 2-4 and the API block.
+
+**Deviation noted:** spec §5's "narrative-exclude list" is implemented as a *narrow allowlist + negative tests* (Task 2) rather than a second exclude pass — same guarantee, less code (DRY/YAGNI). Documented in the parse-layer docstring.

--- a/docs/superpowers/specs/2026-06-16-prose-dependency-reconciler-design.md
+++ b/docs/superpowers/specs/2026-06-16-prose-dependency-reconciler-design.md
@@ -88,10 +88,10 @@ These three call-sites are *documented* now; whether they invoke the script lite
 
 ## 11. Acceptance criteria (mapped from the Issue)
 
-- [ ] Existing open prose dependency chains reflected as native `blockedBy` edges (§7 steps 1-3).
-- [ ] `is:blocked` / blockedBy audit returns the real blocked set (§7 step 4).
-- [ ] Convention documented — scanner cross-ref'd into `feedback_dependency_tracking.md`; the three call-sites named (§10).
-- [ ] `scripts/pm/scan_prose_deps.py` lands with the four modes (§6) and parse-layer pytest coverage (§9).
+- [x] Existing open prose dependency chains reflected as native `blockedBy` edges (§7 steps 1-3). — backfill found them already reflected (already-wired); the lone `needs-wiring` candidate was a reviewed false positive, so zero edges needed wiring.
+- [x] `is:blocked` / blockedBy audit returns the real blocked set (§7 step 4). — verified via `is:blocked` alone (12) + GraphQL ground truth; surfaced that the `is:open is:blocked` combo is broken (returns 0).
+- [x] Convention documented — scanner cross-ref'd into `feedback_dependency_tracking.md`; the call-sites named; query guidance corrected (§10). _(memory edit, for MM to commit)_
+- [x] `scripts/pm/scan_prose_deps.py` lands with the four modes (§6) and parse-layer pytest coverage (§9). — 41 tests, markdown-aware parsing, code-review polish applied.
 
 ## 12. Open questions for the plan
 

--- a/docs/superpowers/specs/2026-06-16-prose-dependency-reconciler-design.md
+++ b/docs/superpowers/specs/2026-06-16-prose-dependency-reconciler-design.md
@@ -1,0 +1,99 @@
+# Prose-Dependency Reconciler — Design (Issue #722)
+
+**Status:** design approved (brainstorm), pending spec review → writing-plans
+**Issue:** [#722 — populate native blockedBy on the dependency graph](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/722)
+**Arc:** `arc:board-governance` (active)
+**Author:** PM
+**Date:** 2026-06-16
+
+## 1. Problem
+
+Cross-Issue dependencies on board 9 live in **prose** — Issue bodies say "depends on #M" / "blocked on #M" — but the corresponding **native GitHub `blockedBy` edge** is usually never wired. So `is:blocked` audits return ~0 despite real dependency chains (e.g. #707→#708→#709 calibration; #680→PR #714), and "what's blocked?" can't be answered mechanically.
+
+The cost is concrete and recent: on 2026-06-16, [Issue #745](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/745) was committed to Ready by hand while its body said "depends on #722" (open) — a prose-only dependency with zero native edge, so `is:blocked` passed it clean. The same blind spot caused [Issue #594](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/594) to sit un-pulled for 4 days after its blockers cleared.
+
+The convention and the mechanism already exist (`shared/feedback_dependency_tracking.md`: "set the native edge at creation/discovery", via the `addBlockedBy` GraphQL mutation or the simpler REST `dependencies/blocked_by` POST). What's missing is (a) a **backfill** of the existing prose deps into native edges, and (b) a way to **sustain** graph accuracy so the convention stays honest.
+
+## 2. Scope (decision: B — backfill + reusable reconciler)
+
+Three options were weighed:
+- **A. Backfill only** (AC-as-written): one-time scan + wire + verify; documented convention sustains it. Rejected — leaves the DoR/best-next blocked-check re-grepping by hand every commit.
+- **B. Backfill + a reusable prose↔native drift-checker** *(chosen)*. The backfill *requires* writing the scan anyway; making it reusable is cheap and gives the convention a drift-detector — the same pattern every other board convention uses to stay honest.
+- **C. B + a create/edit hook** that flags a prose-dep-without-edge. Rejected as premature — the mechanism-over-memory ladder reserves hooks for rules that have slipped ≥2× on the same shape; this is slip #1.
+
+**Out of scope:** cross-repo dependencies (single-repo project, untested); auto-removal of closed-blocker edges (the native graph auto-reflects closure — no manual cleanup); a CI gate (the `--check` mode is built, but wiring it into a workflow is a separate follow-up if wanted).
+
+## 3. Deliverable
+
+`scripts/pm/scan_prose_deps.py` — a **prose↔native dependency reconciler**. Plain `python3` + `gh` subprocess, alongside `scripts/pm/recheck_milestone.py` (same convention — no special env; `gh` on PATH). Run once to drive the backfill; kept afterward as a board-hygiene drift-checker and as the tool the DoR/best-next blocked-check calls instead of ad-hoc grep.
+
+## 4. Architecture — four thin layers
+
+Each layer is independently testable; the parse layer holds the risk and gets the real test coverage.
+
+| Layer | Job | How |
+|-------|-----|-----|
+| **fetch** | get open issues + bodies | `gh issue list --state open --limit 1000 --json number,title,body,state`. Uses the **issue list**, not the project board — so the board's Done-first pagination trap does not apply (that trap is `projectV2.items`-specific). `--limit 1000` per the default-limit convention. |
+| **parse** | body → `(dependent N, blocker M)` pairs | regex over a blocker-phrase allowlist; narrative-phrase exclude. Detailed in §5. |
+| **reconcile** | diff prose pairs vs the native graph | for each pair: is M open? does a native `blockedBy N→M` edge already exist? → classify into `needs-wiring` / `already-wired` / `closed-blocker (skip)` / `un-wireable (PR blocker)`. |
+| **act** | report / wire / exit-code | mode-dependent (§6). |
+
+## 5. Parse layer — false-positive control
+
+The parse layer is the only risky part: a false positive that gets wired creates a **wrong `blockedBy` edge**, which marks real work un-pullable (the inverse failure of the bug we're fixing). Controls:
+
+- **Blocker-phrase allowlist** (case-insensitive), each immediately followed by `#<digits>`:
+  `depends on`, `blocked by`, `blocked on`, `blocked-by:`, `gated on`, `requires`.
+- **Narrative-phrase exclude** (these are *why*-context, NOT *what*-blockers — wiring them is wrong):
+  `informs`, `consumes`, `relates to`, `related to`, `follow-up to`, `supersedes`, `superseded by`, `see`, `cf.`.
+- **Reconcile-stage filters** (not parse-stage — keep parse purely syntactic):
+  - **Closed blocker M → drop** (convention: only edges for currently-open blockers).
+  - **M is a PR, not an issue → report as `un-wireable (prose-only)`**, never auto-acted. Native dependencies are issue↔issue; a "blocked by PR #714" stays prose. Detect via the issue/PR type on lookup.
+  - **Self-reference (N == M) → drop.**
+  - **Duplicate pairs → dedupe.**
+- **Never auto-wire blind.** Default mode only reports. Wiring requires a human review gate (§7).
+
+**Heuristic, not perfect.** The allowlist will miss exotic phrasings and may over-catch a blocker phrase used in historical/negated context ("previously blocked by #X, now resolved"). Both failure modes are caught by the human review gate before `--apply`. The scanner's job is to *surface candidates*, not to decide autonomously.
+
+## 6. Modes (one tool, four entry points)
+
+- `--report` *(default)* — print the drift table: `dependent | blocker | blocker-state | native-edge? | action`. Read-only. Drives the backfill review and the hygiene sweep.
+- `--apply <issue-list>` — wire native edges for the **PM-reviewed subset** (passed explicitly, drawn from the `--report` output — the report *is* the review gate), via the REST `dependencies/blocked_by` POST. Refuses to wire anything outside the `needs-wiring` classification (closed-blocker, PR-blocker, already-wired are no-ops). Prints each edge as created. Idempotent.
+- `--check` — exit non-zero if any drift exists (open prose blocker with no edge). For the board-hygiene sweep / future CI.
+- `--issue N` — single-issue scope; composes with the above. This is what the **DoR commitment-act check** and the **best-next backstop** call: "does candidate N have an unwired open prose blocker?"
+
+## 7. Backfill execution flow (the AC)
+
+1. `scan_prose_deps.py --report` → full drift table across open issues.
+2. **PM reviews** — strike false positives, PR-blockers, and any narrative the allowlist over-caught. Human gate; non-negotiable per the blind-wire risk (§5).
+3. `scan_prose_deps.py --apply` on the reviewed set → native edges wired.
+4. **Verify:** `gh search issues "is:blocked"` returns the real blocked set (AC item 2). Spot-check a known chain (#707→#708→#709).
+
+## 8. Integration — the "sustain" half
+
+- **DoR / commitment-act** (`shared/feedback_board_hygiene.md`) — the blocked-check added 2026-06-16 calls `--issue N` instead of ad-hoc grep.
+- **Best-next backstop** (`shared/feedback_best_next_issue.md` Step 1) — same `--issue N` call.
+- **Board-hygiene sweep** — periodic `--check` surfaces drift (a prose dep authored without an edge) as a hygiene finding — the drift-detector that keeps "set edge at creation" honest.
+
+These three call-sites are *documented* now; whether they invoke the script literally vs. remain a convention pointer is a plan-level choice (the script makes either cheap).
+
+## 9. Testing
+
+- **pytest on the parse layer** (`workflow/tests/.venv`) — fixture bodies → expected pairs: allowlist hits, narrative excludes, multi-blocker, closed-blocker filtering at reconcile, PR-blocker flagging, self-reference, dedupe. The false-positive risk lives here, so this is where coverage concentrates.
+- **Light integration** on reconcile/act — mock the `gh` calls (or a dry-run against a couple of known live chains). No live mutations in tests.
+
+## 10. Doc / convention updates
+
+- Cross-ref the scanner into `shared/feedback_dependency_tracking.md` "How to apply" (the scanner is *how* you find/reconcile prose deps) and name the three call-sites. The convention ("stated → edge at creation") is unchanged; #722 gives it a drift-checker, not a new rule.
+
+## 11. Acceptance criteria (mapped from the Issue)
+
+- [ ] Existing open prose dependency chains reflected as native `blockedBy` edges (§7 steps 1-3).
+- [ ] `is:blocked` / blockedBy audit returns the real blocked set (§7 step 4).
+- [ ] Convention documented — scanner cross-ref'd into `feedback_dependency_tracking.md`; the three call-sites named (§10).
+- [ ] `scripts/pm/scan_prose_deps.py` lands with the four modes (§6) and parse-layer pytest coverage (§9).
+
+## 12. Open questions for the plan
+
+1. **Single-issue `--issue N` perf** — does the DoR/best-next call need its own native-edge lookup per candidate, or can it reuse a cached full-scan? (Likely per-candidate; the call is rare and interactive.)
+2. **PR-blocker representation** — leave un-wireable PR blockers as prose-only forever, or open a follow-up to track them another way? (Lean: prose-only is fine; PR blockers resolve fast.)

--- a/research/lab_notebook/pm.md
+++ b/research/lab_notebook/pm.md
@@ -6,6 +6,22 @@ Format and rules unchanged from the unified notebook — see `shared/feedback_la
 
 ---
 
+## 2026-06-16
+
+### 20:59 UTC — Editor: PM
+
+#### Prose-dependency reconciler ([Issue #722](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/722) / [PR #764](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/764)) — and the `is:open is:blocked` query is broken
+
+**What shipped.** `scripts/pm/scan_prose_deps.py` — a prose↔native dependency reconciler (fetch → parse → reconcile → act; four modes `--report`/`--apply`/`--check`/`--issue N`; 39 pytest cases). Built subagent-driven (fresh implementer + two-stage review per task). The parse layer is markdown-aware (unwraps `[Issue #N](url)` links, strips `**` emphasis) on a narrow blocker-phrase allowlist, then strict phrase→#N adjacency — recall-limited by design (narrative-gap deps like "depends on the registry from #732" are not auto-caught; the human review gate fills them).
+
+**The backfill found the graph already clean — wired nothing.** The one `needs-wiring` candidate (#705→#626) was a **reviewed false positive**: #705's body says "*#538–542* blocked on #626" (context about MM-slimming work), not #705 itself. All real open deps were already natively wired (#416→#413, #725→#719, #745→#722, #736→#681/#735). The team has been following the "set the edge at creation" convention, so #722's value is the reusable scanner (drift-detection + the DoR/best-next blocked-check tool), and it verified the graph rather than repairing it.
+
+**The real finding — and the correction to this morning's #745 story.** Live testing revealed `gh search issues "is:open is:blocked"` (and any `is:blocked` + open-filter combo) **silently returns 0 even for genuinely-wired blocked issues** — a GitHub-search bug. Bare `is:blocked` works (12); GraphQL `blockedBy` is authoritative. This overturns the morning diagnosis: #745 was demoted as "prose-only, zero native edge," but its timeline shows a `blocked_by_added` event on **2026-06-15** — the edge existed. The morning miss was really (a) *no* blocked-check at the commitment act, and (b) a post-hoc `is:open is:blocked` returning 0, misread as "no edge." Corrected six memory rules (DoR, best-next, MEMORY.md inline, dependency-tracking query block + operator caveat, morning-routine ×2) to lead with "verify with a query that WORKS" — `is:blocked` alone / GraphQL — and demote the prose-scan to a secondary backstop. (MM to commit the memory edits.)
+
+**Process note.** The live smoke test (Task 5) earned its keep twice: it caught the markdown-blind parser (clean `depends on #N` tests passed, but real bodies use `**depends on** #722` and `[Issue #N](url)`) *and* surfaced the `is:open is:blocked` bug. Unit tests on curated fixtures could not have found either — the integration run against the real board did. Mirrors the standing "run the chr22 integration before merge for new rules" lesson, one tier up.
+
+---
+
 ## 2026-06-15
 
 ### 17:53 UTC — Editor: PM

--- a/scripts/pm/scan_prose_deps.py
+++ b/scripts/pm/scan_prose_deps.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""Reconcile prose-stated Issue dependencies into native GitHub blockedBy edges.
+
+Finds bodies saying "depends on #M" / "blocked on #M" etc., diffs them against
+the native blockedBy graph, and reports or wires the missing edges.
+
+Usage:
+  scripts/pm/scan_prose_deps.py                 # --report (default): drift table
+  scripts/pm/scan_prose_deps.py --issue N       # single-issue scope
+  scripts/pm/scan_prose_deps.py --check         # exit 2 if any drift
+  scripts/pm/scan_prose_deps.py --apply         # wire all needs-wiring records
+  scripts/pm/scan_prose_deps.py --apply --only 745 594   # wire only these dependents
+
+Exits 0 clean / 2 drift-present (--check) / 1 on error.
+"""
+import argparse
+import json
+import re
+import subprocess
+import sys
+
+REPO = "Jin-HoMLee/splice-neoepitope-pipeline"
+
+
+def gh(*args, parse_json=True):
+    """Run a gh command; return parsed JSON (default) or raw stdout text."""
+    result = subprocess.run(["gh", *args], capture_output=True, text=True, check=True)
+    return json.loads(result.stdout) if parse_json else result.stdout
+
+
+def fetch_open_issues():
+    """All open issues with bodies. Uses the issue list (NOT the project board),
+    so the board's Done-first pagination trap does not apply."""
+    return gh(
+        "issue", "list", "--repo", REPO, "--state", "open", "--limit", "1000",
+        "--json", "number,title,body,state",
+    )

--- a/scripts/pm/scan_prose_deps.py
+++ b/scripts/pm/scan_prose_deps.py
@@ -63,3 +63,64 @@ def parse_dependencies(number, body):
     blockers = {int(m.group(1)) for m in BLOCKER_RE.finditer(body)}
     blockers.discard(number)  # self-reference
     return [(number, b) for b in sorted(blockers)]
+
+
+def classify(dependent, blocker, *, blocker_meta, existing):
+    """Classify one (dependent, blocker) pair. Pure given resolved inputs."""
+    if dependent == blocker:
+        return "self-ref"
+    if blocker in existing:
+        return "already-wired"
+    if blocker_meta["state"] == "closed":
+        return "closed-blocker"  # convention: only wire currently-open blockers
+    if blocker_meta["is_pr"]:
+        return "un-wireable-pr"  # native deps are issue<->issue
+    return "needs-wiring"
+
+
+def issue_meta(number):
+    """{'state': 'open'|'closed', 'is_pr': bool} via the REST issues endpoint
+    (which serves both issues and PRs; a PR carries a 'pull_request' key)."""
+    obj = gh("api", f"repos/{REPO}/issues/{number}")
+    return {"state": obj["state"], "is_pr": "pull_request" in obj}
+
+
+def native_blockers(number):
+    """Set of issue numbers this issue is already natively blockedBy."""
+    q = (
+        'query { repository(owner: "Jin-HoMLee", name: "splice-neoepitope-pipeline") {'
+        f"  issue(number: {number}) {{ blockedBy(first: 50) {{ nodes {{ number }} }} }}"
+        "}}"
+    )
+    data = gh("api", "graphql", "-f", f"query={q}")
+    nodes = data["data"]["repository"]["issue"]["blockedBy"]["nodes"]
+    return {n["number"] for n in nodes}
+
+
+def reconcile(pairs):
+    """Resolve + classify each (dependent, blocker) pair into a record dict.
+    Caches per-issue lookups so each blocker/dependent is fetched once."""
+    meta_cache = {}
+    edges_cache = {}
+
+    def meta(n):
+        if n not in meta_cache:
+            meta_cache[n] = issue_meta(n)
+        return meta_cache[n]
+
+    def edges(n):
+        if n not in edges_cache:
+            edges_cache[n] = native_blockers(n)
+        return edges_cache[n]
+
+    records = []
+    for dependent, blocker in pairs:
+        bmeta = meta(blocker)
+        action = classify(dependent, blocker, blocker_meta=bmeta, existing=edges(dependent))
+        records.append({
+            "dependent": dependent,
+            "blocker": blocker,
+            "state": bmeta["state"],
+            "action": action,
+        })
+    return records

--- a/scripts/pm/scan_prose_deps.py
+++ b/scripts/pm/scan_prose_deps.py
@@ -191,6 +191,8 @@ def _scan(issue_number=None):
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--issue", type=int, help="restrict scan to a single dependent issue")
+    parser.add_argument("--report", action="store_true",
+                        help="print the drift table (default action; explicit form)")
     parser.add_argument("--check", action="store_true", help="exit 2 if any needs-wiring drift")
     parser.add_argument("--apply", action="store_true", help="wire the needs-wiring edges")
     parser.add_argument("--only", type=int, nargs="*", default=None,

--- a/scripts/pm/scan_prose_deps.py
+++ b/scripts/pm/scan_prose_deps.py
@@ -20,6 +20,7 @@ import subprocess
 import sys
 
 REPO = "Jin-HoMLee/splice-neoepitope-pipeline"
+REPO_OWNER, REPO_NAME = REPO.split("/")
 
 
 def gh(*args, parse_json=True):
@@ -72,6 +73,9 @@ def parse_dependencies(number, body):
     (e.g. "depends on the registry from #732") is NOT caught — strict adjacency
     is deliberate to avoid false-matching tool/hardware deps ("requires
     NetMHCpan-4.0"). Such cases are surfaced via the human review gate, not here.
+    Two more exotic gaps: a link title with multiple issue refs (e.g. "[#5 and #6](url)")
+    keeps only the first #N after link-unwrap; and a blocker phrase embedded inside a
+    link title (e.g. "[depends on #722](url)") is stripped by link-unwrap and missed.
     Blocker open/closed and PR-vs-issue filtering happen later, in reconcile()."""
     if not body:
         return []
@@ -108,7 +112,7 @@ def native_blockers(number):
     an empty set if the issue has no blockedBy node (defensive — a malformed or
     empty response should not crash a full-board scan)."""
     q = (
-        'query { repository(owner: "Jin-HoMLee", name: "splice-neoepitope-pipeline") {'
+        f'query {{ repository(owner: "{REPO_OWNER}", name: "{REPO_NAME}") {{'
         f"  issue(number: {number}) {{ blockedBy(first: 50) {{ nodes {{ number }} }} }}"
         "}}"
     )
@@ -148,6 +152,7 @@ def reconcile(pairs):
 
 
 _ACTION_ORDER = ["needs-wiring", "un-wireable-pr", "already-wired", "closed-blocker", "self-ref"]
+_ACTION_RANK = {a: i for i, a in enumerate(_ACTION_ORDER)}
 
 
 def render_report(records):
@@ -155,7 +160,7 @@ def render_report(records):
         return "scan_prose_deps: no prose-dependency drift found.\n"
     lines = [f"{'DEPENDENT':>9}  {'BLOCKER':>7}  {'STATE':<7}  ACTION",
              "-" * 44]
-    key = lambda r: (_ACTION_ORDER.index(r["action"]), r["dependent"], r["blocker"])
+    key = lambda r: (_ACTION_RANK.get(r["action"], len(_ACTION_ORDER)), r["dependent"], r["blocker"])
     for r in sorted(records, key=key):
         lines.append(f"#{r['dependent']:<8} #{r['blocker']:<6} {r['state']:<7}  {r['action']}")
     return "\n".join(lines) + "\n"
@@ -177,9 +182,13 @@ def wire(records):
 
 
 def _scan(issue_number=None):
-    """Fetch -> parse -> reconcile. Single-issue if issue_number given."""
+    """Fetch -> parse -> reconcile. Single-issue if issue_number given.
+
+    Single-issue scope fetches that issue directly (the hot path for the
+    DoR / best-next per-candidate check) rather than listing the whole board."""
     if issue_number is not None:
-        issues = [i for i in fetch_open_issues() if i["number"] == issue_number]
+        obj = gh("api", f"repos/{REPO}/issues/{issue_number}")
+        issues = [{"number": obj["number"], "body": obj.get("body")}]
     else:
         issues = fetch_open_issues()
     pairs = []
@@ -198,6 +207,8 @@ def main():
     parser.add_argument("--only", type=int, nargs="*", default=None,
                         help="with --apply: wire only these dependent issue numbers")
     args = parser.parse_args()
+    if args.only is not None and not args.apply:
+        parser.error("--only requires --apply")
 
     records = _scan(args.issue)
     needs = [r for r in records if r["action"] == "needs-wiring"]

--- a/scripts/pm/scan_prose_deps.py
+++ b/scripts/pm/scan_prose_deps.py
@@ -35,3 +35,31 @@ def fetch_open_issues():
         "issue", "list", "--repo", REPO, "--state", "open", "--limit", "1000",
         "--json", "number,title,body,state",
     )
+
+
+# Blocker-phrase allowlist — deliberately narrow: only verbs that mean "this is
+# blocked until #M". Narrative verbs (informs/consumes/relates to/see/fixes/...)
+# are NOT listed, so they never match — that IS the exclude mechanism (a narrow
+# allowlist), proven by test_parse_narrative_phrases_excluded.
+# Note: blocked-by: allows optional # (e.g. "blocked-by:722" or "blocked-by:#722");
+# others require # to avoid false matches like "requires 5 steps".
+BLOCKER_RE = re.compile(
+    r"(?:"
+    r"(?:depends on|blocked by|blocked on|gated on|requires)\s*#"
+    r"|blocked-by:?\s*#?"
+    r")(\d+)",
+    re.IGNORECASE,
+)
+
+
+def parse_dependencies(number, body):
+    """Return sorted, deduped (dependent, blocker) pairs from one issue body.
+
+    Pure: no I/O. Matches only the blocker-phrase allowlist; drops self-references.
+    Blocker open/closed and PR-vs-issue filtering happen later, in reconcile().
+    """
+    if not body:
+        return []
+    blockers = {int(m.group(1)) for m in BLOCKER_RE.finditer(body)}
+    blockers.discard(number)  # self-reference
+    return [(number, b) for b in sorted(blockers)]

--- a/scripts/pm/scan_prose_deps.py
+++ b/scripts/pm/scan_prose_deps.py
@@ -52,15 +52,30 @@ BLOCKER_RE = re.compile(
 )
 
 
+def _normalize(text):
+    """Strip markdown that breaks blocker-phrase -> #N adjacency.
+
+    Unwraps issue-ref markdown links ([Issue #719](url) -> #719) and removes
+    emphasis/code markers (* `) so a bolded or linked dependency still matches
+    BLOCKER_RE. Underscores are left intact (they appear in identifiers)."""
+    text = re.sub(r"\[[^\]]*?#(\d+)[^\]]*?\]\([^)]*\)", r"#\1", text)  # unwrap links first
+    text = re.sub(r"[*`]", "", text)                                    # then strip emphasis
+    return text
+
+
 def parse_dependencies(number, body):
     """Return sorted, deduped (dependent, blocker) pairs from one issue body.
 
-    Pure: no I/O. Matches only the blocker-phrase allowlist; drops self-references.
-    Blocker open/closed and PR-vs-issue filtering happen later, in reconcile().
-    """
+    Pure: no I/O. Normalizes markdown (emphasis + issue-ref links) then matches
+    the blocker-phrase allowlist with strict adjacency; drops self-references.
+    KNOWN LIMITATION: a multi-word narrative gap between the phrase and #N
+    (e.g. "depends on the registry from #732") is NOT caught — strict adjacency
+    is deliberate to avoid false-matching tool/hardware deps ("requires
+    NetMHCpan-4.0"). Such cases are surfaced via the human review gate, not here.
+    Blocker open/closed and PR-vs-issue filtering happen later, in reconcile()."""
     if not body:
         return []
-    blockers = {int(m.group(1)) for m in BLOCKER_RE.finditer(body)}
+    blockers = {int(m.group(1)) for m in BLOCKER_RE.finditer(_normalize(body))}
     blockers.discard(number)  # self-reference
     return [(number, b) for b in sorted(blockers)]
 

--- a/scripts/pm/scan_prose_deps.py
+++ b/scripts/pm/scan_prose_deps.py
@@ -68,7 +68,7 @@ def parse_dependencies(number, body):
 def classify(dependent, blocker, *, blocker_meta, existing):
     """Classify one (dependent, blocker) pair. Pure given resolved inputs."""
     if dependent == blocker:
-        return "self-ref"
+        return "self-ref"  # unreachable via reconcile (parse drops self-refs); defensive
     if blocker in existing:
         return "already-wired"
     if blocker_meta["state"] == "closed":
@@ -86,14 +86,20 @@ def issue_meta(number):
 
 
 def native_blockers(number):
-    """Set of issue numbers this issue is already natively blockedBy."""
+    """Set of issue numbers this issue is already natively blockedBy.
+
+    Uses the GraphQL blockedBy edge (GitHub enforces a max of 50 blockers per
+    direction per issue, so first:50 is a true ceiling, not a sample). Returns
+    an empty set if the issue has no blockedBy node (defensive — a malformed or
+    empty response should not crash a full-board scan)."""
     q = (
         'query { repository(owner: "Jin-HoMLee", name: "splice-neoepitope-pipeline") {'
         f"  issue(number: {number}) {{ blockedBy(first: 50) {{ nodes {{ number }} }} }}"
         "}}"
     )
     data = gh("api", "graphql", "-f", f"query={q}")
-    nodes = data["data"]["repository"]["issue"]["blockedBy"]["nodes"]
+    issue = (data.get("data", {}).get("repository", {}) or {}).get("issue") or {}
+    nodes = (issue.get("blockedBy") or {}).get("nodes") or []
     return {n["number"] for n in nodes}
 
 
@@ -124,3 +130,74 @@ def reconcile(pairs):
             "action": action,
         })
     return records
+
+
+_ACTION_ORDER = ["needs-wiring", "un-wireable-pr", "already-wired", "closed-blocker", "self-ref"]
+
+
+def render_report(records):
+    if not records:
+        return "scan_prose_deps: no prose-dependency drift found.\n"
+    lines = [f"{'DEPENDENT':>9}  {'BLOCKER':>7}  {'STATE':<7}  ACTION",
+             "-" * 44]
+    key = lambda r: (_ACTION_ORDER.index(r["action"]), r["dependent"], r["blocker"])
+    for r in sorted(records, key=key):
+        lines.append(f"#{r['dependent']:<8} #{r['blocker']:<6} {r['state']:<7}  {r['action']}")
+    return "\n".join(lines) + "\n"
+
+
+def wire(records):
+    """POST a native blockedBy edge for each record (must be needs-wiring).
+    Uses the REST dependencies endpoint, which takes the blocker's numeric DB id."""
+    wired = []
+    for r in records:
+        dependent, blocker = r["dependent"], r["blocker"]
+        blocker_db_id = gh("api", f"repos/{REPO}/issues/{blocker}", parse_json=True)["id"]
+        gh("api", "--method", "POST",
+           f"repos/{REPO}/issues/{dependent}/dependencies/blocked_by",
+           "-F", f"issue_id={blocker_db_id}", parse_json=False)
+        print(f"  wired: #{dependent} blocked_by #{blocker}")
+        wired.append((dependent, blocker))
+    return wired
+
+
+def _scan(issue_number=None):
+    """Fetch -> parse -> reconcile. Single-issue if issue_number given."""
+    if issue_number is not None:
+        issues = [i for i in fetch_open_issues() if i["number"] == issue_number]
+    else:
+        issues = fetch_open_issues()
+    pairs = []
+    for i in issues:
+        pairs.extend(parse_dependencies(i["number"], i.get("body")))
+    return reconcile(pairs)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--issue", type=int, help="restrict scan to a single dependent issue")
+    parser.add_argument("--check", action="store_true", help="exit 2 if any needs-wiring drift")
+    parser.add_argument("--apply", action="store_true", help="wire the needs-wiring edges")
+    parser.add_argument("--only", type=int, nargs="*", default=None,
+                        help="with --apply: wire only these dependent issue numbers")
+    args = parser.parse_args()
+
+    records = _scan(args.issue)
+    needs = [r for r in records if r["action"] == "needs-wiring"]
+
+    if args.apply:
+        subset = needs if args.only is None else [r for r in needs if r["dependent"] in args.only]
+        if not subset:
+            print("scan_prose_deps: nothing to wire.")
+            return 0
+        wire(subset)
+        return 0
+
+    print(render_report(records), end="")
+    if args.check:
+        return 2 if needs else 0
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/workflow/tests/test_scan_prose_deps.py
+++ b/workflow/tests/test_scan_prose_deps.py
@@ -55,3 +55,41 @@ def test_parse_empty_or_none_body():
 
 def test_parse_case_insensitive():
     assert spd.parse_dependencies(2, "DEPENDS ON #5") == [(2, 5)]
+
+
+def test_classify_needs_wiring():
+    r = spd.classify(745, 722, blocker_meta={"state": "open", "is_pr": False}, existing=set())
+    assert r == "needs-wiring"
+
+def test_classify_already_wired():
+    r = spd.classify(745, 722, blocker_meta={"state": "open", "is_pr": False}, existing={722})
+    assert r == "already-wired"
+
+def test_classify_closed_blocker():
+    r = spd.classify(594, 211, blocker_meta={"state": "closed", "is_pr": False}, existing=set())
+    assert r == "closed-blocker"
+
+def test_classify_un_wireable_pr():
+    r = spd.classify(680, 714, blocker_meta={"state": "open", "is_pr": True}, existing=set())
+    assert r == "un-wireable-pr"
+
+
+def test_reconcile_classifies_each_pair(monkeypatch):
+    meta = {
+        722: {"state": "open", "is_pr": False},   # needs-wiring
+        211: {"state": "closed", "is_pr": False}, # closed-blocker
+        714: {"state": "open", "is_pr": True},    # un-wireable-pr
+        708: {"state": "open", "is_pr": False},   # already-wired (in existing)
+    }
+    monkeypatch.setattr(spd, "issue_meta", lambda n: meta[n])
+    monkeypatch.setattr(spd, "native_blockers", lambda n: {708} if n == 709 else set())
+
+    pairs = [(745, 722), (594, 211), (680, 714), (709, 708)]
+    records = spd.reconcile(pairs)
+    actions = {(r["dependent"], r["blocker"]): r["action"] for r in records}
+    assert actions == {
+        (745, 722): "needs-wiring",
+        (594, 211): "closed-blocker",
+        (680, 714): "un-wireable-pr",
+        (709, 708): "already-wired",
+    }

--- a/workflow/tests/test_scan_prose_deps.py
+++ b/workflow/tests/test_scan_prose_deps.py
@@ -175,3 +175,21 @@ def test_parse_narrative_gap_not_caught_documented_limitation():
     # the tool/hardware lines above. These are surfaced by the human review gate instead.
     body = "Depends on the assembled registry ([Issue #732](https://example/732))."
     assert spd.parse_dependencies(737, body) == []
+
+
+def test_classify_self_ref():
+    # The defensive self-ref arm (unreachable via reconcile, but present in classify).
+    r = spd.classify(745, 745, blocker_meta={"state": "open", "is_pr": False}, existing=set())
+    assert r == "self-ref"
+
+
+def test_main_apply_only_subsets_by_dependent(monkeypatch, capsys):
+    # --only restricts --apply to the named dependents among the needs-wiring set.
+    wired = []
+    monkeypatch.setattr(spd, "wire", lambda recs: wired.extend((r["dependent"], r["blocker"]) for r in recs) or [])
+    two_needs = [
+        {"dependent": 745, "blocker": 722, "state": "open", "action": "needs-wiring"},
+        {"dependent": 705, "blocker": 626, "state": "open", "action": "needs-wiring"},
+    ]
+    rc, _ = _run_main(monkeypatch, capsys, ["--apply", "--only", "745"], [(745, 722), (705, 626)], two_needs)
+    assert rc == 0 and wired == [(745, 722)]  # only 745 wired, 705 excluded by --only

--- a/workflow/tests/test_scan_prose_deps.py
+++ b/workflow/tests/test_scan_prose_deps.py
@@ -16,3 +16,42 @@ import scan_prose_deps as spd  # noqa: E402
 
 def test_repo_constant():
     assert spd.REPO == "Jin-HoMLee/splice-neoepitope-pipeline"
+
+
+@pytest.mark.parametrize("phrase", [
+    "depends on #722", "blocked by #722", "blocked on #722",
+    "blocked-by:722", "gated on #722", "requires #722",
+])
+def test_parse_allowlist_phrases_match(phrase):
+    body = f"Some context. This {phrase} to proceed."
+    assert spd.parse_dependencies(745, body) == [(745, 722)]
+
+
+@pytest.mark.parametrize("phrase", [
+    "informs #722", "consumes #722", "relates to #722", "related to #722",
+    "follow-up to #722", "supersedes #722", "superseded by #722",
+    "see #722", "cf. #722", "fixes #722",
+])
+def test_parse_narrative_phrases_excluded(phrase):
+    # Narrative cross-refs are *why*-context, never blockers — must yield nothing.
+    body = f"This PR {phrase}."
+    assert spd.parse_dependencies(745, body) == []
+
+
+def test_parse_multiple_blockers_deduped_and_sorted():
+    body = "Depends on #708 and blocked by #707. Also depends on #708 again."
+    assert spd.parse_dependencies(709, body) == [(709, 707), (709, 708)]
+
+
+def test_parse_self_reference_dropped():
+    body = "This depends on #745 (itself, nonsensically)."
+    assert spd.parse_dependencies(745, body) == []
+
+
+def test_parse_empty_or_none_body():
+    assert spd.parse_dependencies(1, "") == []
+    assert spd.parse_dependencies(1, None) == []
+
+
+def test_parse_case_insensitive():
+    assert spd.parse_dependencies(2, "DEPENDS ON #5") == [(2, 5)]

--- a/workflow/tests/test_scan_prose_deps.py
+++ b/workflow/tests/test_scan_prose_deps.py
@@ -1,0 +1,18 @@
+"""Tests for scripts/pm/scan_prose_deps.py — the prose-dependency reconciler (Issue #722).
+
+Parse layer is pure and gets the bulk of coverage; reconcile/act monkeypatch the
+gh-backed helpers so nothing touches the network.
+"""
+import sys
+from pathlib import Path
+
+import pytest
+
+_PM_DIR = Path(__file__).resolve().parents[2] / "scripts" / "pm"
+sys.path.insert(0, str(_PM_DIR))
+
+import scan_prose_deps as spd  # noqa: E402
+
+
+def test_repo_constant():
+    assert spd.REPO == "Jin-HoMLee/splice-neoepitope-pipeline"

--- a/workflow/tests/test_scan_prose_deps.py
+++ b/workflow/tests/test_scan_prose_deps.py
@@ -136,3 +136,37 @@ def test_main_apply_wires_only_needs_wiring(monkeypatch, capsys):
     monkeypatch.setattr(spd, "wire", lambda recs: wired.extend((r["dependent"], r["blocker"]) for r in recs) or [])
     rc, _ = _run_main(monkeypatch, capsys, ["--apply"], [(745, 722)], _records())
     assert rc == 0 and wired == [(745, 722)]
+
+
+# --- markdown-aware parsing (real-world body formats; live-smoke regression) ---
+
+def test_parse_bold_phrase():
+    # "This Issue **depends on** #722" — bold markers between phrase and #N
+    assert spd.parse_dependencies(745, "This Issue **depends on** #722 rather than folding.") == [(745, 722)]
+
+def test_parse_markdown_link_ref():
+    # "Blocked on [Issue #719](url)" — issue ref as a markdown link
+    body = "Blocked on [Issue #719](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/719)."
+    assert spd.parse_dependencies(725, body) == [(725, 719)]
+
+def test_parse_bold_plus_link():
+    # "Blocked by** [Issue #629](url)" — both bold and link
+    body = "Blocked by** [Issue #629](https://github.com/x/y/issues/629) — htslib drift."
+    assert spd.parse_dependencies(636, body) == [(636, 629)]
+
+def test_parse_short_link_form():
+    # "[#42](url)" link form
+    assert spd.parse_dependencies(1, "depends on [#42](https://example/42)") == [(1, 42)]
+
+def test_parse_tool_deps_still_ignored():
+    # NON-issue deps must stay filtered (no #N after the phrase)
+    assert spd.parse_dependencies(566, "requires NetMHCpan-4.0 + netMHCstabpan licenses") == []
+    assert spd.parse_dependencies(708, "depends on paid-commercial tools (netMHCpan, netMHCstabpan)") == []
+    assert spd.parse_dependencies(601, "blocked on P100: needs bf16 which Pascal lacks") == []
+
+def test_parse_narrative_gap_not_caught_documented_limitation():
+    # KNOWN LIMITATION (documented): a multi-word gap between phrase and #N is NOT caught.
+    # Strict post-normalization adjacency is deliberate — loosening it would false-match
+    # the tool/hardware lines above. These are surfaced by the human review gate instead.
+    body = "Depends on the assembled registry ([Issue #732](https://example/732))."
+    assert spd.parse_dependencies(737, body) == []

--- a/workflow/tests/test_scan_prose_deps.py
+++ b/workflow/tests/test_scan_prose_deps.py
@@ -137,6 +137,11 @@ def test_main_apply_wires_only_needs_wiring(monkeypatch, capsys):
     rc, _ = _run_main(monkeypatch, capsys, ["--apply"], [(745, 722)], _records())
     assert rc == 0 and wired == [(745, 722)]
 
+def test_main_explicit_report_flag(monkeypatch, capsys):
+    # The documented `--report` flag must be accepted and behave like the default.
+    rc, out = _run_main(monkeypatch, capsys, ["--report"], [(745, 722)], _records())
+    assert rc == 0 and "needs-wiring" in out
+
 
 # --- markdown-aware parsing (real-world body formats; live-smoke regression) ---
 

--- a/workflow/tests/test_scan_prose_deps.py
+++ b/workflow/tests/test_scan_prose_deps.py
@@ -93,3 +93,46 @@ def test_reconcile_classifies_each_pair(monkeypatch):
         (680, 714): "un-wireable-pr",
         (709, 708): "already-wired",
     }
+
+
+def _records():
+    return [
+        {"dependent": 745, "blocker": 722, "state": "open", "action": "needs-wiring"},
+        {"dependent": 594, "blocker": 211, "state": "closed", "action": "closed-blocker"},
+    ]
+
+def test_render_report_lists_each_record():
+    out = spd.render_report(_records())
+    assert "745" in out and "722" in out and "needs-wiring" in out
+    assert "594" in out and "closed-blocker" in out
+
+def test_render_report_empty():
+    assert "no prose-dependency drift" in spd.render_report([]).lower()
+
+def _run_main(monkeypatch, capsys, argv, pairs, records):
+    monkeypatch.setattr(spd, "fetch_open_issues",
+                        lambda: [{"number": 745, "title": "x", "body": "depends on #722", "state": "OPEN"}])
+    monkeypatch.setattr(spd, "parse_dependencies", lambda n, b: pairs)
+    monkeypatch.setattr(spd, "reconcile", lambda p: records)
+    monkeypatch.setattr(sys, "argv", ["scan_prose_deps.py", *argv])
+    rc = spd.main()
+    return rc, capsys.readouterr().out
+
+def test_main_report_default_exit_zero(monkeypatch, capsys):
+    rc, out = _run_main(monkeypatch, capsys, [], [(745, 722)], _records())
+    assert rc == 0 and "needs-wiring" in out
+
+def test_main_check_exits_2_on_drift(monkeypatch, capsys):
+    rc, _ = _run_main(monkeypatch, capsys, ["--check"], [(745, 722)], _records())
+    assert rc == 2
+
+def test_main_check_exits_0_when_clean(monkeypatch, capsys):
+    clean = [{"dependent": 594, "blocker": 211, "state": "closed", "action": "closed-blocker"}]
+    rc, _ = _run_main(monkeypatch, capsys, ["--check"], [(594, 211)], clean)
+    assert rc == 0
+
+def test_main_apply_wires_only_needs_wiring(monkeypatch, capsys):
+    wired = []
+    monkeypatch.setattr(spd, "wire", lambda recs: wired.extend((r["dependent"], r["blocker"]) for r in recs) or [])
+    rc, _ = _run_main(monkeypatch, capsys, ["--apply"], [(745, 722)], _records())
+    assert rc == 0 and wired == [(745, 722)]


### PR DESCRIPTION
Closes #722.

Builds `scripts/pm/scan_prose_deps.py` (fetch → parse → reconcile → act) — a reusable prose↔native dependency reconciler — and runs it to reconcile the existing graph.

## Outcome: the graph was already clean
The backfill **wired nothing**, and that's the correct result:
- Real open deps are already natively wired (#416→#413, #725→#719, #745→#722, #736→#681/#735, …) — the team has been following the "set the edge at creation" convention.
- The scanner's one `needs-wiring` candidate (#705→#626) is a **reviewed false positive** (context: "#538–542 blocked on #626", not #705 itself) — struck at the human review gate.
- Narrative-gap candidates (#732/#569 chains) are closed-blockers or already-wired.

So #722's lasting value is the **reusable scanner** (drift-detection + the DoR/best-next blocked-check tool), and it verified the graph is healthy.

## Bonus finding (verified live): `is:open is:blocked` is broken
`gh search issues "is:open is:blocked"` (and any `is:blocked` + open-filter combo) **silently returns 0** even for genuinely-wired blocked issues — a GitHub-search bug. Bare `is:blocked` works (returns the real 12); GraphQL `blockedBy` is authoritative. This was the actual root cause of the #745 mis-handling earlier today (its native edge existed; the broken query hid it). Memory corrected accordingly (see below).

## Test plan
- [x] `workflow/tests/.venv/bin/python -m pytest workflow/tests/test_scan_prose_deps.py -v` — 39 passing (parse layer incl. markdown-aware + adversarial cases)
- [x] `--report` lists drift; `--issue 745` returns the already-wired row; `--check` exits 2 on drift
- [x] live `--report` run (read-only) — surfaced 1 candidate (reviewed FP)
- [x] `wire()` REST path validated via read-back; no edges needed wiring
- [x] AC2 verified — `is:blocked` returns the real open-blocked set (12)

## Memory edits — for MM to commit (personas repo)
- `shared/feedback_dependency_tracking.md` — scanner cross-ref under "How to apply"; query block corrected (`is:blocked` alone + authoritative GraphQL); operator caveat.
- `shared/feedback_board_hygiene.md`, `shared/feedback_best_next_issue.md`, `pm/MEMORY.md`, `pm/feedback_morning_routine.md` (×2) — corrected the #745 origin (wired, not prose-only) and the `is:open is:blocked`-is-broken finding across the blocked-check rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)