### PR TITLE
process(pm): Radar-style status-ring funnel in landscape doc (#553, partial)

### DIFF
--- a/research/lab_notebook/pm.md
+++ b/research/lab_notebook/pm.md
@@ -8,6 +8,20 @@ Format and rules unchanged from the unified notebook — see `shared/feedback_la
 
 ## 2026-07-02
 
+### 15:22 UTC - Editor: PM
+
+#### [PR #939](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/939) - Radar-style status-ring funnel for the landscape doc ([#553](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/553))
+
+**Trigger.** Pulled [#553](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/553) (Backlog -> In progress) as the best-next PM item: active-arc (`board-governance`), DoR-ready, unblocked, and high context-continuity with the same-session `multi_agent_landscape.md` governance cross-link.
+
+**What shipped (this PR, project repo).** Retrofitted `research/multi_agent_landscape.md` into a staging -> commit funnel using ThoughtWorks Technology Radar ring vocabulary (calendar cadence dropped): a header "Entry status: the funnel" section (ring enum + borrow-rings-drop-cadence + DoR convention), all 9 entries ringed, DoR/Next lines on the active ones, and a Maintenance funnel-convention note + board-hygiene grep step. Ring assignments: Copilot=`Assess`, Pattern Language=`Trial` (#353), Fugu/Conductor=`Hold`, Managed Agents/Symphony/Trends/Mason/AddyOsmani=`Reference`, none `Rejected`.
+
+**Design deviation, confirmed.** Added a **6th `Reference` ring** beyond #553's 5-ring design - about half the entries are pattern-confirmation/reinforcement (evaluated, no product adopted, but the idea confirmed our approach or lent vocabulary), which none of `Assess/Trial/Adopt/Hold/Rejected` captured honestly. The distinction: `Rejected` = walked away, not useful; `Reference` = walked away from the product, kept the idea. Flagged the deviation before implementing; **PM confirmed keeping the 6th ring**.
+
+**Companion memory ACs (4/5/8) done, shipping via MM drain.** Edited in the personas working tree: board-hygiene funnel-grep step, PM landscape-hook ring reference, same-hook-only bundling clause. AC7 (uncapped comment-on-tracked-Issue route) was **already present** in the shared file - verified, no edit (avoided duplication). These ship via the standard memory-drain flow, not a cross-repo PR (#882's convention is not live yet).
+
+**#553 stays open** until the memory edits drain; this PR delivers the project-repo half and does not close it. Graduation-to-cross-role trigger (its Future section) is gated on the pilot running one full `Assess -> Trial -> Adopt/Rejected` cycle, which has not happened - #553 is its own open carrier for it.
+
 ### 14:06 UTC - Editor: PM
 
 #### [PR #936](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/936) - agent-team governance deep-research report (2026-07)

--- a/research/multi_agent_landscape.md
+++ b/research/multi_agent_landscape.md
@@ -30,9 +30,9 @@ Entries re-ring on a *named event* - a promotion trigger firing, or an eval Issu
 The same edit that flips the ring opens the board #9 eval Issue (role label + priority rationale + per-tool Quarto deck, per the eval-Issue convention), cross-linked both ways.
 Terminal flips (`Adopt` / `Hold` / `Reference` / `Rejected`) are recorded back here when the eval Issue closes, via the close-time outcome-routing ritual.
 
-> **Ring-set note (2026-07-02, [#553](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/553)):** `Reference` is a 6th ring added during the retrofit, beyond #553's original 5-ring design.
+> **Ring-set note (2026-07-02, [#553](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/553)):** `Reference` is a 6th ring added during the retrofit, beyond #553's original 5-ring design, and **confirmed by PM**.
 > About half the existing entries are "pattern-confirmation / reinforcement" - evaluated, no product adopted, but the idea confirmed our approach or lent vocabulary - which none of `Assess/Trial/Adopt/Hold/Rejected` captured honestly (not watched, not to-avoid, and not "Rejected" when we endorse the idea).
-> Pending PM confirmation; fold these into `Rejected` if the 6th ring is unwanted.
+> The distinction it draws: `Rejected` = walked away, not useful; `Reference` = walked away from the product, kept the idea.
 
 ---
 
@@ -151,7 +151,7 @@ Update triggers:
 - New Issue concretely borrows from or extends a framework listed here → backfill the framework's rationale block with the Issue link.
 - Framework deprecated or pivoted → don't delete the entry; update the rationale with the deprecation note (the doc is a journal of *which* options we considered, not just current options).
 
-Last sweep: 2026-07-02 (adopted the Technology Radar-style `status:` ring funnel [#553](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/553): retrofitted all entries with a ring + per-entry DoR on active ones, added the funnel convention + board-hygiene grep step; introduced a 6th `Reference` ring pending PM confirmation).
+Last sweep: 2026-07-02 (adopted the Technology Radar-style `status:` ring funnel [#553](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/553): retrofitted all entries with a ring + per-entry DoR on active ones, added the funnel convention + board-hygiene grep step; introduced a 6th `Reference` ring, confirmed by PM).
 Prior: 2026-07-01 (companion governance-evidence report [`agent_team_governance_research_2026-07.md`](agent_team_governance_research_2026-07.md) cross-linked; adds MAST failure taxonomy + review-debt/review-column-WIP finding, neither previously tracked here).
 Prior: 2026-05-21 (Microsoft Conductor backfilled to Frameworks as counter-position to LLM-as-orchestrator).
 Prior: 2026-05-15 (GitHub Copilot desktop app backfilled to Frameworks as pattern-confirmation).

--- a/research/multi_agent_landscape.md
+++ b/research/multi_agent_landscape.md
@@ -10,36 +10,68 @@ For our position relative to this landscape — why PM/Sci/Dev, why "multi-role"
 
 ---
 
+## Entry status: the funnel
+
+Every entry carries a **`status:`** ring: a maturity signal borrowed from the ThoughtWorks Technology Radar, adapted so this curated landscape doubles as a staging -> commit funnel.
+
+| Ring | Meaning | Terminal? |
+|------|---------|-----------|
+| `Assess` | Watching ("too early" / "Observe"); carries a one-line **DoR** naming the event that would promote it to `Trial`. | no |
+| `Trial` | Eval candidate; has (or gets, on promotion) an open board #9 eval Issue. | no (-> `#N`) |
+| `Adopt` | Adopted into the pipeline or our practice. | yes (-> `#N`) |
+| `Hold` | Counter-position: evaluated, actively avoid, never start. | yes |
+| `Reference` | Evaluated; no product adoption, but the idea or pattern informed our thinking or confirmed our approach. | yes |
+| `Rejected` | Evaluated a plausible candidate and walked away; records *why*. | yes |
+
+We borrow the Radar's ring taxonomy but drop its calendar cadence.
+Entries re-ring on a *named event* - a promotion trigger firing, or an eval Issue closing - never on a bi-annual Radar date.
+
+**Promotion is the `Assess -> Trial` flip.**
+The same edit that flips the ring opens the board #9 eval Issue (role label + priority rationale + per-tool Quarto deck, per the eval-Issue convention), cross-linked both ways.
+Terminal flips (`Adopt` / `Hold` / `Reference` / `Rejected`) are recorded back here when the eval Issue closes, via the close-time outcome-routing ritual.
+
+> **Ring-set note (2026-07-02, [#553](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/553)):** `Reference` is a 6th ring added during the retrofit, beyond #553's original 5-ring design.
+> About half the existing entries are "pattern-confirmation / reinforcement" - evaluated, no product adopted, but the idea confirmed our approach or lent vocabulary - which none of `Assess/Trial/Adopt/Hold/Rejected` captured honestly (not watched, not to-avoid, and not "Rejected" when we endorse the idea).
+> Pending PM confirmation; fold these into `Rejected` if the 6th ring is unwanted.
+
+---
+
 ## Frameworks
 
 Concrete products / tooling that could plausibly displace, augment, or be borrowed from for our PM/Sci/Dev workflow.
 
 ### Anthropic Managed Agents — Multiagent Orchestration + Dreaming + Outcomes
 
+- **status:** Reference
 - **Source:** [Anthropic blog, 2026-05-06](https://claude.com/blog/new-in-claude-managed-agents); [9to5Mac coverage, 2026-05-07](https://9to5mac.com/2026/05/07/anthropic-updates-claude-managed-agents-with-three-new-features/).
 - **Summary:** Three features. **Multiagent Orchestration:** a lead agent delegates to autonomous specialist agents on a shared filesystem; specialists run in parallel, lead checks back mid-workflow, persistent events so every agent remembers what it has done. **Dreaming:** scheduled review of past sessions to extract patterns and curate memory across agents — auto-update by default, optional human review gate. **Outcomes:** users write success rubrics; agents iterate autonomously toward them, with an independent grader that "isn't influenced by the agent's reasoning"; webhook on completion.
 - **Our rationale:** **Observe — per-feature mapping.** **Multiagent Orchestration** maps directly onto the autonomous pattern that [multi-role, not multi-agent](#our-position) explicitly does *not* claim — in our setup the human opens the next session and there is no agent-to-agent trigger. The model vendor itself using "multi-agent" in this autonomous sense validates the framing distinction. **Dreaming** is the closest production analog to our `/memory` memory-rehydration pattern, but inverted: their default is auto-update with optional review; ours is always human-initiated and reviewed at write time. **Outcomes** has no direct analog in our setup (we don't yet codify success rubrics for autonomous iteration; closest precursor is the GitHub-Actions `Claude Code` review trigger, which has a human-set criterion but no agent-driven re-iteration). Closed [Issue #305](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/305) with landscape-tightening (the concrete contrast belongs here; the framing rule in `shared/feedback_multi_role_not_multi_agent.md` stays unchanged).
 
 ### OpenAI Symphony
 
+- **status:** Reference
 - **Source:** Reported late April 2026 (no public docs yet — pattern-only)
 - **Summary:** Enterprise multi-agent orchestration; uses PM-style project boards as the control plane for coding agents.
 - **Our rationale:** **Pattern-confirmation, no action.** The "boards-as-control-plane" framing matches what we do — GitHub Projects v2 IS our PM/Sci/Dev coordination surface (Status / Priority / Size / Target Date fields drive triage). Product itself targets corporate teams (not solo/research), so no adoption path. Confirms the convergent pattern.
 
 ### Sakana Fugu
 
+- **status:** Hold (roster counter-position; the 3 borrowed secondary mechanics are tracked separately as Adopt at #324 / #325 / #326)
 - **Source:** [Sakana 2026 (beta)](https://sakana.ai/fugu-beta/)
 - **Summary:** Multi-agent orchestration as a foundation model — dynamically assembles agent teams from a pool, no fixed roles.
 - **Our rationale:** **Explicit counter-position.** Opposite of our fixed PM/Sci/Dev split — per [Role decomposition is domain-bespoke](#our-position), our roster is intentionally bespoke to bioinformatics research (Scientist exists because literature/biology reasoning has no analog in pure coding). Fugu optimises for generality; we optimise for domain fit. Still borrowed three secondary mechanics: [Issue #324](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/324) (model routing per task type), [Issue #325](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/325) (post-merge critic), [Issue #326](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/326) (memory consolidation).
 
 ### GitHub Copilot desktop app
 
+- **status:** Assess
+- **DoR (-> Trial):** GitHub ships GA with an *agent-callable* surface (API / CLI), not just the desktop UI (per [UI features ≠ agent capabilities](#our-position)).
 - **Source:** [GitHub changelog 2026-05-14](https://github.blog/changelog/2026-05-14-github-copilot-app-is-now-available-in-technical-preview/) (technical preview)
 - **Summary:** GitHub-native desktop client to start agentic dev sessions from an issue/PR/prompt; isolates work in-flight, supports mid-session steering, lands via PR review.
 - **Our rationale:** **Pattern-confirmation, no action.** Same parallel-session UI shape as Claude Code Agent View (news_log 2026-05-13) and convergent with our PM/Sci/Dev orchestration — but GitHub-anchored rather than terminal/IDE-anchored. Fits the "boards-as-control-plane" framing (cf. [OpenAI Symphony](#openai-symphony)). Tech preview only; too early for adoption decision but worth watching for GA + agent-callable surface (per [UI features ≠ agent capabilities](#our-position)). No action.
 
 ### Microsoft Conductor
 
+- **status:** Hold
 - **Source:** [Microsoft Open Source blog, 2026-05-14](https://opensource.microsoft.com/blog/2026/05/14/conductor-deterministic-orchestration-for-multi-agent-ai-workflows/); [microsoft/conductor](https://github.com/microsoft/conductor) (MIT, Python 3.12+)
 - **Summary:** YAML-first CLI for multi-agent workflows. Routing between agents is **deterministic** — Jinja2 templates + expression evaluation handle conditions and branching; the orchestration layer itself spends zero LLM tokens. Static parallel groups (`fail_fast` / `continue_on_error` / `all_or_nothing`); dynamic for-each over variable-length arrays with batched concurrency. Backends: GitHub Copilot SDK or Anthropic Claude.
 - **Our rationale:** **Explicit counter-position to LLM-as-orchestrator, partial echo of our shape.** Most multi-agent frameworks make the orchestrator itself an LLM that plans which agents to call — that pays token cost, latency, and unpredictability on every routing decision. Conductor argues: when workflow structure is *known*, declarative YAML + deterministic routing wins (diffable like CI/CD, zero token spend on routing). Our equivalent of "the routing layer" is the human + the GitHub Projects board + standup file — also zero LLM tokens spent on routing (the routing artifacts live in non-LLM substrates), also declarative-ish (Status / Priority / Size / Target Date fields are the YAML-analog). Difference: ours stays human-discretionary at every hop (PM judges triage, doesn't follow a fixed graph), Conductor's is fixed-at-definition-time. Useful as a thought-experiment: *which subset of PM's morning routine is workflow-known-enough to encode in a Conductor-style YAML?* Likely candidates: closure audit (mechanical), milestone health check (already script-driven). Unlikely candidates: triage scoping, news interpretation. No adoption action — too early, and Python-3.12+ pin doesn't fit our 3.11 baseline — but the deterministic-vs-LLM-orchestrator axis is now a first-class evaluation criterion when surveying future frameworks (per the user's *deterministic-before-semantic* preference, established 2026-05-21).
@@ -52,24 +84,29 @@ Essays and reports that shape how the field talks about itself. Distinct from fr
 
 ### Anthropic 2026 Agentic Coding Trends Report
 
+- **status:** Reference
 - **Source:** Anthropic 2026 (PDF; tracked via [Issue #235](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/235))
 - **Summary:** Industry data on multi-agent coding workflows. Proposes canonical 4-specialist split: Architecture & Design / Implementation & Coding / Testing & Validation / Review & Docs.
 - **Our rationale:** **Pattern borrow + roster reject.** Convergent pattern (one orchestrator + multiple specialists, each with own context) applies. Roster doesn't — that report is scoped to *coding*; we're scoped to bioinformatics research, where literature integration and biological interpretation have no analog in pure coding (so Scientist instead of Designer). Primary source for both [Role decomposition is domain-bespoke](#our-position) and [multi-role, not multi-agent](#our-position). Skim + 5 PM-practices cross-checks in [Issue #235](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/235).
 
 ### Mason — "Coherence Through Orchestration, Not Autonomy"
 
+- **status:** Reference
 - **Source:** [Mike Mason, Jan 2026](https://mikemason.ca/writing/ai-coding-agents-jan-2026/)
 - **Summary:** Argues "multi-agent" coding works because of orchestration discipline, not agent autonomy.
 - **Our rationale:** **Direct reinforcement.** Primary external source for [multi-role, not multi-agent](#our-position) — we don't claim autonomy, we claim disciplined orchestration. The user is the message bus; agents communicate via human-readable artifacts (standup, sub-issues). No action — already internalised.
 
 ### AddyOsmani — "The Code Agent Orchestra"
 
+- **status:** Reference
 - **Source:** [AddyOsmani blog, 2026-05-12](https://addyosmani.com/blog/code-agent-orchestra/)
 - **Summary:** Essay on what makes multi-agent coding work — section roles, conductor metaphor.
 - **Our rationale:** **Convergent vocabulary.** Maps cleanly onto our 3-layer orchestration: human (conductor) → PM (section leader) → Sci/Dev (instrumentalists). No new action items — this landscape doc itself ([Issue #337](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/337)) is the response to the essay.
 
 ### digitalapplied — "Pattern Language 2026"
 
+- **status:** Trial
+- **Next (-> Adopt / Rejected):** [Issue #353](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/353) decides whether to re-describe our shape in producer / consumer / coordinator / critic / judge terms.
 - **Source:** [digitalapplied, 2026-05](https://www.digitalapplied.com/blog/multi-agent-orchestration-patterns-producer-consumer)
 - **Summary:** Formal taxonomy reducing every reliable multi-agent system to 5 archetypes — producer (decomposes ambiguity into work items), consumer (executes them), coordinator (routes + bounded fan-out), critic (suggestions, no gate authority), judge (binary go/no-go). 12 composition rules (acyclicity, idempotent consumers, bounded fan-out, etc.); 8 predictable failure modes (cycle formation, critic-judge deadlock, coordinator overload, silent drift, others). Maps cleanly to LangGraph, CrewAI, OpenAI Agents SDK, Claude Agent SDK without changing the underlying shape.
 - **Our rationale:** **Vocabulary candidate — open question.** Distinct from AddyOsmani above (essay vs. taxonomy) and from the Trends Report (coding-scoped vs. domain-agnostic). Possible re-description of our shape: `human = meta-coordinator → PM = coordinator + judge → Scientist = producer + critic + Developer = consumer + producer (infra) + critic`. The 8-failure-mode list doubles as a portfolio audit lens (have we hit critic-judge deadlock? silent drift?). Decision tracked via [Issue #353](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/353) (PM vocabulary adoption).
@@ -101,14 +138,21 @@ The standup file (`pm/shared/team_standup.md`), the GitHub Projects v2 board, an
 
 ## Maintenance
 
-PM-owned. Update triggers:
+PM-owned.
 
-- Morning-briefing item tagged `methodology-signal` surfaces → PM decides whether to add an entry here (or whether the item is chat-only and not landscape-doc-worthy).
+**Funnel convention.** Every entry carries a `status:` ring (see [Entry status: the funnel](#entry-status-the-funnel)); active entries (`Assess` / `Trial`) carry a one-line DoR naming the event that promotes them.
+The board-hygiene sweep greps for active entries whose promotion trigger has fired or whose tracked Issue went stale (most sweeps answer "nothing ready").
+
+Update triggers:
+
+- Morning-briefing item tagged `methodology-signal` surfaces → PM decides whether to add an entry here (ring it `Assess` with a DoR, or a terminal ring - `Reference` / `Hold` / `Rejected` - if no promotion path), or whether the item is chat-only and not landscape-doc-worthy.
+- Board-hygiene sweep: `grep -nE "status: (Assess|Trial)" research/multi_agent_landscape.md` → for each active entry, has its DoR trigger fired (promote to `Trial` + open the eval Issue in the same edit), or has its tracked Issue gone stale?
 - New framing memory in `pm/shared/` cross-references this doc → update [Our position](#our-position) to mention it.
 - New Issue concretely borrows from or extends a framework listed here → backfill the framework's rationale block with the Issue link.
 - Framework deprecated or pivoted → don't delete the entry; update the rationale with the deprecation note (the doc is a journal of *which* options we considered, not just current options).
 
-Last sweep: 2026-07-01 (companion governance-evidence report [`agent_team_governance_research_2026-07.md`](agent_team_governance_research_2026-07.md) cross-linked; adds MAST failure taxonomy + review-debt/review-column-WIP finding, neither previously tracked here).
+Last sweep: 2026-07-02 (adopted the Technology Radar-style `status:` ring funnel [#553](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/553): retrofitted all entries with a ring + per-entry DoR on active ones, added the funnel convention + board-hygiene grep step; introduced a 6th `Reference` ring pending PM confirmation).
+Prior: 2026-07-01 (companion governance-evidence report [`agent_team_governance_research_2026-07.md`](agent_team_governance_research_2026-07.md) cross-linked; adds MAST failure taxonomy + review-debt/review-column-WIP finding, neither previously tracked here).
 Prior: 2026-05-21 (Microsoft Conductor backfilled to Frameworks as counter-position to LLM-as-orchestrator).
 Prior: 2026-05-15 (GitHub Copilot desktop app backfilled to Frameworks as pattern-confirmation).
 Prior: 2026-05-14 (Gartner cancellation forecast backfilled to `our_position` #2 as external validation).


### PR DESCRIPTION
Implements the **project-repo** half of [#553](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/553): turns `research/multi_agent_landscape.md` into a staging -> commit funnel using ThoughtWorks Technology Radar ring vocabulary (calendar cadence dropped). Ring set **confirmed** (6 rings, keep `Reference`). This PR ships the project-repo half; it **does not close #553** (the companion memory ACs ship via the MM memory-drain flow - see below).

## What changed

- **Header** - new `Entry status: the funnel` section: the ring enum, the borrow-rings-drop-cadence decision, the promotion mechanic (`Assess -> Trial` flip opens the eval Issue), and the per-entry DoR convention.
- **All 9 entries retrofitted** with a `status:` ring. `Assess`/`Trial` entries carry a one-line DoR (named promotion trigger).
- **Maintenance** - funnel-convention note + a board-hygiene grep step (`grep -nE "status: (Assess|Trial)"`); bumped Last sweep.

## Ring assignments

| Ring | Entries |
|---|---|
| `Assess` | Copilot desktop (DoR: GA + agent-callable surface) |
| `Trial` | Pattern Language (open eval [#353](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/353)) |
| `Hold` | Fugu, Conductor |
| `Reference` | Managed Agents, Symphony, Trends Report, Mason, AddyOsmani |
| `Rejected` | _(none - correctly empty)_ |

## ⚠️ Decision needed: the 6th ring

#553's design specifies **5** rings (`Assess/Trial/Adopt/Hold/Rejected`). The retrofit surfaced that ~half the entries are *pattern-confirmation / reinforcement* - evaluated, no product adopted, but the idea confirmed our approach or lent vocabulary. None of the 5 fit honestly (not watched, not to-avoid, not "Rejected" when we endorse the idea). I added a **6th `Reference` ring** and flagged it inline in the doc. **Fold into `Rejected` if you'd rather keep it to 5.**

## Companion #553 memory ACs (done, shipping via MM drain)

The shared-memory conventions live in the **personas repo** and were edited once the ring set was confirmed:
- **AC4** - landscape-funnel grep step added to the board-hygiene sweep checklist (`shared/feedback_board_hygiene.md`).
- **AC5** - the PM landscape-maintenance hook now references the ring convention (`pm/feedback_morning_routine.md`).
- **AC8** - same-hook-only bundling clause added near the Issue-creation cap (`shared/feedback_morning_routine.md`).
- **AC7** - already present (the uncapped "comment on a tracked Issue" route was added to the shared file after #553 was filed); no edit needed.

These are working-tree edits shipping via the standard MM memory-drain flow (#882's cross-repo-PR convention is not live yet). **#553 stays open** until they drain, then closes with all ACs ticked.

## Test plan

- [x] All 9 entries carry a `status:` ring (ring count == heading count).
- [x] Header anchor `#entry-status-the-funnel` resolves from the Maintenance cross-link.
- [x] `Assess`/`Trial` entries carry a DoR/Next line; terminal entries do not.
- [x] PM confirms the ring set: **6 rings confirmed** (keep `Reference`), 2026-07-02.
