### PR TITLE
tooling(pm): per-role Ready floor-5 + total cap-15 gate

### DIFF
--- a/research/lab_notebook/pm.md
+++ b/research/lab_notebook/pm.md
@@ -6,6 +6,24 @@ Format and rules unchanged from the unified notebook — see `shared/feedback_la
 
 ---
 
+## 2026-06-22
+
+### 14:38 UTC — Editor: PM
+
+#### Morning routine → mechanized the Ready-queue floor/cap gate — [Issue #754](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/754) / [PR #827](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/827)
+
+Full morning routine, then pulled the day's warm-up ([#754](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/754)) to In progress and shipped it to review. Two threads worth recording — a method fix the user surfaced, and the #754 implementation + its review.
+
+**Recap-window method fix (user-caught).** The morning recap/closure-audit window was anchored on a reflexive "yesterday" / the latest `episodes/` filename. The user pushed on *how* I knew "last session = 06-21" — and the episode filename is unreliable: `2026-06-21-0118.md` is the **tail of a cross-midnight 06-20 session**, not a 06-21 routine, so it doesn't mark when the board was last checked. Web-checked the best practice (incremental-processing **watermark + overlap/idempotency**); the durable fix is a hook-written last-run marker ([Issue #820](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/820), filed). Interim: anchor on a **conservative 7-day floor + dedup** (idempotent scan never misses a weekend/absence gap) — corrected the routine memory accordingly, and re-ran today's scan at the wide floor, which caught [#794](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/794)/[PR #816](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/816) merging mid-session that the narrow query missed. **Lesson:** a side-channel that *correlates* with "last check" (episode stamp) is not the same as *recording* it — when correctness depends on a high-water mark, persist the mark, don't infer it.
+
+**#754 — per-role floor-5 / cap-18 gate.** Replaced the count-only floor-of-3 in `check_ready_queue.sh` (blind to per-role distribution — it read "healthy, 10 ≥ 3" while every role sat below floor, the 06-16 + 06-18 incidents) with a two-part gate: per-role floor 5 (PM/Sci/Dev, MM excluded) + total cap. TDD throughout (RED-verified, mutation-checked the MM-exclusion test actually bites); live smoke confirmed it surfaces the real starvation the old script hid.
+
+The **bot review caught a genuine design flaw**: `cap = 3 × floor = 15` is zero-headroom — with single-role items, meeting every floor *is* hitting the cap, so exit-0/"healthy" is mathematically unreachable. Took it to the user as a design decision (it changed my own #754 spec); chose **cap → 18** (summed floors 15 + 3 headroom) so a reachable healthy band (15–17) exists. Added `test_floors_met_under_cap_is_the_healthy_band` as the regression guard — it would have failed under cap=15. Also made `--help` robust (awk-until-first-non-comment, killing the hardcoded-line-range fragility the reviewer flagged) + per-role jq guard + unconditional breakdown. **Lesson:** a clean-looking derivation (`3 roles × 5`) can encode a degenerate gate — a health check that can't structurally return "healthy" in normal operation is the smell; the WIP limit must exceed the summed minimums.
+
+**Also this session:** cleared 4 stale parent Target dates (#538/#527/#539/#126 — un-milestoned epics shouldn't carry a Target per #690-A); closed the perpetually-open `[FYI]` "Team Coordination is live" [Discussion #738](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/discussions/738) + refined the coordination rule (an announcement-FYI is resolved on broadcast, close it at the next sweep); triaged 5 No-Status items into Backlog + routed 11 under-triaged Backlog items to [#814](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/814); filed [#824](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/824) (Signals — `gh` CLI native dependencies eval). Memory edits (recap-window, FYI-close, #754 cap→18 across Beat 3b / floor-gate / MEMORY.md / post-it) staged in the personas repo for MM.
+
+---
+
 ## 2026-06-19
 
 ### 22:18 UTC — Editor: PM

--- a/scripts/check_ready_queue.sh
+++ b/scripts/check_ready_queue.sh
@@ -1,64 +1,108 @@
 #!/usr/bin/env bash
 # scripts/check_ready_queue.sh
 #
-# Surfaces a starved Ready queue: counts open issues at board Status
-# `Ready` (the committed pull-queue) and emits a [REPLENISH] nudge when
-# the count falls below THRESHOLD. Intended for the PM morning-routine
-# "Ready-queue replenishment" phase (Phase 2.8).
+# Surfaces an unhealthy Ready queue using a two-part gate (Issue #754):
+#   - PER-ROLE FLOOR (default 5) for PM / Scientist / Developer — a Kanban
+#     "minimum order point" that prevents role-starvation. Memory Manager is
+#     EXCLUDED (memory-curation pulls cross-repo / opportunistically, not from
+#     a maintained board Ready buffer).
+#   - TOTAL CAP (default 15 = 3 roles x 5) — a WIP limit on the commitment
+#     buffer so Ready doesn't over-deepen and inflate lead time.
 #
-# Why: under late-commitment Kanban the failure mode shifts from a bloated
-# Backlog to a starved Ready queue — too few committed, refined items for
-# Dev/Sci to pull. Phase 2.6 (check_milestone_health.sh) watches milestone
-# deadlines; this is its mirror, watching committed pull-queue depth. The
-# nudge pulls a Backlog -> Ready commitment sweep forward off the bi-weekly
-# cadence (see shared/feedback_board_hygiene.md).
+# The floor is a replenish *trigger*, not a force-commit quota: below floor
+# for a role, pull that role's highest-priority DoR-ready Backlog; if fewer
+# than the floor are DoR-ready, commit what's ready and flag a grooming gap —
+# never force low-value work into Ready just to hit the number. The cap is a
+# soft WIP limit: at/over cap, hold new commitments.
+#
+# Replaces the prior single count-only floor-of-3, which was blind to per-role
+# distribution and priority mix (it skipped a warranted commitment on
+# 2026-06-16 while PM had 0 / Dev had 1 pullable Ready item).
+#
+# Intended for the PM morning-routine Replenishment beat (commitment half).
 #
 # Usage:
-#   bash scripts/check_ready_queue.sh [--threshold <count>]
+#   bash scripts/check_ready_queue.sh [--floor <count>] [--cap <count>]
 #
 # Env:
-#   READY_QUEUE_THRESHOLD  override default threshold (3)
+#   READY_QUEUE_FLOOR      override per-role floor (default 5)
+#   READY_QUEUE_CAP        override total cap (default 15)
+#   READY_QUEUE_JSON_FILE  read the Ready-items JSON array from this file
+#                          instead of calling board_open_items.py (test seam)
 #
 # Exit codes:
-#   0 — Ready queue healthy (count >= threshold)
-#   2 — Ready queue below threshold (replenishment nudge)
+#   0 — healthy (every role at/above floor AND total below cap)
+#   2 — needs attention (a role below floor, or total at/over cap)
 #   1 — usage / runtime error
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-THRESHOLD="${READY_QUEUE_THRESHOLD:-3}"
+FLOOR="${READY_QUEUE_FLOOR:-5}"
+CAP="${READY_QUEUE_CAP:-15}"
+
+# Roles subject to the per-role floor. MM is intentionally excluded (#754).
+FLOOR_ROLES=(pm scientist developer)
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
-        --threshold) [[ -n "${2:-}" ]] || { echo "--threshold requires a value" >&2; exit 1; }; THRESHOLD="$2"; shift 2 ;;
+        --floor) [[ -n "${2:-}" ]] || { echo "--floor requires a value" >&2; exit 1; }; FLOOR="$2"; shift 2 ;;
+        --cap)   [[ -n "${2:-}" ]] || { echo "--cap requires a value" >&2; exit 1; }; CAP="$2"; shift 2 ;;
         -h|--help)
-            sed -n '2,25p' "$0" | sed 's|^# \{0,1\}||'
+            sed -n '2,40p' "$0" | sed 's|^# \{0,1\}||'
             exit 0
             ;;
         *) echo "unknown arg: $1" >&2; exit 1 ;;
     esac
 done
 
-[[ "$THRESHOLD" =~ ^[0-9]+$ ]] || { echo "threshold must be a non-negative integer, got: $THRESHOLD" >&2; exit 1; }
+[[ "$FLOOR" =~ ^[0-9]+$ ]] || { echo "floor must be a non-negative integer, got: $FLOOR" >&2; exit 1; }
+[[ "$CAP" =~ ^[0-9]+$ ]]   || { echo "cap must be a non-negative integer, got: $CAP" >&2; exit 1; }
 
-# board_open_items.py paginates the ProjectV2 board (#9) and filters to open
-# items at Status=Ready; its progress chatter goes to stderr (dropped here),
-# the JSON array to stdout.
-READY_JSON="$(python3 "$SCRIPT_DIR/board_open_items.py" --status Ready --json 2>/dev/null)" || {
-    echo "error: board_open_items.py failed (gh auth / network?)" >&2
-    exit 1
-}
+# Source the Ready-items JSON: a fixture file (test seam) when set, else the
+# live board via board_open_items.py (progress chatter on stderr is dropped;
+# the JSON array lands on stdout).
+if [[ -n "${READY_QUEUE_JSON_FILE:-}" ]]; then
+    READY_JSON="$(cat "$READY_QUEUE_JSON_FILE")" || {
+        echo "error: could not read READY_QUEUE_JSON_FILE=$READY_QUEUE_JSON_FILE" >&2
+        exit 1
+    }
+else
+    READY_JSON="$(python3 "$SCRIPT_DIR/board_open_items.py" --status Ready --json 2>/dev/null)" || {
+        echo "error: board_open_items.py failed (gh auth / network?)" >&2
+        exit 1
+    }
+fi
 
-COUNT="$(printf '%s' "$READY_JSON" | jq 'length' 2>/dev/null)" || {
+TOTAL="$(printf '%s' "$READY_JSON" | jq 'length' 2>/dev/null)" || {
     echo "error: could not parse Ready-queue JSON" >&2
     exit 1
 }
 
-if [[ "$COUNT" -lt "$THRESHOLD" ]]; then
-    echo "[REPLENISH] Ready queue at ${COUNT} (< threshold ${THRESHOLD}) — pull a Backlog → Ready commitment sweep (see shared/feedback_board_hygiene.md)."
+needs_attention=0
+breakdown=""
+
+# Per-role floor check. An item counts toward every role label it carries
+# (a role:pm + role:memory_manager item counts toward pm), so we test label
+# membership rather than a single role field.
+for role in "${FLOOR_ROLES[@]}"; do
+    count="$(printf '%s' "$READY_JSON" | jq --arg r "role:$role" '[.[] | select(.labels | index($r))] | length')"
+    breakdown+="${role}=${count} "
+    if [[ "$count" -lt "$FLOOR" ]]; then
+        echo "[REPLENISH ${role}: ${count} < ${FLOOR}] — pull ${role}'s highest-priority DoR-ready Backlog (see shared/feedback_board_hygiene.md)."
+        needs_attention=1
+    fi
+done
+
+# Total cap check (soft WIP limit on the commitment buffer).
+if [[ "$TOTAL" -ge "$CAP" ]]; then
+    echo "[CAP] Ready at ${TOTAL} (>= ${CAP}) — hold new commitments; the Ready buffer is at its WIP limit."
+    needs_attention=1
+fi
+
+if [[ "$needs_attention" -eq 1 ]]; then
     exit 2
 fi
 
-echo "Ready queue: healthy — ${COUNT} committed items ready to pull (threshold ${THRESHOLD})."
+echo "Ready queue: healthy — per-role floor met (${breakdown%% }), total ${TOTAL} (floor ${FLOOR}/role, cap ${CAP})."
 exit 0

--- a/scripts/check_ready_queue.sh
+++ b/scripts/check_ready_queue.sh
@@ -6,8 +6,11 @@
 #     "minimum order point" that prevents role-starvation. Memory Manager is
 #     EXCLUDED (memory-curation pulls cross-repo / opportunistically, not from
 #     a maintained board Ready buffer).
-#   - TOTAL CAP (default 15 = 3 roles x 5) — a WIP limit on the commitment
-#     buffer so Ready doesn't over-deepen and inflate lead time.
+#   - TOTAL CAP (default 18 = floor x 3 roles + 3 headroom) — a WIP limit on
+#     the commitment buffer so Ready doesn't over-deepen and inflate lead time.
+#     The headroom above the summed floors (15) leaves a reachable "healthy"
+#     band (total 15-17 = all floors met, under cap). A zero-headroom cap=15
+#     could only ever read REPLENISH or CAP, never healthy (#754 review).
 #
 # The floor is a replenish *trigger*, not a force-commit quota: below floor
 # for a role, pull that role's highest-priority DoR-ready Backlog; if fewer
@@ -26,20 +29,22 @@
 #
 # Env:
 #   READY_QUEUE_FLOOR      override per-role floor (default 5)
-#   READY_QUEUE_CAP        override total cap (default 15)
+#   READY_QUEUE_CAP        override total cap (default 18)
 #   READY_QUEUE_JSON_FILE  read the Ready-items JSON array from this file
 #                          instead of calling board_open_items.py (test seam)
 #
 # Exit codes:
 #   0 — healthy (every role at/above floor AND total below cap)
 #   2 — needs attention (a role below floor, or total at/over cap)
+#       Both conditions share exit 2 — distinguish via stdout:
+#       `[REPLENISH <role>: K < F]` (commit more) vs `[CAP] …` (hold).
 #   1 — usage / runtime error
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 FLOOR="${READY_QUEUE_FLOOR:-5}"
-CAP="${READY_QUEUE_CAP:-15}"
+CAP="${READY_QUEUE_CAP:-18}"
 
 # Roles subject to the per-role floor. MM is intentionally excluded (#754).
 FLOOR_ROLES=(pm scientist developer)
@@ -49,7 +54,7 @@ while [[ $# -gt 0 ]]; do
         --floor) [[ -n "${2:-}" ]] || { echo "--floor requires a value" >&2; exit 1; }; FLOOR="$2"; shift 2 ;;
         --cap)   [[ -n "${2:-}" ]] || { echo "--cap requires a value" >&2; exit 1; }; CAP="$2"; shift 2 ;;
         -h|--help)
-            sed -n '2,40p' "$0" | sed 's|^# \{0,1\}||'
+            awk 'NR>1 && /^#/ {sub(/^# ?/, ""); print; next} NR>1 {exit}' "$0"
             exit 0
             ;;
         *) echo "unknown arg: $1" >&2; exit 1 ;;
@@ -86,7 +91,10 @@ breakdown=""
 # (a role:pm + role:memory_manager item counts toward pm), so we test label
 # membership rather than a single role field.
 for role in "${FLOOR_ROLES[@]}"; do
-    count="$(printf '%s' "$READY_JSON" | jq --arg r "role:$role" '[.[] | select(.labels | index($r))] | length')"
+    count="$(printf '%s' "$READY_JSON" | jq --arg r "role:$role" '[.[] | select(.labels | index($r))] | length')" || {
+        echo "error: could not count Ready items for role:$role" >&2
+        exit 1
+    }
     breakdown+="${role}=${count} "
     if [[ "$count" -lt "$FLOOR" ]]; then
         echo "[REPLENISH ${role}: ${count} < ${FLOOR}] — pull ${role}'s highest-priority DoR-ready Backlog (see shared/feedback_board_hygiene.md)."
@@ -100,9 +108,12 @@ if [[ "$TOTAL" -ge "$CAP" ]]; then
     needs_attention=1
 fi
 
+# Always print the full per-role breakdown so every run is self-documenting
+# (not just the healthy path) — roles at/above floor are otherwise silent.
 if [[ "$needs_attention" -eq 1 ]]; then
+    echo "Ready by role: ${breakdown%% } — total ${TOTAL} (floor ${FLOOR}/role, cap ${CAP}) — needs attention."
     exit 2
 fi
 
-echo "Ready queue: healthy — per-role floor met (${breakdown%% }), total ${TOTAL} (floor ${FLOOR}/role, cap ${CAP})."
+echo "Ready by role: ${breakdown%% } — total ${TOTAL} (floor ${FLOOR}/role, cap ${CAP}) — healthy."
 exit 0

--- a/workflow/tests/test_check_ready_queue.py
+++ b/workflow/tests/test_check_ready_queue.py
@@ -1,0 +1,87 @@
+"""Tests for scripts/check_ready_queue.sh — per-role Ready floor + total cap (Issue #754).
+
+The script reads the board via board_open_items.py, which hits the network.
+For deterministic offline tests it accepts a fixture seam: when
+READY_QUEUE_JSON_FILE points at a JSON array, the script reads Ready items
+from that file instead of calling board_open_items.py. We feed crafted
+fixtures and assert the per-role [REPLENISH], [CAP], and exit-code behavior.
+
+Gate (Issue #754):
+  - per-role floor 5 for PM / Scientist / Developer (MM excluded)
+  - total cap 15 on the Ready buffer
+  - exit 2 if any role below floor OR total at/over cap; else exit 0
+"""
+import json
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "check_ready_queue.sh"
+
+
+def _item(number, *roles, status="Ready"):
+    return {"number": number, "status": status,
+            "labels": [f"role:{r}" for r in roles]}
+
+
+def _run(items):
+    """Run the script with a JSON fixture injected via READY_QUEUE_JSON_FILE."""
+    with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as f:
+        json.dump(items, f)
+        path = f.name
+    try:
+        env = {**os.environ, "READY_QUEUE_JSON_FILE": path}
+        return subprocess.run(["bash", str(SCRIPT)], env=env,
+                              capture_output=True, text=True)
+    finally:
+        os.unlink(path)
+
+
+def _spread(role, n, start):
+    return [_item(start + i, role) for i in range(n)]
+
+
+def test_role_below_floor_emits_per_role_replenish_and_exit_2():
+    # PM=2 (below floor 5), Sci=5, Dev=5
+    items = _spread("pm", 2, 100) + _spread("scientist", 5, 200) + _spread("developer", 5, 300)
+    r = _run(items)
+    assert "[REPLENISH pm: 2 < 5]" in r.stdout, r.stdout
+    assert r.returncode == 2, (r.returncode, r.stdout, r.stderr)
+
+
+def test_all_roles_at_floor_under_cap_is_healthy():
+    # 5 items each carrying all three roles -> pm=sci=dev=5, total=5 (< cap 15)
+    items = [_item(400 + i, "pm", "scientist", "developer") for i in range(5)]
+    r = _run(items)
+    assert "healthy" in r.stdout, r.stdout
+    assert "[REPLENISH" not in r.stdout, r.stdout
+    assert r.returncode == 0, (r.returncode, r.stdout, r.stderr)
+
+
+def test_total_at_cap_flags_cap_and_exit_2():
+    # Disjoint: pm=5, sci=5, dev=5 -> no floor breach, but total=15 == cap
+    items = _spread("pm", 5, 100) + _spread("scientist", 5, 200) + _spread("developer", 5, 300)
+    r = _run(items)
+    assert "[CAP] Ready at 15 (>= 15)" in r.stdout, r.stdout
+    assert "[REPLENISH" not in r.stdout, r.stdout
+    assert r.returncode == 2, (r.returncode, r.stdout, r.stderr)
+
+
+def test_memory_manager_excluded_from_floor():
+    # pm/sci/dev all met via shared-role items; MM has only 1 (< floor) but is excluded
+    items = [_item(400 + i, "pm", "scientist", "developer") for i in range(5)]
+    items += [_item(500, "memory_manager")]
+    r = _run(items)
+    assert "memory_manager" not in r.stdout, r.stdout
+    assert "[REPLENISH" not in r.stdout, r.stdout
+    assert r.returncode == 0, (r.returncode, r.stdout, r.stderr)
+
+
+def test_multiple_roles_below_floor_each_reported():
+    # PM=1, Sci=0, Dev=5 -> two replenish lines
+    items = _spread("pm", 1, 100) + _spread("developer", 5, 300)
+    r = _run(items)
+    assert "[REPLENISH pm: 1 < 5]" in r.stdout, r.stdout
+    assert "[REPLENISH scientist: 0 < 5]" in r.stdout, r.stdout
+    assert r.returncode == 2, (r.returncode, r.stdout, r.stderr)

--- a/workflow/tests/test_check_ready_queue.py
+++ b/workflow/tests/test_check_ready_queue.py
@@ -25,14 +25,14 @@ def _item(number, *roles, status="Ready"):
             "labels": [f"role:{r}" for r in roles]}
 
 
-def _run(items):
+def _run(items, *args):
     """Run the script with a JSON fixture injected via READY_QUEUE_JSON_FILE."""
     with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as f:
         json.dump(items, f)
         path = f.name
     try:
         env = {**os.environ, "READY_QUEUE_JSON_FILE": path}
-        return subprocess.run(["bash", str(SCRIPT)], env=env,
+        return subprocess.run(["bash", str(SCRIPT), *args], env=env,
                               capture_output=True, text=True)
     finally:
         os.unlink(path)
@@ -60,12 +60,22 @@ def test_all_roles_at_floor_under_cap_is_healthy():
 
 
 def test_total_at_cap_flags_cap_and_exit_2():
-    # Disjoint: pm=5, sci=5, dev=5 -> no floor breach, but total=15 == cap
-    items = _spread("pm", 5, 100) + _spread("scientist", 5, 200) + _spread("developer", 5, 300)
+    # Disjoint pm=6/sci=6/dev=6 -> no floor breach, but total=18 == cap
+    items = _spread("pm", 6, 100) + _spread("scientist", 6, 200) + _spread("developer", 6, 300)
     r = _run(items)
-    assert "[CAP] Ready at 15 (>= 15)" in r.stdout, r.stdout
+    assert "[CAP] Ready at 18 (>= 18)" in r.stdout, r.stdout
     assert "[REPLENISH" not in r.stdout, r.stdout
     assert r.returncode == 2, (r.returncode, r.stdout, r.stderr)
+
+
+def test_floors_met_under_cap_is_the_healthy_band():
+    # 5/5/5 disjoint = 15: every floor met AND under cap 18 -> reachable healthy
+    # band. This case was the degenerate CAP-at-floor under the old cap=15.
+    items = _spread("pm", 5, 100) + _spread("scientist", 5, 200) + _spread("developer", 5, 300)
+    r = _run(items)
+    assert "healthy" in r.stdout, r.stdout
+    assert "[CAP]" not in r.stdout and "[REPLENISH" not in r.stdout, r.stdout
+    assert r.returncode == 0, (r.returncode, r.stdout, r.stderr)
 
 
 def test_memory_manager_excluded_from_floor():
@@ -85,3 +95,40 @@ def test_multiple_roles_below_floor_each_reported():
     assert "[REPLENISH pm: 1 < 5]" in r.stdout, r.stdout
     assert "[REPLENISH scientist: 0 < 5]" in r.stdout, r.stdout
     assert r.returncode == 2, (r.returncode, r.stdout, r.stderr)
+
+
+def test_empty_ready_replenishes_all_three():
+    r = _run([])
+    for role in ("pm", "scientist", "developer"):
+        assert f"[REPLENISH {role}: 0 < 5]" in r.stdout, r.stdout
+    assert r.returncode == 2, (r.returncode, r.stdout, r.stderr)
+
+
+def test_floor_flag_lowers_threshold():
+    # PM=2 would breach the default floor 5, but --floor 2 makes it healthy
+    items = _spread("pm", 2, 100) + _spread("scientist", 5, 200) + _spread("developer", 5, 300)
+    r = _run(items, "--floor", "2")
+    assert "[REPLENISH" not in r.stdout, r.stdout
+    assert "[CAP]" not in r.stdout, r.stdout  # total 12 < cap 15
+    assert r.returncode == 0, (r.returncode, r.stdout, r.stderr)
+
+
+def test_invalid_floor_exits_1():
+    r = _run([], "--floor", "abc")
+    assert r.returncode == 1, (r.returncode, r.stdout, r.stderr)
+    assert "floor must be" in r.stderr, r.stderr
+
+
+def test_breakdown_printed_on_unhealthy_path():
+    # Roles at/above floor are otherwise silent; the breakdown makes every run self-documenting
+    items = _spread("pm", 2, 100) + _spread("scientist", 5, 200) + _spread("developer", 5, 300)
+    r = _run(items)
+    assert "Ready by role:" in r.stdout, r.stdout
+    assert "pm=2" in r.stdout and "scientist=5" in r.stdout and "developer=5" in r.stdout, r.stdout
+
+
+def test_help_has_no_code_leak():
+    r = subprocess.run(["bash", str(SCRIPT), "--help"], capture_output=True, text=True)
+    assert r.returncode == 0, (r.returncode, r.stderr)
+    assert "set -euo pipefail" not in r.stdout, r.stdout
+    assert "SCRIPT_DIR=" not in r.stdout, r.stdout


### PR DESCRIPTION
Closes #754.

## Summary
Replaces the count-only **floor-of-3** in `scripts/check_ready_queue.sh` with a two-part gate ([Issue #754](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/754)):
- **Per-role floor 5** for PM / Scientist / Developer — a Kanban minimum-order-point that prevents role-starvation. **MM excluded.**
- **Total cap 15** — a soft WIP limit on the Ready buffer.

Emits a per-role `[REPLENISH <role>: K < 5]` line for any role below floor, a `[CAP] Ready at N (>= 15)` flag at the buffer limit, **exit 2** if either fires, else healthy + exit 0. Counting is by **role-label membership** (a multi-role item counts toward each of its roles). Floor/cap override via `--floor`/`--cap` or `READY_QUEUE_FLOOR`/`READY_QUEUE_CAP`.

## Why
The old global count was blind to per-role distribution + priority mix: it reported "healthy — 10 ≥ 3" while every role sat below the real per-role floor (the 2026-06-16 + 2026-06-18 under-stocking incidents). The live smoke on this branch confirms it: the board reads pm=3 / sci=4 / dev=4 — **all sub-floor** — which the new gate surfaces and the old one hid.

## Test plan
- [x] `test_check_ready_queue.py` — 5 tests, **RED-verified** before implementing (first run failed against the old script)
- [x] Mutation check: adding `memory_manager` to the floor roles makes the MM-exclusion test fail → it genuinely bites
- [x] Full suite green (33 passed incl. `test_board_open_items`)
- [x] `bash -n` syntax check clean
- [x] Live smoke against the real board (no fixture) — surfaces the real per-role starvation
- [x] `--help` renders

## Notes
- **Memory edits (AC 4/5) ride the personas repo for MM to land** — Beat 3b rewritten + floor-of-3 references updated/dropped (MEMORY.md, the floor-gate file, post-it). This is the cross-repo split #754 anticipated ("memory edit — for MM to land").
- The 5 ACs on [Issue #754](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/754) will be ticked after review, before merge.

**Created by:** PM