### PR TITLE
feat(pm): make board_open_items.py parent-aware (subIssuesSummary) (#742)

### DIFF
--- a/research/lab_notebook/developer.md
+++ b/research/lab_notebook/developer.md
@@ -6,6 +6,18 @@ Format and rules unchanged from the unified notebook — see `shared/feedback_la
 
 ---
 
+## 2026-06-17 — board_open_items.py is parent-aware ([PR #768](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/768) closes [Issue #742](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/742))
+
+### Editor: Developer
+
+**Why.** The PM weekly triage + flow-health sweeps read `scripts/board_open_items.py --json`, which exposed no parenthood signal. So parent/epic Issues drew false-positive flags for conditions that are correct-by-design: a parent carries no Size (it rolls up from sub-issues), and its board Status *mirrors* a child, reading as independent "aging WIP" drift. Surfaced 2026-06-15 when the morning sweep flagged parents [#547](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/547) and [#680](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/680). A memory note doesn't fire at sweep-time; the signal is computable, so the tool computes it (deterministic-first / mechanism-over-memory).
+
+**The fix.** The `... on Issue` GraphQL fragment now requests `subIssuesSummary { total }`; `normalize()` derives `is_parent` (`total > 0`), mirroring the parenthood derivation already in `.claude/hooks/check_gh_issue_develop_parent.py`. The PR fragment is untouched (PRs have no sub-issues → `is_parent` False structurally, enforced at the query layer not by defensive code). `--json` carries `is_parent` (additive key); the table marks parents `Issue/P` in the Kind column (mirrors the `/D` draft marker; mutually exclusive — a parent is always an Issue, never a draft); `--exclude-parents` drops parents at the source so the sweeps can filter without `jq`. Scope is the *signal* + filter — wiring the PM sweeps to call `--exclude-parents` is a deferred consumer follow-up (AC note on #742).
+
+**Verification.** TDD throughout (RED watched before each GREEN): 8 new tests in `workflow/tests/test_board_open_items.py` (the CI-gated home — the pre-existing `scripts/tests/test_board_open_items_arc.py` is *not* CI-collected, a separate latent gap left untouched). Live smoke test on board #9: #547/#680 flag `is_parent=true`; `--exclude-parents` dropped 9 parents (113→104) with zero leaks; #547 confirmed Size-unset (the targeted false-positive). Full `workflow/tests/` suite green (529→ +8); arc suite 9 green. Bot review **LGTM, no blockers** — addressed two notes: widened the Kind column to 8 (its `"Issue/D"` rationale was wrong — `Issue/D` can't occur, so `Issue/P` is the *first* overflow and this PR introduced it; added a column-alignment regression test), and asserted `is_parent` in the JSON-contract test. Declined a third (leaf-row lookup fragility — robust in practice). No chr22 integration run needed (board-tooling change, not a Snakemake rule).
+
+---
+
 ## 2026-06-16 — closure gate lints gating boxes outside an AC section ([PR #761](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/761) closes [Issue #730](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/730))
 
 ### 20:37 UTC — Editor: Developer — scope post-merge `check_ac` to the AC section ([PR #763](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/763) closes [Issue #726](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/726))

--- a/scripts/board_open_items.py
+++ b/scripts/board_open_items.py
@@ -287,9 +287,12 @@ def format_table(
     # only --json exposes it). Issue #689.
     arc_hdr = f"{'Arc':<18} {'Ph':<7} " if arc_columns else ""
     arc_sep = f"{'-' * 18} {'-' * 7} " if arc_columns else ""
+    # Kind column is 8 wide to fit the longest marker "Issue/P" (parent); plain
+    # "Issue" / draft "PR/D" are shorter. A narrower budget overflows and shifts
+    # every column to its right out from under its header.
     lines = [
-        f"{'Status':<17} {'P':<3} {'Sz':<3} {'Age':<5} {'Role':<17} {'Kind':<5} {'#':<5} {arc_hdr}Title",
-        f"{'-' * 17} {'-' * 3} {'-' * 3} {'-' * 5} {'-' * 17} {'-' * 5} {'-' * 5} {arc_sep}{'-' * 60}",
+        f"{'Status':<17} {'P':<3} {'Sz':<3} {'Age':<5} {'Role':<17} {'Kind':<8} {'#':<5} {arc_hdr}Title",
+        f"{'-' * 17} {'-' * 3} {'-' * 3} {'-' * 5} {'-' * 17} {'-' * 8} {'-' * 5} {arc_sep}{'-' * 60}",
     ]
     for it in items:
         role = (it["role"] or "(none)").removeprefix("role:")[:16]
@@ -306,7 +309,7 @@ def format_table(
             arc_cell = ""
         lines.append(
             f"{it['status']:<17} {it['priority'] or '?':<3} {it['size'] or '?':<3} "
-            f"{age:<5} {role:<17} {kind:<5} {it['number']:<5} {arc_cell}{title}"
+            f"{age:<5} {role:<17} {kind:<8} {it['number']:<5} {arc_cell}{title}"
         )
     return "\n".join(lines) + "\n"
 

--- a/scripts/board_open_items.py
+++ b/scripts/board_open_items.py
@@ -21,6 +21,7 @@ Usage:
   scripts/board_open_items.py --status Ready --priority P1
   scripts/board_open_items.py --sort-updated --role scientist   # recent momentum
   scripts/board_open_items.py --stale-days 21                    # dormancy sweep
+  scripts/board_open_items.py --exclude-parents                  # drop epics (Size/flow sweeps)
   scripts/board_open_items.py --json | jq '.[] | select(.size == "S")'
 """
 from __future__ import annotations
@@ -47,6 +48,7 @@ query($owner: String!, $number: Int!, $after: String) {
             ... on Issue {
               number title state url
               createdAt updatedAt closedAt
+              subIssuesSummary { total }
               labels(first: 20) { nodes { name } }
             }
             ... on PullRequest {
@@ -151,12 +153,18 @@ def normalize(item: dict[str, Any]) -> dict[str, Any] | None:
         (l.removeprefix("arc-phase:") for l in labels if l.startswith("arc-phase:")),
         None,
     )
+    # A parent/epic has >=1 sub-issue. PRs (and the rare node the query returned
+    # no summary for) have no subIssuesSummary block → treated as a leaf. Mirrors
+    # `.claude/hooks/check_gh_issue_develop_parent.py` (total > 0 → parent).
+    sub_summary = content.get("subIssuesSummary") or {}
+    is_parent = (sub_summary.get("total") or 0) > 0
     return {
         "number": content.get("number"),
         "title": content.get("title", ""),
         "url": content.get("url", ""),
         "kind": "PR" if content.get("__typename") == "PullRequest" else "Issue",
         "is_draft": content.get("isDraft", False),
+        "is_parent": is_parent,
         "state": state,
         "status": status or "No Status",
         "priority": priority,
@@ -285,7 +293,9 @@ def format_table(
     ]
     for it in items:
         role = (it["role"] or "(none)").removeprefix("role:")[:16]
-        kind = it["kind"] + ("/D" if it["is_draft"] else "")
+        # "/D" = draft PR; "/P" = parent/epic Issue (mutually exclusive — a parent
+        # is always an Issue, never a draft).
+        kind = it["kind"] + ("/D" if it["is_draft"] else "") + ("/P" if it["is_parent"] else "")
         title = (it["title"] or "")[:60]
         age = age_label(it.get("updated_at"), now)
         if arc_columns:
@@ -310,6 +320,11 @@ def main() -> int:
     p.add_argument("--arc", help='Filter by arc label (e.g. "scoring-tcr-pmhc" or "arc:scoring-tcr-pmhc")')
     p.add_argument("--arc-phase", dest="arc_phase", choices=["active", "next", "later"],
                    help="Filter by arc focus phase")
+    p.add_argument("--exclude-parents", dest="exclude_parents", action="store_true",
+                   help="Drop parent/epic issues (>=1 sub-issue) from the result. "
+                        "Parents carry no Size and mirror a child's Status, so the PM "
+                        "triage/flow sweeps flag them as false drift; this filters them "
+                        "out at the source (Issue #742).")
     p.add_argument("--arc-columns", dest="arc_columns", action="store_true",
                    help="Add Arc + phase columns to the table (slug after 'arc:'); "
                         "useful with --arc-phase active to see each issue's arc "
@@ -329,6 +344,8 @@ def main() -> int:
     raw = fetch_all_items()
     normalized = [n for it in raw if (n := normalize(it)) is not None]
     filtered = [it for it in normalized if matches_filter(it, args)]
+    if args.exclude_parents:
+        filtered = [it for it in filtered if not it["is_parent"]]
     if args.sort_updated or args.stale_days is not None:
         filtered = apply_recency(
             filtered, sort_updated=args.sort_updated, stale_days=args.stale_days, now=now

--- a/workflow/tests/test_board_open_items.py
+++ b/workflow/tests/test_board_open_items.py
@@ -27,25 +27,36 @@ NOW = datetime(2026, 6, 4, 12, 0, 0, tzinfo=timezone.utc)
 
 def _board_item(number, *, updated="2026-06-04T00:00:00Z",
                 created="2026-05-01T00:00:00Z", closed=None, role="role:pm",
-                status="Ready", priority=None, size=None):
-    """A minimal ProjectV2 board node shaped like the GraphQL response."""
+                status="Ready", priority=None, size=None, sub_total=None,
+                typename="Issue", is_draft=False):
+    """A minimal ProjectV2 board node shaped like the GraphQL response.
+
+    `sub_total=None` omits the `subIssuesSummary` block entirely (mimics a node
+    the query didn't return one for — e.g. a PR); an int injects
+    `subIssuesSummary { total: <n> }` like the Issue fragment does.
+    """
     field_values = [{"name": status, "field": {"name": "Status"}}]
     if priority:
         field_values.append({"name": priority, "field": {"name": "Priority"}})
     if size:
         field_values.append({"name": size, "field": {"name": "Size"}})
+    content = {
+        "__typename": typename,
+        "number": number,
+        "title": f"issue {number}",
+        "state": "OPEN",
+        "url": f"https://example/{number}",
+        "createdAt": created,
+        "updatedAt": updated,
+        "closedAt": closed,
+        "labels": {"nodes": [{"name": role}]},
+    }
+    if typename == "PullRequest":
+        content["isDraft"] = is_draft
+    if sub_total is not None:
+        content["subIssuesSummary"] = {"total": sub_total}
     return {
-        "content": {
-            "__typename": "Issue",
-            "number": number,
-            "title": f"issue {number}",
-            "state": "OPEN",
-            "url": f"https://example/{number}",
-            "createdAt": created,
-            "updatedAt": updated,
-            "closedAt": closed,
-            "labels": {"nodes": [{"name": role}]},
-        },
+        "content": content,
         "fieldValues": {"nodes": field_values},
     }
 
@@ -264,3 +275,54 @@ def test_format_table_now_defaults_to_real_clock():
     table = boi.format_table(items)  # no now= → exercises the None branch
     assert "Age" in table.splitlines()[0]
     assert "issue 1" in table
+
+
+# --- parent-awareness (Issue #742) -----------------------------------------
+
+def test_normalize_is_parent_true_when_subissues():
+    n = boi.normalize(_board_item(742, sub_total=3))
+    assert n["is_parent"] is True
+
+
+def test_normalize_is_parent_false_when_zero_subissues():
+    n = boi.normalize(_board_item(742, sub_total=0))
+    assert n["is_parent"] is False
+
+
+def test_normalize_is_parent_false_when_summary_absent():
+    # a node with no subIssuesSummary block (e.g. the query returned none) → leaf
+    n = boi.normalize(_board_item(742, sub_total=None))
+    assert n["is_parent"] is False
+
+
+def test_normalize_pr_is_not_parent():
+    # PRs have no sub-issues; the PR fragment carries no subIssuesSummary
+    n = boi.normalize(_board_item(742, typename="PullRequest", role="role:pm"))
+    assert n["kind"] == "PR"
+    assert n["is_parent"] is False
+
+
+def test_main_json_carries_is_parent(monkeypatch, capsys):
+    raw = [_board_item(1, sub_total=2), _board_item(2, sub_total=0)]
+    _, out = _run_main(monkeypatch, capsys, ["--json"], raw)
+    parsed = {it["number"]: it for it in json.loads(out)}
+    assert parsed[1]["is_parent"] is True
+    assert parsed[2]["is_parent"] is False
+
+
+def test_format_table_marks_parent_in_kind():
+    parent = boi.normalize(_board_item(1, sub_total=4))
+    leaf = boi.normalize(_board_item(2, sub_total=0))
+    table = boi.format_table([parent, leaf], now=NOW)
+    # parent's Kind cell carries the /P marker, mirroring the /D draft convention
+    assert "Issue/P" in table
+    # the leaf row stays a plain "Issue" (no stray /P)
+    leaf_row = [ln for ln in table.splitlines() if ln.strip().endswith("issue 2")][0]
+    assert "/P" not in leaf_row
+
+
+def test_exclude_parents_filters_out_parents(monkeypatch, capsys):
+    raw = [_board_item(1, sub_total=3), _board_item(2, sub_total=0)]
+    _, out = _run_main(monkeypatch, capsys, ["--exclude-parents", "--json"], raw)
+    nums = [it["number"] for it in json.loads(out)]
+    assert nums == [2]  # the parent (#1) is dropped, the leaf (#2) stays

--- a/workflow/tests/test_board_open_items.py
+++ b/workflow/tests/test_board_open_items.py
@@ -199,8 +199,9 @@ def test_main_json_emits_flat_array(monkeypatch, capsys):
     assert isinstance(parsed, list)      # not an envelope object
     assert len(parsed) == 2              # what `jq length` would report
     assert {it["number"] for it in parsed} == {1, 2}
-    # additive timestamp keys reach the JSON output (the PR-body additive-field claim)
-    assert all(k in parsed[0] for k in ("created_at", "updated_at", "closed_at"))
+    # additive keys reach the JSON output (the PR-body additive-field claim):
+    # timestamps (Issue #642) + is_parent (Issue #742)
+    assert all(k in parsed[0] for k in ("created_at", "updated_at", "closed_at", "is_parent"))
 
 
 def test_main_default_no_flags_uses_sort_key(monkeypatch, capsys):
@@ -326,3 +327,15 @@ def test_exclude_parents_filters_out_parents(monkeypatch, capsys):
     _, out = _run_main(monkeypatch, capsys, ["--exclude-parents", "--json"], raw)
     nums = [it["number"] for it in json.loads(out)]
     assert nums == [2]  # the parent (#1) is dropped, the leaf (#2) stays
+
+
+def test_format_table_parent_kind_keeps_column_alignment():
+    # "Issue/P" is 7 chars and must not overflow the Kind column and shift the
+    # # column out from under its header (the first kind value to exceed the
+    # old 5-char budget; "Issue"=5 fit, drafts are "PR/D"=4).
+    parent = boi.normalize(_board_item(547, sub_total=4))
+    lines = boi.format_table([parent], now=NOW).splitlines()
+    header, row = lines[0], lines[2]  # 0=header, 1=separator, 2=data
+    assert "Issue/P" in row
+    # the issue number sits exactly under the '#' header label
+    assert row.index("547") == header.index("#")


### PR DESCRIPTION
**Created by:** Developer

Closes #742.

Makes `scripts/board_open_items.py` parent-aware so the PM weekly triage + flow-health sweeps stop flagging epics for conditions that are **correct-by-design** (a parent carries no Size — it rolls up from sub-issues; its Status *mirrors* a child, reading as independent drift). Surfaced 2026-06-15 when the morning sweep flagged parents #547 and #680 as size/flow gaps.

## What changed

- **GraphQL** — the `... on Issue` fragment now requests `subIssuesSummary { total }` (the `... on PullRequest` fragment is untouched — PRs have no sub-issues).
- **`normalize()`** — exposes an `is_parent` boolean (`total > 0`); PRs and sub-issue-less issues normalize to `False`.
- **`--json`** — carries `is_parent` for every item (additive key; existing keys unchanged → the `check_ready_queue.sh` flat-array contract holds).
- **Table** — parents render `Issue/P` in the `Kind` column, mirroring the existing `/D` draft marker (mutually exclusive: a parent is always an Issue, never a draft).
- **`--exclude-parents`** — drops parents from the result, so the sweeps can filter them at the source without `jq`.

Parenthood derivation mirrors `.claude/hooks/check_gh_issue_develop_parent.py` (`subIssuesSummary.total > 0`).

**Scope note:** this ships the *signal* + filter. Wiring the PM sweeps to actually call `--exclude-parents` (and point flow-health at the aging child) is the consumer's follow-up — see the AC note on #742.

## Test plan

- [x] 7 new unit tests in `workflow/tests/test_board_open_items.py` (CI's `pipeline-pytest` collection): `is_parent` true/false/absent, PR-not-parent, JSON carries the key, table `/P` marker, `--exclude-parents` filtering — all written test-first (verified RED before implementing).
- [x] Full `workflow/tests/` suite green (529 passed, 6 skipped); non-CI `scripts/tests/test_board_open_items_arc.py` still green (9 passed).
- [x] Live smoke test against board #9: known parents #547/#680 flag `is_parent=true`; `--exclude-parents` drops 9 parents (113→104) with zero leaks; `#547` confirmed Size-unset (the targeted false-positive).
