### PR TITLE
fix(filter): label normal_shared by source instead of one bucket (#940)

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -10,9 +10,9 @@
 #   patient_id   sample_id    sample_type    fastq1    fastq2
 #
 # sample_type values:
-#   "Primary Tumor"        — junctions used for neoepitope prediction
-#   "Solid Tissue Normal"  — filters out non-tumor-specific junctions (tissue-matched)
-#   "Blood Derived Normal" — used for HLA typing AND as a conservative junction
+#   "Primary Tumor"        - junctions used for neoepitope prediction
+#   "Solid Tissue Normal"  - filters out non-tumor-specific junctions (tissue-matched)
+#   "Blood Derived Normal" - used for HLA typing AND as a conservative junction
 #                            normal: a junction present in blood is a self-antigen,
 #                            so it is subtracted too. Any sample_type containing
 #                            "normal" contributes to junction subtraction; the

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -11,8 +11,14 @@
 #
 # sample_type values:
 #   "Primary Tumor"        — junctions used for neoepitope prediction
-#   "Solid Tissue Normal"  — filters out non-tumor-specific junctions
-#   "Blood Derived Normal" — used for HLA typing only (WES or RNA-seq)
+#   "Solid Tissue Normal"  — filters out non-tumor-specific junctions (tissue-matched)
+#   "Blood Derived Normal" — used for HLA typing AND as a conservative junction
+#                            normal: a junction present in blood is a self-antigen,
+#                            so it is subtracted too. Any sample_type containing
+#                            "normal" contributes to junction subtraction; the
+#                            filter_junctions `normal_source` column records which
+#                            normal type removed each junction (Issue #940), so a
+#                            blood-sourced exclusion is explicit, not silent.
 #
 # For single-end data, leave fastq2 empty.
 # gs:// paths are downloaded automatically by the download_fastq rule.

--- a/research/lab_notebook/scientist.md
+++ b/research/lab_notebook/scientist.md
@@ -6,6 +6,41 @@ Format and rules unchanged from the unified notebook — see `shared/feedback_la
 
 ---
 
+## 2026-07-04
+
+### Editor: Scientist
+
+#### [PR #980](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/980) - label `normal_shared` junctions by which normal removed them. Closes [Issue #940](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/940).
+
+**The premise was wrong, and correcting it changed the fix.**
+[Issue #940](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/940) (and my first read of it) framed the problem as "`Blood Derived Normal` is used for junction subtraction, filtering out genuine tumor-specific junctions."
+On inspection that direction is largely incorrect: a genuinely tumor-restricted junction is, by definition, absent from the patient's normal blood, so blood subtraction *keeps* it (`_build_normal_junction_sources` only adds a junction seen with >= `min_normal_reads` in a normal).
+What blood actually removes are junctions *present* in the patient's blood - ubiquitous/housekeeping and leukocyte splicing - which is a legitimate, conservative safety filter (a blood-expressed junction is a self-antigen, not tumor-specific).
+The mismatched-normal worry that *is* real runs the other way (blood fails to subtract tissue-of-origin normal junctions, which then leak through as false `tumor_exclusive`), but that hole is already covered by the always-on GTEx pan-tissue population filter ([Issue #212](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/212)).
+
+**So the real defect was narrower: silence + conflation, not lost candidates.**
+`config.yaml` documented `Blood Derived Normal -> HLA typing only` while the code silently pooled it into subtraction, and every normal collapsed into one undifferentiated `normal_shared` bucket - so for patient_002 (osteosarcoma, whose only normal is a CD3+ T-cell PBMC) the weak T-cell-vs-bone subtraction (`normal_shared=154` in the 2026-06-23 STAR run) looked like real tissue-matched filtering.
+
+**Decision (Jin-Ho chose, from three options I surfaced): direction #3 - keep subtracting with all normals, but label by source.**
+Rejected #1 (exclude blood entirely) because it would strip patient_002's only normal down to GTEx-only and discard the valid conservative blood filter; rejected #2 (just update the config to legitimize blood) because it leaves the `normal_shared` bucket ambiguous.
+#3 preserves the conservative filter *and* makes provenance explicit.
+
+**What shipped.**
+`_build_normal_junction_set` -> `_build_normal_junction_sources` now returns `{junction: set[sample_type]}` (membership semantics preserved, so classification is byte-for-byte unchanged); a new backward-compatible `normal_source` column records which normal type(s) removed each `normal_shared` junction; and the filter-stats funnel gains descriptive `normal_shared:<type>` breakdown rows (kept out of the reconciling partition).
+`config.yaml`'s legend was corrected so code and config agree.
+
+**patient_002 impact (cross-ref [Issue #636](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/636)).**
+Zero numeric change - the same junctions are excluded, so `normal_shared=154` holds and no re-run is needed - but those 154 now carry `normal_source = "Blood Derived Normal"`, converting a silent weakness into a visible, interpretable one.
+
+**Verification.**
+Full workflow suite green (618 passed / 31 skipped); a live E2E CLI run on a tumor + solid + blood manifest labeled the blood-shared junction `Blood Derived Normal` and the solid-shared one `Solid Tissue Normal`, both subtracted.
+The `@-claude` review returned no blocking issues; I extended a test to cover the multi-type sorted comma-join and converted the config legend em-dashes to plain hyphens.
+
+**Follow-up.**
+The provenance lands in the TSV but not yet in `report.html` (the report's funnel pivot drops the per-source rows) - surfacing it there is filed as [Issue #983](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/983), out of #940's filter scope.
+
+---
+
 ## 2026-07-03
 
 ### 15:29 UTC - Editor: Scientist

--- a/workflow/scripts/filter_junctions.py
+++ b/workflow/scripts/filter_junctions.py
@@ -21,7 +21,15 @@ filter is a no-op and no junction is labeled gtex_pantissue_shared.
 
 Output TSV columns:
   junction_id  chrom  start  end  strand  mapped_reads  sample_id  sample_type
-  junction_origin  reading_frame
+  junction_origin  normal_source  reading_frame
+
+normal_source (Issue #940) records which normal sample_type(s) removed a
+`normal_shared` junction (e.g. ``Solid Tissue Normal``, ``Blood Derived Normal``,
+or both, comma-joined), so the exclusion's provenance is explicit rather than
+collapsed into one bucket. It is empty for `gtex_pantissue_shared` and
+`tumor_exclusive` rows. All available normals still contribute to subtraction
+(a blood-present junction is a self-antigen, a valid conservative filter); the
+column only makes *which* normal did the removing visible.
 
 reading_frame (0, 1, or 2) is the canonical CDS reading frame at the splice donor,
 derived from the GENCODE GTF when gencode_gtf is supplied. Empty string means the frame
@@ -220,26 +228,36 @@ def _build_cds_donor_lookup(
 # Core classification logic
 # ---------------------------------------------------------------------------
 
-def _build_normal_junction_set(
-    normal_files: list[tuple[Path, str]],
+def _build_normal_junction_sources(
+    normal_files: list[tuple[Path, str, str]],
     reference_junctions: frozenset[tuple[str, int, int, str]],
     min_reads: int,
-) -> frozenset[tuple[str, int, int, str]]:
-    """Build the set of unannotated junctions reliably seen in normal samples.
+) -> dict[tuple[str, int, int, str], set[str]]:
+    """Map each unannotated junction reliably seen in a normal sample to the set
+    of normal ``sample_type``\\ s that contain it.
 
     A junction is included if it has >= min_reads in at least one normal sample
-    and is not in the reference annotation.
+    and is not in the reference annotation. The value set records *which* normal
+    types (e.g. ``Solid Tissue Normal``, ``Blood Derived Normal``) it was seen in,
+    so the downstream ``normal_shared`` label carries its provenance rather than
+    collapsing every normal into one undifferentiated bucket (Issue #940).
+
+    Both normal types are used for subtraction on purpose: a junction present in
+    the patient's blood is a self-antigen, not tumor-specific, so subtracting it is
+    a valid conservative filter. The labeling stays honest about which normal did
+    the removing; it does not drop blood.
 
     Args:
-        normal_files:         List of (file_path, sample_id) for normal samples.
+        normal_files:         List of (file_path, sample_id, sample_type) for normals.
         reference_junctions:  Frozenset of annotated junction tuples to exclude.
         min_reads:            Minimum read count to trust a normal junction.
 
     Returns:
-        Frozenset of ``(chrom, start, end, strand)`` tuples.
+        dict mapping ``(chrom, start, end, strand)`` to a set of ``sample_type``
+        strings. Membership (``junction in result``) preserves the old set semantics.
     """
-    normal_set: set[tuple[str, int, int, str]] = set()
-    for path, sample_id in normal_files:
+    sources: dict[tuple[str, int, int, str], set[str]] = defaultdict(set)
+    for path, sample_id, sample_type in normal_files:
         rows = _read_junction_file(path)
         n_added = 0
         for junc_id, reads, _annotated in rows:  # annotated flag unused here
@@ -248,14 +266,15 @@ def _build_normal_junction_set(
             parsed = _parse_junction_id(junc_id)
             if parsed is None or parsed in reference_junctions:
                 continue
-            normal_set.add(parsed)
+            sources[parsed].add(sample_type)
             n_added += 1
         log.info(
-            "Normal sample %s: %d unannotated junctions (min_reads=%d)",
-            sample_id, n_added, min_reads,
+            "Normal sample %s (%s): %d unannotated junctions (min_reads=%d)",
+            sample_id, sample_type, n_added, min_reads,
         )
-    log.info("Normal junction set: %d unique unannotated junctions", len(normal_set))
-    return frozenset(normal_set)
+    log.info("Normal junction set: %d unique unannotated junctions across %d normal type(s)",
+             len(sources), len({st for s in sources.values() for st in s}))
+    return dict(sources)
 
 
 def classify_junctions(
@@ -330,14 +349,14 @@ def classify_junctions(
 
     # Split files into tumor and normal
     tumor_files: list[tuple[Path, str, str]] = []
-    normal_files: list[tuple[Path, str]] = []
+    normal_files: list[tuple[Path, str, str]] = []
 
     for fp in junction_files:
         fp = Path(fp)
         sample_id = fp.parent.name
         sample_type = manifest.get(sample_id, "Unknown")
         if "normal" in sample_type.lower():
-            normal_files.append((fp, sample_id))
+            normal_files.append((fp, sample_id, sample_type))
         else:
             tumor_files.append((fp, sample_id, sample_type))
 
@@ -348,8 +367,10 @@ def classify_junctions(
             "manifest for normal_shared filtering."
         )
 
-    # Build normal junction set
-    normal_junction_set = _build_normal_junction_set(
+    # Build the normal-junction provenance map: junction → set of normal sample_types
+    # that contain it. Membership drives the normal_shared classification (unchanged);
+    # the value set drives the normal_source provenance column (Issue #940).
+    normal_junction_sources = _build_normal_junction_sources(
         normal_files, ref_junctions, min_reads=min_normal_reads
     )
 
@@ -380,6 +401,10 @@ def classify_junctions(
         n_mean_filtered = n_raw - len(rows)
 
         n_annotated = n_normal_shared = n_gtex_shared = n_tumor_exclusive = 0
+        # Per-normal-source breakdown of normal_shared (Issue #940). A junction seen
+        # in >1 normal type counts once per type it matched, so these are descriptive
+        # (they can sum to >= n_normal_shared) and are NOT part of the funnel partition.
+        normal_source_counts: dict[str, int] = defaultdict(int)
         # STAR col-6 annotated-flag cross-check counters (Issue #375).
         n_star_annot_not_in_ref = 0
         n_ref_not_star_annot = 0
@@ -429,9 +454,17 @@ def classify_junctions(
             # makes gtex_pantissue_shared the filter's *marginal* contribution beyond
             # the matched normal (a junction already removed as normal_shared is not
             # re-counted), keeping the funnel a clean partition.
-            if parsed in normal_junction_set:
+            normal_source = ""
+            if parsed in normal_junction_sources:
                 origin = "normal_shared"
                 n_normal_shared += 1
+                # Provenance: which normal sample_type(s) removed this junction
+                # (Issue #940). Sorted + comma-joined so a junction seen in both a
+                # solid and a blood normal reads e.g. "Blood Derived Normal,Solid Tissue Normal".
+                matched_types = normal_junction_sources[parsed]
+                normal_source = ",".join(sorted(matched_types))
+                for st in matched_types:
+                    normal_source_counts[st] += 1
             elif parsed in gtex_junctions:
                 origin = "gtex_pantissue_shared"
                 n_gtex_shared += 1
@@ -454,6 +487,7 @@ def classify_junctions(
                     "sample_id": sample_id,
                     "sample_type": sample_type,
                     "junction_origin": origin,
+                    "normal_source": normal_source,
                     "reading_frame": reading_frame,
                 }
             )
@@ -496,12 +530,25 @@ def classify_junctions(
                 "count": count,
             })
 
+        # Per-normal-source breakdown of normal_shared (Issue #940), one descriptive
+        # row per normal type that removed at least one junction. Category is
+        # ``normal_shared:<normal sample_type>``. Descriptive, not a funnel partition
+        # (a junction in >1 normal type is counted under each), so these are kept
+        # separate from the reconciling funnel rows above.
+        for normal_type, count in sorted(normal_source_counts.items()):
+            stats_rows.append({
+                "sample_id": sample_id,
+                "sample_type": sample_type,
+                "category": f"normal_shared:{normal_type}",
+                "count": count,
+            })
+
     df = pd.DataFrame(
         all_classified,
         columns=[
             "junction_id", "chrom", "start", "end", "strand",
             "mapped_reads", "sample_id", "sample_type", "junction_origin",
-            "reading_frame",
+            "normal_source", "reading_frame",
         ],
     )
     output_path = Path(output_path)

--- a/workflow/tests/test_filter_junctions.py
+++ b/workflow/tests/test_filter_junctions.py
@@ -5,7 +5,7 @@ import pytest
 
 from filter_junctions import (
     _build_cds_donor_lookup,
-    _build_normal_junction_set,
+    _build_normal_junction_sources,
     _load_reference_junctions,
     _parse_junction_id,
     _read_junction_file,
@@ -119,10 +119,10 @@ class TestLoadReferenceJunctions:
 
 
 # ---------------------------------------------------------------------------
-# _build_normal_junction_set
+# _build_normal_junction_sources
 # ---------------------------------------------------------------------------
 
-class TestBuildNormalJunctionSet:
+class TestBuildNormalJunctionSources:
     def _write_junction_file(self, path, rows):
         """Write a junction TSV: junction_id<TAB>reads."""
         path.write_text("".join(f"{jid}\t{reads}\n" for jid, reads in rows))
@@ -131,26 +131,39 @@ class TestBuildNormalJunctionSet:
         f = tmp_path / "normal.tsv"
         self._write_junction_file(f, [("chr22:101:200:+", 5)])
         ref = frozenset()
-        result = _build_normal_junction_set([(f, "normal")], ref, min_reads=2)
+        result = _build_normal_junction_sources([(f, "normal", "Solid Tissue Normal")], ref, min_reads=2)
         assert ("chr22", 100, 200, "+") in result
+        # provenance: the sample_type that contained it is recorded
+        assert result[("chr22", 100, 200, "+")] == {"Solid Tissue Normal"}
 
     def test_excludes_junctions_below_min_reads(self, tmp_path):
         f = tmp_path / "normal.tsv"
         self._write_junction_file(f, [("chr22:101:200:+", 1)])
         ref = frozenset()
-        result = _build_normal_junction_set([(f, "normal")], ref, min_reads=2)
+        result = _build_normal_junction_sources([(f, "normal", "Solid Tissue Normal")], ref, min_reads=2)
         assert ("chr22", 100, 200, "+") not in result
 
     def test_excludes_reference_junctions(self, tmp_path):
         f = tmp_path / "normal.tsv"
         self._write_junction_file(f, [("chr22:101:200:+", 5)])
         ref = frozenset({("chr22", 100, 200, "+")})
-        result = _build_normal_junction_set([(f, "normal")], ref, min_reads=2)
+        result = _build_normal_junction_sources([(f, "normal", "Solid Tissue Normal")], ref, min_reads=2)
         assert len(result) == 0
 
-    def test_empty_normal_files_returns_empty_set(self):
-        result = _build_normal_junction_set([], frozenset(), min_reads=2)
+    def test_empty_normal_files_returns_empty(self):
+        result = _build_normal_junction_sources([], frozenset(), min_reads=2)
         assert len(result) == 0
+
+    def test_junction_in_two_normal_types_records_both(self, tmp_path):
+        solid = tmp_path / "solid.tsv"
+        blood = tmp_path / "blood.tsv"
+        self._write_junction_file(solid, [("chr22:101:200:+", 5)])
+        self._write_junction_file(blood, [("chr22:101:200:+", 4)])
+        result = _build_normal_junction_sources(
+            [(solid, "n1", "Solid Tissue Normal"), (blood, "n2", "Blood Derived Normal")],
+            frozenset(), min_reads=2,
+        )
+        assert result[("chr22", 100, 200, "+")] == {"Solid Tissue Normal", "Blood Derived Normal"}
 
 
 # ---------------------------------------------------------------------------
@@ -362,6 +375,8 @@ class TestClassifyJunctions:
         df = pd.read_csv(output, sep="\t")
         assert len(df) == 1
         assert df.iloc[0]["junction_origin"] == "tumor_exclusive"
+        # Issue #940: normal_source is empty for non-normal_shared rows.
+        assert pd.isna(df.iloc[0]["normal_source"]) or df.iloc[0]["normal_source"] == ""
 
     def test_normal_shared_labeled_correctly(self, tmp_path):
         tumor_f = tmp_path / "tumor" / "raw_junctions.tsv"
@@ -396,6 +411,61 @@ class TestClassifyJunctions:
         df = pd.read_csv(output, sep="\t")
         assert len(df) == 1
         assert df.iloc[0]["junction_origin"] == "normal_shared"
+        # Issue #940: the exclusion carries its provenance.
+        assert df.iloc[0]["normal_source"] == "Solid Tissue Normal"
+
+    def test_blood_derived_normal_is_used_and_labeled(self, tmp_path):
+        """Issue #940: a Blood Derived Normal still subtracts (conservative
+        self-antigen filter), and the resulting normal_shared row is labeled with
+        that source so it is distinguishable from a solid-tissue exclusion."""
+        tumor_f = tmp_path / "tumor" / "raw_junctions.tsv"
+        solid_f = tmp_path / "solid" / "raw_junctions.tsv"
+        blood_f = tmp_path / "blood" / "raw_junctions.tsv"
+        for f in (tumor_f, solid_f, blood_f):
+            f.parent.mkdir()
+
+        # Two tumor junctions clear the mean filter: one shared with blood only,
+        # one shared with solid only. Plus a noise junction below the mean.
+        self._write_junction_file(tumor_f, [
+            ("chr22:201:300:+", 100),   # shared with blood
+            ("chr22:601:700:+", 100),   # shared with solid
+            ("chr22:401:500:+", 1),     # noise, filtered out
+        ])
+        self._write_junction_file(solid_f, [("chr22:601:700:+", 5)])
+        self._write_junction_file(blood_f, [("chr22:201:300:+", 5)])
+
+        manifest = tmp_path / "manifest.tsv"
+        self._write_manifest(manifest, [
+            ("tumor", "Primary Tumor"),
+            ("solid", "Solid Tissue Normal"),
+            ("blood", "Blood Derived Normal"),
+        ])
+        ref_bed = tmp_path / "ref.bed"
+        self._write_reference_bed(ref_bed, [])
+
+        output = tmp_path / "novel.tsv"
+        stats = tmp_path / "stats.tsv"
+        classify_junctions(
+            junction_files=[tumor_f, solid_f, blood_f],
+            manifest_path=manifest,
+            reference_bed=ref_bed,
+            output_path=output,
+            stats_output_path=stats,
+        )
+
+        df = pd.read_csv(output, sep="\t")
+        src = dict(zip(df["junction_id"], df["normal_source"]))
+        assert src["chr22:201:300:+"] == "Blood Derived Normal"
+        assert src["chr22:601:700:+"] == "Solid Tissue Normal"
+        # both were removed as normal_shared (blood is used, not dropped)
+        assert (df["junction_origin"] == "normal_shared").sum() == 2
+
+        # Stats funnel carries the per-source breakdown, and normal_shared total is intact.
+        sdf = pd.read_csv(stats, sep="\t")
+        cats = dict(zip(sdf["category"], sdf["count"]))
+        assert cats["normal_shared"] == 2
+        assert cats["normal_shared:Blood Derived Normal"] == 1
+        assert cats["normal_shared:Solid Tissue Normal"] == 1
 
     def test_annotated_junctions_discarded(self, tmp_path):
         tumor_f = tmp_path / "tumor" / "raw_junctions.tsv"
@@ -765,8 +835,9 @@ class TestClassifyJunctionsStats:
 
         # Long-format per tumor sample: 6 funnel rows (Issue #214 + the
         # gtex_pantissue_shared row from Issue #212, always emitted) +
-        # 4 descriptive distribution rows (Issue #215) = 10 total.
-        assert len(stats) == 10
+        # 4 descriptive distribution rows (Issue #215) + 1 per-normal-source
+        # breakdown row (Issue #940, one normal type removed a junction) = 11 total.
+        assert len(stats) == 11
         assert (stats["sample_id"] == "tumor").all()
         assert (stats["sample_type"] == "Primary Tumor").all()
 
@@ -781,6 +852,8 @@ class TestClassifyJunctionsStats:
         assert by_cat["tumor_exclusive"] == 1
         # No GTEx blacklist supplied → the row is still emitted with count 0.
         assert by_cat["gtex_pantissue_shared"] == 0
+        # Issue #940: per-source breakdown row for the one normal type used.
+        assert by_cat["normal_shared:Solid Tissue Normal"] == 1
 
     def test_funnel_reconciles_arithmetically(self, tmp_path):
         """junctions_raw must equal the sum of the downstream partition categories."""

--- a/workflow/tests/test_filter_junctions.py
+++ b/workflow/tests/test_filter_junctions.py
@@ -424,15 +424,17 @@ class TestClassifyJunctions:
         for f in (tumor_f, solid_f, blood_f):
             f.parent.mkdir()
 
-        # Two tumor junctions clear the mean filter: one shared with blood only,
-        # one shared with solid only. Plus a noise junction below the mean.
+        # Tumor junctions clearing the mean filter: one shared with blood only,
+        # one with solid only, one with BOTH (exercises the sorted comma-join).
+        # Plus a noise junction below the mean.
         self._write_junction_file(tumor_f, [
             ("chr22:201:300:+", 100),   # shared with blood
             ("chr22:601:700:+", 100),   # shared with solid
+            ("chr22:701:800:+", 100),   # shared with BOTH
             ("chr22:401:500:+", 1),     # noise, filtered out
         ])
-        self._write_junction_file(solid_f, [("chr22:601:700:+", 5)])
-        self._write_junction_file(blood_f, [("chr22:201:300:+", 5)])
+        self._write_junction_file(solid_f, [("chr22:601:700:+", 5), ("chr22:701:800:+", 5)])
+        self._write_junction_file(blood_f, [("chr22:201:300:+", 5), ("chr22:701:800:+", 5)])
 
         manifest = tmp_path / "manifest.tsv"
         self._write_manifest(manifest, [
@@ -457,15 +459,19 @@ class TestClassifyJunctions:
         src = dict(zip(df["junction_id"], df["normal_source"]))
         assert src["chr22:201:300:+"] == "Blood Derived Normal"
         assert src["chr22:601:700:+"] == "Solid Tissue Normal"
-        # both were removed as normal_shared (blood is used, not dropped)
-        assert (df["junction_origin"] == "normal_shared").sum() == 2
+        # a junction in both normals carries both, sorted + comma-joined
+        assert src["chr22:701:800:+"] == "Blood Derived Normal,Solid Tissue Normal"
+        # all three removed as normal_shared (blood is used, not dropped)
+        assert (df["junction_origin"] == "normal_shared").sum() == 3
 
-        # Stats funnel carries the per-source breakdown, and normal_shared total is intact.
+        # Stats funnel carries the per-source breakdown (a both-normals junction
+        # counts under each source, so the per-source rows can sum to > normal_shared),
+        # and the funnel normal_shared total counts distinct junctions.
         sdf = pd.read_csv(stats, sep="\t")
         cats = dict(zip(sdf["category"], sdf["count"]))
-        assert cats["normal_shared"] == 2
-        assert cats["normal_shared:Blood Derived Normal"] == 1
-        assert cats["normal_shared:Solid Tissue Normal"] == 1
+        assert cats["normal_shared"] == 3
+        assert cats["normal_shared:Blood Derived Normal"] == 2   # chr22:201 + chr22:701
+        assert cats["normal_shared:Solid Tissue Normal"] == 2    # chr22:601 + chr22:701
 
     def test_blood_only_manifest_subtracts_and_labels(self, tmp_path):
         """Issue #940 AC: a Blood-Derived-Normal-only manifest (patient_002's shape:

--- a/workflow/tests/test_filter_junctions.py
+++ b/workflow/tests/test_filter_junctions.py
@@ -467,6 +467,45 @@ class TestClassifyJunctions:
         assert cats["normal_shared:Blood Derived Normal"] == 1
         assert cats["normal_shared:Solid Tissue Normal"] == 1
 
+    def test_blood_only_manifest_subtracts_and_labels(self, tmp_path):
+        """Issue #940 AC: a Blood-Derived-Normal-only manifest (patient_002's shape:
+        a CD3+ PBMC as the sole normal) still subtracts, and the exclusion is
+        explicitly attributed to blood - not silent, not dropped."""
+        tumor_f = tmp_path / "tumor" / "raw_junctions.tsv"
+        blood_f = tmp_path / "blood" / "raw_junctions.tsv"
+        for f in (tumor_f, blood_f):
+            f.parent.mkdir()
+
+        self._write_junction_file(tumor_f, [
+            ("chr22:201:300:+", 100),   # shared with blood -> normal_shared (blood)
+            ("chr22:601:700:+", 100),   # absent in blood -> tumor_exclusive
+            ("chr22:401:500:+", 1),     # noise, filtered out
+        ])
+        self._write_junction_file(blood_f, [("chr22:201:300:+", 5)])
+
+        manifest = tmp_path / "manifest.tsv"
+        self._write_manifest(manifest, [
+            ("tumor", "Primary Tumor"),
+            ("blood", "Blood Derived Normal"),
+        ])
+        ref_bed = tmp_path / "ref.bed"
+        self._write_reference_bed(ref_bed, [])
+
+        output = tmp_path / "novel.tsv"
+        classify_junctions(
+            junction_files=[tumor_f, blood_f],
+            manifest_path=manifest,
+            reference_bed=ref_bed,
+            output_path=output,
+        )
+
+        df = pd.read_csv(output, sep="\t")
+        src = dict(zip(df["junction_id"], df["normal_source"]))
+        origin = dict(zip(df["junction_id"], df["junction_origin"]))
+        assert origin["chr22:201:300:+"] == "normal_shared"
+        assert src["chr22:201:300:+"] == "Blood Derived Normal"
+        assert origin["chr22:601:700:+"] == "tumor_exclusive"
+
     def test_annotated_junctions_discarded(self, tmp_path):
         tumor_f = tmp_path / "tumor" / "raw_junctions.tsv"
         normal_f = tmp_path / "normal" / "raw_junctions.tsv"


### PR DESCRIPTION
Closes #940.

## What & why

`filter_junctions.py` pooled every "normal" sample (including `Blood Derived Normal`) into one undifferentiated `normal_shared` bucket, silently contradicting the config legend and hiding *which* normal removed a junction.

After review (see the reframing comment on #940), the original premise - that blood subtraction "filters out genuine tumor-specific junctions" - is largely wrong: a true tumor-restricted junction is absent from blood, so it survives; what blood removes are blood-present self-antigens (a valid conservative filter), and tissue-of-origin leakage is already covered by the always-on GTEx pan-tissue filter (#212). So the real defect is **silence + conflation**, not lost candidates.

**Fix (direction #3):** keep subtracting with all available normals, but attribute each `normal_shared` exclusion to the normal `sample_type`(s) that matched.

- `_build_normal_junction_set` → `_build_normal_junction_sources`: returns `{junction: set[sample_type]}` (membership semantics preserved → classification unchanged).
- New **backward-compatible** `normal_source` output column (comma-joined sample_types for `normal_shared` rows, empty otherwise) + a descriptive per-source breakdown in the stats funnel (`normal_shared:<type>`); the reconciling funnel partition is unchanged.
- `config.yaml` legend updated so code and config agree (blood *does* subtract, as a conservative filter, and is no longer silent).

**Schema note:** adds one column (`normal_source`) to the junctions TSV. Backward-compatible - the two downstream consumers (`assemble_contigs.py`, `generate_report.py`) select by column name. patient_002 counts are unchanged in magnitude (same junctions excluded); the blood-sourced subtraction is now just visible.

## Test plan

- [x] Full workflow suite green: `workflow/tests/.venv/bin/python -m pytest workflow/tests/` → 618 passed, 31 skipped.
- [x] New unit coverage: provenance in `_build_normal_junction_sources` (single + two-type), `normal_source` on solid vs blood, empty on tumor_exclusive, per-source stats rows, and a Blood-Derived-Normal-only manifest (patient_002's shape).
- [x] Live E2E (real CLI path): tumor + solid + blood manifest → blood-shared junction labeled `Blood Derived Normal`, solid-shared labeled `Solid Tissue Normal`, both subtracted; stats funnel shows `normal_shared=2` with per-source breakdown 1/1.