### PR TITLE
feat(scoring): wire calibrated_immunogenicity_log_odds into the pipeline (post-MHCflurry, pre-TCRdock)

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -142,6 +142,18 @@ mhcflurry:
   hla_c_weight:                    0.5
 
 # -----------------------------------------------------------------
+# Immunogenicity calibrator (Issue #547 / #709)
+# -----------------------------------------------------------------
+# Applies a fitted centered-isotonic calibrator to genotype_presentation_score,
+# emitting calibrated_immunogenicity_log_odds (a PROVISIONAL, SECONDARY ranking
+# signal — presentation_score stays primary) + out_of_calibration_support. The
+# "provisional" status is discharged by Issue #870 (validate SNV→splice transfer
+# on measured labels); splice accuracy stays open at Issue #680. Artifact is a
+# committed serialized calibrator (centered-isotonic knots).
+calibrator:
+  artifact: "research/experiments/issue_547_immunogenicity_calibration/outputs/calibrator_v1.joblib"
+
+# -----------------------------------------------------------------
 # TCRdock structural validation (Step 6 — optional, GPU required)
 # -----------------------------------------------------------------
 # Disabled by default. All settings live in config/gpu_config.yaml.

--- a/research/lab_notebook/developer.md
+++ b/research/lab_notebook/developer.md
@@ -6,6 +6,25 @@ Format and rules unchanged from the unified notebook — see `shared/feedback_la
 
 ---
 
+## 2026-06-30 - Wire calibrated_immunogenicity_log_odds into the pipeline (#709)
+
+### 12:39 UTC - Editor: Developer - calibrator Snakemake wiring (#709 / PR #907)
+
+**What:** Wired the fitted immunogenicity calibrator (`calibrator_v1.joblib`, from the #547/#708 research experiment) into the Snakemake DAG as a new `apply_calibrator` rule, post-MHCflurry / pre-TCRdock. Emits `calibrated_immunogenicity_log_odds` + `out_of_calibration_support` onto the presentation TSV.
+
+**Contract (per Sci's #826 provisional-GO verdict):** secondary signal only — `genotype_presentation_score` stays the primary ranker (rule adds columns, no re-sort); `out_of_calibration_support` flags scores outside the artifact's `[cx[0], cx[-1]]` support (read from the artifact, not hard-coded); provisional status discharged by #870.
+
+**Design calls:**
+- CLI/argparse + `shell:` invocation (not `script:`) — sidesteps the `__future__`/wrapper gotchas, matches the `bed12_to_junctions.py` precedent.
+- Load the joblib knots directly + `np.interp` rather than vendoring the producer class — no research-dir import; the artifact is pure data (no sklearn unpickle), so the rule env needs only joblib+numpy.
+- Repointed **both** `generate_report` (always-run → pulls the rule into the default CPU-only DAG) and `run_tcrdock` (pre-TCRdock positioning). Wiring only into TCRdock would have left the rule dead in the default config (TCRdock off by default) — the key DAG-topology call.
+
+**Verification:** TDD (8 tests red→green); chr22 integration green (5440 rows, 0 NaN, 565/5440 correctly flagged out-of-support at the score extremes; `python` env rebuilt with joblib; report consumed the calibrated TSV); DAG rendered post-MHCflurry/pre-TCRdock; CI 4/4 (incl. `conda-env-solve` on linux-64).
+
+**Bot review (PR #907):** no blocking bugs. Addressed 3 findings (`efe9b06`): non-monotonic-`cx` guard (np.interp is silently wrong on unsorted xp), error-path tests (ValueError/KeyError), dropped a dead `importorskip`. Deferred 2 to coordinated follow-ups: the artifact still lives under `research/experiments/.../outputs/` and is now a mandatory production dep — proper relocation touches the Sci notebook's save path (cross-role) → **#908**; report-HTML surfacing of the new column → **#906**.
+
+---
+
 ## 2026-06-26 - Cloud cost-out + local CPU keep-alive baseline (GCP decommissioned; 2 latent bugs fixed)
 
 ### 21:57 UTC - Editor: Developer - live board GraphQL schema-drift smoke (#771 / PR #890)

--- a/workflow/envs/python.yaml
+++ b/workflow/envs/python.yaml
@@ -9,6 +9,7 @@ dependencies:
   - pandas >=2.0
   - numpy >=1.25
   - scipy >=1.11
+  - joblib >=1.3
   - matplotlib >=3.8
   - seaborn >=0.13
   - requests >=2.31

--- a/workflow/rules/analysis.smk
+++ b/workflow/rules/analysis.smk
@@ -59,8 +59,12 @@ def _generate_report_input(wildcards):
         "filtering_stats": os.path.join(
             _RES, wildcards.patient_id, "reports", "filtering_stats.tsv"
         ),
+        # Calibrated TSV (apply_calibrator) — carries genotype_presentation_score
+        # plus calibrated_immunogenicity_log_odds + out_of_calibration_support.
+        # Consuming it here pulls the calibrator into the default DAG (the report
+        # is a terminal target that always runs, unlike the GPU-gated TCRdock).
         "predictions_tsv": os.path.join(
-            _RES, wildcards.patient_id, "mhcflurry", "presentation.tsv"
+            _RES, wildcards.patient_id, "mhcflurry", "presentation_calibrated.tsv"
         ),
         "contigs_fasta": os.path.join(
             _RES, wildcards.patient_id, "contigs", "contigs.fa"

--- a/workflow/rules/mhc_affinity.smk
+++ b/workflow/rules/mhc_affinity.smk
@@ -80,3 +80,38 @@ rule run_mhcflurry:
         "../envs/python.yaml"
     script:
         "../scripts/run_mhcflurry.py"
+
+
+rule apply_calibrator:
+    """Apply the fitted immunogenicity calibrator to genotype_presentation_score.
+
+    Emits two columns onto the presentation TSV (Issue #709):
+      - calibrated_immunogenicity_log_odds — a PROVISIONAL, SECONDARY ranking
+        signal; genotype_presentation_score stays the primary ranker, so this
+        rule only ADDS columns (no re-sort). Provisional status discharged by
+        Issue #870.
+      - out_of_calibration_support — True outside the calibrator's interpolation
+        support [cx[0], cx[-1]] (read from the artifact, not hard-coded).
+
+    Slots post-MHCflurry / pre-TCRdock. Consumed by generate_report (always, so
+    the calibrator runs in the default CPU-only pipeline) and run_tcrdock (when
+    enabled)."""
+    input:
+        presentation_tsv=rules.run_mhcflurry.output.mhc_presentation_tsv,
+        calibrator=config["calibrator"]["artifact"],
+    output:
+        calibrated_tsv=os.path.join(
+            _RES, "{patient_id}", "mhcflurry", "presentation_calibrated.tsv"
+        ),
+    log:
+        os.path.join(_LOGS, "{patient_id}", "mhc_affinity", "calibrate.log"),
+    conda:
+        "../envs/python.yaml"
+    shell:
+        """
+        python workflow/scripts/apply_calibrator.py \\
+            --input {input.presentation_tsv} \\
+            --calibrator {input.calibrator} \\
+            --output {output.calibrated_tsv} \\
+            > {log} 2>&1
+        """

--- a/workflow/rules/structure.smk
+++ b/workflow/rules/structure.smk
@@ -48,7 +48,10 @@ if _TCRDOCK_ENABLED:
         """
         input:
             unpack(_vdjdb_panel_input),
-            predictions_tsv=rules.run_mhcflurry.output.mhc_presentation_tsv,
+            # Calibrated TSV (apply_calibrator) — positions the calibrator rule
+            # pre-TCRdock in the DAG (Issue #709). TCRdock ranks by the unchanged
+            # genotype_presentation_score; the added columns are carried through.
+            predictions_tsv=rules.apply_calibrator.output.calibrated_tsv,
         output:
             pdb=os.path.join(
                 _RES, "{patient_id}", "tcrdock", "top_candidate.pdb"

--- a/workflow/scripts/apply_calibrator.py
+++ b/workflow/scripts/apply_calibrator.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""apply_calibrator.py — wire the fitted immunogenicity calibrator into the pipeline.
+
+Slots between MHCflurry (`presentation.tsv`, carries `genotype_presentation_score`)
+and TCRdock. Emits two new columns onto the presentation TSV:
+
+  * ``calibrated_immunogenicity_log_odds`` — ``np.interp(score, cx, cy)`` over the
+    serialized centered-isotonic knots in ``calibrator_v1.joblib``. This is a
+    **provisional, SECONDARY** ranking signal: ``genotype_presentation_score`` stays
+    the primary ranker, so this script only ADDS columns and never re-sorts rows.
+    The "provisional" status is discharged by Issue #870 (validate the SNV->splice
+    transfer on measured labels); accuracy for splice stays open at Issue #680.
+  * ``out_of_calibration_support`` (bool) — True where the score is outside the
+    interpolation support ``[cx[0], cx[-1]]`` (both the floor-clip and ceil-clip),
+    where ``np.interp`` returns a flat constant rather than a fitted gradient. NaN
+    scores are also flagged (a missing score cannot be certified in-support).
+
+The support thresholds are read FROM the artifact (``cx[0]`` / ``cx[-1]``), never
+hard-coded, so a future calibrator refit cannot silently desync the flag from the
+curve.
+
+Calibrator fitting + training lives in the research experiment
+(``research/experiments/issue_547_immunogenicity_calibration/``); production only
+applies the serialized knots — no research-dir import, no fitting code here.
+
+Issue #709 (https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/709).
+"""
+
+import argparse
+import logging
+from pathlib import Path
+from typing import Optional, Tuple, Union
+
+import joblib
+import numpy as np
+import pandas as pd
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
+)
+log = logging.getLogger(__name__)
+
+DEFAULT_SCORE_COL = "genotype_presentation_score"
+KNOWN_CALIBRATOR_VERSIONS = {"v1"}
+
+
+def calibrate(scores, cx, cy) -> Tuple[np.ndarray, np.ndarray]:
+    """Apply the centered-isotonic calibrator knots to an array of scores.
+
+    Args:
+        scores: genotype_presentation_score values (array-like; NaN allowed).
+        cx, cy: calibrator knot x/y arrays (``cx`` strictly increasing).
+
+    Returns:
+        ``(log_odds, out_of_support)`` — ``log_odds`` is ``np.interp(scores, cx, cy)``
+        (flat-clipped outside ``[cx[0], cx[-1]]``, NaN preserved); ``out_of_support``
+        is a boolean array, True outside ``[cx[0], cx[-1]]`` or where the score is NaN.
+    """
+    scores = np.asarray(scores, dtype=float)
+    cx = np.asarray(cx, dtype=float)
+    cy = np.asarray(cy, dtype=float)
+
+    log_odds = np.interp(scores, cx, cy)  # np.interp(nan) -> nan; clips to endpoints
+    nan_mask = np.isnan(scores)
+    # np.interp already returns nan for nan input, but be explicit (defensive).
+    log_odds = np.where(nan_mask, np.nan, log_odds)
+    out_of_support = (scores < cx[0]) | (scores > cx[-1]) | nan_mask
+    return log_odds, out_of_support
+
+
+def load_calibrator_knots(calibrator_path: Union[str, Path]) -> Tuple[np.ndarray, np.ndarray]:
+    """Load ``(cx, cy)`` knot arrays from a serialized calibrator artifact.
+
+    The artifact is a joblib dict (``{cx, cy, version, ...}``) produced by
+    ``PresentationCalibrator.save``. Only the knots are needed to apply it. An
+    unrecognised ``version`` warns (the cx/cy format is stable) rather than failing.
+    """
+    d = joblib.load(calibrator_path)
+    version = d.get("version", "unknown")
+    if version not in KNOWN_CALIBRATOR_VERSIONS:
+        log.warning(
+            "calibrator version %r not in known set %s; applying on cx/cy knots anyway",
+            version,
+            sorted(KNOWN_CALIBRATOR_VERSIONS),
+        )
+    cx = np.asarray(d["cx"], dtype=float)
+    cy = np.asarray(d["cy"], dtype=float)
+    if cx.ndim != 1 or cx.shape != cy.shape or cx.size < 2:
+        raise ValueError(
+            f"malformed calibrator knots in {calibrator_path}: "
+            f"cx{cx.shape} cy{cy.shape}"
+        )
+    return cx, cy
+
+
+def apply_calibrator(
+    input_tsv: Union[str, Path],
+    calibrator_path: Union[str, Path],
+    output_tsv: Union[str, Path],
+    score_col: str = DEFAULT_SCORE_COL,
+) -> int:
+    """Read ``input_tsv``, append calibrated columns, write ``output_tsv``.
+
+    Returns the number of rows written. Row order and all original columns are
+    preserved unchanged (secondary-signal guardrail).
+    """
+    input_tsv = Path(input_tsv)
+    output_tsv = Path(output_tsv)
+    output_tsv.parent.mkdir(parents=True, exist_ok=True)
+
+    df = pd.read_csv(input_tsv, sep="\t")
+    if score_col not in df.columns:
+        raise KeyError(
+            f"input TSV {input_tsv} lacks required score column {score_col!r}"
+        )
+
+    cx, cy = load_calibrator_knots(calibrator_path)
+    log_odds, out_of_support = calibrate(df[score_col].to_numpy(dtype=float), cx, cy)
+    df["calibrated_immunogenicity_log_odds"] = log_odds
+    df["out_of_calibration_support"] = out_of_support
+
+    df.to_csv(output_tsv, sep="\t", index=False)
+    n_oos = int(np.asarray(out_of_support).sum())
+    log.info(
+        "Calibrated %d rows (%d out-of-support, support=[%.4f, %.4f]) -> %s",
+        len(df),
+        n_oos,
+        cx[0],
+        cx[-1],
+        output_tsv,
+    )
+    return len(df)
+
+
+def _cli_main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Append calibrated_immunogenicity_log_odds + "
+        "out_of_calibration_support to an MHCflurry presentation TSV."
+    )
+    parser.add_argument("--input", required=True, help="MHCflurry presentation.tsv")
+    parser.add_argument(
+        "--calibrator", required=True, help="serialized calibrator (.joblib)"
+    )
+    parser.add_argument("--output", required=True, help="augmented TSV output")
+    parser.add_argument(
+        "--score-col",
+        default=DEFAULT_SCORE_COL,
+        help=f"score column to calibrate (default: {DEFAULT_SCORE_COL})",
+    )
+    args = parser.parse_args()
+    apply_calibrator(args.input, args.calibrator, args.output, args.score_col)
+
+
+if __name__ == "__main__":
+    _cli_main()

--- a/workflow/scripts/apply_calibrator.py
+++ b/workflow/scripts/apply_calibrator.py
@@ -92,6 +92,14 @@ def load_calibrator_knots(calibrator_path: Union[str, Path]) -> Tuple[np.ndarray
             f"malformed calibrator knots in {calibrator_path}: "
             f"cx{cx.shape} cy{cy.shape}"
         )
+    # np.interp requires strictly-increasing xp; on unsorted xp it returns
+    # silently-wrong values (no error). centered_isotonic() produces sorted cx
+    # today, but guard against a malformed/resorted future artifact.
+    if not np.all(np.diff(cx) > 0):
+        raise ValueError(
+            f"calibrator cx knots must be strictly increasing "
+            f"(np.interp requires sorted xp): {calibrator_path}"
+        )
     return cx, cy
 
 

--- a/workflow/tests/requirements-test.txt
+++ b/workflow/tests/requirements-test.txt
@@ -2,3 +2,4 @@ pytest>=8.0
 pandas>=2.0
 biopython>=1.81
 pyyaml>=6.0
+joblib>=1.3

--- a/workflow/tests/test_apply_calibrator.py
+++ b/workflow/tests/test_apply_calibrator.py
@@ -1,0 +1,124 @@
+"""Tests for apply_calibrator.py — wire the fitted immunogenicity calibrator into
+the pipeline as a post-MHCflurry / pre-TCRdock column.
+
+Issue #709 (https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/709).
+
+The calibrator artifact (`calibrator_v1.joblib`) is a serialized dict of centered-
+isotonic knots {cx, cy}. Applying it is `np.interp(score, cx, cy)` — flat-clipped
+outside the support `[cx[0], cx[-1]]`. Per the Scientist's #826 contract:
+
+  * `calibrated_immunogenicity_log_odds` is a **provisional secondary** signal —
+    `genotype_presentation_score` stays primary, so the rule only ADDS columns and
+    must NOT re-sort rows.
+  * `out_of_calibration_support` flags rows outside `[cx[0], cx[-1]]` (both the
+    floor-clip and ceil-clip), where `np.interp` returns a flat constant.
+"""
+
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from apply_calibrator import apply_calibrator, calibrate
+
+# A tiny synthetic calibrator: knots chosen so np.interp is hand-checkable.
+#   cx = [0.1, 0.5, 0.9]   cy = [-5.0, -1.0, 0.0]
+_CX = [0.1, 0.5, 0.9]
+_CY = [-5.0, -1.0, 0.0]
+
+
+# --------------------------------------------------------------------------- #
+# Pure-logic tests (numpy only) — calibrate(scores, cx, cy)
+# --------------------------------------------------------------------------- #
+def test_calibrate_in_support_interpolates():
+    log_odds, oos = calibrate([0.5, 0.3], _CX, _CY)
+    # 0.5 -> exact knot -1.0; 0.3 -> halfway on [0.1,0.5] segment -> -3.0
+    assert log_odds[0] == pytest.approx(-1.0)
+    assert log_odds[1] == pytest.approx(-3.0)
+    assert not oos[0] and not oos[1]
+
+
+def test_calibrate_floor_clip_is_flat_and_flagged():
+    log_odds, oos = calibrate([0.05], _CX, _CY)
+    assert log_odds[0] == pytest.approx(-5.0)  # flat at cy[0]
+    assert bool(oos[0]) is True
+
+
+def test_calibrate_ceil_clip_is_flat_and_flagged():
+    log_odds, oos = calibrate([0.95], _CX, _CY)
+    assert log_odds[0] == pytest.approx(0.0)  # flat at cy[-1]
+    assert bool(oos[0]) is True
+
+
+def test_calibrate_boundary_is_in_support():
+    # Exactly cx[0]/cx[-1] is IN support (flag is strict < / >).
+    _, oos = calibrate([0.1, 0.9], _CX, _CY)
+    assert not oos[0] and not oos[1]
+
+
+def test_calibrate_nan_score_is_flagged_out_of_support():
+    # NaN presentation score must not silently read as in-support (NaN < x is False).
+    log_odds, oos = calibrate([np.nan], _CX, _CY)
+    assert np.isnan(log_odds[0])
+    assert bool(oos[0]) is True
+
+
+# --------------------------------------------------------------------------- #
+# IO round-trip — apply_calibrator(input_tsv, calibrator_path, output_tsv)
+# --------------------------------------------------------------------------- #
+@pytest.fixture
+def synthetic_calibrator(tmp_path):
+    joblib = pytest.importorskip("joblib")
+    path = tmp_path / "calibrator_v1.joblib"
+    joblib.dump({"cx": np.array(_CX), "cy": np.array(_CY), "version": "v1"}, path)
+    return path
+
+
+@pytest.fixture
+def presentation_tsv(tmp_path):
+    df = pd.DataFrame(
+        {
+            "peptide": ["AAA", "BBB", "CCC"],
+            "genotype_presentation_score": [0.5, 0.05, 0.95],
+            "presentation_class": ["weak", "non", "strong"],
+        }
+    )
+    path = tmp_path / "presentation.tsv"
+    df.to_csv(path, sep="\t", index=False)
+    return path
+
+
+def test_apply_calibrator_adds_two_columns(synthetic_calibrator, presentation_tsv, tmp_path):
+    out = tmp_path / "presentation_calibrated.tsv"
+    apply_calibrator(presentation_tsv, synthetic_calibrator, out)
+    res = pd.read_csv(out, sep="\t")
+    assert "calibrated_immunogenicity_log_odds" in res.columns
+    assert "out_of_calibration_support" in res.columns
+    # values: 0.5->-1.0 (in), 0.05->-5.0 (floor, oos), 0.95->0.0 (ceil, oos)
+    assert res["calibrated_immunogenicity_log_odds"].tolist() == pytest.approx([-1.0, -5.0, 0.0])
+    assert res["out_of_calibration_support"].tolist() == [False, True, True]
+
+
+def test_apply_calibrator_preserves_original_columns_and_order(
+    synthetic_calibrator, presentation_tsv, tmp_path
+):
+    # Secondary-signal guardrail: original columns + ROW ORDER unchanged (no re-rank).
+    out = tmp_path / "presentation_calibrated.tsv"
+    apply_calibrator(presentation_tsv, synthetic_calibrator, out)
+    res = pd.read_csv(out, sep="\t")
+    assert res["peptide"].tolist() == ["AAA", "BBB", "CCC"]
+    assert res["presentation_class"].tolist() == ["weak", "non", "strong"]
+
+
+def test_apply_calibrator_empty_input_writes_header(synthetic_calibrator, tmp_path):
+    empty = tmp_path / "empty.tsv"
+    pd.DataFrame({"genotype_presentation_score": pd.Series([], dtype=float)}).to_csv(
+        empty, sep="\t", index=False
+    )
+    out = tmp_path / "out.tsv"
+    apply_calibrator(empty, synthetic_calibrator, out)
+    res = pd.read_csv(out, sep="\t")
+    assert "calibrated_immunogenicity_log_odds" in res.columns
+    assert "out_of_calibration_support" in res.columns
+    assert len(res) == 0

--- a/workflow/tests/test_apply_calibrator.py
+++ b/workflow/tests/test_apply_calibrator.py
@@ -16,11 +16,12 @@ outside the support `[cx[0], cx[-1]]`. Per the Scientist's #826 contract:
 
 from pathlib import Path
 
+import joblib
 import numpy as np
 import pandas as pd
 import pytest
 
-from apply_calibrator import apply_calibrator, calibrate
+from apply_calibrator import apply_calibrator, calibrate, load_calibrator_knots
 
 # A tiny synthetic calibrator: knots chosen so np.interp is hand-checkable.
 #   cx = [0.1, 0.5, 0.9]   cy = [-5.0, -1.0, 0.0]
@@ -69,7 +70,6 @@ def test_calibrate_nan_score_is_flagged_out_of_support():
 # --------------------------------------------------------------------------- #
 @pytest.fixture
 def synthetic_calibrator(tmp_path):
-    joblib = pytest.importorskip("joblib")
     path = tmp_path / "calibrator_v1.joblib"
     joblib.dump({"cx": np.array(_CX), "cy": np.array(_CY), "version": "v1"}, path)
     return path
@@ -122,3 +122,30 @@ def test_apply_calibrator_empty_input_writes_header(synthetic_calibrator, tmp_pa
     assert "calibrated_immunogenicity_log_odds" in res.columns
     assert "out_of_calibration_support" in res.columns
     assert len(res) == 0
+
+
+# --------------------------------------------------------------------------- #
+# Fail-loud guards
+# --------------------------------------------------------------------------- #
+def test_load_calibrator_knots_rejects_shape_mismatch(tmp_path):
+    bad = tmp_path / "bad.joblib"
+    joblib.dump({"cx": np.array([0.1, 0.5]), "cy": np.array([-5.0]), "version": "v1"}, bad)
+    with pytest.raises(ValueError):
+        load_calibrator_knots(bad)
+
+
+def test_load_calibrator_knots_rejects_non_monotonic_cx(tmp_path):
+    # np.interp silently returns wrong values on unsorted xp — guard must reject it.
+    bad = tmp_path / "nonmono.joblib"
+    joblib.dump(
+        {"cx": np.array([0.5, 0.1, 0.9]), "cy": np.array(_CY), "version": "v1"}, bad
+    )
+    with pytest.raises(ValueError):
+        load_calibrator_knots(bad)
+
+
+def test_apply_calibrator_missing_score_col_raises(synthetic_calibrator, tmp_path):
+    bad_tsv = tmp_path / "noscore.tsv"
+    pd.DataFrame({"peptide": ["AAA"]}).to_csv(bad_tsv, sep="\t", index=False)
+    with pytest.raises(KeyError):
+        apply_calibrator(bad_tsv, synthetic_calibrator, tmp_path / "out.tsv")


### PR DESCRIPTION
**Created by:** Developer

Wires the fitted immunogenicity calibrator into the Snakemake DAG as a post-MHCflurry / pre-TCRdock rule.

Closes #709.

## What changed

- New `apply_calibrator` rule (`mhc_affinity.smk`) — applies the `calibrator_v1.joblib` centered-isotonic knots via `np.interp`; support thresholds read **from the artifact**, not hard-coded.
- New `workflow/scripts/apply_calibrator.py` (CLI/argparse, NaN-safe) + 8 unit tests.
- `generate_report` + `run_tcrdock` repointed to the calibrated TSV — the report path pulls the rule into the **default CPU-only DAG** (TCRdock is GPU-gated/off by default); the TCRdock input satisfies the pre-TCRdock positioning AC.
- `calibrator.artifact` config key; `joblib` added to `python.yaml` + `requirements-test.txt`.

## Contract (per the Scientist's [#826 verdict](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/709#issuecomment-4842862950))

- `calibrated_immunogenicity_log_odds` is a **provisional, secondary** ranking signal — `genotype_presentation_score` stays primary, so the rule only ADDS columns (no re-sort).
- `out_of_calibration_support` flags scores outside `[cx[0], cx[-1]]` (and NaN). Provisional status discharged by [Issue #870](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/870).

## Test plan

- [x] 8 new unit tests (`test_apply_calibrator.py`: in/floor/ceil/boundary/NaN + IO round-trip + row-order guardrail) + full suite green (609 passed, 6 skipped)
- [x] chr22 integration run locally (new-rule policy) — `python` env rebuilt with `joblib`, `apply_calibrator` executed on real MHCflurry output (5440 rows, 0 NaN, 565 out-of-support correctly flagged at the score extremes), repointed `generate_report` consumed the calibrated TSV cleanly
- [x] DAG rendered (`scripts/visualize_dag.sh`) — `apply_calibrator` positioned post-MHCflurry / pre-TCRdock
- [x] Developer lab-notebook entry (added post-review, pre-merge)

## Follow-up

- Surface `calibrated_immunogenicity_log_odds` in the report HTML — tracked in [Issue #906](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/906) (out of this PR's wiring scope; report currently *reads* the calibrated TSV but does not yet display the column).

