### PR TITLE
data(scoring): NeoRanking + IMPROVE calibration cohort tables — schema + reconcile (#707)

### DIFF
--- a/research/experiments/issue_547_immunogenicity_calibration/README.md
+++ b/research/experiments/issue_547_immunogenicity_calibration/README.md
@@ -1,0 +1,106 @@
+# issue_547 — immunogenicity calibration
+
+**Goal:** build the post-MHCflurry **immunogenicity calibration** layer (KDE + centered isotonic regression) that maps `presentation_score` → `calibrated_immunogenicity_log_odds`. This folder is the **epic-level home** for that work; the first sub-issue ([Issue #707](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/707)) acquires the labelled training cohorts chosen in [Issue #592](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/592) and confirms their schema is usable. Nothing downstream (#708 calibrator, #709 Snakemake wiring) starts until the tables are in hand and parseable.
+
+**Parent epic:** [Issue #547](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/547) · **acquisition sub-issue:** [Issue #707](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/707)
+
+Folder is **epic-keyed** (`issue_547`, not `issue_707`) because the cohort data + calibrator are shared across the sub-issues; it mirrors the GCS prefix `gs://splice-neoepitope-project/experiments/issue_547/`.
+
+## Layout
+
+```
+issue_547_immunogenicity_calibration/
+├── README.md            # this file (committed)
+├── data_manifest.yaml   # pinned schema v1 — paths + checksums + fetch cmds + license (committed)
+├── data/                # raw cohort tables — GITIGNORED (root .gitignore `data/`); not on fresh clones
+└── (later) notebook.ipynb + outputs/   # the #708 calibrator analysis
+```
+
+Raw tables are **never committed**: NeoRanking is LICR copyright (no redistribution) and the tables are large. `data/` is gitignored repo-wide; recreate it with `mkdir -p data/` after clone and fetch per `data_manifest.yaml`.
+
+## Status (2026-06-17)
+
+| Step | State |
+|------|-------|
+| Sources located + recorded | ✅ figshare share links + filenames + LICR license (`data_manifest.yaml`) |
+| Byte-download (browser route) | ✅ 3 NeoRanking tables downloaded + unzipped into `data/` |
+| Checksums + sizes | ✅ sha256 + byte sizes in `data_manifest.yaml` |
+| Schema + join-feasibility doc | ✅ see "Schema & join feasibility" below |
+| GCS mirror (>100 MB) | ✅ `gs://splice-neoepitope-project/experiments/issue_547/` |
+| Cohort-composition reconcile vs #592 | ✅ paper+data confirmed: mutation 131 pt / neo-pep 99 pt, 178 CD8 neo-peptides, **no Bjerregaard** — #592 correcting note drafted (pending post) |
+| IMPROVE/Borch augment | 📄 access path documented (not blocking; byte-download deferred to VM) |
+
+## Schema & join feasibility (NeoRanking, confirmed from the downloaded tables 2026-06-17)
+
+Two parallel TSVs, same patient cohort at two granularities; both keyed on `patient` + the
+mutation/peptide identity columns. HLA per patient in `HLA_allotypes.txt`.
+
+| table | rows | cols | grain |
+|---|---|---|---|
+| `Neopep_data_org.txt` | 1,787,710 | 57 | one row per candidate **8–12mer neo-peptide** |
+| `Mutation_data_org.txt` | 48,306 | 59 | one row per **mutation** (long/mut-seq level) |
+| `HLA_allotypes.txt` | 150 patients | 2 | `Patient` ⇥ comma-separated 4-digit alleles |
+
+**Columns that matter for calibration** (neo-peptide table):
+
+| role | column | notes |
+|---|---|---|
+| peptide | `mutant_seq` | the 8–12mer; 0 missing |
+| immunogenicity label | `response_type` | `CD8` = positive, `negative` = assayed-no-response, `not_tested` = exclude |
+| HLA allele | `mutant_best_alleles` | MixMHCpred best allele for the peptide; 0 missing |
+| cohort | `dataset` | `NCI` / `TESLA` / `HiTIDE` |
+| split | `train_test` | author train/test partition |
+
+**Label encoding** (neo-peptide table): `not_tested` 1,364,625 · `negative` 422,907 · **`CD8` 178**.
+The calibration target is the assayed subset (`CD8` ∪ `negative` = 423,085 peptides); `not_tested`
+candidates are dropped (neither positive nor negative). Mutation-level immunogenic count = 213 CD8.
+
+**Peptide-length distribution** (`mutant_seq`): 8mer 297,537 · 9mer 337,905 · 10mer 377,640 ·
+11mer 417,204 · 12mer 357,424 — **all within MHCflurry's 8–15 supported range**.
+
+**Join to `genotype_presentation_score` — FEASIBLE.** Every neo-peptide row carries both a peptide
+(`mutant_seq`) and an HLA allele (`mutant_best_alleles`), 0 missing on either. So each assayed row is
+directly scoreable by `Class1PresentationPredictor` (peptide + allele → `presentation_score` /
+`presentation_percentile`), which is exactly the input the calibrator (#708) maps to an immunogenicity
+log-odds. Per-patient genotype scoring can use the ≤6 alleles from `HLA_allotypes.txt`.
+
+## Outputs index
+
+- `data_manifest.yaml` — **pinned schema v1** (Issue #707): paths + checksums + fetch commands + license. Raw tables are **not** committed (LICR copyright, no redistribution).
+
+## Cohort-composition reconcile (primary-source confirmed)
+
+[Issue #592](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/592) described NeoRanking as *"NCI-train + TESLA + HiTIDE + Bjerregaard, ~165 positives / 74 patients."* The **paper itself** (Müller 2023 Methods + Data S1, read from the Zotero PDF) states the cohort is:
+
+| cohort | patients (mutation) | patients (neo-pep) | CD8 (mut / neo-pep) | source accession |
+|---|---|---|---|---|
+| NCI (Rosenberg/Gartner) | 112 | 80 | 147 / 103 | dbGaP `phs001003.v1.p1` |
+| TESLA | 8 | 8 | 36 / 34 | Synapse `syn21048999` |
+| HiTIDE (in-house) | 11 | 11 | 30 / 41 | EGA `EGAS00001007101` |
+| **total** | **131** | **99** | **213 / 178** | — |
+
+So #592 **diverges**: it's **131 patients, not 74**, and the cohorts are NCI + TESLA + HiTIDE — **no Bjerregaard** (that + the "74 pt / ~165 pos" framing is the **NeoGuider** 7-cohort benchmark bleeding in). Now **confirmed from the downloaded tables** (2026-06-17): mutation-level 131 patients / 213 immunogenic mutations; neo-peptide-level 99 patients (32 NCI patients have no testable 8–12mer) / **178 immunogenic neo-peptides** — matching the paper's "~178". A single consolidated correcting note for #592 is drafted (AC #5; pending post).
+
+## Download (browser route — into `data/`)
+
+**⚠️ The NeoRanking README mislabels its figshare links** — it points the data-table names at the *classifier* records. Use the links from the **paper's** Data and Code Availability statement (Müller 2023, attachment `96V52NKW`) instead:
+
+| data matrix (feature values + immunogenicity annotations) | real figshare link |
+|---|---|
+| neo-peptide → `Neopep_data_org.txt` | [147e67dde683fb769908](https://figshare.com/s/147e67dde683fb769908) |
+| mutation → `Mutation_data_org.txt` | [2462b62bb6630fe2d257](https://figshare.com/s/2462b62bb6630fe2d257) |
+| `HLA_allotypes.txt` | [35361871fdad4d1754d7](https://figshare.com/s/35361871fdad4d1754d7) |
+
+Then (run from this folder):
+
+```bash
+sha256sum data/Neopep_data_org.txt data/Mutation_data_org.txt data/HLA_allotypes.txt   # → fill PENDING in manifest
+gsutil cp data/*.txt gs://splice-neoepitope-project/experiments/issue_547/
+```
+
+The `Classifier_neopeptide.zip` / `Classifiers_mutation.zip` already in `data/` came from the README's `a000…`/`3c27…` links — those are the trained NCI-train LR/XGBoost **classifiers**, not data tables (kept for potential #708 figure-repro).
+
+## Cross-experiment deps
+
+- Consumes the cohort selection decision from [Issue #592](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/592) (the cohort-calibration gate deck).
+- Produces the cohort tables consumed by [Issue #708](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/708) (calibrator) and [Issue #709](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/709) (Snakemake wiring).

--- a/research/experiments/issue_547_immunogenicity_calibration/README.md
+++ b/research/experiments/issue_547_immunogenicity_calibration/README.md
@@ -27,8 +27,8 @@ Raw tables are **never committed**: NeoRanking is LICR copyright (no redistribut
 | Checksums + sizes | ✅ sha256 + byte sizes in `data_manifest.yaml` |
 | Schema + join-feasibility doc | ✅ see "Schema & join feasibility" below |
 | GCS mirror (>100 MB) | ✅ `gs://splice-neoepitope-project/experiments/issue_547/` |
-| Cohort-composition reconcile vs #592 | ✅ paper+data confirmed: mutation 131 pt / neo-pep 99 pt, 178 CD8 neo-peptides, **no Bjerregaard** — #592 correcting note drafted (pending post) |
-| IMPROVE/Borch augment | 📄 access path documented (not blocking; byte-download deferred to VM) |
+| Cohort-composition reconcile vs #592 | ✅ paper+data confirmed: mutation 131 pt / neo-pep 99 pt, 178 CD8 neo-peptides, **no Bjerregaard** — #592 correcting note posted |
+| IMPROVE/Borch augment | ✅ downloaded — CV training table (17,520 / 467) + CEDAR benchmark from `SRHgroup/IMPROVE_paper` (the repo named in the paper's Data Availability Statement) |
 
 ## Schema & join feasibility (NeoRanking, confirmed from the downloaded tables 2026-06-17)
 
@@ -64,6 +64,28 @@ directly scoreable by `Class1PresentationPredictor` (peptide + allele → `prese
 `presentation_percentile`), which is exactly the input the calibrator (#708) maps to an immunogenicity
 log-odds. Per-patient genotype scoring can use the ≤6 alleles from `HLA_allotypes.txt`.
 
+### IMPROVE / Borch augment (`data/improve_borch/`, confirmed 2026-06-17)
+
+Source: `github.com/SRHgroup/IMPROVE_paper` @ `c670942` (the repo named in the paper's **Data
+Availability Statement** — Hadrup group, DTU; *not* `mnielLab`). Two TSVs copied; the larger
+`data.zip`/`results.zip` bundles stay in the repo (reproducible via `git clone`).
+
+| file | rows | cols | grain |
+|---|---|---|---|
+| `In_house_neoepitope_for_CV.tsv` | 17,520 | 3 | the training set — one row per candidate peptide |
+| `Neoepitopes_CEDAR_benchmark_data.tsv` | 2,436 | 3 | external CEDAR held-out benchmark (548 positive) |
+
+Schema (both): `Mut_peptide` · `HLA_allele` · `response`. **`response` is BINARY: 1 = immunogenic,
+0 = not** (17,053 neg / 467 pos in the CV table — matches the paper's "17,520 / 467"). No `not_tested`
+class, unlike NeoRanking. Lengths 8–11mers (8:515 · 9:10,561 · 10:4,716 · 11:1,728), all in range;
+0 missing peptide/HLA → fully scoreable.
+
+**Join nuance:** IMPROVE HLA is `HLA-A01:01` (no asterisk); NeoRanking is `A*01:01`. Both must be
+normalized to MHCflurry's canonical `HLA-A*01:01` before scoring. Pooling the two cohorts also means
+reconciling the 3-way (`CD8`/`negative`/`not_tested`) vs binary (`1`/`0`) label encodings — the
+calibrator (#708) consumes assayed-positive vs assayed-negative, so map NeoRanking `CD8`→1,
+`negative`→0, drop `not_tested`; IMPROVE is already in that form.
+
 ## Outputs index
 
 - `data_manifest.yaml` — **pinned schema v1** (Issue #707): paths + checksums + fetch commands + license. Raw tables are **not** committed (LICR copyright, no redistribution).
@@ -79,7 +101,7 @@ log-odds. Per-patient genotype scoring can use the ≤6 alleles from `HLA_alloty
 | HiTIDE (in-house) | 11 | 11 | 30 / 41 | EGA `EGAS00001007101` |
 | **total** | **131** | **99** | **213 / 178** | — |
 
-So #592 **diverges**: it's **131 patients, not 74**, and the cohorts are NCI + TESLA + HiTIDE — **no Bjerregaard** (that + the "74 pt / ~165 pos" framing is the **NeoGuider** 7-cohort benchmark bleeding in). Now **confirmed from the downloaded tables** (2026-06-17): mutation-level 131 patients / 213 immunogenic mutations; neo-peptide-level 99 patients (32 NCI patients have no testable 8–12mer) / **178 immunogenic neo-peptides** — matching the paper's "~178". A single consolidated correcting note for #592 is drafted (AC #5; pending post).
+So #592 **diverges**: it's **131 patients, not 74**, and the cohorts are NCI + TESLA + HiTIDE — **no Bjerregaard** (that + the "74 pt / ~165 pos" framing is the **NeoGuider** 7-cohort benchmark bleeding in). Now **confirmed from the downloaded tables** (2026-06-17): mutation-level 131 patients / 213 immunogenic mutations; neo-peptide-level 99 patients (32 NCI patients have no testable 8–12mer) / **178 immunogenic neo-peptides** — matching the paper's "~178". A single consolidated correcting note was posted on #592 (AC #5).
 
 ## Download (browser route — into `data/`)
 

--- a/research/experiments/issue_547_immunogenicity_calibration/README.md
+++ b/research/experiments/issue_547_immunogenicity_calibration/README.md
@@ -13,10 +13,12 @@ issue_547_immunogenicity_calibration/
 ├── README.md            # this file (committed)
 ├── data_manifest.yaml   # pinned schema v1 — paths + checksums + fetch cmds + license (committed)
 ├── data/                # raw cohort tables — GITIGNORED (root .gitignore `data/`); not on fresh clones
+│   ├── neoranking/      #   primary: Neopep + Mutation + HLA_allotypes (+ source .zip)
+│   └── improve_borch/   #   augment: In_house_neoepitope_for_CV + CEDAR benchmark
 └── (later) notebook.ipynb + outputs/   # the #708 calibrator analysis
 ```
 
-Raw tables are **never committed**: NeoRanking is LICR copyright (no redistribution) and the tables are large. `data/` is gitignored repo-wide; recreate it with `mkdir -p data/` after clone and fetch per `data_manifest.yaml`.
+Raw tables are **never committed**: NeoRanking is LICR copyright (no redistribution) and the tables are large. `data/` is gitignored repo-wide; recreate it with `mkdir -p data/{neoranking,improve_borch}` after clone and fetch per `data_manifest.yaml`. The GCS mirror at `gs://…/experiments/issue_547/` uses the **same two subdirs** (`neoranking/` + `improve_borch/`).
 
 ## Status (2026-06-17)
 
@@ -103,7 +105,9 @@ calibrator (#708) consumes assayed-positive vs assayed-negative, so map NeoRanki
 
 So #592 **diverges**: it's **131 patients, not 74**, and the cohorts are NCI + TESLA + HiTIDE — **no Bjerregaard** (that + the "74 pt / ~165 pos" framing is the **NeoGuider** 7-cohort benchmark bleeding in). Now **confirmed from the downloaded tables** (2026-06-17): mutation-level 131 patients / 213 immunogenic mutations; neo-peptide-level 99 patients (32 NCI patients have no testable 8–12mer) / **178 immunogenic neo-peptides** — matching the paper's "~178". A single consolidated correcting note was posted on #592 (AC #5).
 
-## Download (browser route — into `data/`)
+## Download
+
+### NeoRanking primary → `data/neoranking/` (browser route)
 
 **⚠️ The NeoRanking README mislabels its figshare links** — it points the data-table names at the *classifier* records. Use the links from the **paper's** Data and Code Availability statement (Müller 2023, attachment `96V52NKW`) instead:
 
@@ -113,14 +117,24 @@ So #592 **diverges**: it's **131 patients, not 74**, and the cohorts are NCI + T
 | mutation → `Mutation_data_org.txt` | [2462b62bb6630fe2d257](https://figshare.com/s/2462b62bb6630fe2d257) |
 | `HLA_allotypes.txt` | [35361871fdad4d1754d7](https://figshare.com/s/35361871fdad4d1754d7) |
 
-Then (run from this folder):
+### IMPROVE augment → `data/improve_borch/` (git clone)
+
+Source from the **paper's** Data Availability Statement (Borch 2024, Frontiers full text): `github.com/SRHgroup/IMPROVE_paper` (Hadrup group, DTU) — **not** `mnielLab`.
 
 ```bash
-sha256sum data/Neopep_data_org.txt data/Mutation_data_org.txt data/HLA_allotypes.txt   # → fill PENDING in manifest
-gsutil cp data/*.txt gs://splice-neoepitope-project/experiments/issue_547/
+git clone --depth 1 https://github.com/SRHgroup/IMPROVE_paper.git
+cp IMPROVE_paper/neoepitope_tabels/{In_house_neoepitope_for_CV,Neoepitopes_CEDAR_benchmark_data}.tsv data/improve_borch/
 ```
 
-The `Classifier_neopeptide.zip` / `Classifiers_mutation.zip` already in `data/` came from the README's `a000…`/`3c27…` links — those are the trained NCI-train LR/XGBoost **classifiers**, not data tables (kept for potential #708 figure-repro).
+### Verify + mirror (run from this folder)
+
+```bash
+sha256sum data/neoranking/*.txt data/improve_borch/*.tsv          # → match the manifest
+gsutil -m cp data/neoranking/*.txt    gs://splice-neoepitope-project/experiments/issue_547/neoranking/
+gsutil    cp data/improve_borch/*.tsv gs://splice-neoepitope-project/experiments/issue_547/improve_borch/
+```
+
+The `Classifier_neopeptide.zip` / `Classifiers_mutation.zip` from the NeoRanking README's `a000…`/`3c27…` links are the trained NCI-train LR/XGBoost **classifiers**, not data tables (kept out of `data/` here; fetch only if reproducing #708 figures).
 
 ## Cross-experiment deps
 

--- a/research/experiments/issue_547_immunogenicity_calibration/README.md
+++ b/research/experiments/issue_547_immunogenicity_calibration/README.md
@@ -66,6 +66,11 @@ directly scoreable by `Class1PresentationPredictor` (peptide + allele → `prese
 `presentation_percentile`), which is exactly the input the calibrator (#708) maps to an immunogenicity
 log-odds. Per-patient genotype scoring can use the ≤6 alleles from `HLA_allotypes.txt`.
 
+**HLA coverage (verified 2026-06-17).** `HLA_allotypes.txt` lists **150** patients vs **131** in the
+data tables — but the 131 (mutation ∪ neo-pep) are a **strict subset** of the 150: every patient with
+mutations/peptides has an HLA genotype (0 missing), so full-genotype scoring is safe for all of them.
+The 19 surplus are HLA-only patients with no rows in either data table → drop silently on join.
+
 ### IMPROVE / Borch augment (`data/improve_borch/`, confirmed 2026-06-17)
 
 Source: `github.com/SRHgroup/IMPROVE_paper` @ `c670942` (the repo named in the paper's **Data

--- a/research/experiments/issue_547_immunogenicity_calibration/data_manifest.yaml
+++ b/research/experiments/issue_547_immunogenicity_calibration/data_manifest.yaml
@@ -1,0 +1,85 @@
+# data_manifest.yaml — calibration cohort tables for the immunogenicity-calibration epic
+#
+# Schema v1 — PINNED by Issue #707 (first artifact set in this epic crosses the
+# >100 MB git-exclusion threshold; CLAUDE.md "Size guidance").
+#
+# Raw tables are NOT committed to git: NeoRanking is LICR (Ludwig Institute for
+# Cancer Research) copyright with no OSS license — consume for training/calibration
+# only, do NOT redistribute. Tables are fetched per-clone (or on the GPU VM) into a
+# gitignored path and mirrored to GCS; this manifest carries only paths + checksums
+# + fetch commands so the data is reproducible without redistributing it.
+
+schema_version: 1
+issue: 707                       # data-acquisition sub-issue
+parent_epic: 547                 # KDE + centered-isotonic calibration epic
+gcs_prefix: gs://splice-neoepitope-project/experiments/issue_547/
+local_path: research/experiments/issue_547_immunogenicity_calibration/data/   # gitignored (root .gitignore `data/`); per-clone / on-VM
+
+datasets:
+  - name: neoranking
+    role: primary                # calibration training cohort
+    citation: "Müller M. et al., Immunity 2023; doi:10.1016/j.immuni.2023.09.002"
+    code: https://github.com/bassanilab/NeoRanking
+    license: "LICR (Ludwig Institute for Cancer Research) copyright — no OSS license; no redistribution"
+    # ⚠️ SOURCE-OF-TRUTH NOTE: the NeoRanking *README* mislabels its figshare links —
+    # it points the data-table names at the CLASSIFIER records. The authoritative links
+    # below are from the *paper's* "Data and Code Availability" statement (Müller 2023,
+    # read from the Zotero PDF, attachment 96V52NKW). The README links a000.../3c27...
+    # are the trained LR/XGBoost CLASSIFIERS (the *_clf model zips), NOT the data.
+    #
+    # Cohort composition: CONFIRMED from the paper AND from the downloaded tables (2026-06-17):
+    #   Mutation-level (Mutation_data_org.txt): NCI 112 pt (dbGaP phs001003.v1.p1)
+    #     + TESLA 8 pt (Synapse syn21048999) + HiTIDE/in-house 11 pt (EGA EGAS00001007101)
+    #     = 131 patients. NO Bjerregaard. Immunogenic (response_type==CD8) = 213 mutations.
+    #   Neo-peptide-level (Neopep_data_org.txt): NCI 80 + TESLA 8 + HiTIDE 11 = 99 patients
+    #     (32 NCI pt have no testable 8-12mer); immunogenic (CD8) = 178 neo-peptides
+    #     — matches the paper's "~178 immunogenic neo-peptides".
+    #   #592's "~165 pos / 74 pt / +Bjerregaard" is NeoGuider-benchmark framing — diverges.
+    cohorts: "mutation-level 131 pt (NCI 112 + TESLA 8 + HiTIDE 11), 213 CD8; neo-pep-level 99 pt (NCI 80 + TESLA 8 + HiTIDE 11), 178 CD8 — paper+data confirmed; no Bjerregaard"
+    # Label encoding (response_type), neo-peptide table: not_tested 1,364,625 / negative 422,907 / CD8 178.
+    #   POSITIVE = "CD8" (confirmed CD8+ T-cell response). NEGATIVE = "negative" (assayed, no response).
+    #   not_tested = candidate never immuno-assayed (EXCLUDE from calibration — neither pos nor neg).
+    # Peptide lengths (mutant_seq): 8mer 297,537 / 9mer 337,905 / 10mer 377,640 / 11mer 417,204 / 12mer 357,424
+    #   — all within MHCflurry's 8-15 supported range. Join coverage: 0 missing mutant_seq, 0 missing mutant_best_alleles.
+    files:
+      - filename: Neopep_data_org.txt        # paper: "Combined data matrix neo-pep" (feature values + immunogenicity annotations); 1,787,710 rows × 57 cols, TSV
+        figshare_share: https://figshare.com/s/147e67dde683fb769908
+        fetch: "download from the figshare data link above (NOT the a000... classifier record); unzip Neopep_data_org.txt.zip"
+        sha256: 7bb920ad717491ea6f8300a420913c789aeea7da99712b41a7ffef8eb84fd3d8
+        size_bytes: 715165507
+      - filename: Mutation_data_org.txt       # paper: "Combined data matrix mut-seq"; 48,306 rows × 59 cols, TSV
+        figshare_share: https://figshare.com/s/2462b62bb6630fe2d257
+        fetch: "download from the figshare data link above (NOT the 3c27... classifier record); unzip Mutation_data_org.txt.zip"
+        sha256: 00e59ab81b72bef09bdfbb75f11b5338785e32eb427fd5903f1a1375190abe74
+        size_bytes: 20582134
+      - filename: HLA_allotypes.txt           # paper: "HLA allotypes for all patients"; 150 patients, TSV (Patient \t comma-sep alleles)
+        figshare_share: https://figshare.com/s/35361871fdad4d1754d7
+        fetch: "download from its own figshare record (per paper Data Availability)"
+        sha256: 790644a3aa15c0abb7e5e1e8b9436950ff52668779093907ae1c3e99172b6740
+        size_bytes: 7518
+    # Reference-only figshare records (downloaded already / optional):
+    classifier_neopep_share: https://figshare.com/s/a000b0990465ab3e9d33   # trained neo-pep LR/XGBoost (Classifier_neopeptide.zip — in data/)
+    classifier_mut_share: https://figshare.com/s/3c27fa3b705a74bdfa10      # trained mutation LR/XGBoost (Classifiers_mutation.zip — in data/)
+    ipmsdb_share: https://figshare.com/s/4f551e68e44d9cbf9ccd              # ipMSDB peptide feature DB (optional)
+
+  - name: improve_borch
+    role: augment            # NOT blocking — calibrator (#708) proceeds on neoranking primary; this enlarges the negative/positive pool later
+    status: access_path_documented   # download deferred to the open-egress VM (figshare/Frontiers pages are JS-gated behind the local sandbox proxy)
+    citation: "Borch A. et al., Front. Immunol. 2024; doi:10.3389/fimmu.2024.1360281"
+    cohort: "17,520 candidates / 467 immunogenic (IMPROVE training set)"
+    license: "Frontiers is OA (CC-BY); confirm supplementary data-availability terms on download"
+    access_path:
+      - "Paper Data Availability Statement: doi.org/10.3389/fimmu.2024.1360281 — the IMPROVE training table is in the article's Supplementary Material + the project repo."
+      - "Code/repo: github.com/mnielLab/IMPROVE (Nielsen lab). Training data shipped with the repo / Frontiers supplementary."
+    files:
+      - filename: PENDING        # resolve exact supplementary filename when fetched on the VM
+        source: "Frontiers supplementary (10.3389/fimmu.2024.1360281) or github.com/mnielLab/IMPROVE"
+        fetch: "on the open-egress VM: clone IMPROVE repo / pull Frontiers supplementary; then sha256sum + size into this manifest"
+        sha256: PENDING
+        size_bytes: PENDING
+
+# Status (2026-06-17): NeoRanking primary FULLY in hand — 3 tables downloaded, unzipped,
+# checksummed (sha256 + size above), schema confirmed, cohort composition reconciled
+# (mutation 131 pt / neo-pep 99 pt; 178 CD8 neo-peptides), all rows join-ready
+# (peptide + HLA present). Tables mirrored to gs://splice-neoepitope-project/experiments/issue_547/.
+# IMPROVE/Borch augment: access path documented (not blocking); byte-download deferred to VM.

--- a/research/experiments/issue_547_immunogenicity_calibration/data_manifest.yaml
+++ b/research/experiments/issue_547_immunogenicity_calibration/data_manifest.yaml
@@ -59,6 +59,11 @@ datasets:
         figshare_share: https://figshare.com/s/35361871fdad4d1754d7
         fetch: "download from its own figshare record (per paper Data Availability)"
         sha256: 790644a3aa15c0abb7e5e1e8b9436950ff52668779093907ae1c3e99172b6740
+        # JOIN NOTE (verified 2026-06-17): 150 patients here vs 131 in the data tables.
+        # The 131 data-table patients (mutation ∪ neo-pep) are a STRICT SUBSET of the 150 —
+        # i.e. every patient with mutations/peptides HAS an HLA genotype (0 missing), so
+        # full-genotype scoring is safe for all of them. The 19 surplus are HLA-only patients
+        # absent from both data tables → no matching peptide rows; drop silently on join.
         size_bytes: 7518
     # Reference-only figshare records (downloaded already / optional):
     classifier_neopep_share: https://figshare.com/s/a000b0990465ab3e9d33   # trained neo-pep LR/XGBoost (Classifier_neopeptide.zip — in data/)

--- a/research/experiments/issue_547_immunogenicity_calibration/data_manifest.yaml
+++ b/research/experiments/issue_547_immunogenicity_calibration/data_manifest.yaml
@@ -14,6 +14,8 @@ issue: 707                       # data-acquisition sub-issue
 parent_epic: 547                 # KDE + centered-isotonic calibration epic
 gcs_prefix: gs://splice-neoepitope-project/experiments/issue_547/
 local_path: research/experiments/issue_547_immunogenicity_calibration/data/   # gitignored (root .gitignore `data/`); per-clone / on-VM
+# Each dataset lives under its own subdir (per-dataset `local_subdir`), mirrored 1:1 under gcs_prefix:
+#   neoranking/  (primary)  +  improve_borch/  (augment)  — both locally and in GCS.
 
 datasets:
   - name: neoranking
@@ -41,6 +43,7 @@ datasets:
     #   not_tested = candidate never immuno-assayed (EXCLUDE from calibration — neither pos nor neg).
     # Peptide lengths (mutant_seq): 8mer 297,537 / 9mer 337,905 / 10mer 377,640 / 11mer 417,204 / 12mer 357,424
     #   — all within MHCflurry's 8-15 supported range. Join coverage: 0 missing mutant_seq, 0 missing mutant_best_alleles.
+    local_subdir: neoranking/        # under the gitignored data/ path; mirrored to gcs_prefix + neoranking/
     files:
       - filename: Neopep_data_org.txt        # paper: "Combined data matrix neo-pep" (feature values + immunogenicity annotations); 1,787,710 rows × 57 cols, TSV
         figshare_share: https://figshare.com/s/147e67dde683fb769908

--- a/research/experiments/issue_547_immunogenicity_calibration/data_manifest.yaml
+++ b/research/experiments/issue_547_immunogenicity_calibration/data_manifest.yaml
@@ -63,23 +63,39 @@ datasets:
     ipmsdb_share: https://figshare.com/s/4f551e68e44d9cbf9ccd              # ipMSDB peptide feature DB (optional)
 
   - name: improve_borch
-    role: augment            # NOT blocking — calibrator (#708) proceeds on neoranking primary; this enlarges the negative/positive pool later
-    status: access_path_documented   # download deferred to the open-egress VM (figshare/Frontiers pages are JS-gated behind the local sandbox proxy)
+    role: augment            # NOT blocking — calibrator (#708) proceeds on neoranking primary; this enlarges the positive/negative pool later
+    status: downloaded       # 2026-06-17: data in hand from the repo named in the paper's Data Availability Statement
     citation: "Borch A. et al., Front. Immunol. 2024; doi:10.3389/fimmu.2024.1360281"
-    cohort: "17,520 candidates / 467 immunogenic (IMPROVE training set)"
-    license: "Frontiers is OA (CC-BY); confirm supplementary data-availability terms on download"
-    access_path:
-      - "Paper Data Availability Statement: doi.org/10.3389/fimmu.2024.1360281 — the IMPROVE training table is in the article's Supplementary Material + the project repo."
-      - "Code/repo: github.com/mnielLab/IMPROVE (Nielsen lab). Training data shipped with the repo / Frontiers supplementary."
+    cohort: "In-house CV training set: 17,520 candidates / 467 immunogenic (response==1). Matches the paper's headline cohort."
+    license: "Frontiers article is OA (CC-BY); the repo ships data + scripts publicly. Treat like neoranking (consume, do not redistribute via git)."
+    # SOURCE-OF-TRUTH: from the PAPER's Data Availability Statement (Frontiers full text), NOT a guess.
+    #   Data + scripts: https://github.com/SRHgroup/IMPROVE_paper  (SRHgroup = Sine Reker Hadrup group, DTU; NOT mnielLab)
+    #   Tool/model:     https://github.com/SRHgroup/IMPROVE_tool
+    #   Pinned at IMPROVE_paper commit c67094276b52358b5202ad9e5597acd87888ea1d (clone --depth 1, 2026-06-17).
+    # Schema (both tables): Mut_peptide \t HLA_allele \t response. BINARY label: response 1 = immunogenic, 0 = not.
+    #   (cf. neoranking's 3-way CD8/negative/not_tested — IMPROVE has no not_tested class.)
+    #   HLA format is "HLA-A01:01" (no asterisk) vs neoranking "A*01:01" → normalize both to MHCflurry "HLA-A*01:01" on join.
+    #   CV table peptide lengths: 8mer 515 / 9mer 10,561 / 10mer 4,716 / 11mer 1,728 — all in MHCflurry 8-15 range.
+    #   Join coverage: 0 missing Mut_peptide, 0 missing HLA_allele → fully Class1PresentationPredictor-scoreable.
+    local_subdir: improve_borch/    # under the gitignored data/ path
     files:
-      - filename: PENDING        # resolve exact supplementary filename when fetched on the VM
-        source: "Frontiers supplementary (10.3389/fimmu.2024.1360281) or github.com/mnielLab/IMPROVE"
-        fetch: "on the open-egress VM: clone IMPROVE repo / pull Frontiers supplementary; then sha256sum + size into this manifest"
-        sha256: PENDING
-        size_bytes: PENDING
+      - filename: In_house_neoepitope_for_CV.tsv   # THE training set (17,520 rows × 3 cols); from neoepitope_tabels/ in the repo
+        source: "github.com/SRHgroup/IMPROVE_paper @ c670942 :: neoepitope_tabels/In_house_neoepitope_for_CV.tsv"
+        fetch: "git clone --depth 1 https://github.com/SRHgroup/IMPROVE_paper.git; cp neoepitope_tabels/In_house_neoepitope_for_CV.tsv"
+        sha256: ee837eb8ee1d6d42320ad49f33b5f2b159640dcba6e70da794b59b2e9bb64d2d
+        size_bytes: 410649
+      - filename: Neoepitopes_CEDAR_benchmark_data.tsv   # external CEDAR benchmark (2,436 rows; 548 positive) — held-out test, not training
+        source: "github.com/SRHgroup/IMPROVE_paper @ c670942 :: neoepitope_tabels/Neoepitopes_CEDAR_benchmark_data.tsv"
+        fetch: "from the same clone: cp neoepitope_tabels/Neoepitopes_CEDAR_benchmark_data.tsv"
+        sha256: 3616a9db074c5cf0724e676470f6958bbd165117706b769f4bf40bb52e0c929b
+        size_bytes: 57264
+    # Larger bundles in the repo (NOT copied locally; reproducible via the clone above):
+    #   data.zip (103 MB — 01_Validated_neoepitopes.txt + RNA + benchmark_comparison), results.zip (33 MB — CV/NNAlign predictions).
 
 # Status (2026-06-17): NeoRanking primary FULLY in hand — 3 tables downloaded, unzipped,
 # checksummed (sha256 + size above), schema confirmed, cohort composition reconciled
 # (mutation 131 pt / neo-pep 99 pt; 178 CD8 neo-peptides), all rows join-ready
 # (peptide + HLA present). Tables mirrored to gs://splice-neoepitope-project/experiments/issue_547/.
-# IMPROVE/Borch augment: access path documented (not blocking); byte-download deferred to VM.
+# IMPROVE/Borch augment ALSO in hand (2026-06-17): CV training table (17,520/467) + CEDAR
+# benchmark from SRHgroup/IMPROVE_paper @ c670942 (the repo in the paper's Data Availability
+# Statement — corrected from an earlier wrong mnielLab guess); mirrored to .../issue_547/improve_borch/.

--- a/research/lab_notebook/scientist.md
+++ b/research/lab_notebook/scientist.md
@@ -6,6 +6,20 @@ Format and rules unchanged from the unified notebook — see `shared/feedback_la
 
 ---
 
+## 2026-06-17
+
+### 15:30 UTC — Editor: Scientist
+
+#### [PR #772](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/772) acquires the NeoRanking + IMPROVE immunogenicity calibration cohorts — closes [Issue #707](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/707) (data-acquisition leaf of the [#547](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/547) calibration epic).
+
+**What shipped.** `research/experiments/issue_547_immunogenicity_calibration/` (epic-keyed) now carries the labelled training cohorts chosen in [#592](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/592), with `README.md` + `data_manifest.yaml` committed and the raw tables gitignored + GCS-mirrored (LICR copyright + >100 MB). **NeoRanking primary** (Müller 2023): `Neopep_data_org.txt` (1,787,710 rows × 57 cols, 8–12mers), `Mutation_data_org.txt`, `HLA_allotypes.txt`. **IMPROVE augment** (Borch 2024): `In_house_neoepitope_for_CV.tsv` (17,520 rows) + a CEDAR benchmark. All sha256'd + size-pinned; mirrored to `gs://splice-neoepitope-project/experiments/issue_547/{neoranking,improve_borch}/`.
+
+**Schema + join feasibility (the de-risking result).** NeoRanking label = `response_type` {**CD8 = 178** immunogenic / negative = 422,907 / not_tested = 1,364,625 (exclude)}; IMPROVE label = binary `response` {1 = 467 / 0 = 17,053}. Both cohorts: peptides all in MHCflurry's 8–15 range, **0 missing peptide or HLA** → every assayed row is directly `Class1PresentationPredictor`-scoreable, which is exactly the calibrator (#708) input. Two pooling nuances documented for #708: HLA `HLA-A01:01` (IMPROVE) vs `A*01:01` (NeoRanking) → normalize to `HLA-A*01:01`; and 3-way vs binary label reconcile (NeoRanking CD8→1, negative→0, drop not_tested; IMPROVE already binary).
+
+**Cohort reconcile — the [#592](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/592) correction (AC #5).** Confirmed from the paper **and** the downloaded tables: NeoRanking is **131 patients** (NCI 112 + TESLA 8 + HiTIDE 11) at mutation level / 99 at neo-pep level, **178 immunogenic neo-peptides**, and **no Bjerregaard**. #592's "+Bjerregaard / 74 pt / ~165 pos" was NeoGuider-7-cohort-benchmark bleed. [Correcting note posted](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/592#issuecomment-4732075479).
+
+**Verification / meta — primary-source slip, caught pre-merge.** The IMPROVE source I first wrote into the manifest (`github.com/mnielLab/IMPROVE`) was a **guess from memory, and wrong — that repo does not exist**. It only surfaced because the user asked to actually attempt the clone. The authoritative route was the paper's own Data Availability Statement (read from the Frontiers full text → `github.com/SRHgroup/IMPROVE_paper`, Hadrup group), which is real and ships the data. This is the third primary-source slip this week (cf. the figshare-README mislabel on this same issue, and the patient_002 config/manifest staleness) — the recurring failure mode is *answering "where does X live" from recall instead of the authoritative artifact*. The discipline that did hold: every numeric claim (178 CD8, 131 patients, 17,520/467) was tallied from the downloaded bytes, not asserted; the IMPROVE "17,520 / 467" matched the paper exactly once fetched. Promote candidate flagged for the next consolidation pass.
+
 ## 2026-06-15
 
 ### 14:30 UTC — Editor: Scientist


### PR DESCRIPTION
**Created by:** Scientist

Closes #707.

Acquires + characterizes the labelled immunogenicity training cohorts chosen in #592 for the #547 calibration epic, and confirms their schema calibrates MHCflurry `presentation_score`. This is the data reality-check that de-risks the whole calibration track — nothing downstream (#708 calibrator, #709 Snakemake wiring) starts until the tables are in hand and parseable.

Raw tables are **not committed** (NeoRanking is LICR copyright + >100 MB); the experiment ships only `README.md` + `data_manifest.yaml`. Bytes live in gitignored `data/` and are mirrored to `gs://splice-neoepitope-project/experiments/issue_547/`.

## What landed

**NeoRanking primary** (Müller et al., *Immunity* 2023) — 3 tables, sha256 + sizes pinned:
- `Neopep_data_org.txt` — 1,787,710 rows × 57 cols (8–12mers). Label `response_type`: **CD8 = 178** (immunogenic) / negative = 422,907 / not_tested = 1,364,625.
- `Mutation_data_org.txt` — 48,306 rows; `HLA_allotypes.txt` — 150 patients.

**IMPROVE augment** (Borch et al., *Front. Immunol.* 2024) — from `SRHgroup/IMPROVE_paper` @ `c670942` (the repo named in the paper's Data Availability Statement):
- `In_house_neoepitope_for_CV.tsv` — 17,520 rows, binary `response` {0: 17,053, 1: 467} — matches the paper's headline cohort.
- `Neoepitopes_CEDAR_benchmark_data.tsv` — 2,436-row external benchmark.

**Cohort reconcile (the #592 correction):** mutation-level **131 patients** (NCI 112 + TESLA 8 + HiTIDE 11), neo-pep-level 99; **178 immunogenic neo-peptides**; **no Bjerregaard**. #592's "+Bjerregaard / 74 pt / ~165 pos" was NeoGuider-benchmark bleed — [correcting note posted](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/592#issuecomment-4732075479).

**Join feasibility:** every assayed row in both cohorts carries a peptide + HLA, 0 missing → directly `Class1PresentationPredictor`-scoreable. Two pooling nuances documented (HLA `HLA-A01:01` vs `A*01:01` → normalize to `HLA-A*01:01`; 3-way vs binary label reconcile for #708).

## Test plan

- [x] All 3 NeoRanking tables + 2 IMPROVE tables downloaded, unzipped, sha256'd; checksums + sizes in `data_manifest.yaml`
- [x] Schema documented (peptide / label / HLA / cohort cols; pos-vs-neg encoding; length distribution) in README
- [x] Join to `genotype_presentation_score` confirmed feasible (0 missing peptide/HLA, both cohorts)
- [x] Cohort composition reconciled vs #592 + correcting note posted
- [x] No-redistribute storage: `data_manifest.yaml` (paths + checksums + fetch cmds), raw tables gitignored, all 5 objects mirrored to GCS (verified, sizes match local)
- [x] IMPROVE source corrected from a wrong `mnielLab/IMPROVE` guess to the paper-stated `SRHgroup/IMPROVE_paper`
- [x] Local + GCS layout normalized into symmetric `neoranking/` + `improve_borch/` subdirs
- [x] Lab-notebook entry (added after review, before merge)

## Out of scope
Model fitting (#708 KDE + centered-isotonic calibrator) and Snakemake wiring (#709).
