### PR TITLE
chore(pm): sync arc_taxonomy.tsv — add #803-807 to arc:scoring-tcr-pmhc

### DIFF
--- a/scripts/pm/arc_taxonomy.tsv
+++ b/scripts/pm/arc_taxonomy.tsv
@@ -5,7 +5,7 @@
 arc:aligner-junctions     active  297 375 377 378 411 636
 arc:junction-filtering    later   126 212 304 381 594 663
 arc:variant-cohort        later   413 416 436 437 438 440
-arc:scoring-tcr-pmhc      active  433 492 547 566 585 601 659
+arc:scoring-tcr-pmhc      active  433 492 547 566 585 601 659 803 804 805 806 807
 arc:results-reporting     later   193 198 233 435 455
 arc:cloud-reproducibility next    66 183 195 310 630 651 658 664 669 673 674
 arc:memory-methodology    later   248 265 324 326 346 353 527 538 539 540 541 542 672


### PR DESCRIPTION
Source-of-truth hygiene for the arc manifest (`scripts/pm/arc_taxonomy.tsv`).

The five #708 calibrator-hardening follow-ups (#803-807) already carry the `arc:scoring-tcr-pmhc` label (applied at filing) but were missing from the manifest line, which stopped at `659` -> arc-system drift. This appends them.

**Left un-phased** (per PM call): they are uncommitted Backlog hardening and the active focus slate is already at its <=3 cap, so they are not stamped `arc-phase:active`. `apply_arc_labels.sh` reconcile only touches manifested issues, so this carries no label-loss risk.

## Test plan
- [x] Manifest line for `arc:scoring-tcr-pmhc` now lists 803-807
- [x] No `arc-phase` change (un-phased, as decided)

Closes #808

<!-- skip-lab-notebook: routine -->
**Created by:** PM