### PR TITLE
fix(guards): surface canonical review trigger in bot-mention deny message (#975)

### DIFF
--- a/.agents/hooks/check_at_claude.py
+++ b/.agents/hooks/check_at_claude.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
-"""Pre-flight hook: refuse `gh (pr|issue) (comment|create)` whose body contains
-a literal @claude bot mention, except the canonical `@claude review` trigger.
+"""Pre-flight hook: refuse `gh (pr|issue) (comment|create|edit)` whose body
+contains a literal @claude bot mention, except the canonical `@claude review`
+trigger.
 
 See memory/shared/feedback_no_at_claude_mention.md for the originating rule.
 Spec: https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/360
@@ -41,12 +42,15 @@ def main() -> int:
                     "hookEventName": "PreToolUse",
                     "permissionDecision": "deny",
                     "permissionDecisionReason": (
-                        "Stray @claude mention in `gh (pr|issue) (comment|create)` body. "
+                        "Stray @claude mention in `gh (pr|issue) (comment|create|edit)` body. "
                         "The Claude Code GitHub Action triggers on ANY literal @claude "
                         "(incl. inside parens, ACs, code spans, quoted historical refs). "
-                        "See memory/shared/feedback_no_at_claude_mention.md. For "
-                        "non-trigger references, use the zero-width workaround @-claude "
-                        "(literal substring @claude must not appear)."
+                        "See memory/shared/feedback_no_at_claude_mention.md. "
+                        "To intentionally request a bot review, use exactly "
+                        '--body "@claude review" (the canonical trigger is the one '
+                        "allowed form). For any OTHER (non-trigger) reference, use the "
+                        "zero-width workaround @-claude (literal substring @claude must "
+                        "not appear)."
                     ),
                 }
             }

--- a/research/lab_notebook/developer.md
+++ b/research/lab_notebook/developer.md
@@ -8,6 +8,16 @@ Format and rules unchanged from the unified notebook — see `shared/feedback_la
 
 ## 2026-07-04 - CCR sandbox gh re-probe: native issue-dependency fields still unavailable in-sandbox ([PR #974](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/974) closes [Issue #941](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/941))
 
+### 01:43 UTC - Editor: Developer - surface the canonical review trigger in the bot-mention deny message ([Issue #975](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/975))
+
+**Context.** [Issue #975](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/975) (a papercut surfaced by the #799 guard work): the `check_at_claude.py` deny message advertised the `@-claude` zero-width workaround (for non-trigger references) but never the canonical `--body "@claude review"` carve-out. So an agent legitimately requesting a bot review got denied with no hint of the allowed form and had to read the hook source (observed on a personas-repo PR).
+
+**Change.** Deny message now names **both** escape hatches - request a review with exactly `--body "@claude review"`, use `@-claude` for any other reference. Folded in the accuracy fix I flagged in the [#979](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/979) review: the message + module docstring said `(comment|create)` but the regex has always covered `edit`; both now say `(comment|create|edit)`. Deny/allow logic byte-unchanged - this is message wording + tests only ([PR #984](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/984), closes #975).
+
+**TDD + review.** Added `TestDenyMessageGuidance` RED-first (2 failed on the old message: canonical-trigger + edit-scope; the `@-claude` assertion already passed), GREEN after the fix; suite 15 passed. Bot review LGTM; applied its nit to assert the exact `(comment|create|edit)` token instead of a bare `"edit"` substring (which would match "edited"/"credit"). Left the single-quoted-form nit as-is - one canonical form in the message is clearer.
+
+**Process note.** Third quick-win of the session under the standing autonomy cadence, and the second clean run of the content-based bot-review poll (2m47s, caught correctly).
+
 ### 01:28 UTC - Editor: Developer - canonicalize the bot-mention guard to one user-level source ([Issue #799](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/799))
 
 **Context.** [Issue #799](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/799) ([#665](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/665) gap 1): the `check_at_claude.py` bot-mention guard was registered in **both** the project `.agents/settings.json` and the MM's user-level `~/.claude/settings.json`, so in the project cwd it double-fired - a drift risk. The guard must fire cwd-agnostically (a project comment can be drafted from the project clones *or* the personas cwd), and only a user-level global registration does that; a project-scoped hook fires only when its own repo is cwd.

--- a/tools/ci/test_check_at_claude.py
+++ b/tools/ci/test_check_at_claude.py
@@ -123,9 +123,10 @@ class TestDenyMessageGuidance:
         assert "@-claude" in reason
 
     def test_reason_names_guarded_edit_subcommand(self):
-        # the guard covers `edit` too; the message should not undersell its scope
+        # the guard covers `edit` too; assert the actual scope token, not a bare
+        # "edit" substring (which would also match "edited"/"credit")
         _, out, _ = _run(_payload(self.STRAY))
-        assert "edit" in _deny_reason(out)
+        assert "(comment|create|edit)" in _deny_reason(out)
 
 
 class TestFailOpen:

--- a/tools/ci/test_check_at_claude.py
+++ b/tools/ci/test_check_at_claude.py
@@ -37,6 +37,12 @@ def _is_deny(stdout: str) -> bool:
     )
 
 
+def _deny_reason(stdout: str) -> str:
+    """The human-facing `permissionDecisionReason` string from a deny decision."""
+    parsed = json.loads(stdout)
+    return parsed["hookSpecificOutput"]["permissionDecisionReason"]
+
+
 class TestAllowPaths:
     def test_non_gh_command_allowed(self):
         rc, out, _ = _run(_payload("ls -la"))
@@ -94,6 +100,32 @@ class TestDenyPaths:
             )
         )
         assert rc == 0 and _is_deny(out)
+
+
+class TestDenyMessageGuidance:
+    """#975: the deny message must surface BOTH escape hatches, so an agent
+    denied while legitimately requesting a review can construct the correct
+    command from the message alone, without reading the hook source.
+    """
+
+    STRAY = 'gh pr comment 1 --body "ping @claude for review"'
+
+    def test_reason_names_canonical_review_trigger(self):
+        _, out, _ = _run(_payload(self.STRAY))
+        reason = _deny_reason(out)
+        # the one allowed form, and how to invoke it
+        assert "@claude review" in reason
+        assert "--body" in reason
+
+    def test_reason_names_zero_width_workaround(self):
+        _, out, _ = _run(_payload(self.STRAY))
+        reason = _deny_reason(out)
+        assert "@-claude" in reason
+
+    def test_reason_names_guarded_edit_subcommand(self):
+        # the guard covers `edit` too; the message should not undersell its scope
+        _, out, _ = _run(_payload(self.STRAY))
+        assert "edit" in _deny_reason(out)
 
 
 class TestFailOpen:


### PR DESCRIPTION
**Created by:** Developer

## Summary

The `@claude` bot-mention guard's deny message told you about the `@-claude` zero-width workaround (for *non-trigger* references) but never mentioned the canonical `--body "@claude review"` carve-out. So an agent legitimately requesting a bot review got denied with no hint of the allowed form, and had to read the hook source to discover it (observed 2026-07-04 on a personas-repo PR, [Issue #975](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/975)).

## Change

`.claude/hooks/check_at_claude.py` deny message now surfaces **both** escape hatches:
- **To request a bot review:** use exactly `--body "@claude review"` (the one allowed form).
- **For any other reference:** use the zero-width `@-claude` workaround.

Also folded in the accuracy fix flagged in the [#979](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/979) review: the message (and the module docstring) said `(comment|create)` but the guard also covers `edit` - both now say `(comment|create|edit)`, matching the actual regex.

Behavior is unchanged (deny/allow logic untouched); this is message wording + its test.

## Test plan

- [x] New `TestDenyMessageGuidance` tests assert the deny reason names the canonical `@claude review` trigger, the `--body` invocation, the `@-claude` workaround, and the `edit` scope - added RED first (2 failed on the old message), GREEN after the fix
- [x] Full `tools/ci/test_check_at_claude.py` suite green: 15 passed (all pre-existing deny/allow + fail-open cases still pass)
- [x] Live sanity: a stray `@claude` comment still denies, and the reason now guides the agent to the correct command

Closes #975.
