### PR TITLE
tooling(scientist): bake DOI-exact dedup into zotero_add.py (#896)

### DIFF
--- a/research/scripts/test_zotero_add.py
+++ b/research/scripts/test_zotero_add.py
@@ -410,6 +410,8 @@ def test_normalize_doi_lowercases_trims_and_strips_prefix():
     assert zotero_add.normalize_doi("https://doi.org/10.1/A") == "10.1/a"
     assert zotero_add.normalize_doi("http://dx.doi.org/10.1/A") == "10.1/a"
     assert zotero_add.normalize_doi("doi:10.1/B") == "10.1/b"
+    # whitespace after the resolver prefix is also stripped (space after 'doi:')
+    assert zotero_add.normalize_doi("doi: 10.1/x") == "10.1/x"
     assert zotero_add.normalize_doi("") == ""
     assert zotero_add.normalize_doi(None) == ""
 
@@ -434,6 +436,33 @@ def test_fetch_library_doi_index_paginates(monkeypatch):
     assert len(index) == total
     assert index["10.1000/x0"] == "K0"
     assert index["10.1000/x149"] == "K149"
+
+
+def test_fetch_library_doi_index_normalizes_url_form_stored_doi(monkeypatch):
+    """A DOI stored in resolver-URL form is normalized to bare in the index, so a
+    bare candidate DOI still matches an item stored as a full doi.org URL."""
+    body = '[{"key":"K1","data":{"DOI":"https://doi.org/10.1/URLform"}}]'
+    monkeypatch.setattr(zotero_add.urllib.request, "urlopen", lambda req: _FakeResp(body, "1"))
+    index = zotero_add.fetch_library_doi_index("0000", "key")
+    assert "10.1/urlform" in index
+    assert index["10.1/urlform"] == "K1"
+
+
+def test_fetch_library_doi_index_terminates_on_exact_page_boundary(monkeypatch):
+    """total == limit (exactly one full page) must terminate, not loop forever."""
+    import urllib.parse as up
+
+    total = 100
+
+    def _fake_urlopen(req):
+        start = int(up.parse_qs(up.urlparse(req.full_url).query)["start"][0])
+        n = min(100, max(0, total - start))
+        items = [{"key": f"K{start + i}", "data": {"DOI": f"10.1000/y{start + i}"}} for i in range(n)]
+        return _FakeResp(json.dumps(items), str(total))
+
+    monkeypatch.setattr(zotero_add.urllib.request, "urlopen", _fake_urlopen)
+    index = zotero_add.fetch_library_doi_index("0000", "key")
+    assert len(index) == 100
 
 
 def test_fetch_library_doi_index_tolerates_control_chars(monkeypatch):
@@ -537,3 +566,20 @@ def test_dedup_network_failure_aborts_with_force_hint(monkeypatch):
     msg = str(exc.value)
     assert "--force" in msg
     assert "Traceback" not in msg
+
+
+def test_dry_run_skips_dedup_scan(monkeypatch):
+    """--dry-run is a pure offline preview: it must not hit the Zotero library scan."""
+    _setup_add_env(monkeypatch, ["zotero_add.py", "10.1093/bioadv/vbae080", "--dry-run"])
+
+    def _must_not_scan(uid, key):
+        raise AssertionError("dry-run must not perform the dedup library scan")
+
+    monkeypatch.setattr(zotero_add, "fetch_library_doi_index", _must_not_scan)
+    monkeypatch.setattr(zotero_add, "post_to_zotero",
+                        lambda *a, **k: (_ for _ in ()).throw(AssertionError("dry-run must not POST")))
+
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        zotero_add.main()
+    assert '"DOI": "10.1093/bioadv/vbae080"' in buf.getvalue()

--- a/research/scripts/test_zotero_add.py
+++ b/research/scripts/test_zotero_add.py
@@ -1,6 +1,7 @@
 """Tests for zotero_add — crossref/datacite mappers + CrossRef-404 DataCite fallback."""
 
 import io
+import json
 import sys
 import urllib.error
 from contextlib import redirect_stdout
@@ -381,4 +382,158 @@ def test_datacite_urlerror_on_fallback_exits_clean_not_traceback(monkeypatch):
     msg = str(exc.value)
     assert "DataCite" in msg
     assert "Connection refused" in msg
+    assert "Traceback" not in msg
+
+
+# --- DOI-exact dedup pre-check (Issue #896) --------------------------------
+
+
+class _FakeResp:
+    """Minimal urlopen() context-manager stand-in for the Zotero library scan."""
+
+    def __init__(self, body, total):
+        self._body = body.encode("utf-8")
+        self.headers = {"Total-Results": total}  # dict supports .get()
+
+    def read(self):
+        return self._body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+
+def test_normalize_doi_lowercases_trims_and_strips_prefix():
+    assert zotero_add.normalize_doi("  10.1126/SciAdv.X  ") == "10.1126/sciadv.x"
+    assert zotero_add.normalize_doi("https://doi.org/10.1/A") == "10.1/a"
+    assert zotero_add.normalize_doi("http://dx.doi.org/10.1/A") == "10.1/a"
+    assert zotero_add.normalize_doi("doi:10.1/B") == "10.1/b"
+    assert zotero_add.normalize_doi("") == ""
+    assert zotero_add.normalize_doi(None) == ""
+
+
+def test_fetch_library_doi_index_paginates(monkeypatch):
+    """>100 items must span multiple pages; both are collected and keyed by DOI."""
+    import urllib.parse as up
+
+    total = 150
+
+    def _fake_urlopen(req):
+        start = int(up.parse_qs(up.urlparse(req.full_url).query)["start"][0])
+        n = min(100, max(0, total - start))
+        items = [
+            {"key": f"K{start + i}", "data": {"DOI": f"10.1000/x{start + i}"}}
+            for i in range(n)
+        ]
+        return _FakeResp(json.dumps(items), str(total))
+
+    monkeypatch.setattr(zotero_add.urllib.request, "urlopen", _fake_urlopen)
+    index = zotero_add.fetch_library_doi_index("0000", "key")
+    assert len(index) == total
+    assert index["10.1000/x0"] == "K0"
+    assert index["10.1000/x149"] == "K149"
+
+
+def test_fetch_library_doi_index_tolerates_control_chars(monkeypatch):
+    """Abstract fields carry raw control chars - json must be parsed strict=False."""
+    body = '[{"key":"K1","data":{"DOI":"10.1/ctrl","abstractNote":"a\x01b"}}]'
+    monkeypatch.setattr(zotero_add.urllib.request, "urlopen", lambda req: _FakeResp(body, "1"))
+    index = zotero_add.fetch_library_doi_index("0000", "key")
+    assert index["10.1/ctrl"] == "K1"
+
+
+def _setup_add_env(monkeypatch, argv):
+    monkeypatch.setattr(zotero_add, "fetch_crossref", lambda doi: _journal_crossref())
+    monkeypatch.setattr(zotero_add, "fetch_pubmed", lambda doi: (None, None, None))
+    monkeypatch.setenv("ZOTERO_USER_ID", "0000")
+    monkeypatch.setenv("ZOTERO_API_KEY", "key")
+    monkeypatch.setattr(sys, "argv", argv)
+
+
+def test_dedup_aborts_on_existing_doi(monkeypatch):
+    """An existing DOI aborts the add, surfaces the key + --update-note, no POST."""
+    import pytest
+
+    posted = []
+    _setup_add_env(monkeypatch, ["zotero_add.py", "10.1093/bioadv/vbae080"])
+    monkeypatch.setattr(zotero_add, "fetch_library_doi_index",
+                        lambda uid, key: {"10.1093/bioadv/vbae080": "ABCD1234"})
+    monkeypatch.setattr(zotero_add, "post_to_zotero",
+                        lambda *a, **k: posted.append(a) or {"successful": {"0": {"key": "X"}}})
+
+    with pytest.raises(SystemExit) as exc:
+        zotero_add.main()
+    msg = str(exc.value)
+    assert "ABCD1234" in msg
+    assert "--update-note" in msg
+    assert not posted
+
+
+def test_dedup_proceeds_when_doi_absent(monkeypatch):
+    posted = []
+    _setup_add_env(monkeypatch, ["zotero_add.py", "10.1093/bioadv/vbae080"])
+    monkeypatch.setattr(zotero_add, "fetch_library_doi_index", lambda uid, key: {})
+
+    def _post(item, uid, key):
+        posted.append(item)
+        return {"successful": {"0": {"key": "NEWKEY"}}}
+
+    monkeypatch.setattr(zotero_add, "post_to_zotero", _post)
+    zotero_add.main()
+    assert len(posted) == 1
+    assert posted[0]["DOI"] == "10.1093/bioadv/vbae080"
+
+
+def test_force_bypasses_dedup(monkeypatch):
+    """--force skips the library scan entirely and adds regardless."""
+    posted = []
+    _setup_add_env(monkeypatch, ["zotero_add.py", "10.1093/bioadv/vbae080", "--force"])
+
+    def _no_call(uid, key):
+        raise AssertionError("dedup fetch must be skipped under --force")
+
+    monkeypatch.setattr(zotero_add, "fetch_library_doi_index", _no_call)
+    monkeypatch.setattr(zotero_add, "post_to_zotero",
+                        lambda item, uid, key: posted.append(item) or {"successful": {"0": {"key": "F"}}})
+    zotero_add.main()
+    assert len(posted) == 1
+
+
+def test_dedup_matches_across_doi_casing(monkeypatch):
+    """A canonical DOI in different case than the stored one still matches."""
+    import pytest
+
+    _setup_add_env(monkeypatch, ["zotero_add.py", "10.1093/bioadv/vbae080"])
+    upper = _journal_crossref()
+    upper["DOI"] = "10.1093/BioAdv/VBAE080"
+    monkeypatch.setattr(zotero_add, "fetch_crossref", lambda doi: upper)
+    monkeypatch.setattr(zotero_add, "fetch_library_doi_index",
+                        lambda uid, key: {"10.1093/bioadv/vbae080": "LOW1"})
+    monkeypatch.setattr(zotero_add, "post_to_zotero",
+                        lambda *a, **k: (_ for _ in ()).throw(AssertionError("should not post")))
+
+    with pytest.raises(SystemExit) as exc:
+        zotero_add.main()
+    assert "LOW1" in str(exc.value)
+
+
+def test_dedup_network_failure_aborts_with_force_hint(monkeypatch):
+    """A Zotero outage during the scan aborts cleanly and points at --force."""
+    import pytest
+
+    _setup_add_env(monkeypatch, ["zotero_add.py", "10.1093/bioadv/vbae080"])
+
+    def _boom(uid, key):
+        raise urllib.error.URLError("Connection refused")
+
+    monkeypatch.setattr(zotero_add, "fetch_library_doi_index", _boom)
+    monkeypatch.setattr(zotero_add, "post_to_zotero",
+                        lambda *a, **k: (_ for _ in ()).throw(AssertionError("should not post")))
+
+    with pytest.raises(SystemExit) as exc:
+        zotero_add.main()
+    msg = str(exc.value)
+    assert "--force" in msg
     assert "Traceback" not in msg

--- a/research/scripts/zotero_add.py
+++ b/research/scripts/zotero_add.py
@@ -340,7 +340,7 @@ def normalize_doi(doi):
         "doi:",
     ):
         if d.startswith(prefix):
-            return d[len(prefix):]
+            return d[len(prefix):].strip()
     return d
 
 
@@ -538,7 +538,7 @@ def main():
         candidate_doi = item.get("DOI") or args.doi
         try:
             index = fetch_library_doi_index(user_id, api_key)
-        except (urllib.error.HTTPError, urllib.error.URLError) as e:
+        except (urllib.error.HTTPError, urllib.error.URLError, json.JSONDecodeError) as e:
             reason = getattr(e, "reason", e)
             sys.exit(
                 f"Dedup pre-check could not reach Zotero: {reason}. "

--- a/research/scripts/zotero_add.py
+++ b/research/scripts/zotero_add.py
@@ -325,6 +325,65 @@ def datacite_to_zotero(data, collection, tags, pubmed_date=None, pubmed_abstract
     return item
 
 
+def normalize_doi(doi):
+    """Normalize a DOI for exact matching: strip whitespace, lowercase, and drop a
+    leading resolver prefix (`https://doi.org/`, `doi:`, …).
+
+    DOIs are case-insensitive by registration, so a stored `10.1126/SciAdv.X`
+    must match a candidate `10.1126/sciadv.x`. The prefix strip lets a bare DOI
+    match one stored as a resolver URL.
+    """
+    d = (doi or "").strip().lower()
+    for prefix in (
+        "https://doi.org/", "http://doi.org/",
+        "https://dx.doi.org/", "http://dx.doi.org/",
+        "doi:",
+    ):
+        if d.startswith(prefix):
+            return d[len(prefix):]
+    return d
+
+
+def fetch_library_doi_index(user_id, api_key):
+    """Return {normalized_doi: item_key} for every top-level item in the user's
+    whole Zotero library, paginated.
+
+    Scans the **entire library** (not one collection): post-Issue #675 the papers
+    live across 8 stage sub-collections plus a separate methodology collection
+    (`DA3EWEJ9`), so a single-collection scan is blind to both
+    (feedback_zotero_doi_exact_dedup.md). Child notes/attachments carry no DOI, so
+    `/items/top` is a complete DOI source and lighter than `/items`. JSON is parsed
+    with `strict=False`: abstract fields carry raw control characters that trip the
+    default strict decoder.
+    """
+    index = {}
+    start, limit = 0, 100
+    while True:
+        url = (
+            f"https://api.zotero.org/users/{user_id}/items/top"
+            f"?format=json&limit={limit}&start={start}"
+        )
+        req = urllib.request.Request(url, headers={"Zotero-API-Key": api_key})
+        with urllib.request.urlopen(req) as resp:
+            total = resp.headers.get("Total-Results")
+            batch = json.loads(resp.read().decode("utf-8"), strict=False)
+        if not batch:
+            break
+        for it in batch:
+            doi = normalize_doi(it.get("data", {}).get("DOI", ""))
+            if doi and doi not in index:
+                index[doi] = it.get("key", "")
+        start += limit
+        try:
+            if total is not None and start >= int(total):
+                break
+        except (TypeError, ValueError):
+            pass
+        if len(batch) < limit:
+            break
+    return index
+
+
 def post_to_zotero(item, user_id, api_key):
     url = f"https://api.zotero.org/users/{user_id}/items"
     payload = json.dumps([item]).encode()
@@ -395,6 +454,8 @@ def main():
     parser.add_argument("--note", help="Relevance note to attach to the Zotero entry")
     parser.add_argument("--update-note", metavar="ITEM_KEY", help="Update the note on an existing Zotero item (skips DOI add)")
     parser.add_argument("--dry-run", action="store_true", help="Print item without posting to Zotero")
+    parser.add_argument("--force", action="store_true",
+                        help="Skip the DOI-exact dedup pre-check (add even if the DOI is already in the library)")
     args = parser.parse_args()
 
     if not args.update_note and not args.doi:
@@ -470,6 +531,28 @@ def main():
             print("\n[dry-run] Note:")
             print(args.note)
         return
+
+    # DOI-exact dedup pre-check (Issue #896): refuse a silent duplicate. Scans the
+    # whole library; --force overrides for a genuine intentional-duplicate add.
+    if not args.force:
+        candidate_doi = item.get("DOI") or args.doi
+        try:
+            index = fetch_library_doi_index(user_id, api_key)
+        except (urllib.error.HTTPError, urllib.error.URLError) as e:
+            reason = getattr(e, "reason", e)
+            sys.exit(
+                f"Dedup pre-check could not reach Zotero: {reason}. "
+                f"Re-run, or pass --force to skip the check."
+            )
+        existing_key = index.get(normalize_doi(candidate_doi))
+        if existing_key:
+            sys.exit(
+                f"DOI {candidate_doi} is already in the library as item {existing_key}. "
+                f"Not adding a duplicate.\n"
+                f"To refresh its note instead:\n"
+                f"  python research/scripts/zotero_add.py --update-note {existing_key} --note \"...\"\n"
+                f"To add anyway (intentional duplicate): re-run with --force."
+            )
 
     print("Posting to Zotero...")
     result = post_to_zotero(item, user_id, api_key)


### PR DESCRIPTION
Closes #896.

## What

`zotero_add.py` now runs a deterministic **DOI-exact dedup pre-check** against the **whole Zotero library** before every create, so a re-add of a paper already in the library is refused instead of silently duplicated.

- `normalize_doi()` - lowercase + trim + strip resolver prefixes (`https://doi.org/`, `doi:`) so casing / URL-form variants still match.
- `fetch_library_doi_index()` - paginated scan of the whole user library via `/items/top` (not one collection: post-#675 papers live across 8 stage sub-collections + a separate methodology collection, so a single-collection scan is blind to both). Parsed `strict=False` (abstract fields carry raw control chars).
- `main()` - on an existing-DOI hit, aborts before any POST and surfaces the existing item key + an `--update-note` suggestion. `--force` overrides for a genuine intentional duplicate; a Zotero outage mid-scan aborts cleanly with a `--force` hint.

Closes the manual-pre-check slip that recurred 2026-06-10 and 2026-06-29 (mechanism-over-memory rung 3). The published-preprint DOI-mutation case is out of scope for DOI-exact matching and still needs the manual title backstop (noted in the dedup memory files).

## Test plan

- [x] Unit tests: 9 new (normalization, pagination >100, `strict=False`, abort / proceed / `--force` / cross-casing / network-failure). Full research suite green: `research/.venv/bin/python -m pytest research/scripts/ -q` -> 38 passed.
- [x] Live E2E (non-destructive, real end-user path): ran the actual script on an existing DOI (Teo et al. `10.1126/sciadv.adz1156`) - found key `7STC9NI6` past position 100 in the 152-item library, refused the duplicate, printed the `--update-note` guidance, exit 1. No item created.

<!-- skip-lab-notebook: routine -->