### PR TITLE
fix(pm): split milestone-report closes by stateReason so NOT_PLANNED never counts as delivered (#851)

### DIFF
--- a/research/lab_notebook/pm.md
+++ b/research/lab_notebook/pm.md
@@ -8,6 +8,24 @@ Format and rules unchanged from the unified notebook — see `shared/feedback_la
 
 ## 2026-06-26
 
+### 16:35 UTC - Editor: PM
+
+#### [PR #885](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/885) - milestone_report.py splits closes by stateReason ([Issue #851](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/851))
+
+**The masking bug.** `scripts/pm/milestone_report.py` counted every closed issue as delivered, so a milestone with descoped (NOT_PLANNED) closes rendered an inflated "N / N closed" headline.
+pm-i7's "9 / 9 closed" actually hid 2 superseded issues (#499 -> #776, #533 -> #453), caught only by a manual close-reason audit during the pm-i7 report authoring (the gap that filed #851).
+This is the machine analogue of the parent-rollup close-reason rule (`recheck_parent_status`'s `[REVIEW: NOT_PLANNED child]` flag) applied at milestone rollup - the closure report is the durable close-evidence record, so a masked descope there is permanent misinformation.
+
+**Fix.** Split closed issues by stateReason: metrics report `n_delivered` + `n_descoped` separately; per-role counts, throughput, and cycle time all key off delivered (a descoped issue is not shipped work). At-a-glance gets Delivered/Descoped cards; the inventory badges each descoped row; the narrative seeds a "Descoped" stub so the author routes each dropped issue. Verified live on pm-i7: delivered/descoped = 7/2.
+
+**Review catch (the substantive one).** The @-claude review flagged that my `!= NOT_PLANNED` complement swept GitHub's third close reason - DUPLICATE - into delivered, re-creating the exact masking the PR set out to kill.
+Confirmed live: the repo has 1 DUPLICATE-closed issue (#147).
+Switched to an explicit `DESCOPED_REASONS = {NOT_PLANNED, DUPLICATE}` set so a missing reason still falls through to delivered and a future enum value can't land silently; single-sourced via `is_descoped()` for both the metrics split and the badge.
+Also moved cycle-time onto delivered-only (was inconsistently spanning descoped) and renamed the stale `n_closed` param.
+Lesson: when partitioning on an external enum, enumerate the excluded set explicitly rather than complementing one known value - the complement silently absorbs every value you didn't think of.
+
+**TDD.** Metrics layer test-first throughout (7 initial failing tests, then 4 more for the review findings); 32/32 pass in the bare `ci-tools-pytest` env. Render/data layers verified by live pm-i7 dry-run + HTML render per the design spec (not unit-tested).
+
 ### 13:31 UTC — Editor: PM
 
 **i5 - S3 - Data Preparation milestone closed (6/7 delivered); lone open #636 carried forward.**

--- a/scripts/pm/milestone_report.py
+++ b/scripts/pm/milestone_report.py
@@ -70,6 +70,31 @@ def closed_issues(issues: list[dict]) -> list[dict]:
     return [i for i in issues if i.get("state") == "CLOSED"]
 
 
+def descoped_issues(issues: list[dict]) -> list[dict]:
+    """Closed issues closed as ``NOT_PLANNED`` (descoped / superseded / wontfix).
+
+    These are *not* deliverables — counting them as such inflates the delivered
+    headline and masks dropped scope (the machine analogue of the parent-rollup
+    close-reason rule). Issue #851.
+    """
+    return [
+        i for i in issues
+        if i.get("state") == "CLOSED" and i.get("state_reason") == "NOT_PLANNED"
+    ]
+
+
+def delivered_issues(issues: list[dict]) -> list[dict]:
+    """Closed issues that actually shipped (``stateReason != NOT_PLANNED``).
+
+    A closed issue with no recorded reason is treated as delivered, so legacy
+    data without ``stateReason`` is never silently dropped from the count.
+    """
+    return [
+        i for i in issues
+        if i.get("state") == "CLOSED" and i.get("state_reason") != "NOT_PLANNED"
+    ]
+
+
 def cycle_time_days(issue: dict) -> Optional[float]:
     """(closed_at - created_at) in days for a closed issue; None otherwise."""
     if issue.get("state") != "CLOSED":
@@ -96,10 +121,11 @@ def median_cycle_time(issues: list[dict]) -> Optional[float]:
 
 
 def per_role_counts(issues: list[dict]) -> dict[str, int]:
-    """Closed-issue counts grouped by ``role:*`` (multi-role issues count once
-    per role)."""
+    """Delivered-issue counts grouped by ``role:*`` (multi-role issues count
+    once per role). Descoped (``NOT_PLANNED``) closes are excluded — a dropped
+    issue is not a per-role deliverable (Issue #851)."""
     counts: dict[str, int] = {}
-    for issue in closed_issues(issues):
+    for issue in delivered_issues(issues):
         for role in issue.get("roles", []):
             if role.startswith("role:"):
                 counts[role] = counts.get(role, 0) + 1
@@ -134,15 +160,21 @@ def throughput_per_week(n_closed: int, duration_days: Optional[float]) -> Option
 def compute_metrics(issues: list[dict], milestone: dict) -> dict[str, Any]:
     """Assemble the headline metrics block from the data layer."""
     closed = closed_issues(issues)
+    delivered = delivered_issues(issues)
+    descoped = descoped_issues(issues)
     duration = milestone_duration_days(
         issues, milestone.get("closed_at"), milestone.get("created_at")
     )
     return {
         "n_total": len(issues),
         "n_closed": len(closed),
+        "n_delivered": len(delivered),
+        "n_descoped": len(descoped),
         "n_carried_forward": len(issues) - len(closed),
         "duration_days": duration,
-        "throughput_per_week": throughput_per_week(len(closed), duration),
+        # Throughput keys off *delivered*, not raw closed — descoped issues are
+        # not shipped work and must not inflate the rate (Issue #851).
+        "throughput_per_week": throughput_per_week(len(delivered), duration),
         "avg_cycle_time_days": avg_cycle_time(issues),
         "median_cycle_time_days": median_cycle_time(issues),
         "per_role_counts": per_role_counts(issues),
@@ -223,7 +255,7 @@ def fetch_milestone_issues(name: str) -> list[dict]:
     raw = _gh([
         "issue", "list", "--repo", f"{OWNER}/{REPO}",
         "--milestone", name, "--state", "all", "--limit", "1000",
-        "--json", "number,title,state,labels,createdAt,closedAt,url",
+        "--json", "number,title,state,stateReason,labels,createdAt,closedAt,url",
     ])
     board = _board_fields_by_number()
     issues = []
@@ -231,11 +263,15 @@ def fetch_milestone_issues(name: str) -> list[dict]:
         labels = [lbl["name"] for lbl in it.get("labels", [])]
         num = it["number"]
         b = board.get(num, {})
+        # stateReason: COMPLETED | NOT_PLANNED | None (open). Upper-cased so the
+        # metrics layer can compare against the canonical NOT_PLANNED token.
+        reason = it.get("stateReason")
         issues.append({
             "number": num,
             "title": it["title"],
             "url": it.get("url"),
             "state": it["state"].upper(),
+            "state_reason": reason.upper() if reason else None,
             "created_at": it.get("createdAt"),
             "closed_at": it.get("closedAt"),
             "roles": [l for l in labels if l.startswith("role:")],
@@ -299,7 +335,8 @@ def seed_narrative(milestone: dict, issues: list[dict], metrics: dict) -> str:
     roles = {r for i in issues for r in i.get("roles", [])}
     window = (parse_iso(milestone.get("created_at")), parse_iso(milestone.get("closed_at")))
     seed = _lab_notebook_seed(roles, window)
-    closed = closed_issues(issues)
+    delivered = delivered_issues(issues)
+    descoped = descoped_issues(issues)
     carried = [i for i in issues if i.get("state") != "CLOSED"]
 
     lines = [
@@ -310,7 +347,7 @@ def seed_narrative(milestone: dict, issues: list[dict], metrics: dict) -> str:
         "## Deliverables (Review layer)",
         "",
         "<!-- Lead role: what shipped, grouped by deliverable, with PR + slide links.",
-        f"     The {len(closed)} closed issues are listed in full in the Inventory appendix",
+        f"     The {len(delivered)} delivered issues are listed in the Inventory appendix",
         "     below — narrate the highlights here, don't re-list them. -->",
         "",
         "_Seeded from the lead role's lab-notebook entries in the milestone window — "
@@ -318,6 +355,17 @@ def seed_narrative(milestone: dict, issues: list[dict], metrics: dict) -> str:
         "",
     ]
     lines += [seed or "<!-- no auto-seed found; author from scratch -->"]
+    if descoped:
+        lines += [
+            "",
+            "## Descoped (closed NOT_PLANNED)",
+            "",
+            "<!-- These closed WITHOUT shipping (superseded / YAGNI / wontfix). They are",
+            "     excluded from the delivered count — record why each was dropped + where",
+            "     the need (if any) was routed, so the descope isn't silently masked. -->",
+            "",
+        ]
+        lines += [f"- [#{i['number']}]({i['url']}) {i['title']} — _why descoped: TBD_" for i in descoped]
     lines += [
         "",
         "## Carried-forward & routing",
@@ -376,11 +424,13 @@ def print_metrics(milestone: dict, metrics: dict) -> None:
     print(f"Milestone: {milestone['title']}  [{milestone.get('state')}]")
     print(f"  total / closed / carried-forward : "
           f"{metrics['n_total']} / {metrics['n_closed']} / {metrics['n_carried_forward']}")
+    print(f"  delivered / descoped (closed)    : "
+          f"{metrics['n_delivered']} / {metrics['n_descoped']}")
     print(f"  duration (days)                  : {_fmt(metrics['duration_days'])}")
-    print(f"  throughput (closed/week)         : {_fmt(metrics['throughput_per_week'])}")
+    print(f"  throughput (delivered/week)      : {_fmt(metrics['throughput_per_week'])}")
     print(f"  cycle time avg / median (days)   : "
           f"{_fmt(metrics['avg_cycle_time_days'])} / {_fmt(metrics['median_cycle_time_days'])}")
-    print(f"  per-role (closed)                : {metrics['per_role_counts']}")
+    print(f"  per-role (delivered)             : {metrics['per_role_counts']}")
 
 
 # --- orchestration ----------------------------------------------------------

--- a/scripts/pm/milestone_report.py
+++ b/scripts/pm/milestone_report.py
@@ -70,29 +70,39 @@ def closed_issues(issues: list[dict]) -> list[dict]:
     return [i for i in issues if i.get("state") == "CLOSED"]
 
 
+# GitHub's IssueStateReason enum closes that are NOT deliveries: NOT_PLANNED
+# (won't-do / superseded) and DUPLICATE (tracked elsewhere). Defined as an
+# explicit set rather than a "!= COMPLETED" complement so a closed issue with
+# no recorded reason still falls through to *delivered* (legacy data is never
+# dropped), and so a future enum addition doesn't silently land in either bucket
+# without a deliberate edit here. Issue #851 (DUPLICATE gap caught in review).
+DESCOPED_REASONS = frozenset({"NOT_PLANNED", "DUPLICATE"})
+
+
+def is_descoped(issue: dict) -> bool:
+    """True if the issue closed as a descope (``NOT_PLANNED`` / ``DUPLICATE``)
+    rather than a delivery. Single source for both the metrics split and the
+    inventory badge."""
+    return issue.get("state") == "CLOSED" and issue.get("state_reason") in DESCOPED_REASONS
+
+
 def descoped_issues(issues: list[dict]) -> list[dict]:
-    """Closed issues closed as ``NOT_PLANNED`` (descoped / superseded / wontfix).
+    """Closed issues that did NOT ship (descoped / superseded / wontfix / dup).
 
     These are *not* deliverables — counting them as such inflates the delivered
     headline and masks dropped scope (the machine analogue of the parent-rollup
     close-reason rule). Issue #851.
     """
-    return [
-        i for i in issues
-        if i.get("state") == "CLOSED" and i.get("state_reason") == "NOT_PLANNED"
-    ]
+    return [i for i in issues if is_descoped(i)]
 
 
 def delivered_issues(issues: list[dict]) -> list[dict]:
-    """Closed issues that actually shipped (``stateReason != NOT_PLANNED``).
+    """Closed issues that actually shipped (closed, and not a descope reason).
 
     A closed issue with no recorded reason is treated as delivered, so legacy
     data without ``stateReason`` is never silently dropped from the count.
     """
-    return [
-        i for i in issues
-        if i.get("state") == "CLOSED" and i.get("state_reason") != "NOT_PLANNED"
-    ]
+    return [i for i in issues if i.get("state") == "CLOSED" and not is_descoped(i)]
 
 
 def cycle_time_days(issue: dict) -> Optional[float]:
@@ -150,11 +160,11 @@ def milestone_duration_days(
     return (end - start).total_seconds() / 86400.0
 
 
-def throughput_per_week(n_closed: int, duration_days: Optional[float]) -> Optional[float]:
-    """Closed issues per week; None when duration is zero/unknown (guarded)."""
+def throughput_per_week(n_delivered: int, duration_days: Optional[float]) -> Optional[float]:
+    """Delivered issues per week; None when duration is zero/unknown (guarded)."""
     if not duration_days or duration_days <= 0:
         return None
-    return n_closed / (duration_days / 7.0)
+    return n_delivered / (duration_days / 7.0)
 
 
 def compute_metrics(issues: list[dict], milestone: dict) -> dict[str, Any]:
@@ -172,11 +182,12 @@ def compute_metrics(issues: list[dict], milestone: dict) -> dict[str, Any]:
         "n_descoped": len(descoped),
         "n_carried_forward": len(issues) - len(closed),
         "duration_days": duration,
-        # Throughput keys off *delivered*, not raw closed — descoped issues are
-        # not shipped work and must not inflate the rate (Issue #851).
+        # Throughput + cycle time key off *delivered*, not raw closed — a
+        # descoped issue is not shipped work, so neither the rate nor the
+        # created→closed cycle should count it (Issue #851).
         "throughput_per_week": throughput_per_week(len(delivered), duration),
-        "avg_cycle_time_days": avg_cycle_time(issues),
-        "median_cycle_time_days": median_cycle_time(issues),
+        "avg_cycle_time_days": avg_cycle_time(delivered),
+        "median_cycle_time_days": median_cycle_time(delivered),
         "per_role_counts": per_role_counts(issues),
     }
 
@@ -266,7 +277,7 @@ def fetch_milestone_issues(name: str) -> list[dict]:
         # stateReason: COMPLETED | NOT_PLANNED | None (open). Upper-cased so the
         # metrics layer can compare against the canonical NOT_PLANNED token.
         reason = it.get("stateReason")
-        issues.append({
+        issue = {
             "number": num,
             "title": it["title"],
             "url": it.get("url"),
@@ -279,7 +290,11 @@ def fetch_milestone_issues(name: str) -> list[dict]:
             "status": b.get("status") or ("Done" if it["state"].upper() == "CLOSED" else "—"),
             "priority": b.get("priority") or "—",
             "size": b.get("size") or "—",
-        })
+        }
+        # Single-source the descoped flag for the inventory badge (covers
+        # NOT_PLANNED + DUPLICATE without the template hardcoding the set).
+        issue["is_descoped"] = is_descoped(issue)
+        issues.append(issue)
     return issues
 
 

--- a/scripts/pm/templates/milestone_report.html.j2
+++ b/scripts/pm/templates/milestone_report.html.j2
@@ -29,6 +29,9 @@
   th { color: var(--muted); font-weight: 600; font-size: .78rem; text-transform: uppercase; }
   tr.closed td:first-child { color: var(--ok); }
   tr.open td:first-child { color: var(--warn); }
+  .badge { display: inline-block; border-radius: 999px; padding: .02rem .45rem; font-size: .72rem;
+           border: 1px solid var(--line); margin-left: .35rem; vertical-align: middle; }
+  .badge.descoped { color: var(--warn); border-color: var(--warn); }
   a { color: var(--accent); text-decoration: none; }
   a:hover { text-decoration: underline; }
   .narrative { margin-top: .5rem; }
@@ -54,9 +57,10 @@
   <!-- Section 2: At-a-glance (script-generated) -->
   <h2>At a glance</h2>
   <div class="cards">
-    <div class="card"><div class="n">{{ metrics.n_closed }}</div><div class="l">Closed</div></div>
+    <div class="card"><div class="n">{{ metrics.n_delivered }}</div><div class="l">Delivered</div></div>
+    {% if metrics.n_descoped %}<div class="card"><div class="n">{{ metrics.n_descoped }}</div><div class="l">Descoped</div></div>{% endif %}
     <div class="card"><div class="n">{{ metrics.n_carried_forward }}</div><div class="l">Carried forward</div></div>
-    <div class="card"><div class="n">{{ "%.1f"|format(metrics.throughput_per_week) if metrics.throughput_per_week is not none else "—" }}</div><div class="l">Closed / week</div></div>
+    <div class="card"><div class="n">{{ "%.1f"|format(metrics.throughput_per_week) if metrics.throughput_per_week is not none else "—" }}</div><div class="l">Delivered / week</div></div>
     <div class="card"><div class="n">{{ "%.1f"|format(metrics.avg_cycle_time_days) if metrics.avg_cycle_time_days is not none else "—" }}</div><div class="l">Avg cycle (days)</div></div>
     <div class="card"><div class="n">{{ "%.1f"|format(metrics.median_cycle_time_days) if metrics.median_cycle_time_days is not none else "—" }}</div><div class="l">Median cycle (days)</div></div>
   </div>
@@ -64,7 +68,7 @@
     {% for role, count in metrics.per_role_counts.items() %}
       <span class="pill">{{ role }} · <strong>{{ count }}</strong></span>
     {% else %}
-      <span class="sub">no role-tagged closed issues</span>
+      <span class="sub">no role-tagged delivered issues</span>
     {% endfor %}
   </div>
 
@@ -82,7 +86,7 @@
       <tr class="{{ 'closed' if i.state == 'CLOSED' else 'open' }}">
         <td><a href="{{ i.url }}">#{{ i.number }}</a></td>
         <td>{{ i.title }}</td>
-        <td>{{ i.status }}</td>
+        <td>{{ i.status }}{% if i.state_reason == "NOT_PLANNED" %}<span class="badge descoped">descoped</span>{% endif %}</td>
         <td>{{ i.roles|join(", ")|replace("role:", "") or "—" }}</td>
         <td>{{ i.size }}</td>
         <td>{{ i.priority }}</td>

--- a/scripts/pm/templates/milestone_report.html.j2
+++ b/scripts/pm/templates/milestone_report.html.j2
@@ -86,7 +86,7 @@
       <tr class="{{ 'closed' if i.state == 'CLOSED' else 'open' }}">
         <td><a href="{{ i.url }}">#{{ i.number }}</a></td>
         <td>{{ i.title }}</td>
-        <td>{{ i.status }}{% if i.state_reason == "NOT_PLANNED" %}<span class="badge descoped">descoped</span>{% endif %}</td>
+        <td>{{ i.status }}{% if i.is_descoped %}<span class="badge descoped">descoped</span>{% endif %}</td>
         <td>{{ i.roles|join(", ")|replace("role:", "") or "—" }}</td>
         <td>{{ i.size }}</td>
         <td>{{ i.priority }}</td>

--- a/tools/ci/test_milestone_report.py
+++ b/tools/ci/test_milestone_report.py
@@ -106,27 +106,32 @@ class TestPerRoleCounts:
 
 # --- close-reason split (delivered vs descoped) -----------------------------
 
-# A milestone mixing COMPLETED + NOT_PLANNED closes + one open issue.
+# A milestone mixing COMPLETED + NOT_PLANNED + DUPLICATE closes + one open issue.
+# Descoped = NOT_PLANNED (#2) and DUPLICATE (#5); delivered = #1, #3.
 MIXED = [
     _issue(1, "CLOSED", "2026-06-01T00:00:00Z", "2026-06-03T00:00:00Z", ["role:scientist"], "COMPLETED"),
     _issue(2, "CLOSED", "2026-06-01T00:00:00Z", "2026-06-05T00:00:00Z", ["role:developer"], "NOT_PLANNED"),
     _issue(3, "CLOSED", "2026-06-02T00:00:00Z", "2026-06-08T00:00:00Z", ["role:scientist", "role:developer"], "COMPLETED"),
     _issue(4, "OPEN", "2026-06-04T00:00:00Z", None, ["role:pm"]),
+    _issue(5, "CLOSED", "2026-06-01T00:00:00Z", "2026-06-09T00:00:00Z", ["role:developer"], "DUPLICATE"),
 ]
 
 
 class TestCloseReasonSplit:
-    def test_delivered_excludes_not_planned_and_open(self):
+    def test_delivered_excludes_descoped_and_open(self):
+        # NOT_PLANNED (#2), DUPLICATE (#5), and open (#4) all excluded.
         nums = [i["number"] for i in mr.delivered_issues(MIXED)]
         assert nums == [1, 3]
 
-    def test_descoped_is_not_planned_only(self):
-        nums = [i["number"] for i in mr.descoped_issues(MIXED)]
-        assert nums == [2]
+    def test_descoped_includes_not_planned_and_duplicate(self):
+        # DUPLICATE is a descope (tracked elsewhere), not a delivery — must not
+        # be swept into delivered by a bare "!= NOT_PLANNED" complement.
+        nums = sorted(i["number"] for i in mr.descoped_issues(MIXED))
+        assert nums == [2, 5]
 
-    def test_closed_still_counts_both(self):
+    def test_closed_still_counts_all_closed(self):
         # closed_issues stays the union (delivered + descoped), unchanged.
-        assert [i["number"] for i in mr.closed_issues(MIXED)] == [1, 2, 3]
+        assert sorted(i["number"] for i in mr.closed_issues(MIXED)) == [1, 2, 3, 5]
 
     def test_missing_reason_on_closed_is_delivered(self):
         # Legacy/None reason on a closed issue must not be dropped from delivered.
@@ -134,7 +139,7 @@ class TestCloseReasonSplit:
         assert mr.descoped_issues(SAMPLE) == []
 
     def test_per_role_counts_excludes_descoped(self):
-        # #2 (developer) is NOT_PLANNED -> excluded; only #1 sci + #3 sci+dev count.
+        # #2 + #5 (developer) are descoped -> excluded; only #1 sci + #3 sci+dev.
         assert mr.per_role_counts(MIXED) == {"role:scientist": 2, "role:developer": 1}
 
 
@@ -181,17 +186,28 @@ class TestComputeMetrics:
         assert m["per_role_counts"] == {"role:scientist": 2, "role:developer": 2}
 
     def test_split_counts_and_delivered_throughput(self):
-        # MIXED: 2 delivered (#1,#3) + 1 descoped (#2) + 1 open (#4).
+        # MIXED: 2 delivered (#1,#3) + 2 descoped (#2 NOT_PLANNED, #5 DUPLICATE) + 1 open.
         m = mr.compute_metrics(
             MIXED,
             {"created_at": "2026-06-01T00:00:00Z", "closed_at": "2026-06-08T00:00:00Z"},
         )
-        assert m["n_closed"] == 3
+        assert m["n_closed"] == 4
         assert m["n_delivered"] == 2
-        assert m["n_descoped"] == 1
+        assert m["n_descoped"] == 2
         # throughput keys off *delivered*, not raw closed: 2 over 7 days.
         assert m["throughput_per_week"] == pytest.approx(2.0)
         assert m["per_role_counts"] == {"role:scientist": 2, "role:developer": 1}
+        # cycle time is over delivered only: #1=2d, #3=6d -> avg/median 4.0.
+        # The descoped #2 (4d) and #5 (8d) must not skew it.
+        assert m["avg_cycle_time_days"] == pytest.approx(4.0)
+        assert m["median_cycle_time_days"] == pytest.approx(4.0)
+
+    def test_partition_invariant(self):
+        # delivered + descoped always exactly partitions closed.
+        m = mr.compute_metrics(
+            MIXED, {"created_at": None, "closed_at": "2026-06-08T00:00:00Z"}
+        )
+        assert m["n_delivered"] + m["n_descoped"] == m["n_closed"]
 
     def test_empty_milestone_degrades(self):
         m = mr.compute_metrics([], {"created_at": None, "closed_at": None})

--- a/tools/ci/test_milestone_report.py
+++ b/tools/ci/test_milestone_report.py
@@ -24,14 +24,19 @@ import milestone_report as mr
 
 # --- fixtures ---------------------------------------------------------------
 
-def _issue(number, state, created_at, closed_at, roles):
-    """Minimal normalized-issue dict carrying only what the metrics read."""
+def _issue(number, state, created_at, closed_at, roles, state_reason=None):
+    """Minimal normalized-issue dict carrying only what the metrics read.
+
+    ``state_reason`` mirrors GitHub's ``stateReason`` (COMPLETED / NOT_PLANNED /
+    None for open issues); a closed issue with no reason is treated as delivered.
+    """
     return {
         "number": number,
         "state": state,
         "created_at": created_at,
         "closed_at": closed_at,
         "roles": roles,
+        "state_reason": state_reason,
     }
 
 
@@ -99,6 +104,40 @@ class TestPerRoleCounts:
         assert mr.per_role_counts([]) == {}
 
 
+# --- close-reason split (delivered vs descoped) -----------------------------
+
+# A milestone mixing COMPLETED + NOT_PLANNED closes + one open issue.
+MIXED = [
+    _issue(1, "CLOSED", "2026-06-01T00:00:00Z", "2026-06-03T00:00:00Z", ["role:scientist"], "COMPLETED"),
+    _issue(2, "CLOSED", "2026-06-01T00:00:00Z", "2026-06-05T00:00:00Z", ["role:developer"], "NOT_PLANNED"),
+    _issue(3, "CLOSED", "2026-06-02T00:00:00Z", "2026-06-08T00:00:00Z", ["role:scientist", "role:developer"], "COMPLETED"),
+    _issue(4, "OPEN", "2026-06-04T00:00:00Z", None, ["role:pm"]),
+]
+
+
+class TestCloseReasonSplit:
+    def test_delivered_excludes_not_planned_and_open(self):
+        nums = [i["number"] for i in mr.delivered_issues(MIXED)]
+        assert nums == [1, 3]
+
+    def test_descoped_is_not_planned_only(self):
+        nums = [i["number"] for i in mr.descoped_issues(MIXED)]
+        assert nums == [2]
+
+    def test_closed_still_counts_both(self):
+        # closed_issues stays the union (delivered + descoped), unchanged.
+        assert [i["number"] for i in mr.closed_issues(MIXED)] == [1, 2, 3]
+
+    def test_missing_reason_on_closed_is_delivered(self):
+        # Legacy/None reason on a closed issue must not be dropped from delivered.
+        assert mr.delivered_issues(SAMPLE) == mr.closed_issues(SAMPLE)
+        assert mr.descoped_issues(SAMPLE) == []
+
+    def test_per_role_counts_excludes_descoped(self):
+        # #2 (developer) is NOT_PLANNED -> excluded; only #1 sci + #3 sci+dev count.
+        assert mr.per_role_counts(MIXED) == {"role:scientist": 2, "role:developer": 1}
+
+
 # --- duration & throughput --------------------------------------------------
 
 class TestDurationThroughput:
@@ -132,6 +171,8 @@ class TestComputeMetrics:
         )
         assert m["n_total"] == 4
         assert m["n_closed"] == 3
+        assert m["n_delivered"] == 3  # no state_reason -> all delivered
+        assert m["n_descoped"] == 0
         assert m["n_carried_forward"] == 1
         assert m["duration_days"] == 7.0
         assert m["throughput_per_week"] == pytest.approx(3.0)
@@ -139,9 +180,23 @@ class TestComputeMetrics:
         assert m["median_cycle_time_days"] == pytest.approx(4.0)
         assert m["per_role_counts"] == {"role:scientist": 2, "role:developer": 2}
 
+    def test_split_counts_and_delivered_throughput(self):
+        # MIXED: 2 delivered (#1,#3) + 1 descoped (#2) + 1 open (#4).
+        m = mr.compute_metrics(
+            MIXED,
+            {"created_at": "2026-06-01T00:00:00Z", "closed_at": "2026-06-08T00:00:00Z"},
+        )
+        assert m["n_closed"] == 3
+        assert m["n_delivered"] == 2
+        assert m["n_descoped"] == 1
+        # throughput keys off *delivered*, not raw closed: 2 over 7 days.
+        assert m["throughput_per_week"] == pytest.approx(2.0)
+        assert m["per_role_counts"] == {"role:scientist": 2, "role:developer": 1}
+
     def test_empty_milestone_degrades(self):
         m = mr.compute_metrics([], {"created_at": None, "closed_at": None})
         assert m["n_total"] == m["n_closed"] == m["n_carried_forward"] == 0
+        assert m["n_delivered"] == m["n_descoped"] == 0
         assert m["duration_days"] is None
         assert m["throughput_per_week"] is None
         assert m["avg_cycle_time_days"] is None


### PR DESCRIPTION
## What & why

`scripts/pm/milestone_report.py` counted **all** closed issues as delivered, with no `stateReason` distinction. A milestone with descoped (`NOT_PLANNED`) closes therefore rendered an inflated "N / N closed" headline that read as N deliverables and **silently masked dropped scope**. pm-i7's "9 / 9 closed" actually hid 2 superseded issues (Issue #499 → #776, Issue #533 → #453), caught only by a manual close-reason audit during authoring.

This is the machine analogue of the parent-rollup close-reason rule (`recheck_parent_status`'s `[REVIEW: NOT_PLANNED child]` flag) applied at **milestone** rollup. Closes Issue #851.

## Changes

- **Metrics layer** - `delivered_issues()` / `descoped_issues()` split closed issues by `stateReason` (a closed issue with no reason is treated as delivered, so legacy data is never dropped). `compute_metrics` reports `n_delivered` + `n_descoped` separately; `per_role_counts` and `throughput_per_week` now key off **delivered**, not raw closed.
- **Data layer** - capture `stateReason` from `gh issue list` (`COMPLETED` | `NOT_PLANNED` | `None`).
- **Render layer** - At-a-glance splits into **Delivered** / **Descoped** cards (Descoped only shown when > 0); inventory tags each descoped row with a `descoped` badge; throughput label → "Delivered / week".
- **Narrative seed** - emits a "Descoped (closed NOT_PLANNED)" stub listing each dropped issue so the author records why/where it was routed instead of it vanishing.

## Verification

- Metrics layer is TDD'd: 7 new failing tests written first, then implemented; **31/31** pass in `tools/ci/test_milestone_report.py` (bare `ci-tools-pytest` env - no jinja2/markdown import).
- Live dry-run + full HTML render on **pm-i7**: `delivered / descoped = 7 / 2` (was masked "9/9"); both descoped issues (#499, #533) badged in the inventory and listed in the narrative stub.

## Test plan

- [x] `delivered_issues` / `descoped_issues` split closed by `stateReason`; missing reason → delivered
- [x] `per_role_counts` + throughput exclude descoped closes
- [x] `compute_metrics` exposes `n_delivered` / `n_descoped`
- [x] Data layer captures `stateReason`; render shows split cards + descoped badge
- [x] 31/31 unit tests pass; live pm-i7 render verified (7/2, was 9/9)

**Priority rationale:** P2 - corrects durable closure-evidence artifacts and closes a known masking gap; not urgent but should land before the next milestone close.
