### PR TITLE
docs(infra): record CCR sandbox gh 2.65.0 re-probe; native issue-dep fields unavailable in-sandbox (#941)

### DIFF
--- a/docs/remote_routines.md
+++ b/docs/remote_routines.md
@@ -9,13 +9,13 @@ Remote routines are scheduled or one-time Claude Code agents that run in an **is
 
 ## CCR sandbox environment — reference facts
 
-Empirically probed in the `github-pat` environment (`env_01FffKZvNhx6EVwk7nEqMSkM`) on 2026-06-03. Re-probe if the platform image changes.
+Empirically probed in the `github-pat` environment (`env_01FffKZvNhx6EVwk7nEqMSkM`) on 2026-06-03; `gh` re-confirmed **2.65.0** on 2026-07-04 ([#941](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/941), unchanged since the first probe). Re-probe if the platform image changes.
 
 | Fact | Value | Implication for a routine |
 |---|---|---|
 | OS / CPU | Linux 6.18.5 x86_64, 4 cores | fine for tests/dry-runs; not for heavy compute |
 | Python | 3.11.15 (`/usr/local/bin`) | |
-| `gh` | 2.65.0, authed via `$GH_TOKEN` — fine-grained PAT, **repo + project** scope | can push, open PRs, comment, **and** move project-board fields |
+| `gh` | 2.65.0 (re-confirmed 2026-07-04, [#941](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/941)), authed via `$GH_TOKEN` - fine-grained PAT, **repo + project** scope | can push, open PRs, comment, **and** move project-board fields. **But 2.65.0 < 2.94.0**, so the native `gh issue` dependency JSON fields (`blockedBy` / `blocking` / `parent` / `subIssues`) do **not** exist in-sandbox - any cross-env script (`scripts/audit_and_merge.sh`, the morning blocked-graph hygiene check) must **not** switch to native fields until the platform image bumps `gh`; keep the `is:blocked` search workaround ([#824](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/824), [#942](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/942)). |
 | PyPI egress | ✅ works | `pip install` reaches pypi.org |
 | **network egress** | **allowlisted** — PyPI + GitHub reachable; other hosts (e.g. `api.datacite.org`) return `403 Host not in allowlist` | an in-sandbox live API-shape probe works **only** for GitHub + PyPI; a mapper/fixture that depends on another external API can't be confirmed in-sandbox → build from the documented schema and **defer live confirmation to human/CI** (leave that AC unchecked). Surfaced by #641/[PR #648](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/648). |
 | **pip pyyaml trap** | `pip install --upgrade … pyyaml` **fails** — the debian-managed PyYAML 6.0.1 can't be uninstalled, which **aborts the whole transaction → pytest never installs** | install with **`python3 -m pip install pytest`** (no `--upgrade`, don't touch pyyaml — it's already present). Capture `pip`'s rc directly (`rc=$?` with no pipe; `\| tail` swallows it). |

--- a/research/lab_notebook/developer.md
+++ b/research/lab_notebook/developer.md
@@ -6,6 +6,20 @@ Format and rules unchanged from the unified notebook — see `shared/feedback_la
 
 ---
 
+## 2026-07-04 - CCR sandbox gh re-probe: native issue-dependency fields still unavailable in-sandbox ([PR #974](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/974) closes [Issue #941](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/941))
+
+### 00:29 UTC - Editor: Developer - one-shot sandbox probe + adoption verdict
+
+**Context.** [Issue #941](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/941) (`arc:board-governance`, follow-up from the [#824](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/824) native-issue-dependency eval) asked whether the CCR remote sandbox's `gh` is at or above 2.94.0, the floor at which the native `blockedBy` / `blocking` / `parent` / `subIssues` JSON fields exist. `scripts/audit_and_merge.sh` and the morning blocked-graph hygiene check both run cross-env, so a shared script must not adopt native fields unless the sandbox `gh` clears that floor.
+
+**Premise correction.** The Issue framed the sandbox `gh` as "undocumented and unverified", but `docs/remote_routines.md` already recorded 2.65.0 from the 2026-06-03 probe. The real gap was staleness (a month old, and the doc itself says "re-probe if the platform image changes"), not absence. A fresh probe was still warranted (the image could have bumped) but the finding is "confirmed unchanged", not "discovered" - a [[feedback_rule_as_suspect]]-adjacent reminder to verify an Issue's stated premise before mechanizing it.
+
+**Method + result.** Dispatched a one-shot CCR routine (`probe-ccr-gh-version-941`, sonnet-5) that ran `gh --version` in-sandbox and ferried the result out as issue comments (sandbox stdout is unreachable from outside). Result: still **2.65.0**, unchanged since 2026-06-03, below the 2.94.0 floor. So the native fields do not exist in-sandbox; any cross-env script must keep the `is:blocked` search workaround ([#942](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/942)) as the single code path until the platform image bumps `gh`.
+
+**Deliverables.** [PR #974](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/974): recorded the re-probe date + the below-2.94.0 implication in the `docs/remote_routines.md` env-facts table. Adoption verdict posted on [#824](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/824) (defer native-field adoption; keep one code path). Docs-only; bot review skipped as genuinely trivial (4-line doc change) per the review-offer gate.
+
+**Process note.** First quick win run end-to-end under the newly-standing all-role autonomy cadence (promoted to shared this session). I initially stopped too early - at PR-open, handing the review + lab-notebook back as separate asks - and the user corrected that review-addressed + this entry are *inside* the autonomous zone, with the stop point at just before `gh pr merge`. Memory: `shared/feedback_autonomy_merge_gate_cadence.md`, de-provisionalized from the Dev-only n=1 form.
+
 ## 2026-07-03 - Surface calibrated_immunogenicity_log_odds as a provisional secondary report column ([PR #955](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/955) closes [Issue #906](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/906))
 
 ### 17:10 UTC - Editor: Developer - report-HTML column + Scientist display-semantics sign-off


### PR DESCRIPTION
## Summary

Spike #941: re-probed the CCR remote sandbox's `gh` version to gate the #824 native-issue-dependency-field adoption.

**Result: sandbox `gh` is still 2.65.0** (re-probed 2026-07-04 via one-shot routine `probe-ccr-gh-version-941`), unchanged since the 2026-06-03 probe and **below the 2.94.0 floor** the native `blockedBy` / `blocking` / `parent` / `subIssues` JSON fields require. So those fields do not exist in-sandbox, and any cross-env script (`scripts/audit_and_merge.sh`, the morning blocked-graph hygiene check) must keep the `is:blocked` search workaround ([#942](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/942)) until the platform image bumps `gh`.

This PR records that fact in the `docs/remote_routines.md` env-facts table (AC2). The probe (AC1) and the #824 adoption report (AC3) are on the issues:
- probe result: [#941 comment](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/941#issuecomment-4879968251)
- adoption verdict: [#824 comment](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/824#issuecomment-4879972388)

Closes #941.

## Test plan

- [x] `gh --version` probe ran in the CCR sandbox and returned `gh version 2.65.0 (2025-01-06)` (verdict: below 2.94.0) - ferried out as an issue comment since sandbox stdout is unreachable
- [x] `docs/remote_routines.md` env-facts table records the re-probe date + the `< 2.94.0` implication for native fields
- [x] #824 adoption follow-up reports the sandbox version and the defer-adoption recommendation

Docs-only change; no code paths touched.
