### PR TITLE
fix(tooling): repair stale splice-neoepitope-research Jupyter kernelspec (#923)

### DIFF
--- a/research/README.md
+++ b/research/README.md
@@ -23,6 +23,14 @@ pip install -r requirements.txt
 
 **Usage:** Open any `.ipynb` in VSCode and select `research/.venv` as the kernel (Python 3.14.4).
 
+**Headless execution (one-time, per-clone):** register this clone's venv as the `splice-neoepitope-research` Jupyter kernelspec so `jupyter nbconvert --execute` and agent/CI contexts resolve to a real interpreter:
+```bash
+research/.venv/bin/python -m ipykernel install --user \
+  --name splice-neoepitope-research \
+  --display-name "Splice Neoepitope (research)"
+```
+This is a machine-local registration (`~/Library/Jupyter/kernels/`), not tracked in git - like the `.venv` itself, each clone runs it once. The kernelspec name is global, so the last clone to run it becomes the canonical execution clone; run it from whichever clone you execute notebooks in. After registration, run notebooks from this venv's jupyter (`research/.venv/bin/jupyter nbconvert --to notebook --execute <nb>`) with no `--ExecutePreprocessor.kernel_name` override needed.
+
 The notebooks read pipeline results directly from GCS (`gs://splice-neoepitope-project/results/<patient_id>/`) via `gsutil` — no local data download needed. Make sure `gsutil` is authenticated (`gcloud auth application-default login`).
 
 ---

--- a/research/README.md
+++ b/research/README.md
@@ -29,7 +29,7 @@ research/.venv/bin/python -m ipykernel install --user \
   --name splice-neoepitope-research \
   --display-name "Splice Neoepitope (research)"
 ```
-This is a machine-local registration (`~/Library/Jupyter/kernels/`), not tracked in git - like the `.venv` itself, each clone runs it once. The kernelspec name is global, so the last clone to run it becomes the canonical execution clone; run it from whichever clone you execute notebooks in. After registration, run notebooks from this venv's jupyter (`research/.venv/bin/jupyter nbconvert --to notebook --execute <nb>`) with no `--ExecutePreprocessor.kernel_name` override needed.
+This is a machine-local registration (`~/Library/Jupyter/kernels/` on macOS, `~/.local/share/jupyter/kernels/` on Linux for the GPU-revival path), not tracked in git - like the `.venv` itself, each clone runs it once. The kernelspec name is global, so the last clone to run it becomes the canonical execution clone; run it from whichever clone you execute notebooks in. After registration, run notebooks from this venv's jupyter (`research/.venv/bin/jupyter nbconvert --to notebook --execute <nb>`) with no `--ExecutePreprocessor.kernel_name` override needed.
 
 The notebooks read pipeline results directly from GCS (`gs://splice-neoepitope-project/results/<patient_id>/`) via `gsutil` — no local data download needed. Make sure `gsutil` is authenticated (`gcloud auth application-default login`).
 

--- a/research/lab_notebook/scientist.md
+++ b/research/lab_notebook/scientist.md
@@ -10,6 +10,16 @@ Format and rules unchanged from the unified notebook — see `shared/feedback_la
 
 ### Editor: Scientist
 
+#### [PR #990](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/990) - repair the stale `splice-neoepitope-research` Jupyter kernelspec. Closes [Issue #923](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/923).
+
+**What was broken.** The globally-registered `splice-neoepitope-research` kernelspec pointed at a `Documents/GitHub/...` clone that stopped existing at the 2026-05-14 separate-clone migration, so `jupyter nbconvert --execute` on any research notebook failed at kernel launch (worked around in #914 with a throwaway temp kernel). Confirmed live: `argv[0]` in `~/Library/Jupyter/kernels/splice-neoepitope-research/kernel.json` resolved to a non-existent path.
+
+**Fix (the issue's option 1).** Re-register from the active clone (`research/.venv/bin/python -m ipykernel install --user --name splice-neoepitope-research ...`) - a machine-local action, so the only tracked change is a per-clone registration note added to `research/README.md` beside the existing venv-setup step.
+
+**Verification.** (AC1) re-registered `argv[0]` resolves to `research/.venv/bin/python`; (AC2) the self-contained `issue_737_sparsity` notebook runs end-to-end via `nbconvert --execute` with **no `--kernel_name` override** and 0 error outputs; the repaired named kernel also launches directly (probe prints the venv python + pandas 3.0.3).
+
+**Findings surfaced for follow-up.** The `python3` kernelspec is not "bare" when jupyter is invoked from the venv - it resolves to `research/.venv/share/jupyter/kernels/python3` (the venv's own), so headless runs "just work" from `research/.venv/bin/jupyter`. Bot review (LGTM) flagged two out-of-scope staleness items, both filed rather than folded in: the Linux `--user` path note (applied inline), and the adjacent stale GCS notebook-data line → [#995](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/995) (GCS→R2 correction).
+
 #### [PR #987](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/987) - monotone extrapolation instead of endpoint-clipping in the calibrator. Closes [Issue #805](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/805).
 
 **The bug and the fix.**


### PR DESCRIPTION
Closes #923.

## What

The globally-registered `splice-neoepitope-research` Jupyter kernelspec pointed at a **non-existent** `Documents/GitHub/...` clone (a stale registration from before the 2026-05-14 separate-clone migration), so `jupyter nbconvert --execute` against any research notebook failed out of the box. #914 worked around it with a throwaway temp kernel.

Fix = the issue's recommended **option 1**: re-register the kernelspec from the active clone's venv (a machine-local action, done on this machine) + document the one-time per-clone step in `research/README.md` alongside the existing venv-setup note. No repo code changes are needed for the registration itself; the tracked change is the README note so a fresh clone knows to run it.

## Acceptance criteria

- [x] `splice-neoepitope-research` kernelspec resolves to an existing `research/.venv/bin/python`
- [x] `jupyter nbconvert --execute` runs a research notebook end-to-end with no `--ExecutePreprocessor.kernel_name` workaround
- [x] the registration step is documented in `research/README.md` (per-clone, matching the existing venv-setup note)

## Test plan

- [x] `jq .argv[0]` on the re-registered kernelspec resolves to `research/.venv/bin/python` and the file is executable (AC1)
- [x] `research/.venv/bin/jupyter nbconvert --to notebook --execute` on the self-contained `issue_737_sparsity` research notebook completes with **0 error outputs** and **no kernel_name flag** (AC2)
- [x] the repaired named kernel specifically launches + runs code end-to-end (probe notebook forced onto `splice-neoepitope-research` prints the correct venv python + pandas 3.0.3)

## Notes

- The kernelspec name is global, so the last clone to register becomes the canonical execution clone - documented as such (the issue's accepted "one canonical execution clone" tradeoff).
- Out of scope but spotted: `research/README.md` still points notebook data reads at GCS (`gs://...`), which was decommissioned 2026-06-26 in favor of Cloudflare R2. Flagging for a separate follow-up rather than mixing a data-source correction into this kernelspec fix.