### PR TITLE
feat(infra): RunPod compute port - slim TCRdock image + volume-staged param mounts

### DIFF
--- a/.github/workflows/build-tcrdock-image.yml
+++ b/.github/workflows/build-tcrdock-image.yml
@@ -1,0 +1,77 @@
+name: build-tcrdock-image
+
+# Builds the slimmed TCRdock pipeline image (docker/Dockerfile.pipeline) on a
+# native amd64 runner and pushes it to GHCR, so RunPod can pull it (Issue #844,
+# GCP->RunPod migration). Manual-trigger only: building a multi-GB CUDA image
+# spends Actions minutes and publishes a package, so it never runs on push.
+#
+# The image carries code + CUDA only - the ~16 GB AlphaFold params are staged on
+# the RunPod Network Volume and bind-mounted at run time (see run_tcrdock.py
+# build_docker_mount_args + config/gpu_config.yaml params_host_dir).
+
+on:
+  workflow_dispatch:
+    inputs:
+      push:
+        description: "Push to GHCR (false = build-only smoke test, no publish)"
+        type: boolean
+        default: true
+      tag:
+        description: "Extra image tag (besides latest + commit SHA)"
+        type: string
+        default: ""
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  IMAGE: ghcr.io/jin-homlee/tcrdock-pipeline
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # The CUDA 11.8 devel base + conda + jaxlib wheel need headroom beyond the
+      # ~14 GB the hosted runner leaves free; reclaim the preinstalled toolchains.
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/lib/android \
+                      /opt/hostedtoolcache/CodeQL /usr/local/share/boost
+          df -h /
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        if: ${{ inputs.push }}
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute tags
+        id: tags
+        run: |
+          tags="${IMAGE}:latest"$'\n'"${IMAGE}:${GITHUB_SHA}"
+          if [ -n "${{ inputs.tag }}" ]; then
+            tags="${tags}"$'\n'"${IMAGE}:${{ inputs.tag }}"
+          fi
+          {
+            echo "tags<<EOF"
+            echo "${tags}"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/Dockerfile.pipeline
+          platforms: linux/amd64
+          push: ${{ inputs.push }}
+          tags: ${{ steps.tags.outputs.tags }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/config/gpu_config.yaml
+++ b/config/gpu_config.yaml
@@ -19,6 +19,17 @@ tcrdock:
   n_candidates: 1
   docker_image: "tcrdock:latest"  # built by setup_vm.sh
 
+  # Volume-staged reference data (Issue #844 image slimming). On RunPod the AlphaFold
+  # params live on the Network Volume and are bind-mounted into the container instead
+  # of being baked into the ~25 GB image. The SLIMMED image REQUIRES params_host_dir
+  # set; an empty value means params are baked in (legacy / pre-slim image).
+  params_host_dir: "/workspace/alphafold_params"
+  # BLAST DB externalization is deferred to the #845 smoke test: download_blast.py's
+  # install path is internal to the TCRdock clone and unknown from our repo, so until
+  # #845 resolves it BLAST stays baked in the image and both keys stay empty (no mount).
+  blast_host_dir: ""
+  blast_container_path: ""
+
   # Fallback HLA alleles — overridden by HLA typing (#23) when available
   fallback_hla:
     A: "HLA-A*02:01"

--- a/docker/Dockerfile.pipeline
+++ b/docker/Dockerfile.pipeline
@@ -42,19 +42,15 @@ RUN chmod -R a+rw /opt/TCRdock
 
 WORKDIR /opt/TCRdock
 
-# Download AlphaFold params (model_2_ptm only) and BLAST.
-# ?dl=1 forces Dropbox to serve the raw file instead of an HTML landing page.
-RUN mkdir -p alphafold_params/params && \
-    wget -q -O alphafold_params/params/params_model_2_ptm.npz \
-        "https://www.dropbox.com/s/e3uz9mwxkmmv35z/params_model_2_ptm.npz?dl=1" && \
-    wget -q -O alphafold_params/params/tcrpmhc_run4_af_mhc_params_891.pkl \
-        "https://www.dropbox.com/s/jph8v1mfni1q4y8/tcrpmhc_run4_af_mhc_params_891.pkl?dl=1" && \
-    for f in alphafold_params/params/params_model_2_ptm.npz \
-             alphafold_params/params/tcrpmhc_run4_af_mhc_params_891.pkl; do \
-        size=$(stat -c%s "$f"); \
-        if [ "$size" -lt 1024 ]; then echo "FAIL: $f is only $size bytes" >&2; exit 1; fi; \
-        if head -c 512 "$f" | grep -qi '<html'; then echo "FAIL: $f is HTML, not a model file" >&2; exit 1; fi; \
-    done && \
-    python download_blast.py
+# AlphaFold params are NO LONGER baked into the image (Issue #844 image slimming):
+# the ~16 GB of weights live on the RunPod Network Volume and are bind-mounted at
+# run time onto /opt/TCRdock/alphafold_params (run_tcrdock.py build_docker_mount_args).
+# This is the bulk of the cold-pull win (RunPod Pods land on a fresh host each burst).
+#
+# BLAST stays baked for now: download_blast.py installs into a path internal to the
+# TCRdock clone (unknown from our repo) and may fetch the blast binary, not just a DB —
+# externalizing it onto the volume is deferred to the #845 smoke test, where the path
+# is confirmed. run_tcrdock.py already supports a BLAST bind-mount once that lands.
+RUN python download_blast.py
 
 WORKDIR /data

--- a/workflow/envs/python.yaml
+++ b/workflow/envs/python.yaml
@@ -16,6 +16,7 @@ dependencies:
   - pytest >=8.0
   - pip
   - pip:
-    - --extra-index-url https://download.pytorch.org/whl/cu126
-    - torch ==2.12.0+cu126  # P100 (SM 6.0) compat; PyPI wheels (cu128+) drop Pascal — see CLAUDE.md
+    # Ada (RunPod L4, SM 8.9) is supported by current PyPI CUDA wheels — the P100/Pascal
+    # cu126 pin + extra-index-url is dropped (Issue #844 GCP→RunPod migration).
+    - torch >=2.12
     - mhcflurry >=2.0

--- a/workflow/rules/structure.smk
+++ b/workflow/rules/structure.smk
@@ -64,6 +64,11 @@ if _TCRDOCK_ENABLED:
             fallback_hla=config["tcrdock"]["fallback_hla"],
             fallback_tcr=config["tcrdock"]["fallback_tcr"],
             presentation_percentile_weak=config["mhcflurry"]["presentation_percentile_weak"],
+            # Volume-staged reference mounts (Issue #844 image slimming). Empty → no
+            # mount (params/BLAST baked in the image, legacy).
+            params_host_dir=config["tcrdock"].get("params_host_dir", ""),
+            blast_host_dir=config["tcrdock"].get("blast_host_dir", ""),
+            blast_container_path=config["tcrdock"].get("blast_container_path", ""),
         conda:
             "../envs/python.yaml"
         script:

--- a/workflow/scripts/run_tcrdock.py
+++ b/workflow/scripts/run_tcrdock.py
@@ -329,10 +329,46 @@ def build_tcrdock_input(
 # TCRdock execution
 # ---------------------------------------------------------------------------
 
+# Fixed in-image path where run_prediction.py expects the AlphaFold params
+# (its --data_dir). Issue #844 moves the params out of the image onto the RunPod
+# Network Volume and bind-mounts them back onto THIS path, so --data_dir is
+# unchanged whether the params are baked (legacy) or volume-staged.
+_AF_PARAMS_CONTAINER_PATH = "/opt/TCRdock/alphafold_params"
+
+
+def build_docker_mount_args(
+    output_dir,
+    params_host_dir: str | None = None,
+    blast_host_dir: str | None = None,
+    blast_container_path: str | None = None,
+) -> list:
+    """Build the ``docker run -v`` mount args for the TCRdock container.
+
+    The output dir is always mounted at ``/data``. When ``params_host_dir`` is set
+    (Issue #844 image slimming), the volume-staged AlphaFold params are bind-mounted
+    onto the fixed in-image path (`_AF_PARAMS_CONTAINER_PATH`) so run_prediction.py's
+    ``--data_dir`` needs no change. The BLAST mount is emitted only when BOTH
+    ``blast_host_dir`` and ``blast_container_path`` are set — the in-image BLAST path
+    is internal to the TCRdock clone and is resolved at the #845 smoke test; until
+    then BLAST stays baked in the image and no BLAST mount is added.
+
+    Empty strings (the config defaults) are treated as unset.
+    """
+    mounts = ["-v", f"{output_dir}:/data"]
+    if params_host_dir:
+        mounts += ["-v", f"{params_host_dir}:{_AF_PARAMS_CONTAINER_PATH}:ro"]
+    if blast_host_dir and blast_container_path:
+        mounts += ["-v", f"{blast_host_dir}:{blast_container_path}:ro"]
+    return mounts
+
+
 def run_tcrdock(
     input_tsv: Path,
     output_dir: Path,
     docker_image: str,
+    params_host_dir: str | None = None,
+    blast_host_dir: str | None = None,
+    blast_container_path: str | None = None,
 ) -> Path:
     """Run TCRdock via Docker and return the output directory.
 
@@ -341,13 +377,21 @@ def run_tcrdock(
     The host only needs Docker with the NVIDIA Container Toolkit.
 
     All TCRdock paths are inside the container at /opt/TCRdock/.
-    Input/output files are passed via a single volume mount: output_dir → /data.
+    Input/output files are passed via the output_dir → /data volume mount; with
+    Issue #844 image slimming the AlphaFold params (and optionally the BLAST DB)
+    are bind-mounted from the RunPod Network Volume instead of being baked in.
 
     Args:
         input_tsv:     TCRdock input TSV (from build_tcrdock_input). Must be
                        inside output_dir (it is, by construction).
         output_dir:    Directory for all intermediate and final outputs.
         docker_image:  Docker image name (e.g. "tcrdock:latest").
+        params_host_dir:      Host dir of volume-staged AlphaFold params, mounted
+                       onto the fixed in-image path. Empty/None → params baked in
+                       the image (legacy).
+        blast_host_dir, blast_container_path: Host dir + in-image path of the
+                       volume-staged BLAST DB. Both required to emit the mount;
+                       the in-image path is resolved at the #845 smoke test.
 
     Returns:
         Path to the output directory.
@@ -366,10 +410,14 @@ def run_tcrdock(
         """Translate a host path inside output_dir to its /data/... equivalent."""
         return "/data/" + str(host_path.relative_to(output_dir))
 
+    mount_args = build_docker_mount_args(
+        output_dir, params_host_dir, blast_host_dir, blast_container_path
+    )
+
     def _docker_run(container_cmd: list, label: str) -> None:
         cmd = [
             "docker", "run", "--rm", "--gpus", "all",
-            "-v", f"{output_dir}:/data",
+            *mount_args,
             docker_image,
         ] + container_cmd
         log.info("Running %s:\n  %s", label, " ".join(cmd))
@@ -393,13 +441,14 @@ def run_tcrdock(
     ], "setup_for_alphafold.py")
 
     # Step 2: run_prediction.py — runs AlphaFold inference.
-    # AlphaFold params and the fine-tuned TCR model are inside the image.
+    # --data_dir is the fixed in-image path; the params reach it either baked into
+    # the image (legacy) or bind-mounted from the Network Volume (Issue #844).
     _docker_run([
         "python", "/opt/TCRdock/run_prediction.py",
         "--targets",           _container_path(setup_dir / "targets.tsv"),
         "--outfile_prefix",    _container_path(output_dir / "tcrdock_out"),
         "--model_names",       "model_2_ptm",
-        "--data_dir",          "/opt/TCRdock/alphafold_params",
+        "--data_dir",          _AF_PARAMS_CONTAINER_PATH,
     ], "run_prediction.py")
 
     log.info("TCRdock completed successfully.")
@@ -591,6 +640,9 @@ def run_structural_validation(
     fallback_tcr: dict | None = None,
     vdjdb_panel: str | Path | None = None,
     presentation_percentile_weak: float = 2.0,
+    params_host_dir: str | None = None,
+    blast_host_dir: str | None = None,
+    blast_container_path: str | None = None,
 ) -> None:
     """Run TCRdock structural validation on top neoepitope candidates.
 
@@ -654,7 +706,12 @@ def run_structural_validation(
     input_tsv = build_tcrdock_input(candidates, fallback_hla, work_dir)
 
     # Step 4: Run TCRdock
-    tcrdock_output_dir = run_tcrdock(input_tsv, work_dir, docker_image)
+    tcrdock_output_dir = run_tcrdock(
+        input_tsv, work_dir, docker_image,
+        params_host_dir=params_host_dir,
+        blast_host_dir=blast_host_dir,
+        blast_container_path=blast_container_path,
+    )
 
     # Step 5: Collect outputs
     collect_outputs(tcrdock_output_dir, candidates, output_pdb, output_scores)
@@ -682,6 +739,11 @@ def _snakemake_main() -> None:
         fallback_tcr=snakemake.params.fallback_tcr,  # type: ignore[name-defined]  # noqa: F821
         vdjdb_panel=vdjdb_panel,
         presentation_percentile_weak=float(snakemake.params.presentation_percentile_weak),  # type: ignore[name-defined]  # noqa: F821
+        # Volume-staged reference mounts (Issue #844). Absent on older configs →
+        # default to "" (no mount, legacy in-image params).
+        params_host_dir=getattr(snakemake.params, "params_host_dir", ""),  # type: ignore[name-defined]  # noqa: F821
+        blast_host_dir=getattr(snakemake.params, "blast_host_dir", ""),  # type: ignore[name-defined]  # noqa: F821
+        blast_container_path=getattr(snakemake.params, "blast_container_path", ""),  # type: ignore[name-defined]  # noqa: F821
     )
 
 
@@ -697,6 +759,14 @@ def _cli_main() -> None:
     parser.add_argument("--vdjdb-panel", default=None,
                         help="Per-patient VDJdb panel TSV (Issue #204). Omit to use the DMF5 fallback TCR.")
     parser.add_argument("--presentation-percentile-weak", type=float, default=2.0)
+    parser.add_argument("--params-host-dir", default="",
+                        help="Host dir of volume-staged AlphaFold params (Issue #844). "
+                             "Empty → params baked in the image (legacy).")
+    parser.add_argument("--blast-host-dir", default="",
+                        help="Host dir of the volume-staged BLAST DB (Issue #844; needs --blast-container-path).")
+    parser.add_argument("--blast-container-path", default="",
+                        help="In-image BLAST DB path (resolved at the #845 smoke test). "
+                             "Empty → BLAST baked in the image.")
     args = parser.parse_args()
 
     run_structural_validation(
@@ -707,6 +777,9 @@ def _cli_main() -> None:
         n_candidates=args.n_candidates,
         vdjdb_panel=args.vdjdb_panel,
         presentation_percentile_weak=args.presentation_percentile_weak,
+        params_host_dir=args.params_host_dir,
+        blast_host_dir=args.blast_host_dir,
+        blast_container_path=args.blast_container_path,
     )
 
 

--- a/workflow/tests/test_run_tcrdock.py
+++ b/workflow/tests/test_run_tcrdock.py
@@ -4,8 +4,10 @@ and PDB chain relabeling."""
 import pandas as pd
 
 from run_tcrdock import (
+    _AF_PARAMS_CONTAINER_PATH,
     _normalize_allele_4digit,
     attach_matched_tcrs,
+    build_docker_mount_args,
     build_tcrdock_input,
     collect_outputs,
     relabel_pdb_chains,
@@ -419,3 +421,56 @@ class TestCollectOutputsProvenance:
         assert scores.iloc[0]["panel_status"] == "dmf5_fallback"
         assert scores.iloc[0]["tcr_va"] == _DMF5["va_gene"]
         assert pd.isna(scores.iloc[0]["vdjdb_score"])    # NA score round-trips, no crash
+
+
+class TestDockerMountArgs:
+    """build_docker_mount_args — volume-staged reference mounts (Issue #844 image slimming)."""
+
+    def test_output_only_legacy_in_image(self):
+        """No volume paths → only the output mount (legacy: params/BLAST baked in image)."""
+        mounts = build_docker_mount_args("/tmp/out")
+        assert mounts == ["-v", "/tmp/out:/data"]
+
+    def test_params_mount_on_fixed_in_image_path(self):
+        """params_host_dir → bind-mount onto the fixed in-image path so --data_dir is unchanged."""
+        mounts = build_docker_mount_args("/tmp/out", params_host_dir="/workspace/alphafold_params")
+        assert mounts == [
+            "-v", "/tmp/out:/data",
+            "-v", f"/workspace/alphafold_params:{_AF_PARAMS_CONTAINER_PATH}:ro",
+        ]
+
+    def test_blast_mount_needs_both_host_and_container_path(self):
+        """BLAST mount emitted only when BOTH host dir and the (#845-resolved) container path are set."""
+        both = build_docker_mount_args(
+            "/tmp/out",
+            blast_host_dir="/workspace/blast_db",
+            blast_container_path="/opt/TCRdock/blast_db",
+        )
+        assert "-v" in both and "/workspace/blast_db:/opt/TCRdock/blast_db:ro" in both
+
+        # Either half alone → no BLAST mount (path unknown until #845).
+        host_only = build_docker_mount_args("/tmp/out", blast_host_dir="/workspace/blast_db")
+        assert host_only == ["-v", "/tmp/out:/data"]
+        path_only = build_docker_mount_args("/tmp/out", blast_container_path="/opt/TCRdock/blast_db")
+        assert path_only == ["-v", "/tmp/out:/data"]
+
+    def test_all_mounts_together(self):
+        """AF params + BLAST both staged → output + params + BLAST, output mount first."""
+        mounts = build_docker_mount_args(
+            "/tmp/out",
+            params_host_dir="/workspace/alphafold_params",
+            blast_host_dir="/workspace/blast_db",
+            blast_container_path="/opt/TCRdock/blast_db",
+        )
+        assert mounts == [
+            "-v", "/tmp/out:/data",
+            "-v", f"/workspace/alphafold_params:{_AF_PARAMS_CONTAINER_PATH}:ro",
+            "-v", "/workspace/blast_db:/opt/TCRdock/blast_db:ro",
+        ]
+
+    def test_empty_string_paths_treated_as_unset(self):
+        """Config defaults are empty strings, not None → must be treated as 'no mount'."""
+        mounts = build_docker_mount_args(
+            "/tmp/out", params_host_dir="", blast_host_dir="", blast_container_path="",
+        )
+        assert mounts == ["-v", "/tmp/out:/data"]


### PR DESCRIPTION
**Created by:** Developer

Phase 2 of the GCP→RunPod migration ([parent epic #843](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/843), Runbook §3). Closes #844.

This PR is the **code + image-prep** half of the compute port: it slims the TCRdock image and parameterizes the container mounts so AlphaFold params live on the RunPod Network Volume instead of being baked into the 25 GB image. The **cloud-execution** half (RunPod account, L4-capacity check, GHCR push, pod-template create, volume staging) is operational work that can't run from this arm64 Mac - it's tracked on #844's Acceptance criteria and gates merge.

## What changed (6 files)

- **`workflow/envs/python.yaml`** - drop the P100/Pascal `cu126` torch pin + `--extra-index-url` → `torch >=2.12`. Ada (L4, SM 8.9) is covered by current PyPI CUDA wheels; the pin existed only for Pascal. (Conda-solver-class change → validated by the `pipeline-conda-env-solve` CI job on linux-64, not by dry-run.)
- **`docker/Dockerfile.pipeline`** - stop baking the ~16 GB AlphaFold params into the image; they move to the Network Volume and bind-mount at run time. BLAST stays baked until #845 confirms `download_blast.py`'s install path.
- **`workflow/scripts/run_tcrdock.py`** - new `build_docker_mount_args()` (pure, unit-tested) emits the volume mounts. AF params bind-mount onto the fixed in-image path so `run_prediction.py --data_dir` is unchanged. BLAST mount is parameterized but inert until #845 sets the path. `params_host_dir` / `blast_host_dir` / `blast_container_path` threaded through the rule → config → snakemake + CLI entry points; empty values = legacy in-image (back-compat).
- **`workflow/rules/structure.smk`** - pass the 3 new keys into the rule `params:` (gated behind `if _TCRDOCK_ENABLED`).
- **`config/gpu_config.yaml`** - `params_host_dir: /workspace/alphafold_params`; BLAST keys empty (deferred to #845).
- **`workflow/tests/test_run_tcrdock.py`** - 5 new tests for `build_docker_mount_args` (`TestDockerMountArgs`).

## Test plan

Code (verifiable from this diff):
- [x] 5 new unit tests for `build_docker_mount_args` (output-only / params mount / blast-needs-both / all-together / empty-string-unset)
- [x] Full suite: `workflow/tests/.venv/bin/python -m pytest workflow/tests/` → 603 passed, 6 skipped
- [x] `snakemake -n` parses the `run_tcrdock` rule with the new params (dry-run green)
- [ ] CI `pipeline-conda-env-solve` green on the dropped torch pin (linux-64)
- [ ] CI `pipeline-pytest` + `pipeline-snakemake-dry-run` green

Image (proves this diff yields a working slim image - x86 build, can't run on arm64 Mac):
- [ ] Slim image builds on x86 (`buildx --platform linux/amd64` or a RunPod pod) and is < the pre-slim footprint by ~16 GB
- [ ] Image pushed to GHCR and pulls clean on a fresh host
- [ ] Container starts with AF params bind-mounted from `/workspace/alphafold_params`; `run_prediction.py` sees `--data_dir`

Deferred (not this PR): live chr22 e2e / GPU smoke + BLAST externalization → #845.

## Notes

- **Deploy coupling:** the slimmed Dockerfile and `gpu_config.yaml` (`params_host_dir` set) must ship together - an old (params-baked) image with the new config double-mounts harmlessly, but a slim image with the *old* config (empty `params_host_dir`) starts with no params. Both land in this PR, so they're consistent on merge.
- **CLAUDE.md P100/torch sections left intact on purpose:** the GCP stack is live until cutover (#846), which owns the docs sweep. Half-updating mid-migration rots them.
