### PR TITLE
docs(research): fix stale `resources/` promotion path in research_artifact_conventions.md

### DIFF
--- a/docs/research_artifact_conventions.md
+++ b/docs/research_artifact_conventions.md
@@ -23,7 +23,7 @@ research/experiments/issue_NNN_<short>/
 1. **Default:** each experiment owns its outputs in `<experiment>/outputs/`.
 2. **Shared between ≥2 experiments → `research/experiments/_shared/`.** Promote an artifact here only when a 2nd consumer materializes (YAGNI; don't pre-share). Filenames carry provenance (`gtex_panel_chr22_snaptron_v1.parquet`, not `gtex_panel.parquet`).
 3. **Cross-experiment read, single consumer → explicit path reference.** Document in the consumer's README under "Cross-experiment deps".
-4. **Promoted to production → `resources/`.** When an artifact becomes a stable pipeline input.
+4. **Promoted to production → `references/` or `indices/`.** When an artifact becomes a stable pipeline input. A downloaded or derived *reference input* (genome / annotation / panel) goes to `references/`; a pipeline-*built alignment index* goes to `indices/`. (The old single `resources/` target was retired in [#63](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/63).)
 
 **Bad practices (any size):** symlinks across experiments, copying artifacts, one experiment writing into another's `outputs/`.
 

--- a/docs/research_artifact_conventions.md
+++ b/docs/research_artifact_conventions.md
@@ -23,7 +23,7 @@ research/experiments/issue_NNN_<short>/
 1. **Default:** each experiment owns its outputs in `<experiment>/outputs/`.
 2. **Shared between ≥2 experiments → `research/experiments/_shared/`.** Promote an artifact here only when a 2nd consumer materializes (YAGNI; don't pre-share). Filenames carry provenance (`gtex_panel_chr22_snaptron_v1.parquet`, not `gtex_panel.parquet`).
 3. **Cross-experiment read, single consumer → explicit path reference.** Document in the consumer's README under "Cross-experiment deps".
-4. **Promoted to production → `references/` or `indices/`.** When an artifact becomes a stable pipeline input. A downloaded or derived *reference input* (genome / annotation / panel) goes to `references/`; a pipeline-*built alignment index* goes to `indices/`. (The old single `resources/` target was retired in [#63](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/63).)
+4. **Promoted to production → `references/` or `indices/`.** When an artifact becomes a stable pipeline input. A downloaded or derived *reference input* (genome / annotation / panel) goes to `references/`; a *pipeline-built alignment index* goes to `indices/`. (The old single `resources/` target was retired in [#63](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/63).)
 
 **Bad practices (any size):** symlinks across experiments, copying artifacts, one experiment writing into another's `outputs/`.
 

--- a/research/lab_notebook/scientist.md
+++ b/research/lab_notebook/scientist.md
@@ -8,6 +8,14 @@ Format and rules unchanged from the unified notebook — see `shared/feedback_la
 
 ## 2026-06-26
 
+### 17:30 UTC — Editor: Scientist
+
+#### [PR #888](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/888) — fix stale `resources/` promotion path in research_artifact_conventions.md — closes [Issue #863](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/863)
+
+**What shipped.** Doc-only fix. The cross-experiment data-sharing rules in `docs/research_artifact_conventions.md` pointed promoted experiment artifacts at `resources/`, the production directory retired in #63. Updated the promotion bullet to name the two correct post-#63 destinations - a stable downloaded/derived *reference input* -> `references/`, a pipeline-built *index* -> `indices/` - consistent with AGENTS.md "Reference + Index Layout (nf-core convention)". The fix needed the (tiny) taxonomy call, not a find-replace, which is why it carried its own Issue rather than riding the verbatim-move #862. No code or pipeline impact; all CI green.
+
+---
+
 ### 15:57 UTC — Editor: Scientist
 
 #### [PR #881](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/881) — junction mapping + documented pos/neg labeling scheme for the #680 benchmark — closes [Issue #735](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/735)


### PR DESCRIPTION
Fixes the stale production-promotion target in `docs/research_artifact_conventions.md`. The cross-experiment data-sharing bullet pointed promoted artifacts at `resources/`, retired in #63 (the production `resources/` directory is no longer used). Post-#63 the pipeline splits a downloaded/derived reference input into `references/` and a pipeline-built alignment index into `indices/` (AGENTS.md "Reference + Index Layout (nf-core convention)").

The bullet now names both correct destinations and adds a one-liner on which artifact kind goes where.

## Test plan
- [x] Promotion bullet names `references/` and/or `indices/`, not `resources/` (AC 1)
- [x] One-line note on which artifact kind goes where, consistent with AGENTS.md "Reference + Index Layout" (AC 2)
- [x] Doc-only change; no code or pipeline impact

Closes #863