### PR TITLE
chore(pm): file #678 under arc:immunogenicity-benchmark (dominant-arc of a multi-theme initiative)

### DIFF
--- a/scripts/pm/arc_taxonomy.tsv
+++ b/scripts/pm/arc_taxonomy.tsv
@@ -10,5 +10,5 @@ arc:results-reporting     later   193 198 233 435 455
 arc:cloud-reproducibility next    66 183 195 310 630 651 658 664 669 673 674
 arc:memory-methodology    later   248 265 324 326 346 353 527 538 539 540 541 542 672
 arc:board-governance      active  234 250 294 295 406 445 498 499 533 553 569 578 617 626 633 655 665
-arc:immunogenicity-benchmark next 680 732 733 734 735 736 737
+arc:immunogenicity-benchmark next 678 680 732 733 734 735 736 737
 # unfiled (intentionally NO arc label): 446 451 570 641


### PR DESCRIPTION
One-line taxonomy update recording the arc-slate decision for [parent Issue #678](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/678) (relates-to) — the open-gap research program epic, previously un-arced.

**Decision (arc-slate call, [Issue #690](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/690) follow-on):** #678 is a roadmap-container epic (an *initiative* in agile terms) whose 8 best-bet children already span `immunogenicity-benchmark` / `scoring-tcr-pmhc` / `junction-filtering` by their true storyline. Per standard practice (an initiative spans themes; themes are flexible labels tagged by dominant focus area), a multi-theme initiative takes its **dominant** arc and its children keep their own. #678's flagship (best-bet 1) + cross-cutting open-only-MHC differentiator are an immunogenicity-benchmark story → `arc:immunogenicity-benchmark` (`arc-phase:next`, matching that arc).

Labels already applied to #678 directly (board op); this syncs the source-of-truth TSV.

## Test plan
- [x] `arc:immunogenicity-benchmark` line in `arc_taxonomy.tsv` now lists 678 (parent first)
- [x] #678 carries `arc:immunogenicity-benchmark` + `arc-phase:next` (verified on the Issue)

**Created by:** PM

<!-- skip-lab-notebook: routine -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)