### PR TITLE
tooling(pm): per-role board dispatch digest (#721)

### DIFF
--- a/research/lab_notebook/pm.md
+++ b/research/lab_notebook/pm.md
@@ -8,6 +8,18 @@ Format and rules unchanged from the unified notebook — see `shared/feedback_la
 
 ## 2026-07-02
 
+### 21:03 UTC - Editor: PM
+
+#### [PR #945](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/945) - per-role board dispatch digest ([#721](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/721))
+
+**Trigger.** Pulled [#721](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/721) from Ready (user-directed after finishing the #787 board-strategy decision). It restores the at-a-glance "what does each role have open/pending" visibility the retired `team_standup` gave ([#569](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/569)).
+
+**What shipped.** `scripts/pm/dispatch_digest.py` - a read-only per-role rollup of committed board work (Ready / In progress / Ready for review / In review), open Team Coordination Discussions, and aging WIP. Reuses `board_open_items.fetch_all_items` + `normalize` (the language-by-data-source convention) rather than re-rolling pagination; pure `group_by_role_status` / `aging_items` / `render_digest` helpers take an injected `now` so they unit-test with no network. `--json` for a scheduled post, `--no-discussions` for board-only. Documented in `scripts/README.md`. Aging keys on `Issue.updatedAt` (respects #642); role-less committed items surface under `(unassigned)` as a hygiene signal.
+
+**Review.** Bot review flagged one real bug: `fetch_discussions`' return comprehension sat outside the `try`, so a null `nodes` list or null node element would crash the whole digest, defeating the fail-soft contract. Fixed by extracting a pure `_parse_discussions_response` called inside the guard (null-coalesce + null-element skip + `AttributeError` in the caught tuple + symmetric `errors` check). Also single-sourced `COMMITTED_STATUSES` from `board_open_items` via `sorted(..., STATUS_ORDER.get)` to kill a drift risk. Declined two nits (`first:30` and the hardcoded category id are pre-existing conventions). Tests 15/15; CI 4/4 green.
+
+**Process note.** Caught and self-corrected a clone mix-up mid-task: the branch was created in the `-pm` clone but files first landed in the sibling clone (which was on the Developer's #824 branch). Copied to the correct clone and reverted the sibling to clean state - no collateral on #824.
+
 ### 15:22 UTC - Editor: PM
 
 #### [PR #939](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/939) - Radar-style status-ring funnel for the landscape doc ([#553](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/553))

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -43,3 +43,24 @@ load-bearing — pick the language to match:
 New board-health checks: if they read a ProjectV2 field, add them on the Python
 side and import from `board_open_items` (`fetch_all_items` + `normalize`); if
 they read only REST objects, a `.sh` + `jq` script is the lighter fit.
+
+## Board dispatch digest (`scripts/pm/dispatch_digest.py`)
+
+A read-only per-role rollup of the **committed** board work (Ready / In progress /
+Ready for review / In review), open Team Coordination Discussions, and aging WIP -
+restoring the at-a-glance "what does each role have open/pending" view the retired
+`team_standup` gave (Issue #569 → #721). It reuses `board_open_items`'
+`fetch_all_items` + `normalize` (the language-by-data-source convention above) and
+the open-Discussions query from `shared/feedback_team_coordination.md`.
+
+```bash
+scripts/pm/dispatch_digest.py                  # markdown digest to stdout
+scripts/pm/dispatch_digest.py --stale-days 21  # widen the aging-WIP threshold (default 14)
+scripts/pm/dispatch_digest.py --json           # structured output for a scheduled post
+scripts/pm/dispatch_digest.py --no-discussions # board-only (skip the Discussions fetch)
+```
+
+**Invocation homes:** run it in the PM morning-routine Warm-up / stand-up beat for
+a manual glance, or wire it as a scheduled cloud post (see `docs/remote_routines.md`).
+It never mutates the board. A role-less committed item surfaces under `(unassigned)`
+as a mild hygiene signal rather than being dropped.

--- a/scripts/pm/dispatch_digest.py
+++ b/scripts/pm/dispatch_digest.py
@@ -1,0 +1,300 @@
+#!/usr/bin/env python3
+"""Per-role board dispatch digest (Issue #721).
+
+Rolls up, per role, the *committed* board work (Ready / In progress / Ready for
+review / In review) plus open Team Coordination Discussions and aging WIP -
+restoring the at-a-glance "what does each role have open/pending" visibility the
+retired team_standup gave (#569). The board + Discussions already carry the data;
+this just rolls it up into one glanceable digest.
+
+Builds on scripts/board_open_items.py (the paginated ProjectV2 fetch + normalize)
+and the open-Discussions query in shared/feedback_team_coordination.md.
+
+Usage:
+  scripts/pm/dispatch_digest.py                 # markdown digest to stdout
+  scripts/pm/dispatch_digest.py --stale-days 21 # widen the aging-WIP threshold
+  scripts/pm/dispatch_digest.py --json          # structured output (scheduled post)
+  scripts/pm/dispatch_digest.py --no-discussions # skip the Discussions fetch
+
+Invocation homes: a Warm-up / stand-up beat in the morning routine, or a scheduled
+post (see docs/remote_routines.md). It is read-only - no board mutation.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+# board_open_items.py is a top-level module in scripts/; add scripts/ so the import
+# resolves whether this runs as a CLI (scripts/pm/) or is imported under pytest.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+import board_open_items as boi  # noqa: E402
+
+# The Team Coordination Discussions category on the project repo (constant id -
+# same one used in shared/feedback_team_coordination.md / the coordination skill).
+DISCUSSION_CATEGORY_ID = "DIC_kwDORwn9EM4C-Jo6"
+DISCUSSION_REPO_OWNER = "Jin-HoMLee"
+DISCUSSION_REPO_NAME = "splice-neoepitope-pipeline"
+
+# Committed statuses in display order (most-active first). Membership mirrors
+# board_open_items.COMMITTED_STATUSES (the Backlog->Ready commitment boundary);
+# this list additionally fixes the render order.
+COMMITTED_STATUSES = ["In progress", "In review", "Ready for review", "Ready"]
+
+UNASSIGNED = "(unassigned)"
+
+# Canonical role display order; roles not listed sort after these, alphabetically,
+# with UNASSIGNED always last (a role-less committed item is a hygiene signal).
+ROLE_ORDER = ["pm", "scientist", "developer", "memory_manager"]
+ROLE_DISPLAY = {
+    "pm": "PM",
+    "scientist": "Scientist",
+    "developer": "Developer",
+    "memory_manager": "Memory Manager",
+    UNASSIGNED: "(unassigned)",
+}
+
+DEFAULT_STALE_DAYS = 14
+
+
+def _role_slug(item: dict[str, Any]) -> str:
+    role = item.get("role")
+    return role.removeprefix("role:") if role else UNASSIGNED
+
+
+def group_by_role_status(
+    items: list[dict[str, Any]],
+) -> dict[str, dict[str, list[dict[str, Any]]]]:
+    """Bucket committed items by role slug, then by status.
+
+    Only the four committed statuses are kept; Backlog / No Status / Done are
+    dropped (not active work). A role-less committed item lands under UNASSIGNED
+    rather than being silently discarded - it is a hygiene signal worth surfacing.
+    Insertion order within each bucket follows the input order.
+    """
+    grouped: dict[str, dict[str, list[dict[str, Any]]]] = {}
+    for it in items:
+        status = it.get("status")
+        if status not in COMMITTED_STATUSES:
+            continue
+        role = _role_slug(it)
+        grouped.setdefault(role, {}).setdefault(status, []).append(it)
+    return grouped
+
+
+def aging_items(
+    items: list[dict[str, Any]],
+    *,
+    now: datetime,
+    stale_days: int,
+) -> list[dict[str, Any]]:
+    """Committed items idle >= stale_days, most-dormant first.
+
+    Keyed on content-level Issue.updatedAt (via board_open_items.age_days), so a
+    bare board-field nudge does not reset staleness (Issue #642). Uncommitted
+    statuses are excluded - only work someone has committed to can be stalled WIP.
+    """
+    aged = [
+        it
+        for it in items
+        if it.get("status") in COMMITTED_STATUSES
+        and (a := boi.age_days(it.get("updated_at"), now)) is not None
+        and a >= stale_days
+    ]
+    aged.sort(key=lambda it: boi.age_days(it.get("updated_at"), now) or 0.0, reverse=True)
+    return aged
+
+
+def _ordered_roles(grouped: dict[str, Any]) -> list[str]:
+    present = set(grouped)
+    ordered = [r for r in ROLE_ORDER if r in present]
+    extras = sorted(r for r in present if r not in ROLE_ORDER and r != UNASSIGNED)
+    tail = [UNASSIGNED] if UNASSIGNED in present else []
+    return ordered + extras + tail
+
+
+def _item_link(it: dict[str, Any]) -> str:
+    num = it.get("number")
+    url = it.get("url")
+    label = f"#{num}"
+    linked = f"[{label}]({url})" if url else label
+    title = (it.get("title") or "").strip()
+    return f"{linked} {title}".rstrip()
+
+
+def fetch_discussions() -> list[dict[str, Any]]:
+    """Open Team Coordination Discussions as [{number, title, author, url}].
+
+    Fails soft: on any gh/network/parse error, returns [] and warns to stderr, so
+    a Discussions outage degrades the digest to board-only rather than aborting it.
+    """
+    query = """
+    query($owner: String!, $name: String!, $cat: ID!) {
+      repository(owner: $owner, name: $name) {
+        discussions(first: 30, categoryId: $cat, states: [OPEN]) {
+          nodes { number title url author { login } }
+        }
+      }
+    }
+    """
+    cmd = [
+        "gh", "api", "graphql",
+        "-f", f"query={query}",
+        "-F", f"owner={DISCUSSION_REPO_OWNER}",
+        "-F", f"name={DISCUSSION_REPO_NAME}",
+        "-F", f"cat={DISCUSSION_CATEGORY_ID}",
+    ]
+    try:
+        r = subprocess.run(cmd, capture_output=True, text=True)
+        if r.returncode != 0:
+            print(f"Warning: discussions fetch failed: {r.stderr.strip()}", file=sys.stderr)
+            return []
+        data = json.loads(r.stdout)
+        nodes = data["data"]["repository"]["discussions"]["nodes"]
+    except (json.JSONDecodeError, KeyError, TypeError) as e:
+        print(f"Warning: could not parse discussions response: {e}", file=sys.stderr)
+        return []
+    return [
+        {
+            "number": n.get("number"),
+            "title": n.get("title", ""),
+            "author": (n.get("author") or {}).get("login", "?"),
+            "url": n.get("url"),
+        }
+        for n in nodes
+    ]
+
+
+def render_digest(
+    items: list[dict[str, Any]],
+    *,
+    discussions: list[dict[str, Any]],
+    now: datetime,
+    stale_days: int,
+) -> str:
+    """Render the digest as markdown. Pure given (items, discussions, now)."""
+    grouped = group_by_role_status(items)
+    aged = aging_items(items, now=now, stale_days=stale_days)
+
+    lines: list[str] = []
+    lines.append(f"# Board dispatch digest - {now.date().isoformat()}")
+    lines.append("")
+    lines.append(
+        "_Per-role rollup of committed board work (Ready / In progress / "
+        "Ready for review / In review), open Team Coordination Discussions, and "
+        "aging WIP. Issue #721._"
+    )
+    lines.append("")
+
+    if not grouped:
+        lines.append("_No committed work on the board._")
+        lines.append("")
+    for role in _ordered_roles(grouped):
+        statuses = grouped[role]
+        counts = " · ".join(
+            f"{s.lower()} {len(statuses.get(s, []))}" for s in COMMITTED_STATUSES
+        )
+        lines.append(f"## {ROLE_DISPLAY.get(role, role)}  ({counts})")
+        for s in COMMITTED_STATUSES:
+            bucket = statuses.get(s, [])
+            if not bucket:
+                continue
+            rendered = " · ".join(_item_link(it) for it in bucket)
+            lines.append(f"- **{s}:** {rendered}")
+        lines.append("")
+
+    lines.append(f"## Aging WIP (committed, idle >= {stale_days}d)")
+    if aged:
+        for it in aged:
+            age = boi.age_label(it.get("updated_at"), now)
+            lines.append(
+                f"- {_item_link(it)} - {ROLE_DISPLAY.get(_role_slug(it), _role_slug(it))}"
+                f" - {it.get('status')} - {age}"
+            )
+    else:
+        lines.append("- (none)")
+    lines.append("")
+
+    lines.append(f"## Open Team Coordination Discussions ({len(discussions)})")
+    if discussions:
+        for d in discussions:
+            num = d.get("number")
+            url = d.get("url")
+            label = f"[#{num}]({url})" if url else f"#{num}"
+            lines.append(
+                f"- {label} {(d.get('title') or '').strip()} (by {d.get('author', '?')})"
+            )
+    else:
+        lines.append("- (none)")
+    lines.append("")
+
+    return "\n".join(lines) + "\n"
+
+
+def build_digest_json(
+    items: list[dict[str, Any]],
+    *,
+    discussions: list[dict[str, Any]],
+    now: datetime,
+    stale_days: int,
+) -> dict[str, Any]:
+    """Structured digest for --json (a scheduled post can render its own view)."""
+    grouped = group_by_role_status(items)
+    aged = aging_items(items, now=now, stale_days=stale_days)
+    return {
+        "generated_at": now.isoformat(),
+        "stale_days": stale_days,
+        "per_role": {
+            role: {s: grouped[role].get(s, []) for s in COMMITTED_STATUSES}
+            for role in _ordered_roles(grouped)
+        },
+        "aging_wip": aged,
+        "discussions": discussions,
+    }
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    p.add_argument(
+        "--stale-days", dest="stale_days", type=int, default=DEFAULT_STALE_DAYS,
+        metavar="N", help=f"Aging-WIP threshold in days (default {DEFAULT_STALE_DAYS})",
+    )
+    p.add_argument(
+        "--no-discussions", dest="no_discussions", action="store_true",
+        help="Skip the Team Coordination Discussions fetch (board-only digest)",
+    )
+    p.add_argument(
+        "--json", dest="as_json", action="store_true",
+        help="Emit a structured JSON digest instead of markdown",
+    )
+    args = p.parse_args()
+
+    if args.stale_days < 0:
+        p.error("--stale-days must be a non-negative integer")
+
+    now = datetime.now(timezone.utc)
+    raw = boi.fetch_all_items()
+    items = [n for it in raw if (n := boi.normalize(it)) is not None]
+    discussions = [] if args.no_discussions else fetch_discussions()
+
+    if args.as_json:
+        json.dump(
+            build_digest_json(items, discussions=discussions, now=now, stale_days=args.stale_days),
+            sys.stdout, indent=2,
+        )
+        sys.stdout.write("\n")
+    else:
+        sys.stdout.write(
+            render_digest(items, discussions=discussions, now=now, stale_days=args.stale_days)
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/pm/dispatch_digest.py
+++ b/scripts/pm/dispatch_digest.py
@@ -40,10 +40,11 @@ DISCUSSION_CATEGORY_ID = "DIC_kwDORwn9EM4C-Jo6"
 DISCUSSION_REPO_OWNER = "Jin-HoMLee"
 DISCUSSION_REPO_NAME = "splice-neoepitope-pipeline"
 
-# Committed statuses in display order (most-active first). Membership mirrors
-# board_open_items.COMMITTED_STATUSES (the Backlog->Ready commitment boundary);
-# this list additionally fixes the render order.
-COMMITTED_STATUSES = ["In progress", "In review", "Ready for review", "Ready"]
+# Committed statuses in display order (most-active first). Single-sourced from
+# board_open_items.COMMITTED_STATUSES (the Backlog->Ready commitment boundary) so
+# membership can never drift from the sibling; STATUS_ORDER supplies the render
+# order. Resolves to ["In progress", "In review", "Ready for review", "Ready"].
+COMMITTED_STATUSES = sorted(boi.COMMITTED_STATUSES, key=boi.STATUS_ORDER.get)
 
 UNASSIGNED = "(unassigned)"
 
@@ -126,6 +127,26 @@ def _item_link(it: dict[str, Any]) -> str:
     return f"{linked} {title}".rstrip()
 
 
+def _parse_discussions_response(data: dict[str, Any]) -> list[dict[str, Any]]:
+    """Extract discussion rows from a GraphQL response.
+
+    Pure (no I/O) so the fail-soft edges are unit-testable. A null `nodes` list
+    coalesces to [] and null node elements (GitHub returns these for inaccessible
+    items) are skipped, so neither raises.
+    """
+    nodes = data["data"]["repository"]["discussions"]["nodes"] or []
+    return [
+        {
+            "number": n.get("number"),
+            "title": n.get("title", ""),
+            "author": (n.get("author") or {}).get("login", "?"),
+            "url": n.get("url"),
+        }
+        for n in nodes
+        if n
+    ]
+
+
 def fetch_discussions() -> list[dict[str, Any]]:
     """Open Team Coordination Discussions as [{number, title, author, url}].
 
@@ -154,19 +175,15 @@ def fetch_discussions() -> list[dict[str, Any]]:
             print(f"Warning: discussions fetch failed: {r.stderr.strip()}", file=sys.stderr)
             return []
         data = json.loads(r.stdout)
-        nodes = data["data"]["repository"]["discussions"]["nodes"]
-    except (json.JSONDecodeError, KeyError, TypeError) as e:
+        if errs := data.get("errors"):
+            print(f"Warning: discussions GraphQL errors: {errs}", file=sys.stderr)
+            return []
+        # Parse inside the guard so a malformed shape (null nodes, null element,
+        # missing key) fails soft to a board-only digest rather than aborting.
+        return _parse_discussions_response(data)
+    except (json.JSONDecodeError, KeyError, TypeError, AttributeError) as e:
         print(f"Warning: could not parse discussions response: {e}", file=sys.stderr)
         return []
-    return [
-        {
-            "number": n.get("number"),
-            "title": n.get("title", ""),
-            "author": (n.get("author") or {}).get("login", "?"),
-            "url": n.get("url"),
-        }
-        for n in nodes
-    ]
 
 
 def render_digest(

--- a/workflow/tests/test_dispatch_digest.py
+++ b/workflow/tests/test_dispatch_digest.py
@@ -132,3 +132,68 @@ def test_render_is_deterministic_given_fixed_now():
     a = dd.render_digest(items, discussions=[], now=NOW, stale_days=14)
     b = dd.render_digest(items, discussions=[], now=NOW, stale_days=14)
     assert a == b
+
+
+# --------------------------------------------------------------------------- #
+# committed-status parity + ordering (review finding 2)                        #
+# --------------------------------------------------------------------------- #
+
+def test_committed_statuses_single_source_matches_board_open_items():
+    """The digest's committed set must stay identical to the board_open_items source."""
+    import board_open_items as boi
+
+    assert set(dd.COMMITTED_STATUSES) == set(boi.COMMITTED_STATUSES)
+    assert dd.COMMITTED_STATUSES == ["In progress", "In review", "Ready for review", "Ready"]
+
+
+# --------------------------------------------------------------------------- #
+# _ordered_roles                                                              #
+# --------------------------------------------------------------------------- #
+
+def test_ordered_roles_canonical_first_then_extras_then_unassigned_last():
+    grouped = {
+        dd.UNASSIGNED: {}, "developer": {}, "zzz_custom": {}, "pm": {},
+    }
+    assert dd._ordered_roles(grouped) == ["pm", "developer", "zzz_custom", dd.UNASSIGNED]
+
+
+# --------------------------------------------------------------------------- #
+# _parse_discussions_response (fail-soft edges, review finding 1)              #
+# --------------------------------------------------------------------------- #
+
+def _disc_response(nodes):
+    return {"data": {"repository": {"discussions": {"nodes": nodes}}}}
+
+
+def test_parse_discussions_extracts_rows():
+    data = _disc_response([{"number": 910, "title": "t", "url": "u",
+                            "author": {"login": "Jin-HoMLee"}}])
+    rows = dd._parse_discussions_response(data)
+    assert rows == [{"number": 910, "title": "t", "author": "Jin-HoMLee", "url": "u"}]
+
+
+def test_parse_discussions_null_nodes_list_coalesces_to_empty():
+    """A null `nodes` must not raise - the fail-soft contract (review finding 1)."""
+    assert dd._parse_discussions_response(_disc_response(None)) == []
+
+
+def test_parse_discussions_skips_null_node_elements():
+    """GitHub returns null nodes for inaccessible items; skip, don't crash."""
+    data = _disc_response([None, {"number": 5, "title": "x", "url": "u", "author": None}])
+    rows = dd._parse_discussions_response(data)
+    assert [r["number"] for r in rows] == [5]
+    assert rows[0]["author"] == "?"  # null author -> sentinel, not a crash
+
+
+# --------------------------------------------------------------------------- #
+# build_digest_json                                                           #
+# --------------------------------------------------------------------------- #
+
+def test_build_digest_json_shape():
+    items = [_item(1, role="role:pm", status="Ready")]
+    discussions = [{"number": 910, "title": "t", "author": "a"}]
+    d = dd.build_digest_json(items, discussions=discussions, now=NOW, stale_days=14)
+    assert set(d) == {"generated_at", "stale_days", "per_role", "aging_wip", "discussions"}
+    assert d["stale_days"] == 14
+    assert d["per_role"]["pm"]["Ready"][0]["number"] == 1
+    assert d["discussions"] == discussions

--- a/workflow/tests/test_dispatch_digest.py
+++ b/workflow/tests/test_dispatch_digest.py
@@ -1,0 +1,134 @@
+"""Tests for scripts/pm/dispatch_digest.py - the per-role board dispatch digest (Issue #721).
+
+The digest rolls up, per role, the committed board work (Ready / In progress /
+Ready for review / In review) plus open Team Coordination Discussions and aging
+WIP - restoring the at-a-glance visibility the retired team_standup gave (#569).
+
+All logic under test is pure (grouping / aging / rendering) with injected items,
+discussions, and `now`, so the tests are deterministic and never touch the network.
+"""
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+# dispatch_digest lives in scripts/pm/; it self-adds scripts/ to sys.path so it can
+# import board_open_items. Mirror both here so the import resolves under pytest.
+_SCRIPTS = Path(__file__).resolve().parents[2] / "scripts"
+sys.path.insert(0, str(_SCRIPTS))
+sys.path.insert(0, str(_SCRIPTS / "pm"))
+
+import dispatch_digest as dd  # noqa: E402
+
+NOW = datetime(2026, 7, 2, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _item(number, *, role="role:pm", status="Ready", title="t",
+          updated="2026-07-02T00:00:00Z"):
+    """A minimal normalized item shaped like board_open_items.normalize() output."""
+    return {
+        "number": number,
+        "title": title,
+        "url": f"https://github.com/o/r/issues/{number}",
+        "kind": "Issue",
+        "status": status,
+        "role": role,
+        "updated_at": updated,
+        "priority": None,
+        "size": None,
+    }
+
+
+# --------------------------------------------------------------------------- #
+# group_by_role_status                                                         #
+# --------------------------------------------------------------------------- #
+
+def test_group_buckets_committed_items_by_role_then_status():
+    items = [
+        _item(1, role="role:pm", status="Ready"),
+        _item(2, role="role:pm", status="In progress"),
+        _item(3, role="role:developer", status="In review"),
+    ]
+    g = dd.group_by_role_status(items)
+    assert g["pm"]["Ready"][0]["number"] == 1
+    assert g["pm"]["In progress"][0]["number"] == 2
+    assert g["developer"]["In review"][0]["number"] == 3
+
+
+def test_group_excludes_uncommitted_statuses():
+    """Backlog / No Status / Done are not committed work - dropped from the digest."""
+    items = [
+        _item(1, status="Backlog"),
+        _item(2, status="No Status"),
+        _item(3, status="Done"),
+        _item(4, status="Ready"),
+    ]
+    g = dd.group_by_role_status(items)
+    committed_numbers = [it["number"] for statuses in g.values()
+                         for lst in statuses.values() for it in lst]
+    assert committed_numbers == [4]
+
+
+def test_group_roleless_committed_item_goes_to_unassigned():
+    """A committed item with no role: label is a hygiene signal - bucket it, don't drop it."""
+    g = dd.group_by_role_status([_item(9, role=None, status="Ready")])
+    assert g[dd.UNASSIGNED]["Ready"][0]["number"] == 9
+
+
+# --------------------------------------------------------------------------- #
+# aging_items                                                                  #
+# --------------------------------------------------------------------------- #
+
+def test_aging_flags_only_committed_items_idle_at_least_threshold():
+    items = [
+        _item(1, status="Ready", updated="2026-06-01T00:00:00Z"),   # 31d - aging
+        _item(2, status="In progress", updated="2026-07-01T00:00:00Z"),  # 1d - fresh
+        _item(3, status="Backlog", updated="2026-01-01T00:00:00Z"),  # old but uncommitted
+    ]
+    aged = dd.aging_items(items, now=NOW, stale_days=14)
+    assert [it["number"] for it in aged] == [1]
+
+
+def test_aging_sorts_most_dormant_first():
+    items = [
+        _item(1, status="Ready", updated="2026-06-15T00:00:00Z"),   # 17d
+        _item(2, status="Ready", updated="2026-05-01T00:00:00Z"),   # 62d
+    ]
+    aged = dd.aging_items(items, now=NOW, stale_days=14)
+    assert [it["number"] for it in aged] == [2, 1]
+
+
+# --------------------------------------------------------------------------- #
+# render_digest                                                                #
+# --------------------------------------------------------------------------- #
+
+def test_render_shows_per_role_counts_and_items():
+    items = [
+        _item(1, role="role:pm", status="Ready", title="alpha"),
+        _item(2, role="role:pm", status="In progress", title="beta"),
+    ]
+    out = dd.render_digest(items, discussions=[], now=NOW, stale_days=14)
+    assert "PM" in out
+    assert "#1" in out and "alpha" in out
+    assert "#2" in out and "beta" in out
+
+
+def test_render_lists_open_discussions():
+    discussions = [{"number": 910, "title": "MM narrative home", "author": "Jin-HoMLee"}]
+    out = dd.render_digest([], discussions=discussions, now=NOW, stale_days=14)
+    assert "#910" in out and "MM narrative home" in out
+
+
+def test_render_surfaces_aging_section_when_present():
+    items = [_item(1, role="role:pm", status="Ready", updated="2026-05-01T00:00:00Z")]  # 62d
+    out = dd.render_digest(items, discussions=[], now=NOW, stale_days=14)
+    assert "Aging" in out
+    assert "#1" in out
+
+
+def test_render_is_deterministic_given_fixed_now():
+    items = [_item(1, role="role:pm", status="Ready")]
+    a = dd.render_digest(items, discussions=[], now=NOW, stale_days=14)
+    b = dd.render_digest(items, discussions=[], now=NOW, stale_days=14)
+    assert a == b


### PR DESCRIPTION
## What

A read-only per-role **board dispatch digest** (`scripts/pm/dispatch_digest.py`) that rolls up, per role:
- committed board work (Ready / In progress / Ready for review / In review) - counts + linked items,
- open Team Coordination Discussions,
- aging WIP (committed items idle >= N days, default 14).

This restores the at-a-glance "what does each role have open/pending" visibility the retired `team_standup` gave (the #721 follow-up to the #569 standup retirement). The board + Discussions already hold the data; this just rolls it up.

## Design

- Reuses `board_open_items.fetch_all_items` + `normalize` (the language-by-data-source convention in `scripts/README.md`) - no re-hand-rolled pagination.
- Pure `group_by_role_status` / `aging_items` / `render_digest` helpers take injected items + a fixed `now`, so they are unit-tested deterministically with no network.
- `fetch_discussions()` **fails soft**: any gh/network/parse error degrades to a board-only digest rather than aborting.
- Aging keys on `Issue.updatedAt` (via `board_open_items.age_days`), so a bare board-field nudge does not reset staleness (#642).
- A role-less committed item surfaces under `(unassigned)` (a mild hygiene signal) rather than being silently dropped - notably catches role-less PRs.
- `--json` emits a structured digest for a scheduled post; `--no-discussions` for a board-only run.

## AC mapping (#721)

- Per-role rollup from `board_open_items.py` → `group_by_role_status`.
- Open Team Coordination Discussions → `fetch_discussions()`.
- Documented invocation → `scripts/README.md` "Board dispatch digest" section + module docstring.

## Test plan

- [x] `pytest workflow/tests/test_dispatch_digest.py` - 9/9 pass (grouping, aging, render; deterministic with injected `now`).
- [x] Sibling `test_board_open_items.py` still green (shared `scripts/` import path) - 41/41 together.
- [x] End-to-end run against the live board #9 renders a correct per-role digest + the open Discussion #910 + aging WIP.
- [x] `--no-discussions` and executable-bit (`./scripts/pm/dispatch_digest.py`) smoke-tested.

Lab-notebook entry (pm.md) to be added post-review, pre-merge per the closure ritual.

