### PR TITLE
chore(logs): namespace shared-step logs under logs/_shared/ (#673)

### DIFF
--- a/research/lab_notebook/developer.md
+++ b/research/lab_notebook/developer.md
@@ -8,6 +8,20 @@ Format and rules unchanged from the unified notebook — see `shared/feedback_la
 
 ## 2026-07-04 - CCR sandbox gh re-probe: native issue-dependency fields still unavailable in-sandbox ([PR #974](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/974) closes [Issue #941](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/941))
 
+### 02:58 UTC - Editor: Developer - namespace shared-step logs under logs/_shared/ ([PR #991](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/991) closes [Issue #673](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/673))
+
+**Context.** [Issue #673](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/673): shared reference/index/model-build logs (no `{patient_id}`) wrote to `logs/<step>/` at the top level while per-patient jobs wrote to `logs/<patient_id>/<step>/`, so five step names (alignment, download, filter_junctions, mhc_affinity, proteome_filter) appeared at two depths. Next quick win of the session.
+
+**Change.** Added `_SHARED_LOG = os.path.join(_LOGS, "_shared")` in `common.smk` (with a shared-vs-per-patient convention comment) and routed all 9 shared `log:` directives through it; converted the two hardcoded `logs/download/...` strings - which also fixes a latent bug (they now honor `config["output"]["logs"]` like every other directive, flagged as a bonus by the bot review). `setup_vm.sh` gets an idempotent `logs/<step>` -> `logs/_shared/` migration mirroring the #63 `resources/->references/` block.
+
+**Infra-reality rescope.** Two ACs were premised on GCP infra decommissioned 2026-06-26 ([#854](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/854)): AC #5's "run once" GCS `gcloud storage mv` cannot run (bucket deleted) - reframed as a revival-scoped `setup_vm.sh` comment; AC #4's VM migration is revival-scoped (no live VM). AC #7's GTEx-log coordination resolved itself - PR #653 merged, so `gtex_pan_tissue_bed.log` is folded into the routing (download x3). Core routing has present value on the local CPU core (the hisat2_index / mhcflurry_downloads / build_reference_junctions logs are written locally too). Same verify-premise-against-current-infra discipline as the #942 rescope earlier this session ([[feedback_verify_premise_before_mechanizing]]).
+
+**Verification.** `snakemake -n` resolves the 9-job DAG (no parse error - `_SHARED_LOG` wired); pytest 646 passed / 6 skipped; `bash -n setup_vm.sh` clean; grep confirms no shared `_LOGS` / hardcoded `logs/` strings remain and per-patient `log:` untouched.
+
+**Review.** Bot review LGTM (2m58s), enumerated all 25 `log:` directives (9 shared / 16 per-patient) and confirmed the classification exact, flagged the latent-bug fix as a bonus. Three non-blocking observations dispositioned on the PR, no code change: (1) `patient_id`==step-name migration collision - effectively impossible (accession IDs) and the sibling #63 block shares the assumption; (2) idempotency orphan when both dirs exist - intentional non-clobbering; (3) stale `logs/download/` path in a frozen 2026-05-20 plan doc - left as historical record.
+
+**Process note.** Fifth quick-win of the session under the standing autonomy cadence; content-based bot-review poll caught at 2m58s again.
+
 ### 02:26 UTC - Editor: Developer - rescope #942: the native blockedBy swap was already done; scope-correct the gh floor ([PR #988](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/988) closes [Issue #942](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/942))
 
 **Context.** [Issue #942](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/942) (the implementation half of the #824 eval, follow-up to my 00:29 #941 probe below) asked to swap the `is:blocked` search read to native `blockedBy` in the commitment gate (`scripts/audit_and_merge.sh`) and the morning blocked-graph hygiene check. Picked it as a quick win.

--- a/scripts/setup_vm.sh
+++ b/scripts/setup_vm.sh
@@ -217,6 +217,32 @@ if [[ -d "$OLD_RESOURCES" ]]; then
     done
 fi
 
+# One-shot migration (Issue #673): shared-step logs move from logs/<step>/ to
+# logs/_shared/<step>/, mirroring the shared-vs-per-patient convention now used
+# in the workflow. Idempotent - only moves a top-level step dir that exists AND
+# is not yet present under _shared/ (per-patient logs under logs/<patient_id>/
+# are left untouched). The shared-log rules are cached/skipped once their
+# artifact exists, so a warm VM will not regenerate these logs under the new
+# path on its own; this lets an existing VM adopt the layout without a rebuild.
+# Companion GCS move (mirrors this on the remote store, once per bucket):
+#   for s in alignment download filter_junctions mhc_affinity proteome_filter; do
+#     gcloud storage mv "gs://$GCS_BUCKET/logs/$s" "gs://$GCS_BUCKET/logs/_shared/$s"
+#   done
+# NOTE: the gs://splice-neoepitope-project bucket was decommissioned in the
+# 2026-06-26 $0-budget teardown (Issue #854), so the GCS move is documented for
+# a funded revival, not runnable today.
+LOGS_DIR="$REPO_DIR/logs"
+SHARED_LOGS="$LOGS_DIR/_shared"
+if [[ -d "$LOGS_DIR" ]]; then
+    for s in alignment download filter_junctions mhc_affinity proteome_filter; do
+        if [[ -d "$LOGS_DIR/$s" && ! -d "$SHARED_LOGS/$s" ]]; then
+            log "  Migrating logs/$s/ → logs/_shared/$s/ (Issue #673 layout)"
+            mkdir -p "$SHARED_LOGS"
+            mv "$LOGS_DIR/$s" "$SHARED_LOGS/$s"
+        fi
+    done
+fi
+
 FASTA_GZ="$REFERENCES/GRCh38.primary_assembly.genome.fa.gz"
 FASTA="$REFERENCES/GRCh38.primary_assembly.genome.fa"
 

--- a/workflow/rules/alignment.smk
+++ b/workflow/rules/alignment.smk
@@ -109,7 +109,7 @@ if config.get("alignment", {}).get("aligner") == "hisat2":
                 index_dir=directory(_HISAT2_INDEX_DIR),
                 done=touch(os.path.join(_HISAT2_INDEX_DIR, "index.done")),
             log:
-                os.path.join(_LOGS, "alignment", "hisat2_index.log"),
+                os.path.join(_SHARED_LOG, "alignment", "hisat2_index.log"),
             params:
                 url=_HISAT2_PREBUILT_URL,
             resources:
@@ -140,7 +140,7 @@ if config.get("alignment", {}).get("aligner") == "hisat2":
                 index_dir=directory(_HISAT2_INDEX_DIR),
                 done=touch(os.path.join(_HISAT2_INDEX_DIR, "index.done")),
             log:
-                os.path.join(_LOGS, "alignment", "hisat2_index.log"),
+                os.path.join(_SHARED_LOG, "alignment", "hisat2_index.log"),
             threads: config.get("alignment", {}).get("threads", 8)
             resources:
                 mem_mb=8000,
@@ -267,7 +267,7 @@ elif config.get("alignment", {}).get("aligner") == "star":
             index_dir=directory(_STAR_INDEX_DIR),
             done=touch(os.path.join(_STAR_INDEX_DIR, "index.done")),
         log:
-            os.path.join(_LOGS, "alignment", "star_index.log"),
+            os.path.join(_SHARED_LOG, "alignment", "star_index.log"),
         threads: config.get("alignment", {}).get("threads", 8)
         resources:
             mem_mb=32000,

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -23,6 +23,14 @@ if "samples_tsv" not in config:
 _RES  = config["output"]["results_dir"]
 _LOGS = config["output"]["logs"]
 
+# Log-tree convention: per-patient jobs (a {patient_id} wildcard) write to
+# logs/<patient_id>/<step>/; shared reference/index/model-build jobs (no
+# {patient_id}) write to logs/_shared/<step>/ instead of the top of logs/.
+# Namespacing the shared logs keeps every step-name folder at one depth (2)
+# and mirrors the results-side segregation (indices/, references/) and the
+# research/experiments/_shared/ convention.
+_SHARED_LOG = os.path.join(_LOGS, "_shared")
+
 # ── Wildcard constraints ──────────────────────────────────────────────────────
 wildcard_constraints:
     patient_id="[^/]+",

--- a/workflow/rules/download.smk
+++ b/workflow/rules/download.smk
@@ -60,7 +60,7 @@ rule download_vdjdb_release:
         vdjdb_tsv = f"references/vdjdb/{config['tcrdock']['vdjdb_release']}/vdjdb_full.txt",
         sentinel = f"references/vdjdb/{config['tcrdock']['vdjdb_release']}/.download.done",
     log:
-        f"logs/download/vdjdb_{config['tcrdock']['vdjdb_release']}.log",
+        os.path.join(_SHARED_LOG, "download", f"vdjdb_{config['tcrdock']['vdjdb_release']}.log"),
     params:
         release = config["tcrdock"]["vdjdb_release"],
         sha256 = config["tcrdock"]["vdjdb_sha256"],
@@ -122,7 +122,7 @@ if _GTEX_CFG.get("enabled", False) and _GTEX_REF.startswith("gs://"):
             src=_GTEX_REF,
             sha256=(_GTEX_CFG.get("reference_bed_sha256") or "").strip(),
         log:
-            os.path.join(_LOGS, "download", "gtex_pan_tissue_bed.log"),
+            os.path.join(_SHARED_LOG, "download", "gtex_pan_tissue_bed.log"),
         shell:
             """
             set -euo pipefail
@@ -157,7 +157,7 @@ rule download_imgt_germlines:
     output:
         sentinel = "references/imgt_germlines/.download.done",
     log:
-        "logs/download/imgt_germlines.log",
+        os.path.join(_SHARED_LOG, "download", "imgt_germlines.log"),
     conda:
         "../envs/vdjdb.yaml"
     shell:

--- a/workflow/rules/filter_junctions.smk
+++ b/workflow/rules/filter_junctions.smk
@@ -19,7 +19,7 @@ rule build_reference_junctions:
     output:
         bed=config["reference"]["junction_bed"],
     log:
-        os.path.join(_LOGS, "filter_junctions", "build_reference_junctions.log"),
+        os.path.join(_SHARED_LOG, "filter_junctions", "build_reference_junctions.log"),
     conda:
         "../envs/python.yaml"
     script:

--- a/workflow/rules/mhc_affinity.smk
+++ b/workflow/rules/mhc_affinity.smk
@@ -45,7 +45,7 @@ rule download_mhcflurry_models:
     output:
         sentinel=touch(_MHCFLURRY_SENTINEL),
     log:
-        os.path.join(_LOGS, "mhc_affinity", "mhcflurry_downloads.log"),
+        os.path.join(_SHARED_LOG, "mhc_affinity", "mhcflurry_downloads.log"),
     conda:
         "../envs/python.yaml"
     shell:

--- a/workflow/rules/proteome_filter.smk
+++ b/workflow/rules/proteome_filter.smk
@@ -29,7 +29,7 @@ if _PROTEOME_FILTER_ENABLED:
         output:
             fasta=_PROTEOME_FASTA,
         log:
-            os.path.join(_LOGS, "proteome_filter", "download_proteome.log"),
+            os.path.join(_SHARED_LOG, "proteome_filter", "download_proteome.log"),
         params:
             url="https://rest.uniprot.org/uniprotkb/stream?query=reviewed:true+AND+organism_id:9606&format=fasta&compressed=true",
         conda:


### PR DESCRIPTION
## Summary

Closes #673. Namespaces shared-step logs under `logs/_shared/<step>/` so every step-name folder sits at one depth, instead of shared reference/index/model-build logs leaking into the top of the `logs/` tree while per-patient logs sit at `logs/<patient_id>/<step>/`.

## Changes

- `common.smk`: new `_SHARED_LOG = os.path.join(_LOGS, "_shared")` with a comment documenting the shared-vs-per-patient log convention.
- Routed 9 shared `log:` directives through `_SHARED_LOG` (alignment ×3, download ×3 incl. the now-merged `gtex_pan_tissue_bed.log`, filter_junctions, mhc_affinity, proteome_filter); converted the two hardcoded `logs/download/...` strings.
- `setup_vm.sh`: idempotent `logs/<step>` → `logs/_shared/` migration mirroring the #63 `resources/→references/` block. Revival-scoped (no live VM today); the GCS companion `mv` is documented as a comment (`gs://splice-neoepitope-project` decommissioned per #854, not runnable now).

No per-patient `log:` changes; no DAG/output change (`log:` directives are not in the DAG or consumed by any script/test).

## Rescope note

AC #4/#5 were premised on GCP infra decommissioned 2026-06-26 (#854) - reframed as revival-scoped. AC #7's GTEx branch (PR #653) has since merged, so its log is folded into the routing. Detail in the #673 scope-note comment.

## Test plan

- [x] `snakemake -n --configfile config/test_config.yaml` resolves the 9-job DAG (no parse error; `_SHARED_LOG` wired correctly)
- [x] `workflow/tests/.venv/bin/python -m pytest workflow/tests/` - 646 passed, 6 skipped
- [x] `bash -n scripts/setup_vm.sh` clean
- [x] grep confirms no shared-step `_LOGS` / hardcoded `logs/` strings remain and per-patient `log:` directives are untouched

Closes #673
