### PR TITLE
fix(news): role-scope the dependency poller basket (#755)

### DIFF
--- a/research/lab_notebook/developer.md
+++ b/research/lab_notebook/developer.md
@@ -6,6 +6,18 @@ Format and rules unchanged from the unified notebook — see `shared/feedback_la
 
 ---
 
+## 2026-06-18 — role-scope the dependency poller basket ([PR #773](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/773) closes [Issue #755](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/755))
+
+### Editor: Developer
+
+**Why.** `tools/news/poll_releases.py --role <role>` used `--role` *only* to pick the watermark file — `run()` polled the entire `software + reference_data` basket regardless of role. So a `--role pm` poll surfaced Developer-scope deltas (the trigger was snakemake 9.22→9.23 leaking to a PM poll on 2026-06-16). `tools.yaml` had no role concept at all.
+
+**The fix.** A `roles:` list on every polled entry (`software → [developer]`; `reference_data → [developer, scientist]` so neither role loses a signal it gets today — a dep is both a dev-config and a science-data concern). New pure `select_tools(basket, role)` + a `POLLED_SECTIONS` constant filter the basket by role; an entry with **no** `roles:` key stays visible to all roles (**fail-open** — never silently drop a dep), and `role=None` preserves the unfiltered back-compat path. `main()` now threads `--role` into `run()` (the one-line omission that *was* the bug). **AC3 (PM-poller fork)** resolved as a thin pollable PM basket: a new `pm_tooling:` section holding the `gh` CLI (`cli/cli`, `roles: [pm]`), so the poller stays useful for `--role pm` and "poller-first for every role" stays literally true — Beat 1 memory needed no edit. PM's broader un-enumerable news scope is the discovery half rebuilt under [Issue #766](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/766); `pm_tooling` is just the pollable slice (a GitHub-changelog RSS `feed_type` would be the next step, out of scope here).
+
+**Verification.** TDD throughout (RED watched before each GREEN): 8 new tests in `tools/news/test_poll_releases.py` — the fail-open contract, the exact issue bug (`--role pm` surfaces no Developer deps), `pm_tooling` polled for pm and *not* for developer, plus two live-contract guards on the real YAML (every polled entry role-tagged; a PM poll over the shipped basket sees only `gh-cli`, disjoint from `software`). Suite 25→33. Live smoke: `--role pm` surfaces zero Developer deps; `--role developer` unchanged; `gh-cli` fetched + baseline-seeded cleanly (2.95.0). Bot review **Approve with minor notes** — fixed a stale `watch:` comment that named "software + reference_data only" after `pm_tooling` joined `POLLED_SECTIONS` (`8e399a4`); declined the role-unscoped watch-footer note (global candidate-to-adopt reminder by design, scope beyond this fix — noted as a follow-up if PM flags it). No chr22 integration run (news-tooling change, not a Snakemake rule). CI 4/4 green.
+
+---
+
 ## 2026-06-17 — board_open_items.py is parent-aware ([PR #768](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/768) closes [Issue #742](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/742))
 
 ### Editor: Developer

--- a/tools/news/README.md
+++ b/tools/news/README.md
@@ -46,10 +46,32 @@ open-Issue annotation lookup), `--json` (machine-readable), `--watermark PATH`,
 ## How it works
 
 1. **`tools.yaml`** — the basket: each dependency with its `feed_type`
-   (`pypi` / `github` / `bioconda` / `pytorch_cu126` / `manual`) and any guards.
+   (`pypi` / `github` / `bioconda` / `pytorch_cu126` / `manual`), a `roles:` tag,
+   and any guards. Polled sections: `software`, `reference_data`, `pm_tooling`
+   (`watch` is a name-only footer reminder, never polled).
 2. **`watermark_<role>.yaml`** (gitignored) — `{tool: last_version}` + `last_briefing`.
-3. **`poll_releases.py`** — fetch latest per feed → diff against the watermark →
-   surface only changed tools → write the watermark back.
+3. **`poll_releases.py`** — select the tools tagged for `--role` → fetch latest
+   per feed → diff against the watermark → surface only changed tools → write the
+   watermark back.
+
+### Role scoping (Issue #755)
+
+`--role` filters the **basket**, not just the watermark file: a poll only fetches
+tools whose `roles:` list contains that role.
+
+| Role | Sees | Sourced from |
+|------|------|--------------|
+| `developer` | the full pipeline-software basket + the reference-data feeds | `software` (`[developer]`) + `reference_data` (`[developer, scientist]`) |
+| `scientist` | the reference-data feeds (GENCODE, VDJdb, …) | `reference_data` (`[developer, scientist]`) |
+| `pm` | `gh` CLI only | `pm_tooling` (`[pm]`) |
+
+This is the fix for the bug where `--role pm` surfaced **Developer-scope** deltas
+(e.g. snakemake) because `--role` only chose the watermark file and `run()` polled
+the entire basket regardless. An entry with **no** `roles:` key is visible to every
+role (**fail-open** — an untagged dep is never silently dropped). PM's broader,
+un-enumerable news scope (GitHub Projects features / methodology) is the discovery
+half rebuilt under [Issue #766](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/766);
+`pm_tooling` is just the thin *pollable* slice.
 
 ### Pure-delta semantics
 

--- a/tools/news/poll_releases.py
+++ b/tools/news/poll_releases.py
@@ -252,16 +252,42 @@ def save_watermark(path, data):
 # --------------------------------------------------------------------------- #
 # Orchestration
 # --------------------------------------------------------------------------- #
-def run(basket, watermark, *, check_tracked=True, fetcher=fetch_latest, tracker=find_tracking_issue):
+# Top-level basket sections the poller actually fetches. `watch` is excluded on
+# purpose -- it is a name-only footer reminder, never polled (see tools.yaml).
+POLLED_SECTIONS = ("software", "reference_data", "pm_tooling")
+
+
+def select_tools(basket, role):
+    """Return the polled tools (``POLLED_SECTIONS``) visible to ``role``.
+
+    Each tool may carry a ``roles:`` list (Issue #755). The rules:
+      * ``role is None`` -> every polled tool, no filtering (back-compat).
+      * a tool with no ``roles:`` key -> visible to ALL roles (fail-open; an
+        untagged dep is never silently dropped from a poll).
+      * otherwise -> visible only when ``role`` is in the tool's ``roles`` list.
+
+    This is what stops a ``--role pm`` poll from surfacing Developer-scope deltas
+    while still letting PM poll its own thin ``pm_tooling`` basket.
+    """
+    tools = []
+    for section in POLLED_SECTIONS:
+        tools.extend(basket.get(section, []))
+    if role is None:
+        return tools
+    return [t for t in tools if t.get("roles") is None or role in t["roles"]]
+
+
+def run(basket, watermark, *, role=None, check_tracked=True, fetcher=fetch_latest, tracker=find_tracking_issue):
     """Process the basket against the watermark. Returns (surfaced, updated_watermark).
 
     ``surfaced`` is the list of records to show the user (genuine deltas + watch
-    notes). The watermark dict is updated in place and also returned.
+    notes). The watermark dict is updated in place and also returned. When
+    ``role`` is given, only tools tagged for that role are polled (Issue #755).
     """
     wm_tools = watermark.setdefault("tools", {})
     surfaced = []
 
-    for tool in basket.get("software", []) + basket.get("reference_data", []):
+    for tool in select_tools(basket, role):
         name = tool["tool"]
         latest = fetcher(tool)
         rec = compute_delta(tool, latest, wm_tools.get(name))
@@ -312,7 +338,7 @@ def main(argv=None):
     wm_path = args.watermark or watermark_path(args.role)
     watermark = load_watermark(wm_path)
 
-    surfaced, watermark = run(basket, watermark, check_tracked=not args.no_check_tracked)
+    surfaced, watermark = run(basket, watermark, role=args.role, check_tracked=not args.no_check_tracked)
     watermark["last_briefing"] = date.today().isoformat()
 
     if args.json:

--- a/tools/news/test_poll_releases.py
+++ b/tools/news/test_poll_releases.py
@@ -106,6 +106,74 @@ def test_parse_cu126_index_empty():
 
 
 # --------------------------------------------------------------------------- #
+# role scoping (Issue #755) — the basket is filtered by --role
+# --------------------------------------------------------------------------- #
+def test_select_tools_filters_by_role():
+    basket = {
+        "software": [
+            {"tool": "snakemake", "roles": ["developer"]},
+            {"tool": "vdjdb", "roles": ["developer", "scientist"]},
+        ],
+        "reference_data": [
+            {"tool": "gencode", "roles": ["scientist"]},
+        ],
+    }
+    assert [t["tool"] for t in pr.select_tools(basket, "developer")] == ["snakemake", "vdjdb"]
+    assert [t["tool"] for t in pr.select_tools(basket, "scientist")] == ["vdjdb", "gencode"]
+    assert pr.select_tools(basket, "pm") == []
+
+
+def test_select_tools_untagged_is_visible_to_all_roles():
+    """Fail-open: an entry with no roles: key is never silently dropped."""
+    basket = {"software": [{"tool": "legacy"}]}
+    assert [t["tool"] for t in pr.select_tools(basket, "pm")] == ["legacy"]
+    assert [t["tool"] for t in pr.select_tools(basket, "developer")] == ["legacy"]
+
+
+def test_select_tools_role_none_returns_all():
+    basket = {"software": [{"tool": "a", "roles": ["developer"]}],
+              "reference_data": [{"tool": "b", "roles": ["scientist"]}]}
+    assert [t["tool"] for t in pr.select_tools(basket, None)] == ["a", "b"]
+
+
+def test_run_role_pm_returns_no_developer_deps():
+    """AC: a PM poll must not surface a Developer-scope delta (the #755 bug)."""
+    basket = {"software": [
+        {"tool": "snakemake", "feed_type": "pypi", "feed": "snakemake", "roles": ["developer"]},
+    ]}
+    # A genuine delta exists (9.21 -> 9.22); without role-scoping it would surface.
+    wm = {"tools": {"snakemake": "9.21.0"}}
+    surfaced, _ = pr.run(basket, wm, role="pm", check_tracked=False, fetcher=_fetcher({"snakemake": "9.22.0"}))
+    assert surfaced == []
+
+
+def test_pm_tooling_section_is_polled_for_pm_role():
+    """PM gets its own thin pollable basket (Issue #755, AC3) — and it never leaks to dev."""
+    basket = {"pm_tooling": [
+        {"tool": "gh-cli", "feed_type": "github", "feed": "cli/cli", "roles": ["pm"]},
+    ]}
+    surfaced, _ = pr.run(basket, {"tools": {"gh-cli": "2.40.0"}}, role="pm",
+                         check_tracked=False, fetcher=_fetcher({"gh-cli": "2.41.0"}))
+    assert [r["tool"] for r in surfaced] == ["gh-cli"]
+    dev, _ = pr.run(basket, {"tools": {"gh-cli": "2.40.0"}}, role="developer",
+                    check_tracked=False, fetcher=_fetcher({"gh-cli": "2.41.0"}))
+    assert dev == []
+
+
+def test_run_role_scopes_to_matching_tools():
+    basket = {
+        "software": [{"tool": "snakemake", "feed_type": "pypi", "feed": "snakemake", "roles": ["developer"]}],
+        "reference_data": [{"tool": "gencode", "feed_type": "github", "feed": "x", "roles": ["scientist"]}],
+    }
+    wm = {"tools": {"snakemake": "9.21.0", "gencode": "v47"}}
+    versions = {"snakemake": "9.22.0", "gencode": "v48"}
+    dev, _ = pr.run(basket, dict(tools=dict(wm["tools"])), role="developer", check_tracked=False, fetcher=_fetcher(versions))
+    sci, _ = pr.run(basket, dict(tools=dict(wm["tools"])), role="scientist", check_tracked=False, fetcher=_fetcher(versions))
+    assert [r["tool"] for r in dev] == ["snakemake"]
+    assert [r["tool"] for r in sci] == ["gencode"]
+
+
+# --------------------------------------------------------------------------- #
 # run() — end-to-end with injected fetcher + tracker
 # --------------------------------------------------------------------------- #
 def _fetcher(versions):
@@ -261,3 +329,27 @@ def test_basket_file_parses_and_has_known_guards():
     assert by_name["gcp_dlvm_image"]["feed_type"] == "manual"
     assert "watch_only" not in by_name["gcp_dlvm_image"]
     assert by_name["torch"]["feed_type"] == "pytorch_cu126"
+
+
+def test_basket_file_every_polled_entry_is_role_tagged():
+    """Issue #755: every polled entry carries a roles: list."""
+    pytest.importorskip("yaml")
+    basket = pr.load_basket()
+    for section in pr.POLLED_SECTIONS:
+        for tool in basket.get(section, []):
+            assert isinstance(tool.get("roles"), list) and tool["roles"], \
+                f"{tool['tool']} ({section}) is missing a roles: tag"
+    # software is Developer-scope; reference_data is shared dev+scientist.
+    assert all("developer" in t["roles"] for t in basket["software"])
+    assert all(set(t["roles"]) == {"developer", "scientist"} for t in basket["reference_data"])
+    assert all(t["roles"] == ["pm"] for t in basket["pm_tooling"])
+
+
+def test_real_basket_pm_poll_sees_only_pm_tooling():
+    """The bug the Issue fixes: a PM poll surfaces no Developer deps — only pm_tooling."""
+    pytest.importorskip("yaml")
+    basket = pr.load_basket()
+    pm_tools = {t["tool"] for t in pr.select_tools(basket, "pm")}
+    dev_tools = {t["tool"] for t in basket["software"]}
+    assert pm_tools == {"gh-cli"}
+    assert pm_tools.isdisjoint(dev_tools)

--- a/tools/news/tools.yaml
+++ b/tools/news/tools.yaml
@@ -12,6 +12,14 @@
 #   pytorch_cu126  -> the cu126 wheel channel (NOT plain PyPI — see torch guard)
 #   manual         -> no machine feed; listed for human watch only
 #
+# roles: (Issue #755) — which role(s) a poll surfaces this tool to.
+#   `poll_releases.py --role <role>` polls only the tools whose `roles:` list
+#   contains <role>. This stops a `--role pm` poll from surfacing Developer-scope
+#   deltas. An entry with NO `roles:` key is visible to every role (fail-open — an
+#   untagged dep is never silently dropped). software -> [developer]; the
+#   reference_data feeds carry [developer, scientist] (a dev-config concern AND a
+#   science-data concern, so neither role loses a signal it gets today).
+#
 # guards (optional per-tool keys):
 #   frozen: true       -> never flag (intentionally pinned; e.g. Docker AlphaFold-era stack)
 #   watch_only: true   -> surface as a *watch* note, never an actionable bump (regression risk)
@@ -20,66 +28,78 @@
 software:
   - tool: snakemake
     current_pin: ">=8.0,<9"
+    roles: [developer]
     feed_type: pypi
     feed: snakemake
     note: "9.x is the next-major risk; eval done in Issue #200 (closed)."
 
   - tool: hisat2
     current_pin: ">=2.2.1"
+    roles: [developer]
     feed_type: github
     feed: DaehwanKimLab/hisat2
 
   - tool: regtools
     current_pin: ">=1.0.0"
+    roles: [developer]
     feed_type: github
     feed: griffithlab/regtools
     note: "Drives the samtools/libdeflate conflict (TODO #237)."
 
   - tool: STAR
     current_pin: ">=2.7.11"
+    roles: [developer]
     feed_type: github
     feed: alexdobin/STAR
 
   - tool: samtools
     current_pin: ">=1.18 (conda) / 1.13 (apt VM)"
+    roles: [developer]
     feed_type: github
     feed: samtools/samtools
     note: "Held low by the regtools/libdeflate>=1.26 conflict (TODO #237)."
 
   - tool: bedtools
     current_pin: ">=2.31"
+    roles: [developer]
     feed_type: github
     feed: arq5x/bedtools2
 
   - tool: OptiType
     current_pin: "=1.3.5"
+    roles: [developer]
     feed_type: github
     feed: FRED-2/OptiType
 
   - tool: mhcflurry
     current_pin: ">=2.0"
+    roles: [developer]
     feed_type: pypi
     feed: mhcflurry
     note: "Pulls torch + TF; presentation predictor."
 
   - tool: torch
     current_pin: "==2.12.0+cu126"
+    roles: [developer]
     feed_type: pytorch_cu126
     feed: cu126
     note: "Pascal/P100 SM 6.0 compat. The cu126 wheel channel is load-bearing; a bare PyPI poll always shows a newer non-Pascal build. Preserve the +cu126 local-version tag."
 
   - tool: alphagenome
     current_pin: ">=0.6,<0.7"
+    roles: [developer]
     feed_type: pypi
     feed: alphagenome
 
   - tool: stitchr
     current_pin: ">=1.1.0"
+    roles: [developer]
     feed_type: pypi
     feed: stitchr
 
   - tool: IMGTgeneDL
     current_pin: ">=0.6.1"
+    roles: [developer]
     feed_type: pypi
     feed: IMGTgeneDL
     max_version: "0.6.1"
@@ -87,6 +107,7 @@ software:
 
   - tool: snakevision
     current_pin: "==1.1.0"
+    roles: [developer]
     feed_type: pypi
     feed: snakevision
     note: "Dev DAG tooling (scripts/setup_local.sh)."
@@ -94,6 +115,7 @@ software:
   # --- Frozen: pinned together for AlphaFold-2.3.2-era compat in the Docker image ---
   - tool: TCRdock
     current_pin: "v2.0.0"
+    roles: [developer]
     feed_type: github
     feed: phbradley/TCRdock
     frozen: true
@@ -101,6 +123,7 @@ software:
 
   - tool: jax
     current_pin: "==0.3.25"
+    roles: [developer]
     feed_type: pypi
     feed: jax
     frozen: true
@@ -109,6 +132,7 @@ software:
   # --- Human-watch only: newer images are a P100 regression risk, not a bump target ---
   - tool: gcp_dlvm_image
     current_pin: "pytorch-latest-cu124-v20250327-ubuntu-2204 (driver 550.90.07)"
+    roles: [developer]
     feed_type: manual
     feed: "https://cloud.google.com/deep-learning-vm/docs/release-notes"
     note: >-
@@ -121,7 +145,9 @@ software:
 # NAME-ONLY: the poller never polls this section (run() iterates software +
 # reference_data only). Only the `tool:` name is read — rendered in the briefing
 # footer as a muted reminder. The `note:` is human prose; do not add feed_type/feed
-# here (it would imply polling that does not happen).
+# here (it would imply polling that does not happen). No `roles:` needed — the
+# footer watch-list is not role-scoped (select_tools only filters software +
+# reference_data).
 watch:
   - tool: uv
     note: "Test+research venv adoption tracked in Issue #570 (open)."
@@ -129,20 +155,40 @@ watch:
     note: "Linting-adoption decision has no Issue home yet; deferred (see Issue #639 out-of-scope)."
 
 # Reference DATA feeds (different cadence than software; releases still matter).
+# roles: [developer, scientist] — a dev maintains the config pin; a scientist
+# cares about the data release itself.
 reference_data:
   - tool: gencode
     current_pin: "v47"
+    roles: [developer, scientist]
     feed_type: manual
     feed: "https://www.gencodegenes.org/human/releases.html"
   - tool: vdjdb
     current_pin: "release 2026-05-16"
+    roles: [developer, scientist]
     feed_type: github
     feed: antigenomics/vdjdb-db
   - tool: hisat2_prebuilt_index
     current_pin: "hg38_tran"
+    roles: [developer, scientist]
     feed_type: manual
     feed: "genome-idx.s3.amazonaws.com"
   - tool: snaptron_gtexv2
     current_pin: "gtexv2"
+    roles: [developer, scientist]
     feed_type: manual
     feed: "https://snaptron.cs.jhu.edu"
+
+# PM-scope tooling (Issue #755, AC3). PM's news is mostly the un-enumerable
+# long-tail (GitHub Projects features / methodology) that the discovery half
+# (Issue #766) rebuilds — but the `gh` CLI is a genuinely pollable PM dep, so
+# the poller stays useful (and "poller-first for every role" stays literally
+# true) for `--role pm`. A useful GitHub-changelog feed would need an RSS/Atom
+# feed_type (out of scope here); add it under #766 if wanted.
+pm_tooling:
+  - tool: gh-cli
+    current_pin: "(unpinned; dev/CI convenience tool)"
+    roles: [pm]
+    feed_type: github
+    feed: cli/cli
+    note: "GitHub CLI — PM's pollable surface for board/Projects tooling changes."

--- a/tools/news/tools.yaml
+++ b/tools/news/tools.yaml
@@ -142,12 +142,12 @@ software:
       (no watch_only needed; that guard is for *pollable* watch-only tools).
 
 # Candidate-to-adopt tools (NOT current deps) — the recurring 'revisit if we adopt' items.
-# NAME-ONLY: the poller never polls this section (run() iterates software +
-# reference_data only). Only the `tool:` name is read — rendered in the briefing
-# footer as a muted reminder. The `note:` is human prose; do not add feed_type/feed
-# here (it would imply polling that does not happen). No `roles:` needed — the
-# footer watch-list is not role-scoped (select_tools only filters software +
-# reference_data).
+# NAME-ONLY: the poller never polls this section — `watch` is excluded from
+# POLLED_SECTIONS (which is software + reference_data + pm_tooling). Only the
+# `tool:` name is read — rendered in the briefing footer as a muted reminder. The
+# `note:` is human prose; do not add feed_type/feed here (it would imply polling
+# that does not happen). No `roles:` needed — the footer watch-list is not
+# role-scoped (select_tools only filters the POLLED_SECTIONS).
 watch:
   - tool: uv
     note: "Test+research venv adoption tracked in Issue #570 (open)."


### PR DESCRIPTION
**Created by:** Developer

Closes #755.

## Summary
`poll_releases.py --role <role>` previously used `--role` **only** to pick the watermark file — `run()` polled the entire `software + reference_data` basket regardless, so a `--role pm` poll surfaced **Developer-scope** deltas (e.g. snakemake 9.22→9.23 on 2026-06-16).

This scopes the *basket* by role:

- **`roles:` tag on every polled `tools.yaml` entry** — `software → [developer]`; `reference_data → [developer, scientist]` (a dep is a dev-config concern **and** a science-data concern, so neither role loses a signal it gets today — no Developer regression).
- **`select_tools(basket, role)` + `POLLED_SECTIONS`** filter the basket to the role's tools; an entry with **no** `roles:` key stays visible to every role (**fail-open** — an untagged dep is never silently dropped). `main()` now passes `--role` through to `run()`.
- **AC3 (PM-poller fork) → tiny pollable basket.** New `pm_tooling:` section with the `gh` CLI (`cli/cli`), `roles: [pm]`, so the poller stays useful for `--role pm` and "poller-first for every role" stays literally true. PM's broader, un-enumerable news scope is the discovery half rebuilt under #766; `pm_tooling` is just the thin *pollable* slice. (A useful GitHub-changelog feed needs an RSS/Atom `feed_type` — out of scope here.)

## Acceptance criteria
- [x] `roles:` tag on every `tools.yaml` entry
- [x] `run()` filters the basket to the `--role` set; `--role pm` returns no Developer deps
- [x] PM-poller story resolved (dedicated `pm_tooling` basket) — Beat 1 "poller-first for every role" line stays correct (literally true), so no morning-routine memory edit needed
- [x] Tests for the role filter; `tools/news/README.md` updated

## Test plan
- [x] `workflow/tests/.venv/bin/python -m pytest tools/news/` — **33 passed** (25 pre-existing + 8 new), fully offline
- [x] RED→GREEN watched for the role filter and the `pm_tooling` polling
- [x] Live smoke: `--role pm` surfaces no Developer deps; `--role developer` unchanged; `gh-cli` fetched + seeded cleanly (2.95.0)

## Notes
- Out of scope (possible follow-ups): finer scientist-tagging of method-tools (mhcflurry/OptiType/alphagenome/stitchr) if the Scientist wants method bumps; an RSS `feed_type` for the GitHub changelog (#766).