### PR TITLE
tooling(ci): live board GraphQL schema-drift smoke (#771)

### DIFF
--- a/.github/workflows/recheck-live-smoke.yml
+++ b/.github/workflows/recheck-live-smoke.yml
@@ -23,7 +23,7 @@ on:
   workflow_dispatch: {}
 
 jobs:
-  live-recheck-smoke:
+  live-api-smoke:
     runs-on: ubuntu-latest
     # Bound an unattended nightly job: the per-milestone timeout=60 in the live
     # test caps individual calls, but a hung run shouldn't burn Actions minutes

--- a/.github/workflows/recheck-live-smoke.yml
+++ b/.github/workflows/recheck-live-smoke.yml
@@ -1,12 +1,20 @@
-name: Live recheck smoke (nightly)
+name: Live API smoke (nightly)
 
-# Issue #711: the live recheck integration smoke
-# (TestLiveIntegrationSmoke, @pytest.mark.live) is split OFF the per-PR
-# ci-tools-pytest job so a transient GitHub-API blip can never red a PR. It runs
-# here instead — nightly and NON-BLOCKING (a scheduled workflow, not a required
-# check, so it gates nothing). A real failure surfaces in the Actions tab for
-# follow-up; per-PR integration coverage is provided hermetically by
-# TestRecheckHermeticIntegration (recorded gh fixtures, no live calls).
+# Runs every @pytest.mark.live suite in tools/ci/ against the real GitHub API —
+# split OFF the per-PR ci-tools-pytest job so a transient GitHub-API blip can
+# never red a PR. Nightly and NON-BLOCKING (a scheduled workflow, not a required
+# check, so it gates nothing); a real failure surfaces in the Actions tab for
+# follow-up. Promotion of any of these to a required check is a separate,
+# deliberate decision, not the default.
+#
+# Suites collected here (anything marked `live` under tools/ci/ is auto-included):
+#   - TestLiveIntegrationSmoke (Issue #711): recheck integration runs end-to-end
+#     for every open milestone. Per-PR cover is hermetic (TestRecheckHermeticIntegration,
+#     recorded gh fixtures).
+#   - TestBoardQueryLiveSmoke (Issue #771): the board GraphQL query is schema-valid
+#     against the live Projects API — catches schema drift / a field typo / a
+#     removed field that hand-authored fixtures structurally cannot. Per-PR cover
+#     is the hermetic check_board_query_shape unit suite.
 
 on:
   schedule:
@@ -34,10 +42,11 @@ jobs:
       - name: Install pytest
         run: python -m pip install --upgrade pip pytest pyyaml
 
-      - name: Run live recheck smoke
-        # Selects ONLY the @pytest.mark.live suite. The gh()-level retry with
-        # backoff (Issue #711 D4) absorbs transient blips on this live path; the
-        # REQUIRES_LIVE_GH guard skips cleanly if the project scope is absent.
+      - name: Run live API smoke
+        # Selects every @pytest.mark.live suite under tools/ci/. Per-suite retry
+        # with backoff (recheck: gh() Issue #711 D4; board query:
+        # run_graphql_with_retry, Issue #771) absorbs transient blips on the live
+        # path; the REQUIRES_LIVE_GH guard skips cleanly if project scope is absent.
         run: pytest tools/ci/ -v -m live
         env:
           # PAT with `read:project` scope — live tests resolve project items via

--- a/research/lab_notebook/developer.md
+++ b/research/lab_notebook/developer.md
@@ -8,6 +8,22 @@ Format and rules unchanged from the unified notebook — see `shared/feedback_la
 
 ## 2026-06-26 - Cloud cost-out + local CPU keep-alive baseline (GCP decommissioned; 2 latent bugs fixed)
 
+### 21:57 UTC - Editor: Developer - live board GraphQL schema-drift smoke (#771 / PR #890)
+
+**Why.**
+The board-query tooling (`scripts/board_open_items.py`, `scripts/pm/recheck_*.py`) builds GraphQL against the GitHub Projects API but is validated only against hand-authored fixtures - and a fixture *is* the assumed response, so it can never disagree with itself. A field typo or upstream schema drift passes `pipeline-pytest` + `ci-tools-pytest` green and only surfaces at runtime. Concrete trigger: the `subIssuesSummary { total }` add in #768 was provable only by a *manual* live smoke - no CI gate could have caught a field typo. This is the GitHub-API-boundary analogue of `feedback_integration_run_for_new_rules.md` (fixtures hide what production contains).
+
+**What shipped (PR [#890](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/890)).**
+A **structure-only live smoke**. `tools/ci/_board_query_smoke.py`: pure `check_board_query_shape()` (no GraphQL `errors`, response parses to shape, `pageInfo` pagination contract intact, `subIssuesSummary { total }` present + int-typed on Issue nodes; **no** data-value assertions), `run_graphql_with_retry()` (capped exponential backoff), and a `LIVE_QUERIES` registry importing the **real** `QUERY`/`OWNER`/`PROJECT_NUMBER` from `board_open_items.py` (single source of truth → a field rename auto-flows in; new queries are one registry entry). `tools/ci/test_board_query_smoke.py`: hermetic unit tests for the checker + retry (per-PR, `-m "not live"`) and one `@pytest.mark.live` smoke (nightly).
+
+**Design decision - reuse the existing nightly live job, zero new workflow.**
+The live-smoke infra already existed (`REQUIRES_LIVE_GH` graceful-skip guard, `@pytest.mark.live` marker, the nightly non-blocking `recheck-live-smoke.yml` running `pytest tools/ci/ -m live`). The new suite is auto-collected by that glob - so it inherits advisory/non-blocking for free (a transient GitHub blip can't red a PR; promotion-to-required left as a separate decision). Generalized the workflow name/comments to "Live API smoke" + renamed the job key.
+
+**Review.**
+Bot review: no blockers, ACs met. Fixed 3 findings in `91d9f7b`. **Finding 1 (medium, the sharp one):** `gh api graphql` exits *non-zero* with the `errors` body on stdout when the response carries a GraphQL `errors` array (the headline drift case) - so my retry wrapper would treat deterministic drift as transient, retry 4×, and raise a generic `RuntimeError` instead of the curated message. Verified empirically (bad-field query → exit 1, errors JSON on stdout), then made `run_graphql_with_retry` short-circuit on a parseable errors body (return immediately, no retry). **Finding 2 (low):** threaded the defined-but-ignored `LiveQuery.items_path` through the checker (latent trap for a second envelope). **Finding 3 (nit):** stale job-key rename. Finding 4 (nit) acknowledged, no change.
+
+**Verification.** `tools/ci/ -m "not live"` → 421 passed (19 new in this suite); `tools/ci/test_board_query_smoke.py -m live` → 1 passed against real board #9 (the query *is* schema-valid right now, checker confirms); workflow YAML validates. Stopped at the merge gate for the human's final check + merge.
+
 ### 16:51 UTC - Editor: Developer - deterministic last-session watermark hook (#820 / PR #884)
 
 **Why.**

--- a/tools/ci/_board_query_smoke.py
+++ b/tools/ci/_board_query_smoke.py
@@ -1,0 +1,201 @@
+"""Helpers for the board GraphQL schema-drift smoke (Issue #771).
+
+Not a ``test_*`` module, so pytest does not collect it.
+
+This is the GitHub-API-boundary analogue of the Snakemake integration rule
+(``feedback_integration_run_for_new_rules.md``): the board-query tooling
+(``scripts/board_open_items.py``, ``scripts/pm/recheck_*.py``) builds GraphQL
+queries that the unit tests validate only against hand-authored fixtures — and a
+fixture *is* the assumed response, so it can never disagree with itself. A field
+typo or upstream GitHub schema drift passes the hermetic suites green and only
+surfaces at runtime.
+
+``check_board_query_shape`` is a pure, structure-only checker (unit-tested
+hermetically). ``LIVE_QUERIES`` registers the *real* queries — imported from
+their source modules so a field rename flows in automatically — and the live
+smoke (nightly, advisory) runs each against the real API and feeds the response
+to the checker. It asserts schema validity only; data correctness (which items
+are where, counts) stays the manual live-smoke convention
+(``feedback_live_integration_smoke.md``).
+"""
+import importlib.util
+import json
+import subprocess
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable
+
+# tools/ci/ -> repo root
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _load_module_from_path(name: str, relpath: str):
+    """Import a non-packaged script (``scripts/`` has no ``__init__.py``) by path."""
+    spec = importlib.util.spec_from_file_location(name, _REPO_ROOT / relpath)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+# Single source of truth: the live smoke runs the SAME query string the board
+# tooling ships, so a rename in board_open_items.py is reflected here with no
+# hand-copied duplicate to drift.
+_board_open_items = _load_module_from_path("board_open_items", "scripts/board_open_items.py")
+
+
+@dataclass(frozen=True)
+class LiveQuery:
+    """A real GraphQL query to smoke-test against the live API."""
+
+    name: str
+    query: str
+    variables: dict[str, Any] = field(default_factory=dict)
+    # Path of keys into the parsed response down to the items connection, so the
+    # checker can locate `nodes`/`pageInfo` for queries with a different envelope.
+    items_path: tuple[str, ...] = ("data", "user", "projectV2", "items")
+    # When True, the response must contain ≥1 Issue node — otherwise the
+    # subIssuesSummary check never runs (a vacuous pass). The board always holds
+    # issues, so this is a coverage guard, not a data assertion.
+    require_issue_node: bool = True
+
+
+LIVE_QUERIES: list[LiveQuery] = [
+    LiveQuery(
+        name="board_open_items",
+        query=_board_open_items.QUERY,
+        variables={
+            "owner": _board_open_items.OWNER,
+            "number": _board_open_items.PROJECT_NUMBER,
+        },
+    ),
+]
+
+
+def _dig(obj: Any, path: tuple[str, ...]) -> Any:
+    """Walk a key path, returning None at the first missing/non-dict step."""
+    cur = obj
+    for key in path:
+        if not isinstance(cur, dict) or key not in cur:
+            return None
+        cur = cur[key]
+    return cur
+
+
+def check_board_query_shape(
+    parsed: Any,
+    *,
+    require_issue_node: bool = True,
+) -> list[str]:
+    """Return a list of structural problems with a board GraphQL response.
+
+    Empty list == schema-valid. Structure-only: asserts the response is
+    schema-valid (no GraphQL ``errors``), parses to the expected shape, the
+    pagination contract (``pageInfo``) survives, and ``subIssuesSummary { total }``
+    is present and integer-typed on Issue nodes. Deliberately makes NO assertion
+    on specific board data values (counts, titles, which items are present) —
+    board state changes hourly.
+    """
+    problems: list[str] = []
+
+    if not isinstance(parsed, dict):
+        return [f"response is not a JSON object (got {type(parsed).__name__})"]
+
+    # A field typo / removed field surfaces here — the core schema-drift signal.
+    if parsed.get("errors"):
+        problems.append(f"GraphQL errors present: {parsed['errors']}")
+
+    if parsed.get("data") is None:
+        problems.append("missing `data` (response has no top-level data object)")
+        return problems
+
+    items = _dig(parsed, ("data", "user", "projectV2", "items"))
+    if items is None:
+        problems.append(
+            "missing items connection at data.user.projectV2.items "
+            "(schema drift or wrong query envelope)"
+        )
+        return problems
+
+    page_info = items.get("pageInfo")
+    if not isinstance(page_info, dict):
+        problems.append("missing or malformed pageInfo (board pagination contract)")
+    else:
+        for k in ("hasNextPage", "endCursor"):
+            if k not in page_info:
+                problems.append(f"pageInfo missing `{k}`")
+
+    nodes = items.get("nodes")
+    if not isinstance(nodes, list):
+        problems.append(f"items.nodes is not a list (got {type(nodes).__name__})")
+        return problems
+
+    saw_issue = False
+    for i, node in enumerate(nodes):
+        content = node.get("content") if isinstance(node, dict) else None
+        if not isinstance(content, dict):
+            continue  # a null content node is legal (deleted/inaccessible item)
+        if content.get("__typename") != "Issue":
+            continue
+        saw_issue = True
+        if "subIssuesSummary" not in content:
+            problems.append(f"node[{i}] (Issue) missing subIssuesSummary")
+            continue
+        sub = content["subIssuesSummary"]
+        if not isinstance(sub, dict) or "total" not in sub:
+            problems.append(f"node[{i}] subIssuesSummary missing `total`")
+        elif not isinstance(sub["total"], int):
+            problems.append(
+                f"node[{i}] subIssuesSummary.total is not an int "
+                f"(got {type(sub['total']).__name__})"
+            )
+
+    if require_issue_node and not saw_issue:
+        problems.append(
+            "no Issue nodes in response — subIssuesSummary went unverified "
+            "(coverage guard; the board always holds issues)"
+        )
+
+    return problems
+
+
+def run_graphql_with_retry(
+    q: LiveQuery,
+    *,
+    max_attempts: int = 4,
+    base_delay: float = 1.0,
+    _runner: Callable[[list[str]], "subprocess.CompletedProcess"] | None = None,
+    _sleep: Callable[[float], None] = time.sleep,
+) -> Any:
+    """Run a LiveQuery via ``gh api graphql``, retrying transient failures.
+
+    Transient non-zero exits (TLS timeout, rate-limit, 5xx) are retried with
+    capped exponential backoff so a GitHub blip doesn't red the nightly job.
+    Returns the parsed JSON. ``_runner``/``_sleep`` are injectable for tests.
+    """
+    cmd = ["gh", "api", "graphql", "-f", f"query={q.query}"]
+    for key, value in q.variables.items():
+        cmd.extend(["-F", f"{key}={value}"])
+
+    runner = _runner or (
+        lambda c: subprocess.run(c, capture_output=True, text=True, timeout=60)
+    )
+
+    last_stderr = ""
+    for attempt in range(max_attempts):
+        try:
+            result = runner(cmd)
+        except subprocess.TimeoutExpired:
+            last_stderr = "gh call timed out"
+            result = None
+        if result is not None and result.returncode == 0:
+            return json.loads(result.stdout)
+        if result is not None:
+            last_stderr = result.stderr
+        if attempt < max_attempts - 1:
+            _sleep(base_delay * (2 ** attempt))
+
+    raise RuntimeError(
+        f"gh api graphql failed after {max_attempts} attempts for "
+        f"query '{q.name}': {last_stderr}"
+    )

--- a/tools/ci/_board_query_smoke.py
+++ b/tools/ci/_board_query_smoke.py
@@ -82,10 +82,14 @@ def _dig(obj: Any, path: tuple[str, ...]) -> Any:
     return cur
 
 
+_DEFAULT_ITEMS_PATH = ("data", "user", "projectV2", "items")
+
+
 def check_board_query_shape(
     parsed: Any,
     *,
     require_issue_node: bool = True,
+    items_path: tuple[str, ...] = _DEFAULT_ITEMS_PATH,
 ) -> list[str]:
     """Return a list of structural problems with a board GraphQL response.
 
@@ -95,6 +99,10 @@ def check_board_query_shape(
     is present and integer-typed on Issue nodes. Deliberately makes NO assertion
     on specific board data values (counts, titles, which items are present) —
     board state changes hourly.
+
+    ``items_path`` locates the items connection so a registered query with a
+    different envelope (e.g. an org-scoped project) is checked against its own
+    path rather than the board default — the registry's auto-coverage promise.
     """
     problems: list[str] = []
 
@@ -109,10 +117,10 @@ def check_board_query_shape(
         problems.append("missing `data` (response has no top-level data object)")
         return problems
 
-    items = _dig(parsed, ("data", "user", "projectV2", "items"))
+    items = _dig(parsed, items_path)
     if items is None:
         problems.append(
-            "missing items connection at data.user.projectV2.items "
+            f"missing items connection at {'.'.join(items_path)} "
             "(schema drift or wrong query envelope)"
         )
         return problems
@@ -192,6 +200,16 @@ def run_graphql_with_retry(
             return json.loads(result.stdout)
         if result is not None:
             last_stderr = result.stderr
+            # `gh api graphql` exits non-zero when the response carries a GraphQL
+            # `errors` array (the headline drift case: a renamed/removed field),
+            # printing the errors body to stdout. That's deterministic, not
+            # transient — return it so check_board_query_shape reports the drift
+            # with its curated message instead of exhausting retries into a
+            # generic timeout error. Genuine transient failures (TLS/5xx) have no
+            # parseable errors body, so they fall through to the backoff path.
+            errors_body = _parse_errors_body(result.stdout)
+            if errors_body is not None:
+                return errors_body
         if attempt < max_attempts - 1:
             _sleep(base_delay * (2 ** attempt))
 
@@ -199,3 +217,14 @@ def run_graphql_with_retry(
         f"gh api graphql failed after {max_attempts} attempts for "
         f"query '{q.name}': {last_stderr}"
     )
+
+
+def _parse_errors_body(stdout: str) -> dict[str, Any] | None:
+    """Return the parsed body iff stdout is JSON carrying a GraphQL ``errors`` array."""
+    try:
+        body = json.loads(stdout)
+    except (json.JSONDecodeError, TypeError):
+        return None
+    if isinstance(body, dict) and body.get("errors"):
+        return body
+    return None

--- a/tools/ci/test_board_query_smoke.py
+++ b/tools/ci/test_board_query_smoke.py
@@ -1,0 +1,237 @@
+"""Tests for the board GraphQL schema-drift smoke (Issue #771).
+
+Two layers, mirroring the recheck live-smoke split:
+
+* **Hermetic unit tests** (default, ``-m "not live"``) exercise the pure
+  ``check_board_query_shape`` structure-checker against curated well-formed and
+  malformed responses. These run per-PR in ``ci-tools-pytest`` and are where the
+  checker logic is proven.
+* **One live test** (``@pytest.mark.live``, nightly via ``recheck-live-smoke.yml``)
+  runs the *real* board query against the live GitHub Projects API and asserts
+  the checker finds no structural problems. This is the only layer that can catch
+  upstream schema drift or a field typo in the live query — a hand-authored
+  fixture can never disagree with itself.
+"""
+import _board_query_smoke as bqs
+import pytest
+from _live_gh import REQUIRES_LIVE_GH
+
+
+def _issue_node(with_sub_summary=True):
+    node = {
+        "content": {
+            "__typename": "Issue",
+            "number": 1,
+            "title": "x",
+            "state": "OPEN",
+            "url": "u",
+            "labels": {"nodes": []},
+        },
+        "fieldValues": {"nodes": []},
+    }
+    if with_sub_summary:
+        node["content"]["subIssuesSummary"] = {"total": 0}
+    return node
+
+
+def _well_formed(nodes=None):
+    if nodes is None:
+        nodes = [_issue_node()]
+    return {
+        "data": {
+            "user": {
+                "projectV2": {
+                    "items": {
+                        "pageInfo": {"hasNextPage": False, "endCursor": None},
+                        "nodes": nodes,
+                    }
+                }
+            }
+        }
+    }
+
+
+class TestCheckBoardQueryShape:
+    def test_well_formed_response_has_no_problems(self):
+        assert bqs.check_board_query_shape(_well_formed()) == []
+
+    def test_graphql_errors_flagged(self):
+        # A field typo / removed field surfaces as a top-level `errors` array —
+        # the exact schema-drift signal fixtures structurally cannot catch.
+        resp = _well_formed()
+        resp["errors"] = [{"message": "Field 'subIssueSummary' doesn't exist"}]
+        problems = bqs.check_board_query_shape(resp)
+        assert any("error" in p.lower() for p in problems)
+
+    def test_missing_data_flagged(self):
+        assert bqs.check_board_query_shape({}) != []
+
+    def test_missing_items_connection_flagged(self):
+        resp = {"data": {"user": {"projectV2": {}}}}
+        problems = bqs.check_board_query_shape(resp)
+        assert any("items" in p.lower() for p in problems)
+
+    def test_nodes_not_a_list_flagged(self):
+        resp = _well_formed()
+        resp["data"]["user"]["projectV2"]["items"]["nodes"] = None
+        problems = bqs.check_board_query_shape(resp)
+        assert any("nodes" in p.lower() for p in problems)
+
+    def test_missing_pageinfo_flagged(self):
+        # board_open_items.py paginates on pageInfo; losing it silently truncates.
+        resp = _well_formed()
+        del resp["data"]["user"]["projectV2"]["items"]["pageInfo"]
+        problems = bqs.check_board_query_shape(resp)
+        assert any("pageinfo" in p.lower() for p in problems)
+
+    def test_missing_sub_issues_summary_on_issue_flagged(self):
+        # The concrete trigger for #771: subIssuesSummary { total } must be present.
+        resp = _well_formed(nodes=[_issue_node(with_sub_summary=False)])
+        problems = bqs.check_board_query_shape(resp)
+        assert any("subissuessummary" in p.lower() for p in problems)
+
+    def test_sub_summary_total_wrong_type_flagged(self):
+        resp = _well_formed()
+        resp["data"]["user"]["projectV2"]["items"]["nodes"][0]["content"][
+            "subIssuesSummary"
+        ] = {"total": "not-an-int"}
+        problems = bqs.check_board_query_shape(resp)
+        assert any("total" in p.lower() for p in problems)
+
+    def test_no_value_assertions(self):
+        # Structure-only: the same well-formed shape passes regardless of the
+        # specific board data (counts, titles, states). Two different data sets,
+        # both structurally valid, must both pass.
+        a = _well_formed(nodes=[_issue_node()])
+        b = _well_formed(
+            nodes=[
+                {
+                    "content": {
+                        "__typename": "Issue",
+                        "number": 999,
+                        "title": "totally different",
+                        "state": "CLOSED",
+                        "url": "z",
+                        "labels": {"nodes": [{"name": "role:developer"}]},
+                        "subIssuesSummary": {"total": 42},
+                    },
+                    "fieldValues": {"nodes": []},
+                }
+            ]
+        )
+        assert bqs.check_board_query_shape(a) == []
+        assert bqs.check_board_query_shape(b) == []
+
+    def test_require_issue_node_coverage_guard(self):
+        # A response with zero Issue nodes never exercises the subIssuesSummary
+        # check — a vacuous pass. require_issue_node=True flags it so the live
+        # test can't silently stop covering the field (annotate-canary-style
+        # coverage guard).
+        pr_only = _well_formed(
+            nodes=[
+                {
+                    "content": {"__typename": "PullRequest", "number": 5, "isDraft": False},
+                    "fieldValues": {"nodes": []},
+                }
+            ]
+        )
+        problems = bqs.check_board_query_shape(pr_only, require_issue_node=True)
+        assert any("issue" in p.lower() for p in problems)
+        # Without the guard, the same response is structurally fine.
+        assert bqs.check_board_query_shape(pr_only, require_issue_node=False) == []
+
+
+class TestLiveQueriesRegistry:
+    def test_registry_includes_real_board_query(self):
+        names = [q.name for q in bqs.LIVE_QUERIES]
+        assert "board_open_items" in names
+
+    def test_board_query_is_the_real_one(self):
+        # Single source of truth: a field rename in board_open_items.py must
+        # flow into the live smoke automatically, not via a hand-copied string.
+        entry = next(q for q in bqs.LIVE_QUERIES if q.name == "board_open_items")
+        assert "subIssuesSummary" in entry.query
+        assert "projectV2" in entry.query
+
+
+class _FakeProc:
+    def __init__(self, returncode, stdout="", stderr=""):
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+class TestRunGraphqlWithRetry:
+    _Q = bqs.LiveQuery(name="t", query="query{x}", variables={"owner": "o"})
+
+    def test_returns_parsed_json_on_success(self):
+        runner = lambda cmd: _FakeProc(0, stdout='{"data": {"ok": true}}')
+        sleeps = []
+        out = bqs.run_graphql_with_retry(
+            self._Q, _runner=runner, _sleep=sleeps.append
+        )
+        assert out == {"data": {"ok": True}}
+        assert sleeps == []  # no retry on first-try success
+
+    def test_retries_transient_failure_then_succeeds(self):
+        calls = {"n": 0}
+
+        def runner(cmd):
+            calls["n"] += 1
+            if calls["n"] < 3:
+                return _FakeProc(1, stderr="503 transient")
+            return _FakeProc(0, stdout='{"data": {}}')
+
+        sleeps = []
+        out = bqs.run_graphql_with_retry(
+            self._Q, _runner=runner, _sleep=sleeps.append
+        )
+        assert out == {"data": {}}
+        assert sleeps == [1.0, 2.0]  # exponential backoff between the 3 attempts
+
+    def test_raises_after_exhausting_attempts(self):
+        runner = lambda cmd: _FakeProc(1, stderr="persistent failure")
+        sleeps = []
+        with pytest.raises(RuntimeError, match="failed after 4 attempts"):
+            bqs.run_graphql_with_retry(
+                self._Q, _runner=runner, _sleep=sleeps.append
+            )
+        assert sleeps == [1.0, 2.0, 4.0]  # backed off between each of the 4 tries
+
+    def test_passes_variables_as_field_flags(self):
+        seen = {}
+
+        def runner(cmd):
+            seen["cmd"] = cmd
+            return _FakeProc(0, stdout="{}")
+
+        bqs.run_graphql_with_retry(self._Q, _runner=runner, _sleep=lambda _: None)
+        assert "-F" in seen["cmd"] and "owner=o" in seen["cmd"]
+
+
+@REQUIRES_LIVE_GH
+@pytest.mark.live
+class TestBoardQueryLiveSmoke:
+    """Runs every registered live query against the real GitHub API.
+
+    Catches: schema drift, a renamed/removed field, a field typo in the live
+    query, and auth/scope regressions. Does NOT check data correctness (counts,
+    which items are where) — that stays the manual live-smoke convention
+    (feedback_live_integration_smoke.md). Advisory/nightly only; promotion to a
+    required check is a separate, deliberate decision (Issue #771 ACs).
+    """
+
+    def test_every_live_query_is_schema_valid(self):
+        failures = []
+        for q in bqs.LIVE_QUERIES:
+            parsed = bqs.run_graphql_with_retry(q)
+            problems = bqs.check_board_query_shape(
+                parsed, require_issue_node=q.require_issue_node
+            )
+            if problems:
+                failures.append(f"[{q.name}]\n  " + "\n  ".join(problems))
+        assert not failures, (
+            "live board GraphQL query is no longer schema-valid (drift / field "
+            "typo / removed field) — NOT a data-state change:\n"
+            + "\n".join(failures)
+        )

--- a/tools/ci/test_board_query_smoke.py
+++ b/tools/ci/test_board_query_smoke.py
@@ -122,6 +122,28 @@ class TestCheckBoardQueryShape:
         assert bqs.check_board_query_shape(a) == []
         assert bqs.check_board_query_shape(b) == []
 
+    def test_items_path_is_honored_for_other_envelopes(self):
+        # The registry promises new live queries are auto-covered. A query with a
+        # different envelope sets items_path; the checker must walk it, not the
+        # hardcoded board path. Here the items connection sits under
+        # data.organization.projectV2 instead of data.user.projectV2.
+        resp = {
+            "data": {
+                "organization": {
+                    "projectV2": {
+                        "items": {
+                            "pageInfo": {"hasNextPage": False, "endCursor": None},
+                            "nodes": [_issue_node()],
+                        }
+                    }
+                }
+            }
+        }
+        path = ("data", "organization", "projectV2", "items")
+        assert bqs.check_board_query_shape(resp, items_path=path) == []
+        # Default board path can't find it → flagged (proves the path is actually used).
+        assert bqs.check_board_query_shape(resp) != []
+
     def test_require_issue_node_coverage_guard(self):
         # A response with zero Issue nodes never exercises the subIssuesSummary
         # check — a vacuous pass. require_issue_node=True flags it so the live
@@ -208,6 +230,38 @@ class TestRunGraphqlWithRetry:
         bqs.run_graphql_with_retry(self._Q, _runner=runner, _sleep=lambda _: None)
         assert "-F" in seen["cmd"] and "owner=o" in seen["cmd"]
 
+    def test_schema_error_returns_immediately_without_retry(self):
+        # `gh api graphql` exits NON-ZERO when the response carries a GraphQL
+        # `errors` array (the headline drift case: a renamed/removed field), and
+        # prints the errors body to stdout. That's deterministic, not transient —
+        # return it straight to check_board_query_shape (which flags it with the
+        # curated message) instead of retrying 4x and raising a generic timeout.
+        errors_body = '{"errors": [{"message": "Field \'x\' doesn\'t exist"}]}'
+        calls = {"n": 0}
+
+        def runner(cmd):
+            calls["n"] += 1
+            return _FakeProc(1, stdout=errors_body, stderr="gh: Field 'x'...")
+
+        sleeps = []
+        out = bqs.run_graphql_with_retry(
+            self._Q, _runner=runner, _sleep=sleeps.append
+        )
+        assert out == {"errors": [{"message": "Field 'x' doesn't exist"}]}
+        assert calls["n"] == 1  # no retry on a deterministic schema error
+        assert sleeps == []
+
+    def test_nonjson_failure_still_retried(self):
+        # A genuinely transient failure (TLS/5xx) has no parseable errors body on
+        # stdout — keep retrying with backoff.
+        runner = lambda cmd: _FakeProc(1, stdout="", stderr="503 Service Unavailable")
+        sleeps = []
+        with pytest.raises(RuntimeError, match="failed after 4 attempts"):
+            bqs.run_graphql_with_retry(
+                self._Q, _runner=runner, _sleep=sleeps.append
+            )
+        assert sleeps == [1.0, 2.0, 4.0]
+
 
 @REQUIRES_LIVE_GH
 @pytest.mark.live
@@ -226,7 +280,9 @@ class TestBoardQueryLiveSmoke:
         for q in bqs.LIVE_QUERIES:
             parsed = bqs.run_graphql_with_retry(q)
             problems = bqs.check_board_query_shape(
-                parsed, require_issue_node=q.require_issue_node
+                parsed,
+                require_issue_node=q.require_issue_node,
+                items_path=q.items_path,
             )
             if problems:
                 failures.append(f"[{q.name}]\n  " + "\n  ".join(problems))


### PR DESCRIPTION
Closes #771.

## What

A **structure-only live smoke** for the board GraphQL query — the GitHub-API-boundary analogue of the Snakemake integration rule. The board-query tooling's unit tests validate only against hand-authored fixtures, and a fixture *is* the assumed response, so it can never disagree with itself. A field typo or upstream schema drift passes the hermetic suites green and only surfaces at runtime (concrete trigger: the `subIssuesSummary { total }` add in #768 was provable only by a manual live smoke).

## How

- **`tools/ci/_board_query_smoke.py`** — pure `check_board_query_shape()` (no GraphQL `errors`, response parses to shape, `pageInfo` pagination contract intact, `subIssuesSummary { total }` present + int-typed on Issue nodes; **no** assertion on data values), `run_graphql_with_retry()` (capped exponential backoff), and a `LIVE_QUERIES` registry that imports the **real** `QUERY` from `board_open_items.py` (single source of truth — a field rename flows in automatically; new queries are one registry entry).
- **`tools/ci/test_board_query_smoke.py`** — hermetic unit tests for the checker + retry logic (per-PR, `-m "not live"`) and one `@pytest.mark.live` smoke (nightly).
- **`.github/workflows/recheck-live-smoke.yml`** — generalized to "Live API smoke"; it already globs `tools/ci/ -m live`, so the new suite is auto-collected. **Non-blocking/advisory** (scheduled, not required); promote-to-required is left as a separate, documented decision.

What it catches: schema drift / a renamed-or-removed field / a field typo / auth regression. What it deliberately does NOT: data correctness (which items are where, counts) — that stays the manual live-smoke convention (`feedback_live_integration_smoke.md`).

## Test plan

- [x] Hermetic unit suite green: `pytest tools/ci/ -m "not live"` → 418 passed
- [x] Live smoke passes against real board #9: `pytest tools/ci/ -m live` → 2 passed (recheck + board query)
- [x] Checker's failure modes covered by unit tests (GraphQL errors, missing items/pageInfo/nodes, missing/wrong-typed `subIssuesSummary`, coverage guard, no-value-assertion invariance)
- [x] Workflow YAML validates; nightly job auto-collects the new `-m live` suite

## Acceptance criteria

- [x] A CI check runs the board GraphQL query against the **live** API using the existing `read:project` PAT
- [x] Assertions are **structure-only** — no GraphQL `errors`, response parses to expected shape, required fields present incl. `subIssuesSummary { total }`; **no** data-value assertions
- [x] Covers `board_open_items.py`'s main query; a query registry auto-covers new live queries
- [x] Transient-failure tolerant (retry/backoff) and **initially non-blocking** (advisory); promote-to-required decision documented, not silently defaulted
- [x] Documents what it catches (schema drift / field typo / auth) vs what it does NOT (data correctness)