### PR TITLE
ci(infra): pin review bot to claude-opus-4-8 + effort max (#821)

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -38,6 +38,14 @@ jobs:
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
 
+          # Pin the review-bot model + reasoning effort (forwarded to the Claude Code CLI).
+          # claude-opus-4-8 = latest Opus tier; --effort max = highest reasoning level (Opus-only).
+          # NB: the action loads this workflow from the DEFAULT branch, so changes here only
+          # affect reviews after they land on main. See Issue #821.
+          claude_args: |
+            --model claude-opus-4-8
+            --effort max
+
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |
             actions: read


### PR DESCRIPTION
Part of #821 — kept **open** after merge to track AC2 (the post-merge verification, which can only run once this lands on main).

<!-- skip-lab-notebook: routine -->

## Summary
Pins the review-bot model + reasoning effort in `.github/workflows/claude.yml`. Previously no `--model`/`--effort` was passed to `anthropics/claude-code-action@v1`, so reviews ran on the action's undocumented default model at default effort.

```yaml
          claude_args: |
            --model claude-opus-4-8
            --effort max
```

- `claude-opus-4-8` — latest Opus tier (2026-05-28).
- `--effort max` — highest reasoning level (Opus-only ladder: `low|medium|high|xhigh|max`).
- `claude_args` forwards arbitrary CLI flags ([action usage docs](https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md)).

Scientist-driven at user request; flagging Dev/PM for awareness (CI config is Dev domain).

## Timing
The action loads its workflow from the **default branch**, so this only affects bot reviews **after** it lands on `main`.

## Known caveat
[claude-code#50099](https://github.com/anthropics/claude-code/issues/50099) reports `--effort max` was ignored on CLI v2.1.113 — confirm it's honored on the first bot run; fall back to `xhigh` or a pinned CLI version if not.

## Test plan
- [x] `.github/workflows/claude.yml` parses as valid YAML (`yaml.safe_load`); `claude_args` resolves to `--model claude-opus-4-8\n--effort max`.
- [x] Model ID + effort ladder web-verified (Anthropic release notes; effort-levels docs).
- [x] Post-merge verification deferred to #821 AC2 (issue stays open until the first bot review confirms the model/effort took effect).

**Created by:** Scientist
