### PR TITLE
docs(pm): board governance — parent-anchor retire (A) + WIP cap (D) [#690]

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -347,7 +347,7 @@ Parents/epics do **not** flow through the leaf workflow columns. They sit in a d
 - A parent (`subIssuesSummary.total > 0`) belongs in Status **`Epic`** while open; on completion it closes → **Done** (closed parents are terminal, never re-parked).
 - Read parent progress from the **native sub-issue bar**, not the Status field. A full bar on an open parent (e.g. all children done) signals ready-to-close.
 - The `recheck_parent_status` check (one of the checks dispatched by the `recheck_dispatch.py` hook) **drops its child→parent Status mirror for parents** (they no longer mirror a leaf state); it narrows to leaf-only. Tracked as [Issue #794](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/794).
-- Coupling: with parents parked in `Epic` and roadmap visibility carried by the `arc:` label, the milestone-pin-on-parent anchor is no longer load-bearing — feeds [Issue #690](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/690) sub-question A.
+- Coupling: with parents parked in `Epic` and roadmap visibility carried by the `arc:` label, the milestone-pin-on-parent anchor was no longer load-bearing → **[Issue #690](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/690) sub-question A retired it** (2026-06-19): **parents/epics go un-milestoned.** Milestones are dated stage/time slices on **leaves** (set at `Backlog → Ready`); an epic's cross-iteration roadmap visibility rides its `arc:` label (+ an arc-grouped Project view), never a milestone pin. Matches standard epic practice — epics span sprints and never enter one; their leaves do. Migration: stripped the pins from the 3 then-anchored parents (#416, #547, #680; all arc-covered) + cleared their board Target date. **Sweep rule:** an open parent carrying a milestone is now drift — strip it (after confirming an `arc:` label carries visibility).
 
 Full rule: `.claude/memory/shared/feedback_board_hygiene.md` (parent-status governance section).
 
@@ -370,6 +370,17 @@ Work on board #9 is structured along **three orthogonal axes**, each carried by 
 - The lifecycle **stage** `S<N>` is occasionally called an "iteration" loosely — it is a *phase*, not a time-box.
 
 **Time-boxing decision ([Issue #693](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/693), 2026-06-10): Target date, not the Iteration field.** The chronological clock lives in milestone `due_on` → the board **Target date** field (auto-synced by `recheck_dispatch.py`). The native Projects **Iteration field is declined** — it encodes fixed Scrum-cadence sprints, which clashes with our **Kanban/flow** model (late-commitment Ready queue + WIP limits, no sprints) *and* with the variable-length `i<N>` lifecycle passes. The **Roadmap view** plots off **Target date**; **Start date is left unused** (empty on all items). Pointing the Roadmap's date field at Target date is a **manual UI step** — ProjectV2's API can't mutate view config. **Revisit** only if sprint swimlanes / `@current` auto-roll / velocity Insights are ever wanted — none are used today. Optional future nicety: populate **Start date** for roadmap *duration bars* (start→deadline) — a deliberate date-field choice, still not the Iteration field.
+
+## WIP limits — In-progress overload guard (per-role, advisory)
+
+The Ready queue is guarded against *starvation* (per-role floor-5 / cap-15, [Issue #754](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/754)) but had **no guard against `In progress` *overload*** until [Issue #690](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/690) sub-question D (2026-06-19).
+
+**Rule:** **per-role advisory WIP cap of 3 on `In progress`** (PM / Sci / Dev each; MM excluded). More than 3 In-progress items carrying a single role's `role:` label = a flag, **not** a hard block — surfaced in the **Daily Stand-up WIP-awareness beat** (this just gives that existing beat a concrete trigger number). Classify by the item's `role:` *implementer* label, not by who filed it (same convention as the #754 Ready floor).
+
+**Why these parameters** (matches standard Kanban: "2–3 items per person, per-person WIP is the right starting point, tune from flow data"):
+- **per-role, not per-column** — roles are the throughput unit here; consistent with the #754 per-role Ready gate and the arc `active`-slate cap (3).
+- **cap 3** — top of the standard 2–3/person band; one actively-worked + slack for items blocked pre-PR (work moves *out* of In-progress into the separate `Ready for review` / `In review` columns, so In-progress holds only pre-PR active work). **Tunable** — start here, tighten toward 2 if In-progress fragmentation shows up; we have no flow data yet.
+- **advisory, not blocking** — the major tools (Azure Boards, Jira) implement WIP as a *visual warning when exceeded*, not a pull-stop; advisory matches our house style of keeping guards advisory until a defect recurs ≥2× (then escalate per the mechanism-over-memory ladder).
 
 ## GitHub Safety Wrappers
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -373,9 +373,9 @@ Work on board #9 is structured along **three orthogonal axes**, each carried by 
 
 ## WIP limits — In-progress overload guard (per-role, advisory)
 
-The Ready queue is guarded against *starvation* (per-role floor-5 / cap-15, [Issue #754](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/754)) but had **no guard against `In progress` *overload*** until [Issue #690](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/690) sub-question D (2026-06-19).
+The Ready queue is guarded against *starvation* (per-role floor-5 / cap-15, [Issue #754](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/754); full rule in shared memory `feedback_ready_queue_floor_gate.md` / `feedback_board_hygiene.md`) but had **no guard against `In progress` *overload*** until [Issue #690](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/690) sub-question D (2026-06-19).
 
-**Rule:** **per-role advisory WIP cap of 3 on `In progress`** (PM / Sci / Dev each; MM excluded). More than 3 In-progress items carrying a single role's `role:` label = a flag, **not** a hard block — surfaced in the **Daily Stand-up WIP-awareness beat** (this just gives that existing beat a concrete trigger number). Classify by the item's `role:` *implementer* label, not by who filed it (same convention as the #754 Ready floor).
+**Rule:** **per-role advisory WIP cap of 3 on `In progress`** (PM / Sci / Dev each; **MM** = Memory Manager, the memory-commit role — excluded because it implements no board-tracked work, same reason it's out of the #754 Ready count). More than 3 In-progress items carrying a single role's `role:` label = a flag, **not** a hard block — surfaced in the **Daily Stand-up WIP-awareness beat** (this just gives that existing beat a concrete trigger number). Classify by the item's `role:` *implementer* label, not by who filed it (same convention as the #754 Ready floor).
 
 **Why these parameters** (matches standard Kanban: "2–3 items per person, per-person WIP is the right starting point, tune from flow data"):
 - **per-role, not per-column** — roles are the throughput unit here; consistent with the #754 per-role Ready gate and the arc `active`-slate cap (3).

--- a/research/lab_notebook/pm.md
+++ b/research/lab_notebook/pm.md
@@ -8,6 +8,24 @@ Format and rules unchanged from the unified notebook — see `shared/feedback_la
 
 ## 2026-06-19
 
+### 16:43 UTC — Editor: PM
+
+#### Board governance — 3 sub-questions settled (anchor retire / deferral-tracking / WIP cap) — [Issue #690](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/690) / [PR #796](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/796)
+
+Closed out the three sub-questions carried from the [Issue #633](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/633) board-governance review. Drove each to a recorded verdict, **cross-checked against standard Kanban/Agile practice via web search at the user's request** before mutating anything — all three landed inside the standard band, which is reassuring rather than novel.
+
+**A — retire the parent-as-milestone-anchor (decided: retire).** The pin was a workaround to give epics cross-iteration roadmap visibility; [#693](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/693) (arc labels) + [#776](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/776) (Epic-park) already took that job over, so the pin was dead weight. Parents/epics now go **un-milestoned**; milestones are dated stage slices on **leaves** only. This is textbook — *epics span sprints and never enter one; their leaves do* (Atlassian/Wrike). **Migration executed:** the 3 then-anchored parents (#416, #547, #680) were all arc-covered, so stripped each milestone + cleared its board Target; verified `ms:none` + arc retained on all 3. No remaining open parent leans on a milestone pin.
+
+**C — deferred actions need a tracked open carrier (adopted, memory rung).** Generalized the AC defer-to-follow-up option: *any* deferred action must land on an open Issue / a `- [ ]` on an open parent / a scheduled routine — linked in the same comment — never only a comment on a closed Issue (the [#192](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/192)→[#194](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/194) lost-deferral chain). Mechanism deferred per the ladder (escalate only on ≥2 recurrences). Honored the rule *while writing it* — #678 surfaced as an un-arced parent during the sweep, so I flagged it to the user for the arc-slate call rather than silently parking it.
+
+**D — WIP limits (adopted: per-role advisory cap of 3 on `In progress`).** We guarded Ready starvation ([#754](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/754) floor/cap) but not In-progress overload. Picked per-role (roles are the throughput unit), cap 3 (top of the standard 2–3/person band), **advisory not blocking** — which is exactly how Azure Boards / Jira implement WIP (visual warning, not pull-stop) and matches our house style of advisory-until-a-defect-recurs. It just gives the existing Daily Stand-up WIP-awareness beat a number. Tunable down to 2.
+
+**Bot review** ([PR #796](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/796)) approved with 2 minor doc findings + a nit. Accepted both findings (gloss `MM` at first use; add a `#754` memory pointer) but **corrected the bot's framing on Finding 1** — it proposed "MM = un-onboarded, excluded until active", which is wrong: MM is an active role (commits the personas memory); the real exclusion reason is it implements no *board-tracked* work. Declined the bullet-density nit (bot itself called it a non-blocker, consistent with house style).
+
+**Docs split:** A + D → CLAUDE.md (this PR); C → shared `feedback_closure_ritual.md` + PM Always-in-effect (staged for MM). Side-finding handed up: **#678 is an un-arced parent** — needs an arc-slate decision (its own arc, or fold into immunogenicity-benchmark), out of scope for this anchor decision.
+
+---
+
 ### 15:18 UTC — Editor: PM
 
 #### Epic/parent Status model decided + migrated — [Issue #776](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/776) / [PR #793](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/793)


### PR DESCRIPTION
Settles the three open sub-questions carried from the [Issue #633](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/633) board-governance review into [Issue #690](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/690). All three verdicts were cross-checked against standard Kanban/Agile practice via web search (sources in the Issue decision comment).

## What this PR changes (CLAUDE.md)
- **A — retire the parent-as-milestone-anchor.** Parents/epics go un-milestoned; cross-iteration roadmap visibility rides the `arc:` label (the job #693 arcs + #776 Epic-park took over). Milestones become dated stage/time slices on **leaves** only. The old coupling note is upgraded to the recorded decision + a sweep rule (a milestoned open parent is now drift).
- **D — per-role advisory WIP cap of 3 on `In progress`.** New subsection. Per-role (PM/Sci/Dev; MM excluded), advisory not blocking — the existing Daily Stand-up WIP-awareness beat given a concrete number. Tunable.

## Not in this PR
- **C — deferral-tracking rule** lands in shared memory (`feedback_closure_ritual.md`) + PM Always-in-effect (staged for MM, separate commit path).
- **Board migration** (already applied as direct board ops): stripped the milestone pin + cleared Target on the 3 then-anchored parents (#416, #547, #680 — all arc-covered).

## Test plan
- [x] CLAUDE.md board-governance section renders cleanly (A coupling line updated; D subsection present)
- [x] Verified the 3 stripped parents (#416, #547, #680) now show no milestone + no board Target date
- [x] Verified all 3 retain an `arc:` label (roadmap visibility preserved post-strip)
- [x] #690 ACs ticked/annotated on the Issue before merge

Closes [Issue #690](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/690)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
