### PR TITLE
feat(roles): exempt memory_manager from the lab-notebook check (#748)

### DIFF
--- a/research/lab_notebook/developer.md
+++ b/research/lab_notebook/developer.md
@@ -8,6 +8,16 @@ Format and rules unchanged from the unified notebook — see `shared/feedback_la
 
 ## 2026-06-30 - Wire calibrated_immunogenicity_log_odds into the pipeline (#709)
 
+### 14:38 UTC - Editor: Developer - exempt memory_manager from the lab-notebook gate (#748 / PR #909)
+
+**What:** Taught the closure-ritual lab-notebook check the documented Memory Manager exemption. `collect_notebook_gaps` (`closure_audit.py`) now strips a `_NOTEBOOK_EXEMPT_ROLES = {"memory_manager"}` set from each Issue's role set before the gap check, so a pure `role:memory_manager` PR no longer trips "lab notebook file missing".
+
+**Design call:** strip the MM *role*, not skip the *PR* — a mixed dev+MM Issue still requires the developer entry. Single chokepoint (`collect_notebook_gaps`) covers the pre-merge gate, the bash gate, and the post-merge bot in one place; the bot review confirmed the redundant `_load_notebook("memory_manager")` in the callers is harmless and that centralizing here is the better call.
+
+**Best-practice check (before building):** web-cross-checked the exemption itself — the research audit-trail norm requires *a* trail (MM has it via the personas-repo git log), and the ADR practice of co-locating records with the work argues *against* a project-repo MM notebook. Verdict: best-practice-consistent, so enforcing it is sound (not hardening a questionable rule). One refinement parked as an MM heads-up: ensure MM *synthesis*-level decisions land in a narrative home (ADR/episode), since flat commit subjects under-capture longitudinal synthesis.
+
+**Verification:** TDD (3 chokepoint tests + 2 e2e gate tests, red→green); full `tools/ci` suite 428 green. Bot review LGTM, no blocking findings; e2e wiring tests added per its optional suggestion (`0805e42`).
+
 ### 12:39 UTC - Editor: Developer - calibrator Snakemake wiring (#709 / PR #907)
 
 **What:** Wired the fitted immunogenicity calibrator (`calibrator_v1.joblib`, from the #547/#708 research experiment) into the Snakemake DAG as a new `apply_calibrator` rule, post-MHCflurry / pre-TCRdock. Emits `calibrated_immunogenicity_log_odds` + `out_of_calibration_support` onto the presentation TSV.

--- a/tools/ci/closure_audit.py
+++ b/tools/ci/closure_audit.py
@@ -45,6 +45,13 @@ _UNTICKED = re.compile(r"^\s*-\s*\[\s\]\s", re.MULTILINE)
 _TICKED = re.compile(r"^\s*-\s*\[[xX]\]\s", re.MULTILINE)
 _EXEMPT_FILES = {"research/glossary.md"}
 _EXEMPT_PREFIX = ("research/lab_notebook/",)
+# Roles that keep no project-repo lab notebook and so are skipped by the
+# notebook check (see #748). The Memory Manager works in the personas (memory)
+# repo, not a project-repo clone — its record is the personas-repo git log
+# (`shared/feedback_lab_notebook.md` MM-exemption clause); there is no
+# `research/lab_notebook/memory_manager.md`. Stripped per-role, so a mixed
+# (e.g. developer + memory_manager) Issue still requires the other role's entry.
+_NOTEBOOK_EXEMPT_ROLES = {"memory_manager"}
 # Routine-ship lab-notebook opt-out (see #555): a PR author may skip the
 # notebook check by placing this marker in the PR body. Honors the routine
 # single-PR-closes-single-Issue skip that #483 declared optional — the bot must
@@ -324,6 +331,10 @@ def collect_notebook_gaps(
     gaps: list[tuple[str, str]] = []
     seen: set[frozenset[str]] = set()
     for roles in role_sets_per_issue:
+        # Drop notebook-exempt roles (e.g. memory_manager, #748) before the
+        # check; a pure-exempt Issue collapses to an empty set and is skipped,
+        # while a mixed Issue still enforces its non-exempt roles' entries.
+        roles = roles - _NOTEBOOK_EXEMPT_ROLES
         if not roles:
             continue
         key = frozenset(roles)

--- a/tools/ci/test_closure_audit.py
+++ b/tools/ci/test_closure_audit.py
@@ -386,6 +386,36 @@ def test_collect_notebook_gaps_skips_empty_role_sets():
     ) == []
 
 
+# --- #748: Memory Manager role is lab-notebook-exempt (its record is the
+# personas-repo git log, not research/lab_notebook/) ---
+
+
+def test_collect_notebook_gaps_exempts_pure_memory_manager():
+    """A pure role:memory_manager Issue needs no project-repo notebook entry."""
+    assert ca.collect_notebook_gaps(
+        [{"memory_manager"}], "2026-06-30", 748, {}
+    ) == []
+
+
+def test_collect_notebook_gaps_mixed_mm_still_requires_other_role():
+    """dev+MM Issue with no dev entry → still a developer gap. The exemption
+    strips only the MM role; it does not exempt the whole Issue."""
+    gaps = ca.collect_notebook_gaps(
+        [{"developer", "memory_manager"}], "2026-06-30", 748, {"developer": None}
+    )
+    assert len(gaps) == 1
+    assert "developer" in gaps[0][0]
+    assert "memory_manager" not in gaps[0][0]
+
+
+def test_collect_notebook_gaps_mixed_mm_satisfied_by_other_role_entry():
+    """dev+MM Issue with a developer entry → no gap (MM contributes nothing)."""
+    dev_text = "## 2026-06-30\n\n### 12:00 UTC — Editor: Developer\nClosed #748.\n"
+    assert ca.collect_notebook_gaps(
+        [{"developer", "memory_manager"}], "2026-06-30", 748, {"developer": dev_text}
+    ) == []
+
+
 # --- #743: not_planned (superseded) closes skip only the lab-notebook check ---
 
 

--- a/tools/ci/test_lab_notebook_gate.py
+++ b/tools/ci/test_lab_notebook_gate.py
@@ -70,6 +70,24 @@ def test_missing_notebook_file_returns_gap(monkeypatch):
     assert ca.audit_pr_pre_merge(99, DATE)
 
 
+def test_pure_memory_manager_pr_returns_clean(monkeypatch):
+    # #748: a pure role:memory_manager Issue needs no project-repo notebook entry
+    # (MM's record is the personas-repo git log). End-to-end through the gate.
+    _fake_io(monkeypatch, _pr(), {42: _issue(roles=("memory_manager",))}, {})
+    assert ca.audit_pr_pre_merge(99, DATE) == []
+
+
+def test_mixed_memory_manager_pr_still_requires_other_role(monkeypatch):
+    # #748: dev+MM Issue with no developer entry still gaps (strip-role, not skip-PR).
+    _fake_io(
+        monkeypatch,
+        _pr(),
+        {42: _issue(roles=("developer", "memory_manager"))},
+        {"developer": None},
+    )
+    assert ca.audit_pr_pre_merge(99, DATE)
+
+
 def test_file_exempt_returns_clean(monkeypatch):
     # Diff is entirely the lab-notebook itself → no entry required for itself.
     pr = _pr(files=("research/lab_notebook/scientist.md",))


### PR DESCRIPTION
**Created by:** Developer

Teaches the closure-ritual lab-notebook check the documented Memory Manager exemption: a pure `role:memory_manager` PR no longer trips "lab notebook file missing".

Closes #748.

## What changed

- `collect_notebook_gaps` strips a new `_NOTEBOOK_EXEMPT_ROLES = {"memory_manager"}` from each Issue's role set before the gap check.
- Pure `{memory_manager}` → empty set → skipped (no gap). Mixed `{developer, memory_manager}` → `{developer}` → the other role's entry is still required.
- **Single chokepoint** → covers the pre-merge gate (`audit_pr_pre_merge`), the bash lab-notebook gate, and the post-merge bot.

## Why strip-role (not skip-PR)

A mixed dev+MM Issue must still demand the developer entry; only the MM role is notebook-exempt — its record is the personas-repo git log, per `shared/feedback_lab_notebook.md`. The exemption was also web-cross-checked against best practice (audit-trail norm + ADR co-location) before building it — it's consistent, not a rubber-stamp.

## Test plan

- [x] 3 new tests (pure-MM exempt; mixed still requires other role; mixed satisfied-by-other regression guard) — red→green
- [x] Full `closure_audit` suite (73) + full `tools/ci` suite (426) pass — no regressions
- [x] Developer lab-notebook entry (added post-review, pre-merge)

