### PR TITLE
fix(project_map): drive graph discovery from git ls-files, not the raw working tree

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -82,9 +82,11 @@ jobs:
         # (tools/project_map has none; isolation still keeps collection scopes
         # clean). tools/news is the morning-news poller (Issue #639);
         # tools/project_map is the project-map atlas extractor (Issue #713 —
-        # the 5-invariant suite was CI-invisible under tools/, regressions
-        # ungated). project_map's extractor is stdlib-only and walks the
-        # committed tree, so a clean CI checkout is the canonical run env.
+        # the invariant suite was CI-invisible under tools/, regressions
+        # ungated). project_map's extractor discovers files via `git ls-files`
+        # (Issue #780), so the atlas is reproducible across working-tree states
+        # (a populated local clone matches a clean checkout); it needs git on
+        # PATH, which the actions/checkout step provides.
         #
         # `-m "not live"` deselects the live-API smoke (Issue #711): a transient
         # GitHub-API blip must not red this per-PR job (or poison the hermetic

--- a/tools/project_map/README.md
+++ b/tools/project_map/README.md
@@ -49,11 +49,11 @@ cd tools/project_map && npm install && node verify_render.mjs "$PWD/project_map.
 
 The data-model suite is collected in CI by the `ci-tools-pytest` job
 (`.github/workflows/tests.yml`, Issue #713) and runs on every PR. `build_graph()`
-walks the committed tree without consulting `.gitignore`, so a clean checkout is
-the canonical run environment: a local clone with populated gitignored artifacts
-(`references/`, `logs/`, `data/`, `results/`) can inflate the `project` group and
-trip `test_resource_blob_is_gone`. CI (a fresh checkout) is authoritative; locally,
-re-run against `git worktree add --detach <tmp> HEAD` if that one test fails alone.
+discovers files via `git ls-files` (Issue #780), so the atlas is reproducible
+across working-tree states: a local clone with populated gitignored artifacts
+(`references/`, `logs/`, `data/`, `results/`, `indices/`) produces the identical
+graph as a clean checkout, and the suite passes whether or not the pipeline has
+been run locally. Running the extractor requires a git working tree.
 
 The `verify_render.mjs` render check is a **local-only pre-merge check**, run with
 the one-liner above (Issue #712). It is intentionally *not* CI-wired: it drives a

--- a/tools/project_map/extract_graph.py
+++ b/tools/project_map/extract_graph.py
@@ -47,9 +47,11 @@ def git_tracked_paths():
             ["git", "-C", str(PROJECT_ROOT), "ls-files", "-z"],
             capture_output=True, text=True, check=True).stdout
     except (subprocess.CalledProcessError, FileNotFoundError) as exc:
+        stderr_hint = (getattr(exc, "stderr", "") or "").strip()
         raise RuntimeError(
             "project_map's extractor requires a git working tree "
-            "(`git ls-files` failed); run it from inside the repo.") from exc
+            "(`git ls-files` failed); run it from inside the repo."
+            + (f"\ngit stderr: {stderr_hint}" if stderr_hint else "")) from exc
     tracked_files = {p for p in out.split("\0") if p}
     tracked_dirs = set()
     for path in tracked_files:

--- a/tools/project_map/extract_graph.py
+++ b/tools/project_map/extract_graph.py
@@ -11,6 +11,7 @@ Usage:
 import json
 import os
 import re
+import subprocess
 import sys
 from pathlib import Path
 
@@ -26,6 +27,36 @@ SELF_EXCLUDE_DIRS = {"tools/project_map/vendor"}
 
 def slug(name):
     return name.replace("/", "__").replace(".", "_").replace("-", "_")
+
+
+def git_tracked_paths():
+    """Return ``(tracked_files, tracked_dirs)`` from ``git ls-files``.
+
+    Discovery is restricted to the git-tracked set so gitignored runtime/data
+    dirs (``references/``, ``results/``, ``logs/``, ``data/``, ``indices/``)
+    never enter the atlas — making it reproducible across working-tree states
+    rather than dependent on whether the pipeline has been run locally (#780).
+    git naturally respects ``.gitignore``, so this is a single source of truth.
+
+    Both sets hold repo-root-relative, forward-slash paths. ``tracked_dirs`` is
+    every ancestor directory of a tracked file (so the walk can keep a dir that
+    only contains tracked files deeper down).
+    """
+    try:
+        out = subprocess.run(
+            ["git", "-C", str(PROJECT_ROOT), "ls-files", "-z"],
+            capture_output=True, text=True, check=True).stdout
+    except (subprocess.CalledProcessError, FileNotFoundError) as exc:
+        raise RuntimeError(
+            "project_map's extractor requires a git working tree "
+            "(`git ls-files` failed); run it from inside the repo.") from exc
+    tracked_files = {p for p in out.split("\0") if p}
+    tracked_dirs = set()
+    for path in tracked_files:
+        parts = path.split("/")
+        for i in range(1, len(parts)):
+            tracked_dirs.add("/".join(parts[:i]))
+    return tracked_files, tracked_dirs
 
 
 ISSUE_RE = re.compile(r'(?:^|/)issue_(\d+)')
@@ -751,6 +782,10 @@ def build_graph():
     # "resource" — its substring checks expect a leading slash the relative path
     # lacks — so the `ftype == "env"` dedup guard never fired.)
     file_nodes = {n["id"]: True for n in nodes}
+    # Restrict discovery to the git-tracked tree so gitignored runtime/data dirs
+    # never enter the atlas — the map is then identical between a clean checkout
+    # and a clone that has run the pipeline (#780).
+    tracked_files, tracked_dirs = git_tracked_paths()
     for root, dirs, files in os.walk(PROJECT_ROOT):
         # Prune build artifacts: __pycache__, VCS/env dirs, and Quarto's rendered
         # slide output (`*_files/` holds a vendored reveal.js copy — pure noise; the
@@ -759,11 +794,19 @@ def build_graph():
             "__pycache__", ".snakemake", ".git", ".venv", "node_modules")
             and not d.endswith("_files")]
         rel_root = os.path.relpath(root, PROJECT_ROOT)
+        # Descend only into dirs that contain a tracked file (drops references/,
+        # results/, logs/, data/, indices/ and any other gitignored dir).
+        dirs[:] = [d for d in dirs
+                   if (d if rel_root == "." else f"{rel_root}/{d}") in tracked_dirs]
         if rel_root == ".":
             continue
         if rel_root in SELF_EXCLUDE_DIRS:
             dirs[:] = []  # don't descend into vendored deps
             continue
+        # Keep only tracked files, so the dir node's `size` and the file loop are
+        # both reproducible w.r.t. git rather than the local working tree.
+        files = [f for f in files
+                 if os.path.join(rel_root, f).replace(os.sep, "/") in tracked_files]
         dir_id = slug(rel_root)
         if dir_id in file_nodes:
             continue

--- a/tools/project_map/test_extract_graph.py
+++ b/tools/project_map/test_extract_graph.py
@@ -13,6 +13,9 @@ requires a git working tree.)
 """
 import importlib.util
 import pathlib
+import subprocess
+
+import pytest
 
 _spec = importlib.util.spec_from_file_location(
     "extract_graph", pathlib.Path(__file__).parent / "extract_graph.py")
@@ -73,12 +76,28 @@ def test_resource_blob_is_gone():
         assert frac < 0.40, f"group '{grp}' is {frac:.0%} unclassified 'resource'"
 
 
+def test_git_tracked_paths_surfaces_git_stderr(monkeypatch):
+    """When `git ls-files` fails, the raised error includes git's own stderr so
+    an exotic failure (e.g. a corrupt index) is diagnosable, not just the generic
+    'not a git working tree' hint (#788 review)."""
+    def _boom(*args, **kwargs):
+        raise subprocess.CalledProcessError(
+            returncode=128, cmd=["git", "ls-files"],
+            stderr="fatal: not a git repository (or any of the parent directories)")
+    monkeypatch.setattr(eg.subprocess, "run", _boom)
+    with pytest.raises(RuntimeError, match="not a git repository"):
+        eg.git_tracked_paths()
+
+
 def test_gitignored_runtime_dirs_contribute_no_nodes():
     """Regression for #780: discovery must exclude gitignored runtime/data dirs
     (`references/`, `results/`, `logs/`, `data/`, `indices/`) so the atlas is
     identical between a clean checkout and a clone that has run the pipeline.
     All five are fully gitignored (zero tracked files), so a git-tracked walk
-    must emit no node — dir or file — rooted under any of them."""
+    must emit no node — dir or file — rooted under any of them. The set is
+    illustrative, not exhaustive: the underlying `git ls-files` filter excludes
+    *any* gitignored path by construction; these are the known offenders from
+    the bug report."""
     g = eg.build_graph()
     gitignored_roots = {"references", "results", "logs", "data", "indices"}
     offenders = []

--- a/tools/project_map/test_extract_graph.py
+++ b/tools/project_map/test_extract_graph.py
@@ -4,13 +4,12 @@ Run with the project's pytest venv:
     workflow/tests/.venv/bin/python -m pytest tools/project_map/test_extract_graph.py -v
 
 CI: collected by the `ci-tools-pytest` job in `.github/workflows/tests.yml`
-(Issue #713). `build_graph()` walks the committed tree without consulting
-`.gitignore`, so a *clean* checkout is the canonical run environment — a local
-clone with populated gitignored artifacts (`references/`, `logs/`, `data/`,
-`results/`, …) can inflate the `project` group and trip
-`test_resource_blob_is_gone`. If that test fails locally but the others pass,
-re-run against a pristine tree (`git worktree add --detach <tmp> HEAD`) — CI is
-authoritative.
+(Issue #713). `build_graph()` discovers files via `git ls-files` (Issue #780),
+so the atlas is reproducible across working-tree states: a local clone with
+populated gitignored artifacts (`references/`, `logs/`, `data/`, `results/`,
+`indices/`) produces the identical graph as a clean checkout, and the suite
+passes regardless of whether the pipeline has been run locally. (Running it
+requires a git working tree.)
 """
 import importlib.util
 import pathlib
@@ -72,3 +71,21 @@ def test_resource_blob_is_gone():
     for grp, types in by_group.items():
         frac = types.count("resource") / len(types)
         assert frac < 0.40, f"group '{grp}' is {frac:.0%} unclassified 'resource'"
+
+
+def test_gitignored_runtime_dirs_contribute_no_nodes():
+    """Regression for #780: discovery must exclude gitignored runtime/data dirs
+    (`references/`, `results/`, `logs/`, `data/`, `indices/`) so the atlas is
+    identical between a clean checkout and a clone that has run the pipeline.
+    All five are fully gitignored (zero tracked files), so a git-tracked walk
+    must emit no node — dir or file — rooted under any of them."""
+    g = eg.build_graph()
+    gitignored_roots = {"references", "results", "logs", "data", "indices"}
+    offenders = []
+    for n in g["nodes"]:
+        path = (n.get("path") or "").replace("\\", "/")
+        if path and path.split("/", 1)[0] in gitignored_roots:
+            offenders.append(path)
+    assert not offenders, (
+        f"gitignored runtime dirs leaked {len(offenders)} node(s) into the atlas: "
+        f"{sorted(offenders)[:10]}")


### PR DESCRIPTION
**Created by:** Developer

Closes #780. Relates to [Issue #713](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/713) (project-map extractor).

## Summary
`tools/project_map/extract_graph.py` discovered files by walking the raw working-tree filesystem (`os.walk`), so on any clone that had run the pipeline the gitignored runtime/data dirs (`references/`, `results/`, `logs/`, `data/`, `indices/`) were pulled into the atlas, mis-typed `resource`, tipping the `project` group past the 40% ceiling and reding `test_resource_blob_is_gone` locally — while a clean CI checkout stayed green. The atlas was non-reproducible across working-tree states.

## What changed
- `build_graph()` now restricts discovery to the **git-tracked set** via `git ls-files` (new `git_tracked_paths()` helper): prune dirs containing no tracked file, keep only tracked files per dir. git naturally respects `.gitignore`, so it's a single source of truth.
- New regression test `test_gitignored_runtime_dirs_contribute_no_nodes` (AC3).
- Refreshed the now-stale "walks the committed tree / stdlib-only → clean checkout is canonical" notes in the test docstring + the `tests.yml` CI comment.

## Acceptance criteria
- **AC1** — git-tracked discovery; atlas identical clean-vs-populated → verified **byte-identical, 376 nodes both ways**.
- **AC2** — `pytest tools/project_map/` passes on a populated tree → green (this clone has populated `references/` + `results/`).
- **AC3** — regression test asserting gitignored dirs contribute no nodes → added + passing.

## Test plan
- [x] `pytest tools/project_map/` green on a **populated** working tree (6 passed)
- [x] New regression test reds before the fix (78 leaked nodes), greens after
- [x] AC1 byte-identical check: atlas from populated clone == atlas from a clean `git worktree --detach` checkout (376 nodes each)
- [x] Full `ci-tools-pytest` equivalent green locally (tools/ci 351, tools/news 33, tools/project_map 6)

## Discovered — out of scope (follow-up)
The committed `tools/project_map/graph.json` is **stale** (335 nodes vs. 376 from a fresh clean generation) — unrelated tracked content (e.g. the `issue_393_alphagenome_chr22_poc/` migration in `d8f482f`) that was never regenerated. This is **pre-existing drift, not caused by this change** (the fix produces identical clean-checkout output to the old code), and there's no CI gate regenerating/validating the artifact. Left untouched to keep this PR scoped; flagged for a separate follow-up (regen + a freshness gate).

<!-- skip-lab-notebook: routine -->
