### PR TITLE
process(pm): arc-aware REPLENISH routing in check_ready_queue.sh (#931)

### DIFF
--- a/research/lab_notebook/pm.md
+++ b/research/lab_notebook/pm.md
@@ -8,6 +8,20 @@ Format and rules unchanged from the unified notebook — see `shared/feedback_la
 
 ## 2026-07-03
 
+### 14:46 UTC - Editor: PM
+
+#### Board-governance pulls - #952 finish, #947 dispatch_digest wiring, #931 arc-aware replenishment ([PR #958](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/958) closes [#931](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/931))
+
+**Trigger.** "What's next?" → best-next selector surfaced the In-progress #952 first, then the freshest Ready board-governance items. Worked three in sequence; all three commit (in part) via the MM memory drain.
+
+**#952 (finish).** Most of it was already landed (memory edits + #814 paired + lab entry in PR #957). Found + fixed two residual stale references in `pm/feedback_morning_routine.md` that still asserted the retired numeric cap (line 8 "issue-creation cap"; the "Why Signals sits at position 4" rationale "<=1 Issue/day") - left in place they would have re-asserted the cap. Ticked AC4; sole remaining is the MM cross-repo commit.
+
+**#947 (dispatch_digest wiring).** Wired `scripts/pm/dispatch_digest.py` into Beat 2 (Daily Stand-up) of `pm/feedback_morning_routine.md`: one read-only call replaces the hand-rolled per-role walk (status mechanics + `gh issue list` own-work query + manual cross-role scan); WIP-awareness now reads the digest's per-role `In progress` counts. Ran the digest live first to confirm output before documenting. **Scope note:** AC1 named a `board_open_items.py --status` triple-call "in Beat 2", but that literal call lives in § 1e (Flow health, a distinct age-sorted sweep the digest does not subsume) - left § 1e intact, wired the digest into Beat 2's own walk; flagged for a possible AC-wording follow-up.
+
+**#931 (arc-aware replenishment).** Code (AC2): `check_ready_queue.sh` `[REPLENISH]` routing now counts each role's Backlog candidates carrying `arc-phase:active` and nudges to prefer them (or notes none + "consider promoting a next-phase arc"). Closes the arc→selection loop from the daily gate without relying on memory; priority bands untouched (dynamic selection, not a re-rank, #902 facet 3). TDD (red→green), 3+1 tests, suite 18 green, verified live (pm 24/5, sci 38/3, dev 42/3). Ritual step (AC1) added to `shared/feedback_arc_review.md` "How to apply" (sweep an arc's Backlog on a phase flip to active) - MM drain. `@claude` review: LGTM, no blockers; addressed the one design question (verified the pull lens is a **soft** default with a full-pool fallback, so prefer-at-commit and prefer-at-pull are consistent, not disagreeing) + added the all-active boundary test; declined the negligible eager-jq perf nit.
+
+**Process note.** All three issues split a deliverable across two repos (project-repo code/PR + personas-repo memory drain). Pattern used: PR closes the Issue on the code half; the memory half is staged locally + flagged to MM via a `To: MM` handoff comment on each Issue. #952/#947 (pure-memory) stay open awaiting the MM commit; #931 closes on PR #958 with the memory bullet riding the drain independently.
+
 ### 13:08 UTC - Editor: PM
 
 #### Morning routine - #877 memory-slim dedup reconciliation (closes [#877](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/877)) + news-cap retirement ([#952](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/952))

--- a/scripts/check_ready_queue.sh
+++ b/scripts/check_ready_queue.sh
@@ -21,7 +21,10 @@
 #   - [REPLENISH role] : short AND the role has triaged Backlog candidates ->
 #     commit the highest-priority DoR-ready ones. If none actually meet the
 #     Definition of Ready, that is a grooming gap - refine/file, do NOT stuff
-#     low-value work into Ready just to hit the number.
+#     low-value work into Ready just to hit the number. Arc-aware (Issue #931):
+#     the nudge flags how many candidates are on an active arc (arc-phase:active)
+#     and says to prefer those, so re-selection follows the active slate without
+#     relying on memory (the arc axis lives in shared/feedback_arc_review.md).
 #   - [GROOMING-GAP role] : short AND the role has NO Backlog candidates at all
 #     -> nothing is committable; the remedy is intake/grooming, not commitment.
 #
@@ -121,12 +124,23 @@ for role in "${FLOOR_ROLES[@]}"; do
     ready_count="$(printf '%s' "$READY_JSON" | jq --arg r "role:$role" '[.[] | select(.labels | index($r))] | length')"
     inprog_count="$(printf '%s' "$INPROG_JSON" | jq --arg r "role:$role" '[.[] | select(.labels | index($r))] | length')"
     backlog_count="$(printf '%s' "$BACKLOG_JSON" | jq --arg r "role:$role" '[.[] | select(.labels | index($r))] | length')"
+    # Active-arc Backlog candidates for this role (carry arc-phase:active). The
+    # daily gate is arc-aware: on a REPLENISH shortfall we flag active-arc
+    # candidates so re-selection follows the active slate without relying on
+    # someone remembering the lens at replenishment (Issue #931). The arc axis /
+    # active slate is defined in shared/feedback_arc_review.md.
+    active_count="$(printf '%s' "$BACKLOG_JSON" | jq --arg r "role:$role" '[.[] | select(.labels | index($r)) | select(.labels | index("arc-phase:active"))] | length')"
     ready_breakdown+="${role}=${ready_count} "
     inprog_breakdown+="${role}=${inprog_count} "
     backlog_breakdown+="${role}=${backlog_count} "
     if [[ "$ready_count" -lt "$FLOOR" ]]; then
         if [[ "$backlog_count" -ge 1 ]]; then
-            echo "[REPLENISH ${role}: ${ready_count} < ${FLOOR}] - ${backlog_count} Backlog candidate(s); commit the highest-priority DoR-ready ones. If none meet DoR, it's a grooming gap - refine/file, do not stuff (see shared/feedback_board_hygiene.md)."
+            if [[ "$active_count" -ge 1 ]]; then
+                arc_hint=", ${active_count} on an active arc (arc-phase:active) - prefer these"
+            else
+                arc_hint=", none on an active arc - commit the top DoR-ready pool item, or flag whether a next-phase arc should be promoted"
+            fi
+            echo "[REPLENISH ${role}: ${ready_count} < ${FLOOR}] - ${backlog_count} Backlog candidate(s)${arc_hint}; commit the highest-priority DoR-ready ones. If none meet DoR, it's a grooming gap - refine/file, do not stuff (see shared/feedback_board_hygiene.md)."
         else
             echo "[GROOMING-GAP ${role}: ${ready_count} < ${FLOOR}] - 0 Backlog candidates; nothing committable for this role. File/intake, do not stuff."
         fi

--- a/workflow/tests/test_check_ready_queue.py
+++ b/workflow/tests/test_check_ready_queue.py
@@ -138,6 +138,20 @@ def test_replenish_notes_when_no_active_arc_candidates():
     assert r.returncode == 2, (r.returncode, r.stdout, r.stderr)
 
 
+def test_replenish_all_candidates_active_arc():
+    # Boundary (active_count == backlog_count): every Backlog candidate is on an
+    # active arc, so M == N in "N Backlog candidate(s), M on an active arc".
+    items = (_spread("pm", 2, 100)
+             + [_item(150, "pm", status="Backlog", arc_active=True),
+                _item(151, "pm", status="Backlog", arc_active=True),
+                _item(152, "pm", status="Backlog", arc_active=True)]
+             + _spread("scientist", 5, 200) + _spread("developer", 5, 300))
+    r = _run(items)
+    assert "[REPLENISH pm: 2 < 5]" in r.stdout, r.stdout
+    assert "3 Backlog candidate(s), 3 on an active arc" in r.stdout, r.stdout
+    assert r.returncode == 2, (r.returncode, r.stdout, r.stderr)
+
+
 def test_grooming_gap_unaffected_by_arc_awareness():
     # Short with ZERO Backlog candidates stays GROOMING-GAP (arc logic only
     # applies on the REPLENISH branch, which requires >= 1 candidate).

--- a/workflow/tests/test_check_ready_queue.py
+++ b/workflow/tests/test_check_ready_queue.py
@@ -36,9 +36,11 @@ from pathlib import Path
 SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "check_ready_queue.sh"
 
 
-def _item(number, *roles, status="Ready"):
-    return {"number": number, "status": status,
-            "labels": [f"role:{r}" for r in roles]}
+def _item(number, *roles, status="Ready", arc_active=False):
+    labels = [f"role:{r}" for r in roles]
+    if arc_active:
+        labels.append("arc-phase:active")
+    return {"number": number, "status": status, "labels": labels}
 
 
 def _run(items, *args):
@@ -106,6 +108,45 @@ def test_all_roles_at_floor_healthy():
     assert "healthy" in r.stdout, r.stdout
     assert "[REPLENISH" not in r.stdout and "[GROOMING-GAP" not in r.stdout, r.stdout
     assert r.returncode == 0, (r.returncode, r.stdout, r.stderr)
+
+
+def test_replenish_prefers_active_arc_backlog_candidates():
+    # PM short (2 < 5) with 3 Backlog candidates, 2 of them on an active arc.
+    # The REPLENISH nudge flags the active-arc ones to prefer (Issue #931).
+    items = (_spread("pm", 2, 100)
+             + [_item(150, "pm", status="Backlog", arc_active=True),
+                _item(151, "pm", status="Backlog", arc_active=True),
+                _item(152, "pm", status="Backlog")]
+             + _spread("scientist", 5, 200) + _spread("developer", 5, 300))
+    r = _run(items)
+    assert "[REPLENISH pm: 2 < 5]" in r.stdout, r.stdout
+    assert "3 Backlog candidate(s)" in r.stdout, r.stdout
+    assert "2 on an active arc" in r.stdout, r.stdout
+    assert "prefer these" in r.stdout, r.stdout
+    assert r.returncode == 2, (r.returncode, r.stdout, r.stderr)
+
+
+def test_replenish_notes_when_no_active_arc_candidates():
+    # PM short with Backlog candidates but NONE on an active arc -> the nudge
+    # says so (commit the top DoR-ready pool item / consider promoting an arc).
+    items = (_spread("pm", 2, 100) + _spread("pm", 3, 150, status="Backlog")
+             + _spread("scientist", 5, 200) + _spread("developer", 5, 300))
+    r = _run(items)
+    assert "[REPLENISH pm: 2 < 5]" in r.stdout, r.stdout
+    assert "none on an active arc" in r.stdout, r.stdout
+    assert "prefer these" not in r.stdout, r.stdout
+    assert r.returncode == 2, (r.returncode, r.stdout, r.stderr)
+
+
+def test_grooming_gap_unaffected_by_arc_awareness():
+    # Short with ZERO Backlog candidates stays GROOMING-GAP (arc logic only
+    # applies on the REPLENISH branch, which requires >= 1 candidate).
+    items = (_spread("pm", 2, 100)
+             + _spread("scientist", 5, 200) + _spread("developer", 5, 300))
+    r = _run(items)
+    assert "[GROOMING-GAP pm: 2 < 5]" in r.stdout, r.stdout
+    assert "active arc" not in r.stdout, r.stdout
+    assert r.returncode == 2, (r.returncode, r.stdout, r.stderr)
 
 
 def test_total_at_cap_flags_cap_and_exit_2():


### PR DESCRIPTION
Closes #931.

## What

Makes the daily replenishment gate (`check_ready_queue.sh`) arc-aware. Previously a role's `[REPLENISH]` shortfall surfaced a raw Backlog candidate count with no signal about which candidates sit on an active arc, so re-selection followed the active slate only if someone remembered to apply the arc lens at replenishment.

The `[REPLENISH]` branch now counts this role's Backlog candidates carrying `arc-phase:active` and:
- **`N on an active arc (arc-phase:active) - prefer these`** when there are any, or
- **`none on an active arc - commit the top DoR-ready pool item, or flag whether a next-phase arc should be promoted`** when there aren't.

This closes the arc→selection loop from the daily gate without relying on memory. It is dynamic **selection**, not a priority re-rank (priority stays a coarse class-of-service, #902 facet 3). `GROOMING-GAP` (zero candidates) is unchanged - arc logic only applies on the `>= 1`-candidate REPLENISH branch.

## Scope / two homes
This Issue has two fixes in two homes. This PR is the **code** fix (AC2). The **ritual step** (AC1 - sweep an arc's Backlog on a phase flip to `active`) is a memory edit to `shared/feedback_arc_review.md` that rides the **MM cross-repo drain** (not in this PR); it is staged locally and flagged for MM.

## Test plan
- [x] Added 3 tests to `test_check_ready_queue.py`: active-arc candidates flagged with "prefer these"; no-active-arc note; GROOMING-GAP unaffected by arc awareness.
- [x] Full `test_check_ready_queue.py` suite green (17 passed).
- [x] Verified against a **live board scan** (AC3): all three roles' REPLENISH nudges now show the active-arc candidate count (pm 24/5, sci 38/3, dev 42/3).
- [x] `--help` renders cleanly (no code leak), arc-aware line included.

## AC mapping
- AC1 (ritual step / memory) -> `shared/feedback_arc_review.md`, via MM drain (staged).
- AC2 (arc-aware routing) -> this PR.
- AC3 (verified live + docs updated) -> live scan above + script header doc + memory bullet.
