### PR TITLE
research(scientist): ASNEO cross-check setup — option-B decision + turnkey runner (closes #566)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -250,6 +250,10 @@ research/experiments/issue_224_alphagenome_exp1/outputs/*.parquet
 # LICR-copyright NeoRanking peptides (no redistribution); regenerate via score_cohort.py.
 # The aggregate calibrator_v1.joblib, true_counts.csv, and diagnostic PNGs ARE committed.
 research/experiments/issue_547_immunogenicity_calibration/outputs/*.parquet
+# Issue #566 ASNEO cross-check run scratch (cloned ASNEO repo, STAR BAM, SJ.out.tab,
+# asneo_out/) written by run_asneo_chr22.sh — heavy + regenerable. Small committed
+# notebook artifacts (concordance tables/figures) live elsewhere under outputs/.
+research/experiments/issue_566_asneo_crosscheck/outputs/chr22_run/
 
 # Quarto slide-deck build artefacts — regenerable via `quarto render`
 research/slides/**/*.html

--- a/research/experiments/issue_566_asneo_crosscheck/README.md
+++ b/research/experiments/issue_566_asneo_crosscheck/README.md
@@ -32,6 +32,8 @@ Rationale: isolates the junction-detection signal · open-only/reproducible (Apa
 | **Allele-independent under option B** | ASNEO's `-a` HLA arg is consumed *only* by the bypassed netMHCpan/netCTLpan steps → candidate generation needs no real HLA (use a placeholder); real HLA enters only at the downstream MHCflurry step | `ASNEO.py:256,378+` |
 | MHC call sites (bypassed) | netMHCpan `:218`, netCTLpan `:280`, netMHCpan `:290`, pepmatch wild-type-match `:270` (used only in the bypassed `ProcessNeo`) | `ASNEO.py` |
 | `tmp/` is deleted at end | `main()` `shutil.rmtree(path['tdir'])` — so the patch copies `putative_peptide.txt` to the outdir before cleanup | `ASNEO.py:485` |
+| `-o`/`--outdir` flag exists | `parser.add_argument('-o','--outdir', default='result')` — the runner's `-o` is valid (PR #849 review check #3) | `ASNEO.py:28` |
+| Copy dest is **persistent** | `tdir = outdir/tmp` so `rmtree(tdir)` nukes only the `tmp` *subdir*; `neo_sorted` (hence the patch's `dirname(neo_sorted)`) is `outdir` itself → copied `putative_peptide.txt` survives (PR #849 review check #4) | `ASNEO.py:397,458` |
 
 ## Liftover plan — re-align, don't lift coordinates
 

--- a/research/experiments/issue_566_asneo_crosscheck/README.md
+++ b/research/experiments/issue_566_asneo_crosscheck/README.md
@@ -1,0 +1,55 @@
+# Issue #566 — ASNEO cross-check (open-only, MHCflurry-standardized)
+
+**Parent Issue:** [#566](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/566) (ASNEO cross-check) — itself a single-caller slice of the broader [#679](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/679) open caller benchmark; parked from the [#546](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/546) ASNEO desk eval (verdict: component reuse + cross-check ⚠️).
+
+**Status:** 🟡 scoping (env recipe + liftover/swap plan drafted; no run yet).
+
+## Goal
+
+Run **ASNEO** (our closest published peer: RNA-seq → splice junctions → neoepitopes) as an orthogonal second opinion on the same input, and compare its splice-neoepitope calls against our pipeline. The MHC step is **held constant on MHCflurry** so the comparison isolates *junction-detection + translation* differences rather than confounding them with MHC-predictor differences.
+
+## Scope decision — MHC path: MHCflurry-swap, layered (option B, 2026-06-23)
+
+1. **Primary (MHC-agnostic):** compare the *peptide candidate sets* — junctions detected, frames translated, peptides emitted (Jaccard overlap + divergence breakdown).
+2. **Secondary (ranking):** score *both* candidate sets through the **same MHCflurry** presentation predictor; compare ranking concordance.
+3. **Native NetMHCpan/NetCTLpan path demoted off the critical path** to optional supplementary (only if a license is ever obtained).
+
+Rationale: isolates the junction-detection signal · open-only/reproducible (Apache-2.0) · consistent with #679 · removes the NetMHCpan license gate.
+
+## Verified facts about ASNEO (source-checked 2026-06-23)
+
+| Item | Finding | Source |
+|------|---------|--------|
+| Canonical repo | **`bm2-lab/ASNEO`** (Qi Liu's bm2-lab, Tongji — the *Aging* 2020 authors; pushed 2021-04-09). `zzb23/ASNEO` is the original-author 2019 mirror, same code. | `gh repo view` |
+| Genome build | **hg19 / GRCh37** (`hg19.fa` or `GRCh37.fa`) | README |
+| Input format | **STAR `SJ.out.tab`** (+ optional indexed BAM) | README + `test/run_ASNEO.sh` |
+| Invocation | `python ASNEO.py -j <SJ.out.tab> -a <HLA,...> -g hg19.fa` | `test/run_ASNEO.sh` |
+| Python deps | python3 + sj2psi, pysam, pandas, biopython, sklearn, xgboost; bedtools | README |
+| **Biopython pin** | **< 1.80** — `ASNEO.py:11-12` imports `Bio.SubsMat` (removed 1.80) + `pairwise2` (removed 1.84) | `ASNEO.py:11-12` |
+| Bundled binaries | `src/software.tar.gz` → `netMHCpan-4.0`, `netCTLpan-1.1`, `pepmatch_db_x86_64` (non-redistributable) | `ASNEO.py:446-448` |
+| **Candidate peptides** | written to `putative_peptide.txt` at `ASNEO.py:252`, right before the netMHCpan call (`:256`) — **the MHCflurry-swap interception point** | `ASNEO.py:204,252,463` |
+| MHC call sites (bypassed) | netMHCpan `:218`, netCTLpan `:280`, netMHCpan `:290`, pepmatch self-filter `:270` | `ASNEO.py` |
+
+## Liftover plan — re-align, don't lift coordinates
+
+ASNEO consumes `SJ.out.tab` natively, so the robust path is to **generate a native hg19 `SJ.out.tab`** by re-aligning the same FASTQs with STAR against an hg19 index — *not* to liftover our GRCh38 junction coordinates (cross-build splice-junction liftover is error-prone). Our pipeline's GRCh38 calls stay as-is on our side; ASNEO gets its own hg19 alignment. Both originate from identical reads, so the comparison is fair.
+
+- **First input = chr22 PoC** (smoke): build a chr22-only STAR hg19 index (single-chr index fits in laptop RAM, unlike the whole-genome >8 GB build), align the existing chr22 test FASTQs, feed the resulting `SJ.out.tab` to ASNEO.
+- Then a patient (heavier; VM-bound).
+
+## Env
+
+`asneo_env.yml` — conda recipe pinned to the 2019 era (biopython=1.79, python=3.8); dry-solves cleanly. Bundled NetMHCpan/NetCTLpan/pepmatch are **not** installed (option B bypass). (Filed at the experiment root rather than an `env/` subdir — `env/` collides with the standard `ENV/` gitignore rule on a case-insensitive filesystem.)
+
+## Outputs index
+
+`outputs/` — (empty; populated on first run: ASNEO `putative_peptide.txt`, candidate-set concordance tables, MHCflurry ranking comparison, figures).
+
+## Open sub-questions (carried, not blocking the scoping step)
+
+- Keep ASNEO's `pepmatch` self-proteome filter (`:270`) as part of its "call" definition, or compare the pre-filter k-mer set? (pepmatch is a proteome filter, not an MHC predictor — but is also a bundled binary with its own MuPeXI terms.)
+- Patient input choice + HLA typing source for the secondary MHCflurry step.
+
+## Cross-experiment deps
+
+- Reuses our existing chr22 STAR/HISAT2 test fixtures and MHCflurry setup. No write into other experiments' `outputs/`.

--- a/research/experiments/issue_566_asneo_crosscheck/README.md
+++ b/research/experiments/issue_566_asneo_crosscheck/README.md
@@ -2,7 +2,7 @@
 
 **Parent Issue:** [#566](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/566) (ASNEO cross-check) — itself a single-caller slice of the broader [#679](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/679) open caller benchmark; parked from the [#546](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/546) ASNEO desk eval (verdict: component reuse + cross-check ⚠️).
 
-**Status:** 🟡 scoping (env recipe + liftover/swap plan drafted; no run yet).
+**Status:** 🟢 prepped — env built + validated, ASNEO architecture source-verified, option-B patcher + turnkey chr22 runner written & tested. ⛔ **The run itself is VM-bound** (needs STAR; not usable on the arm64 laptop, project policy = STAR is VM-only) — same constraint as [#636](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/636). No concordance numbers yet.
 
 ## Goal
 
@@ -28,7 +28,10 @@ Rationale: isolates the junction-detection signal · open-only/reproducible (Apa
 | **Biopython pin** | **< 1.80** — `ASNEO.py:11-12` imports `Bio.SubsMat` (removed 1.80) + `pairwise2` (removed 1.84) | `ASNEO.py:11-12` |
 | Bundled binaries | `src/software.tar.gz` → `netMHCpan-4.0`, `netCTLpan-1.1`, `pepmatch_db_x86_64` (non-redistributable) | `ASNEO.py:446-448` |
 | **Candidate peptides** | written to `putative_peptide.txt` at `ASNEO.py:252`, right before the netMHCpan call (`:256`) — **the MHCflurry-swap interception point** | `ASNEO.py:204,252,463` |
-| MHC call sites (bypassed) | netMHCpan `:218`, netCTLpan `:280`, netMHCpan `:290`, pepmatch self-filter `:270` | `ASNEO.py` |
+| Candidate set is **normal-subtracted** | `putative_peptide.txt` = `peps - norm_peps` (k-mers minus `Norm_Protein.fasta` proteome, `:246-249`) — i.e. ASNEO's junction-derived novel peptides *after* its self-filter. The right artifact to compare. | `ASNEO.py:246-253` |
+| **Allele-independent under option B** | ASNEO's `-a` HLA arg is consumed *only* by the bypassed netMHCpan/netCTLpan steps → candidate generation needs no real HLA (use a placeholder); real HLA enters only at the downstream MHCflurry step | `ASNEO.py:256,378+` |
+| MHC call sites (bypassed) | netMHCpan `:218`, netCTLpan `:280`, netMHCpan `:290`, pepmatch wild-type-match `:270` (used only in the bypassed `ProcessNeo`) | `ASNEO.py` |
+| `tmp/` is deleted at end | `main()` `shutil.rmtree(path['tdir'])` — so the patch copies `putative_peptide.txt` to the outdir before cleanup | `ASNEO.py:485` |
 
 ## Liftover plan — re-align, don't lift coordinates
 
@@ -37,18 +40,26 @@ ASNEO consumes `SJ.out.tab` natively, so the robust path is to **generate a nati
 - **First input = chr22 PoC** (smoke): build a chr22-only STAR hg19 index (single-chr index fits in laptop RAM, unlike the whole-genome >8 GB build), align the existing chr22 test FASTQs, feed the resulting `SJ.out.tab` to ASNEO.
 - Then a patient (heavier; VM-bound).
 
-## Env
+## Files & how to run
 
-`asneo_env.yml` — conda recipe pinned to the 2019 era (biopython=1.79, python=3.8); dry-solves cleanly. Bundled NetMHCpan/NetCTLpan/pepmatch are **not** installed (option B bypass). (Filed at the experiment root rather than an `env/` subdir — `env/` collides with the standard `ENV/` gitignore rule on a case-insensitive filesystem.)
+| File | Role |
+|------|------|
+| `asneo_env.yml` | Conda env (biopython=1.79, python=3.8 + bedtools); **built & import-validated** locally. Bundled MHC binaries not installed (option B). (At the experiment root, not `env/` — that collides with the `ENV/` gitignore rule on a case-insensitive FS.) |
+| `apply_optionB_patch.py` | String-anchored patcher: makes ASNEO stop after `putative_peptide.txt`, copy it to the outdir, repoint `bedtools` to PATH (skips `software.tar.gz`), and skip `ProcessNeo`. Self-verifying (each anchor must match once). **Tested against the real `ASNEO.py` — applies + compiles clean.** |
+| `run_asneo_chr22.sh` | Turnkey chr22 PoC runner (VM): fetch hg19 chr22 → STAR hg19 chr22 index → align `SRR9143066` → patch+run ASNEO → `putative_peptide.txt`. `bash -n` clean. |
+| `notebook.ipynb` | *(to add at run time)* MHCflurry concordance: score ASNEO's + our candidate peptides via the same predictor; primary call-concordance + secondary ranking. |
+
+**To run (on the VM):** `conda env create -f asneo_env.yml` (once), then `conda activate asneo && bash research/experiments/issue_566_asneo_crosscheck/run_asneo_chr22.sh` from the repo root. STAR must be on PATH.
 
 ## Outputs index
 
 `outputs/` — (empty; populated on first run: ASNEO `putative_peptide.txt`, candidate-set concordance tables, MHCflurry ranking comparison, figures).
 
-## Open sub-questions (carried, not blocking the scoping step)
+## Open sub-questions
 
-- Keep ASNEO's `pepmatch` self-proteome filter (`:270`) as part of its "call" definition, or compare the pre-filter k-mer set? (pepmatch is a proteome filter, not an MHC predictor — but is also a bundled binary with its own MuPeXI terms.)
-- Patient input choice + HLA typing source for the secondary MHCflurry step.
+- ~~Keep ASNEO's `pepmatch` self-proteome filter as part of its "call"?~~ **Resolved:** the candidate set already has the normal-proteome subtraction applied (`peps - norm_peps`, `:246-249`); the later `pepmatch` (`:270`) is a *wild-type-match* step inside the bypassed `ProcessNeo`, not part of candidate definition. `putative_peptide.txt` is the right comparison artifact.
+- Patient input choice + HLA typing source for the **secondary** MHCflurry step (the primary call-concordance is MHC-agnostic, so this only gates the ranking comparison).
+- Confirm chr22-only genome FASTA + ASNEO's whole-genome `data/iRefSeq.bed` interplay at run time (chr22 junctions → chr22 isoforms only; expected fine, verify on first run).
 
 ## Cross-experiment deps
 

--- a/research/experiments/issue_566_asneo_crosscheck/apply_optionB_patch.py
+++ b/research/experiments/issue_566_asneo_crosscheck/apply_optionB_patch.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Apply the #566 option-B (MHCflurry-swap) modifications to a clone of bm2-lab/ASNEO.
+
+Option B holds the MHC step constant on MHCflurry, so ASNEO's bundled
+NetMHCpan/NetCTLpan/pepmatch binaries are bypassed entirely. This patcher makes
+ASNEO stop right after it writes its junction-derived, normal-subtracted candidate
+peptides (`putative_peptide.txt`, the `peps - norm_peps` set), and copies that file
+to the output dir before the tmp dir is cleaned. Those candidates are then scored
+with MHCflurry downstream (outside ASNEO), apples-to-apples with our pipeline.
+
+String-anchored (not line-numbered) so it survives minor upstream drift; each
+replacement must match exactly once or the script aborts (fail-loud).
+
+Usage:  python apply_optionB_patch.py /path/to/ASNEO/ASNEO.py
+"""
+import sys, py_compile
+
+REPLACEMENTS = [
+    # 1. Use PATH/conda bedtools -> no need to extract the bundled src/software.tar.gz
+    #    (which carries the non-redistributable MHC binaries). Fully open-only.
+    (
+        "    path['bedtools'] = os.path.join(path['sdir'], 'src/bedtools')",
+        "    path['bedtools'] = 'bedtools'  # option B: PATH/conda bedtools; skip bundled src/",
+    ),
+    # 2. Stop ProcessIsoform after the candidate peptides are written; copy them out;
+    #    skip the bundled netMHCpan call + ParseAffit.
+    (
+        "    logging.info(\"Call netMHCpan\")\n"
+        "    RunMHCpan(allele=allele, peptxt=path['pep_txt'], affit=path['affit'])\n"
+        "    ParseAffit(protfa=path['prot_fa'], affit=path['affit'], epit=path['epit'], bind=bind)",
+        "    # option B (MHCflurry-swap): stop after candidate peptides; skip bundled MHC binaries\n"
+        "    shutil.copy(path['pep_txt'], os.path.join(os.path.dirname(path['neo_sorted']), 'putative_peptide.txt'))\n"
+        "    logging.info(\"Option B: wrote %s candidate peptides; skipping netMHCpan/netCTLpan\", len(remain_pep))\n"
+        "    return",
+    ),
+    # 3. Skip ProcessNeo in main (it runs the bypassed MHC scoring + xgboost).
+    (
+        "    ProcessNeo(args.process)",
+        "    # ProcessNeo(args.process)  # option B: skipped (MHC scoring bypassed in ProcessIsoform)",
+    ),
+]
+
+
+def main(target):
+    with open(target) as f:
+        src = f.read()
+    for old, new in REPLACEMENTS:
+        n = src.count(old)
+        if n != 1:
+            sys.exit(f"ABORT: anchor matched {n} times (expected 1):\n{old[:80]}...")
+        src = src.replace(old, new)
+    with open(target, "w") as f:
+        f.write(src)
+    py_compile.compile(target, doraise=True)
+    print(f"OK: applied {len(REPLACEMENTS)} option-B replacements to {target}; compiles clean.")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        sys.exit(__doc__)
+    main(sys.argv[1])

--- a/research/experiments/issue_566_asneo_crosscheck/asneo_env.yml
+++ b/research/experiments/issue_566_asneo_crosscheck/asneo_env.yml
@@ -1,0 +1,24 @@
+# Conda env for running ASNEO (bm2-lab/ASNEO) as the #566 cross-check peer.
+# ASNEO is dormant since ~2019; deps are pinned to that era.
+# KEY PIN: biopython < 1.80 — ASNEO.py:11-12 imports `Bio.SubsMat` (removed in
+# Biopython 1.80) and `pairwise2` (removed in 1.84). 1.79 is the last compatible release.
+# The bundled NetMHCpan/NetCTLpan/pepmatch binaries (src/software.tar.gz) are NOT
+# installed here — the #566 scope decision (option B) bypasses them; ASNEO's
+# junction-derived peptide candidates (putative_peptide.txt, ASNEO.py:252) are
+# intercepted and scored with MHCflurry downstream instead.
+name: asneo
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - python=3.8
+  - biopython=1.79
+  - pysam
+  - pandas
+  - numpy
+  - scikit-learn
+  - xgboost
+  - bedtools
+  - pip
+  - pip:
+      - sj2psi   # PyPI; ASNEO imports it for the SJ.out.tab PSI step

--- a/research/experiments/issue_566_asneo_crosscheck/asneo_env.yml
+++ b/research/experiments/issue_566_asneo_crosscheck/asneo_env.yml
@@ -14,11 +14,14 @@ dependencies:
   - python=3.8
   - biopython=1.79
   - pysam
-  - pandas
-  - numpy
-  - scikit-learn
-  - xgboost
-  - bedtools
+  # Pin era-major numpy/pandas: ASNEO + sj2psi are 2019-vintage; numpy>=1.24 removed
+  # np.int/np.float aliases and pandas>=2.0 removed DataFrame.append — both break old code.
+  # Reproducibility is the whole point of the cross-check, so don't let these float.
+  - numpy<1.24
+  - pandas<2.0
+  - scikit-learn   # only used in ASNEO's ProcessNeo (bypassed under option B) — left unpinned
+  - xgboost        # same — bypassed under option B
+  - bedtools=2.31.1   # the version validated in the README
   - pip
   - pip:
       - sj2psi   # PyPI; ASNEO imports it for the SJ.out.tab PSI step

--- a/research/experiments/issue_566_asneo_crosscheck/run_asneo_chr22.sh
+++ b/research/experiments/issue_566_asneo_crosscheck/run_asneo_chr22.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# #566 ASNEO cross-check — turnkey chr22 PoC runner (option B, MHCflurry-swap).
+#
+# Produces ASNEO's junction-derived candidate peptides (putative_peptide.txt) from
+# the same chr22 test reads our pipeline uses, on hg19, by RE-ALIGNING to hg19 with
+# STAR (ASNEO consumes STAR SJ.out.tab natively — avoids cross-build coordinate liftover).
+#
+# VM-BOUND: needs STAR (not installed/usable on the arm64 laptop; project policy =
+# STAR is VM-only). Run on the project VM (or any host with STAR). The downstream
+# MHCflurry concordance vs our pipeline output is the experiment NOTEBOOK step, not here.
+#
+# Prereqs: conda env `asneo` (research/experiments/issue_566_asneo_crosscheck/asneo_env.yml)
+#          + STAR on PATH. Run from the repo root.
+set -euo pipefail
+
+EXP="research/experiments/issue_566_asneo_crosscheck"
+WORK="${EXP}/outputs/chr22_run"          # gitignored run area
+REF="references/hg19/chr22.fa"
+STAR_IDX="indices/star_hg19_chr22"
+FASTQ="data/test/SRR9143066_test.fastq.gz"   # tumor (SRR9143066), single-end
+ASNEO_DIR="${WORK}/ASNEO"
+HLA_PLACEHOLDER="HLA-A02:01"             # option B: unused for candidate generation (MHC step bypassed)
+THREADS="$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 4)"
+
+mkdir -p "$WORK" "$(dirname "$REF")" "$STAR_IDX"
+
+# 1. hg19 chr22 reference (UCSC; verified 200 OK 2026-06-23) ----------------------
+if [[ ! -s "$REF" ]]; then
+  echo "[1/5] Fetching hg19 chr22 (UCSC)..."
+  curl -L --progress-bar "https://hgdownload.soe.ucsc.edu/goldenPath/hg19/chromosomes/chr22.fa.gz" \
+    | gunzip > "$REF"
+else echo "[1/5] hg19 chr22 present — skip."; fi
+
+# 2. STAR hg19 chr22 index (small genome -> reduced --genomeSAindexNbases) --------
+if [[ ! -s "${STAR_IDX}/SAindex" ]]; then
+  echo "[2/5] Building STAR hg19 chr22 index..."
+  STAR --runMode genomeGenerate --genomeDir "$STAR_IDX" --genomeFastaFiles "$REF" \
+       --genomeSAindexNbases 11 --runThreadN "$THREADS"
+else echo "[2/5] STAR index present — skip."; fi
+
+# 3. Align chr22 test reads -> SJ.out.tab ----------------------------------------
+echo "[3/5] Aligning $FASTQ to hg19 chr22..."
+STAR --runMode alignReads --genomeDir "$STAR_IDX" --readFilesIn "$FASTQ" \
+     --readFilesCommand zcat --runThreadN "$THREADS" \
+     --outSAMtype BAM Unsorted --outFileNamePrefix "${WORK}/chr22_"
+SJ="${WORK}/chr22_SJ.out.tab"
+test -s "$SJ" || { echo "ERROR: $SJ not produced"; exit 1; }
+
+# 4. Clone + option-B patch ASNEO ------------------------------------------------
+echo "[4/5] Cloning + patching ASNEO (option B)..."
+[[ -d "$ASNEO_DIR" ]] || git clone -q --depth 1 https://github.com/bm2-lab/ASNEO.git "$ASNEO_DIR"
+python "${EXP}/apply_optionB_patch.py" "${ASNEO_DIR}/ASNEO.py"
+# NB: src/software.tar.gz (bundled NetMHCpan/NetCTLpan/pepmatch) is NOT extracted —
+# option B uses conda bedtools and bypasses the MHC binaries entirely.
+
+# 5. Run patched ASNEO -> candidate peptides -------------------------------------
+echo "[5/5] Running patched ASNEO -> putative_peptide.txt..."
+python "${ASNEO_DIR}/ASNEO.py" -j "$SJ" -a "$HLA_PLACEHOLDER" -g "$REF" -o "${WORK}/asneo_out"
+echo "DONE -> ${WORK}/asneo_out/putative_peptide.txt"
+echo "Next: notebook.ipynb — score these + our pipeline peptides via MHCflurry; compute concordance."

--- a/research/experiments/issue_566_asneo_crosscheck/run_asneo_chr22.sh
+++ b/research/experiments/issue_566_asneo_crosscheck/run_asneo_chr22.sh
@@ -22,6 +22,8 @@ ASNEO_DIR="${WORK}/ASNEO"
 HLA_PLACEHOLDER="HLA-A02:01"             # option B: unused for candidate generation (MHC step bypassed)
 THREADS="$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 4)"
 
+command -v STAR >/dev/null || { echo "ERROR: STAR not on PATH — this runner is VM-bound (STAR=VM-only)."; exit 1; }
+
 mkdir -p "$WORK" "$(dirname "$REF")" "$STAR_IDX"
 
 # 1. hg19 chr22 reference (UCSC; verified 200 OK 2026-06-23) ----------------------
@@ -42,7 +44,7 @@ else echo "[2/5] STAR index present — skip."; fi
 echo "[3/5] Aligning $FASTQ to hg19 chr22..."
 STAR --runMode alignReads --genomeDir "$STAR_IDX" --readFilesIn "$FASTQ" \
      --readFilesCommand zcat --runThreadN "$THREADS" \
-     --outSAMtype BAM Unsorted --outFileNamePrefix "${WORK}/chr22_"
+     --outSAMtype None --outFileNamePrefix "${WORK}/chr22_"   # ASNEO needs only SJ.out.tab (-j); skip the BAM
 SJ="${WORK}/chr22_SJ.out.tab"
 test -s "$SJ" || { echo "ERROR: $SJ not produced"; exit 1; }
 

--- a/research/lab_notebook/scientist.md
+++ b/research/lab_notebook/scientist.md
@@ -8,6 +8,24 @@ Format and rules unchanged from the unified notebook — see `shared/feedback_la
 
 ## 2026-06-23
 
+### 10:53 UTC — Editor: Scientist
+
+#### [PR #849](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/849) — ASNEO cross-check **setup** (option-B decision + turnkey runner) — closes [Issue #566](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/566); execution carved to [Issue #848](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/848).
+
+**Context.** Warm-up pull on #566 (ASNEO cross-check — our closest published peer, RNA-seq → splice junctions → neoepitopes). Grew into a full setup deliverable + two governance decisions worth recording.
+
+**Decision 1 — MHC path: option B (MHCflurry-swap, layered).** ASNEO ships a bundled (non-redistributable) NetMHCpan/NetCTLpan; our pipeline uses MHCflurry. Chose to **hold the MHC step constant on MHCflurry for both pipelines**: (1) primary = MHC-agnostic call concordance, (2) secondary = ranking via the same MHCflurry predictor, (3) native NetMHCpan demoted to optional supplementary. Rationale: holding the nuisance MHC variable constant **isolates the junction-detection signal** (the thing the cross-check is *for*) instead of confounding it with predictor differences; also open-only, reproducible, consistent with [#679](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/679), and removes the NetMHCpan license gate. Implemented by intercepting ASNEO's normal-subtracted candidate peptides (`putative_peptide.txt`, `ASNEO.py:252`) and bypassing the bundled binaries entirely (`apply_optionB_patch.py`, repoints bedtools to PATH so `software.tar.gz` is never extracted → fully open-only).
+
+**Decision 2 — carve setup from execution (single dual-role issue, not a role-split).** With the prep done and reviewable but the *run* VM-bound (STAR=VM-only), closed #566 on the setup deliverable and carved the run → #848 (`close-issue-with-PR` pattern). Jin-Ho pushed on whether to split #848 by role into single-role issues; checked our own heuristic (`feedback_parent_sub_issues.md` "phases-as-sub-issues" → decompose only when 2+ of {distinct PR / role / timing}) **and** the web (vertical-slice principle / horizontal-slicing anti-pattern; single accountable owner). Conclusion: the run→analysis→writeup is **one vertical slice** (only the role axis diverges; one notebook PR, one VM session) → keep it a single **dual-role** issue (Sci = accountable owner, Dev = task-level VM assist), matching the [#636](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/636) shape. Splitting it would *be* the horizontal anti-pattern. #848 paired-with #636 to amortize one VM spin-up.
+
+**Verified-not-asserted (the discipline that mattered).** Every external claim source-checked before it entered a committed file: canonical repo `bm2-lab/ASNEO` (vs the 2019 author mirror), hg19/GRCh37 build, STAR `SJ.out.tab` input, biopython<1.80 (`Bio.SubsMat` at `:11-12`), the candidate-peptide interception point, hg19 chr22 URL (200 OK). Env built + import-validated; patcher tested against the real `ASNEO.py` (applies + compiles).
+
+**Review (`@claude`, Opus 4.8): approve.** 4 findings triaged against the live source (the bot had no egress, so 3 were analytical): #1 outputs/ not gitignored — **valid, fixed**; #2 `len(remain_pep)` NameError — **false positive** (in scope at `:243`); #3 `-o` flag + #4 copy-dest-vs-`rmtree` — **confirmed safe** on the clone, recorded in the README. Nits adopted: pinned numpy/pandas/bedtools (2019-tool reproducibility), `--outSAMtype None`, fail-fast STAR guard. Re-validated all (`4c5ebb7`).
+
+**Forward.** #848 (run + MHCflurry concordance + writeup) awaits a VM session; turnkey via `run_asneo_chr22.sh`. Notebook lands with #848 (experiment dir currently README+env+runner, no notebook yet — by design).
+
+---
+
 ### 00:11 UTC — Editor: Scientist
 
 #### [PR #840](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/840) — 4-DB no-splice-category audit + Bigot 2021 fold (registry 44 → 79) — closes [Issue #734](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/734) (leaf of [#680](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/680)).


### PR DESCRIPTION
**Created by:** Scientist

Closes #566 — ships the ASNEO cross-check **setup**: env + option-B (MHCflurry-swap) decision + a turnkey, source-verified chr22 runner. The **execution** (run → MHCflurry concordance → writeup) is carved to #848 (VM-bound; pairs with #636).

## What's here
- `research/experiments/issue_566_asneo_crosscheck/` — verified scoping README, `asneo_env.yml`, `apply_optionB_patch.py`, `run_asneo_chr22.sh`.
- Option B holds the MHC step constant on MHCflurry; ASNEO's bundled NetMHCpan/NetCTLpan/pepmatch are bypassed entirely (fully open-only).
- Every external fact source-verified: canonical repo `bm2-lab/ASNEO`, hg19/GRCh37 build, STAR `SJ.out.tab` input, biopython<1.80 (`Bio.SubsMat`), candidate-peptide interception point (`ASNEO.py:252`).

## Test plan
- [x] `asneo` conda env builds + imports validated (biopython 1.79 / `Bio.SubsMat` OK, py3.8, sj2psi+pysam+pandas+sklearn+xgboost, bedtools 2.31.1)
- [x] `apply_optionB_patch.py` applies to the real `ASNEO.py` (3 string anchors, each matched once) and the result compiles clean
- [x] `run_asneo_chr22.sh` passes `bash -n`
- [x] hg19 chr22 reference URL verified (HTTP 200) + env recipe dry-solves cleanly
- [x] Full chr22 run + concordance — **carved to #848** (VM-bound; STAR unavailable on arm64, project policy STAR=VM-only)
