### PR TITLE
chore(pm): gitignore .codex/ local Codex CLI experiment config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -328,6 +328,11 @@ CLAUDE.local.md
 .agents/last_session_marker.json
 .claude/last_session_marker.json
 
+# Codex CLI - per-user local harness config (local experiment; not team tooling yet).
+# Canonical hooks live in .agents/hooks/; promote to a committed config only if Codex
+# graduates to a supported harness.
+.codex/
+
 # Remote-tabix index downloaded by the GTEx pan-tissue builder (Issue #211); the builder
 # now stages it in a temp dir, but ignore the bare name as belt-and-suspenders.
 *.bgz.tbi


### PR DESCRIPTION
## What

Ignore `.codex/` - a per-user local Codex CLI harness config directory (hooks.json + copied hook scripts) created while trying Codex locally. It was showing up as untracked noise in `git status`.

Placed next to the existing `.claude`/`.agents` local-state ignores, since it's the same class of thing (harness config that isn't shared team tooling). The canonical hooks remain single-sourced in `.agents/hooks/`; if Codex graduates to a supported harness we'd promote a slimmed, Codex-schema-correct config into a committed location then.

## Test plan

- [x] `git status` no longer lists `.codex/` (confirmed: ignored).
- [x] No code/pipeline surface touched.