### PR TITLE
docs(pm): epic/parent Status model — "Epic" park + native progress bar (A2) [#776]

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -346,7 +346,7 @@ Parents/epics do **not** flow through the leaf workflow columns. They sit in a d
 **Operating rules:**
 - A parent (`subIssuesSummary.total > 0`) belongs in Status **`Epic`** while open; on completion it closes → **Done** (closed parents are terminal, never re-parked).
 - Read parent progress from the **native sub-issue bar**, not the Status field. A full bar on an open parent (e.g. all children done) signals ready-to-close.
-- The `recheck_parent_status` hook's child→parent Status mirror is **dropped for parents** (they no longer mirror a leaf state); the hook narrows to leaf-only. Tracked as a sequenced follow-up.
+- The `recheck_parent_status` check (one of the checks dispatched by the `recheck_dispatch.py` hook) **drops its child→parent Status mirror for parents** (they no longer mirror a leaf state); it narrows to leaf-only. Tracked as [Issue #794](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/794).
 - Coupling: with parents parked in `Epic` and roadmap visibility carried by the `arc:` label, the milestone-pin-on-parent anchor is no longer load-bearing — feeds [Issue #690](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/690) sub-question A.
 
 Full rule: `.claude/memory/shared/feedback_board_hygiene.md` (parent-status governance section).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -337,6 +337,20 @@ Left-side transitions: **intake-triage** (`No Status → Backlog`) → **commitm
 
 Full rules: `.claude/memory/shared/feedback_board_hygiene.md` (sweep cadence, DoR, commitment-act mechanics) and `.claude/memory/feedback_milestones.md` (milestone naming, the capacity decision tree).
 
+### Parent/epic Status — the "Epic" park (Pattern A2)
+
+Parents/epics do **not** flow through the leaf workflow columns. They sit in a dedicated **`Epic`** Status option, and their real progress is read off GitHub's **native sub-issue progress bar** (completion %, auto-derived from children). Decided in [Issue #776](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/776) (2026-06-19) — **Pattern A** (eliminate the drift class, don't police it) + implementation **A2** (park + native bar, not a custom "Epic status" field).
+
+**Why:** a parent given a single draggable Status drifts silently whenever its children move without it — forward-drift (parent ahead of children, e.g. [Issue #680](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/680)) or stale-terminal (closed/done parent stranded mid-column, e.g. [Issue #232](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/232)). A2 removes the draggable Status from parents entirely, so parent state **cannot disagree** with children. The progress bar is *computed*, never stored — drift-proof by construction — and native (no custom field to maintain). Tradeoff accepted: parents lose To-Do/In-Progress/Done granularity (completion-% only), fine at our low parent count. (Rejected: Pattern B derived-mirror + re-mirror sweep — keeps policing drift and inherits the [Issue #406](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/406) read-back lag; A1 dedicated Epic-status field — a *stored* field that can re-drift unless auto-derived, plus custom-field maintenance.)
+
+**Operating rules:**
+- A parent (`subIssuesSummary.total > 0`) belongs in Status **`Epic`** while open; on completion it closes → **Done** (closed parents are terminal, never re-parked).
+- Read parent progress from the **native sub-issue bar**, not the Status field. A full bar on an open parent (e.g. all children done) signals ready-to-close.
+- The `recheck_parent_status` hook's child→parent Status mirror is **dropped for parents** (they no longer mirror a leaf state); the hook narrows to leaf-only. Tracked as a sequenced follow-up.
+- Coupling: with parents parked in `Epic` and roadmap visibility carried by the `arc:` label, the milestone-pin-on-parent anchor is no longer load-bearing — feeds [Issue #690](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/690) sub-question A.
+
+Full rule: `.claude/memory/shared/feedback_board_hygiene.md` (parent-status governance section).
+
 ## Three-axis work model (stage / arc / due-date)
 
 Work on board #9 is structured along **three orthogonal axes**, each carried by the object that fits it (de-overloading landed by [Issue #693](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/693)):

--- a/research/lab_notebook/pm.md
+++ b/research/lab_notebook/pm.md
@@ -8,6 +8,22 @@ Format and rules unchanged from the unified notebook — see `shared/feedback_la
 
 ## 2026-06-19
 
+### 15:18 UTC — Editor: PM
+
+#### Epic/parent Status model decided + migrated — [Issue #776](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/776) / [PR #793](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/793)
+
+**The decision.** How does a parent/epic carry Status on board number 9? Two parents were found mis-stated in a single 2026-06-18 sweep — [Issue #680](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/680) (open parent showing *In review* while all children sat in Backlog = forward-drift) and [Issue #232](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/232) (closed parent stuck at *Ready for review* = stale-terminal). Root cause: a parent carries a single **stored, draggable** Status that nothing keeps synced to its children. Verdict (user-confirmed): **Pattern A** — eliminate the drift class, don't police it — implemented as **A2**: park parents in a dedicated **`Epic`** Status option and read progress off GitHub's **native sub-issue bar**.
+
+**Why A2 over the "faithful Jira port" (A1).** The decisive property is *drift-proofness by construction*. A1 (a dedicated stored "Epic status" field) reintroduces a stored value that can re-drift unless auto-derived — at which point it's just the progress bar with extra steps. The native sub-issue bar is **computed** from child completion, never stored, so it *cannot* drift; and it's native (no custom field to build/maintain — consistent with the prefer-native posture from the [Issue #715](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/715) eval and the agentic-workflows cost read earlier today). Tradeoff accepted: parents lose To-Do/In-Progress/Done granularity (completion-% only), fine at our low parent count. Rejected Pattern B (derived-mirror + re-mirror sweep) because a sweep keeps *policing* drift and inherits the [Issue #406](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/406) read-back lag we already fight.
+
+**Migration executed this session.** Added the `Epic` Status option **via the UI, not the API** — a single-select field-schema replace risks regenerating option IDs across all 700+ board items; verified post-add that existing option IDs were untouched. Parked the 8 open parents (`#126 #416 #527 #538 #539 #547 #678 #680`, all already in Backlog) into `Epic`; all 8 verified. Hook code rework (drop the `recheck_parent_status` child→parent mirror for parents) filed as [Issue #794](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/794) — documented the expectation now, deferred the code per deferral-tracking (a tracked open item, not a comment on a closed one).
+
+**Bot review** ([comment](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/793#issuecomment-4752260263)) approved with two minor doc points, both valid + applied: (1) the CLAUDE.md hook note said "a sequenced follow-up" without naming #794 — linked it; (2) `recheck_parent_status` vs `recheck_dispatch.py` ambiguity — verified in code they're distinct (`scripts/pm/recheck_parent_status.py` is a check *dispatched by* the `recheck_dispatch.py` hook) and reworded to say so rather than imply one hook.
+
+**Process note — drove the decision, not just recorded it.** This is a research-decision Issue but **not** a Quarto decision-deck tier item: that tier is for *science/methods* calls gating science work; #776 is internal process governance (cf. #580, #693), so it lands in Issue + CLAUDE.md + memory, no deck. Coupling captured for the next pull: parents now parked in `Epic` + roadmap visibility on the `arc:` label means the milestone-pin-on-parent anchor is no longer load-bearing — direct input to [Issue #690](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/690) sub-question A. (Shared-memory half — the `feedback_board_hygiene.md` parent-status section + sweep line — staged for MM via the git-status scan.)
+
+---
+
 ### 10:55 UTC — Editor: PM
 
 #### Friday morning routine — two user catches that each exposed a mis-scoped rule


### PR DESCRIPTION
Closes #776.

## What

Records the **Issue #776** decision on how parent/epic Status is carried on the JH M Lee Lab project (board number 9):

- **Pattern A** — eliminate the drift class (parents stop flowing through leaf workflow columns), not police it.
- **Implementation A2** — park parents in a dedicated **`Epic`** Status option; read real progress off GitHub's **native sub-issue progress bar** (computed from child completion → drift-proof by construction). No custom "Epic status" field to build/maintain.

Rejected: **B** (derived-mirror + re-mirror sweep — keeps policing drift, inherits the Issue #406 read-back lag) and **A1** (a *stored* Epic-status field that can re-drift unless auto-derived).

## Why

A parent given a single draggable Status drifts silently when its children move without it — forward-drift (Issue #680) or stale-terminal (Issue #232). A2 removes the draggable Status from parents so parent state **cannot disagree** with children. Tradeoff accepted: parents lose To-Do/In-Progress/Done granularity (completion-% only), fine at our low parent count.

## Changes

- `CLAUDE.md` — new "Parent/epic Status — the Epic park (Pattern A2)" subsection under board governance.
- `shared/feedback_board_hygiene.md` (personas repo, **staged for MM** — not in this PR) — full parent-status governance section + sweep-checklist line + a note retiring the parent size/flow false-positive.

## Migration — DONE

- `Epic` Status option added (UI, to avoid an API field-schema replace regenerating option IDs).
- 8 open parents parked into `Epic`: `#126 #416 #527 #538 #539 #547 #678 #680` (all were in Backlog).
- Hook code rework (drop child→parent mirror for parents) tracked as **#794**.

## Test plan

- [x] CLAUDE.md subsection renders; cross-links resolve (Issue #776, #680, #232, #406, #690).
- [x] Decision matches user-confirmed verdict (A + A2, 2026-06-19).
- [x] Verdict + migration set recorded as a comment on Issue #776.
- [x] Migration executed — 8 parents verified in `Epic`; existing Status option IDs unchanged post option-add.