### PR TITLE
feat(skills): awaiting-bot-review - auto-poll a PR for the bot review verdict (#864)

### DIFF
--- a/.agents/skills/awaiting-bot-review/SKILL.md
+++ b/.agents/skills/awaiting-bot-review/SKILL.md
@@ -29,6 +29,10 @@ comment" tool.
      --jq '[.comments[] | select(.body|test("@claude review"))] | last | .createdAt'
    ```
 
+   (This `gh --jq` form is safe *because* it passes no `--arg`; the poller uses
+   `gh ... | jq -f` precisely because `gh --jq --arg` is the trap - do not "fix"
+   one to match the other.)
+
    If you can't get it cleanly, omit `--since`; the poller defaults the watermark
    to "now", which is safe (it just ignores anything already on the PR).
 

--- a/.agents/skills/awaiting-bot-review/SKILL.md
+++ b/.agents/skills/awaiting-bot-review/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: awaiting-bot-review
+description: Use immediately after posting the `@claude review` trigger on a PR (or the moment you are about to request a bot code-review) to await the verdict hands-free. Launches a background poller that re-invokes you when the bot's review lands and surfaces its verdict + any blocking findings, so you never wait for the user to say "the review is back". Triggers on requesting a bot/`@claude` PR review, "await the review", "watch for the review", "poll for the review verdict". Never merges - relaying the verdict is the whole job.
+---
+
+# awaiting-bot-review
+
+After you post `@claude review` on a PR, the GitHub Action takes ~5-7 minutes to
+post its verdict. Without this skill the user has to notice it landed and prompt
+you. This skill makes the wait hands-free: launch a background poller on the
+review request, and the harness re-invokes you when it exits so you can relay the
+verdict yourself.
+
+## When this fires
+
+- You just posted (or are about to post) the `@claude review` trigger on a PR.
+- The user asks you to await / watch / poll for a bot review verdict.
+
+Scope is **bot PR reviews only** - this is not a general "wait for any CI/any
+comment" tool.
+
+## Procedure
+
+1. **Capture a watermark** - the `createdAt` of the trigger comment you just
+   posted (so a *prior* review on the same PR can't false-match). Get it with:
+
+   ```bash
+   gh pr view <PR> --json comments \
+     --jq '[.comments[] | select(.body|test("@claude review"))] | last | .createdAt'
+   ```
+
+   If you can't get it cleanly, omit `--since`; the poller defaults the watermark
+   to "now", which is safe (it just ignores anything already on the PR).
+
+2. **Launch the bundled poller as a background task** (this is what makes the
+   wait hands-free - a hook can only *remind*, it cannot deliver the async
+   "review landed" re-invocation; only a harness-tracked background task can):
+
+   ```bash
+   .agents/skills/awaiting-bot-review/scripts/poll_bot_review.sh <PR> --since <watermark>
+   ```
+
+   Run it with the Bash tool's background mode (`run_in_background: true`). Keep
+   working; the harness re-invokes you when the script exits.
+
+3. **On exit, relay - never act.**
+   - Exit `0`: the verdict body is on stdout. Summarize it for the user: the
+     overall call (LGTM / requests-changes) and any **blocking** findings, with
+     your take on each. **Do not merge** - merging stays a user-gated decision.
+   - Exit `3`: timed out (default 25 min) with no landed review. Tell the user it
+     hasn't come back yet; do not auto re-ping (that risks a double review). They
+     can ask you to relaunch.
+   - Exit `2`: a usage error in how the poller was invoked - fix the args and
+     relaunch.
+
+## The bundled script
+
+`scripts/poll_bot_review.sh <PR> [--since ISO8601] [--timeout-min N] [--interval-sec N]`
+
+Detection (in `scripts/match_review.jq`, unit-tested independently): a comment
+authored by `claude`, newer than the watermark, whose body contains
+`"Claude finished"` (the finished state, not the interim "working" state).
+
+**Why a tested bundled script, not inline polling:** an inline poller written on
+PR #862 used `gh ... --jq` with jq's `--arg`, which `gh` rejects
+(`accepts at most 1 arg`), so it errored every iteration and timed out instead of
+catching the review. The script pipes raw JSON to real `jq -f`, and
+`tools/ci/test_poll_bot_review.py` locks in both the predicate and the arg
+parsing so that whole failure class can't regress. Re-deriving the poll inline
+each time invites the bug back - always use this script.

--- a/.agents/skills/awaiting-bot-review/scripts/match_review.jq
+++ b/.agents/skills/awaiting-bot-review/scripts/match_review.jq
@@ -1,0 +1,29 @@
+# Detection predicate for a landed bot code-review (Issue #864).
+#
+# Input: the JSON from `gh pr view <PR> --json comments`
+#   { "comments": [ { "author": {"login": "..."}, "body": "...", "createdAt": "..." }, ... ] }
+# Arg:   $w = watermark, an ISO-8601 UTC timestamp (e.g. the `@claude review`
+#        trigger comment's createdAt). Only comments strictly newer than $w count,
+#        so a PRIOR review on the same PR never re-matches.
+#
+# A review has LANDED when a comment is:
+#   - authored by the bot (login == "claude"),
+#   - newer than the watermark (createdAt > $w), and
+#   - in the finished (not interim "working") state -> body contains "Claude finished".
+#
+# ISO-8601 UTC strings (identical `...Z` shape) compare correctly with `>`
+# lexicographically, so no date parsing is needed.
+#
+# Output: the newest matching comment's body, or nothing (empty) when none has
+# landed yet. An empty result is the caller's "keep polling" signal.
+[
+  .comments[]
+  | select(
+      .author.login == "claude"
+      and .createdAt > $w
+      and (.body | contains("Claude finished"))
+    )
+]
+| sort_by(.createdAt)
+| last
+| if . == null then empty else .body end

--- a/.agents/skills/awaiting-bot-review/scripts/match_review.jq
+++ b/.agents/skills/awaiting-bot-review/scripts/match_review.jq
@@ -16,6 +16,12 @@
 #
 # Output: the newest matching comment's body, or nothing (empty) when none has
 # landed yet. An empty result is the caller's "keep polling" signal.
+# The bot-review comment author login is exactly "claude" (NOT "claude[bot]" or
+# "github-actions[bot]") - empirically verified 2026-07-04 against real landed
+# reviews on PRs #985 and #993 (`gh pr view N --json comments --jq
+# '[.comments[]|select(.body|test("Claude finished")).author.login]|unique'` -> ["claude"]).
+# Pinned so a future reader doesn't "fix" it to a [bot] form and silently break
+# detection. If a future GitHub-App migration changes it, re-verify and update here.
 [
   .comments[]
   | select(

--- a/.agents/skills/awaiting-bot-review/scripts/poll_bot_review.sh
+++ b/.agents/skills/awaiting-bot-review/scripts/poll_bot_review.sh
@@ -18,7 +18,10 @@
 #   --interval-sec Poll cadence in seconds (default 30).
 #
 # Exit codes: 0 = review landed (verdict on stdout); 2 = usage error;
-#             3 = timed out with no landed review.
+#             3 = timed out with no landed review;
+#             4 = gave up after too many consecutive gh/jq failures (check auth /
+#                 that the PR exists) - a persistent error surfaced loudly rather
+#                 than masquerading as a clean timeout.
 #
 # Detection lives in the sibling match_review.jq so it is unit-tested independently
 # of this polling shell (see tests/). The `gh ... | jq -f` form is deliberate: an
@@ -37,11 +40,17 @@ INTERVAL_SEC=30
 
 die() { echo "poll_bot_review: $1" >&2; exit 2; }
 
+# Reject a missing value or one that looks like the next flag, so
+# `--since --timeout-min 5` errors instead of silently taking "--timeout-min" as
+# the watermark (which, via jq's lexicographic compare, sorts below every real
+# timestamp and would false-match everything). (PR #993 review, nit 1.)
+need_val() { case "${2:-}" in ""|-*) die "option $1 requires a value";; esac; }
+
 while [ $# -gt 0 ]; do
   case "$1" in
-    --since)        SINCE="${2:-}"; shift 2 ;;
-    --timeout-min)  TIMEOUT_MIN="${2:-}"; shift 2 ;;
-    --interval-sec) INTERVAL_SEC="${2:-}"; shift 2 ;;
+    --since)        need_val "$1" "${2:-}"; SINCE="$2"; shift 2 ;;
+    --timeout-min)  need_val "$1" "${2:-}"; TIMEOUT_MIN="$2"; shift 2 ;;
+    --interval-sec) need_val "$1" "${2:-}"; INTERVAL_SEC="$2"; shift 2 ;;
     -h|--help)      awk 'NR==1{next} /^set -euo/{exit} /^#/{sub(/^# ?/,"");print}' "${BASH_SOURCE[0]}"; exit 0 ;;
     -*)             die "unknown option: $1" ;;
     *)              [ -z "$PR" ] || die "unexpected extra argument: $1"; PR="$1"; shift ;;
@@ -58,11 +67,29 @@ if [ -z "$SINCE" ]; then
   SINCE="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 fi
 
+# Give up only after this many *consecutive* failed polls, so a transient gh blip
+# (network, secondary rate-limit, a 5xx) does not abort an unattended background
+# watch, while a persistent error (bad auth, deleted PR) still surfaces loudly
+# instead of masquerading as a clean timeout. (PR #993 review, finding 1.)
+MAX_CONSECUTIVE_FAILURES=5
+
 deadline=$(( $(date +%s) + TIMEOUT_MIN * 60 ))
+fails=0
 
 while true; do
-  # Pipe raw JSON to real jq (NOT `gh --jq`) so `jq --arg` works.
-  verdict="$(gh pr view "$PR" --json comments | jq -r --arg w "$SINCE" -f "$MATCH_JQ")"
+  # Pipe raw JSON to real jq (NOT `gh --jq`) so `jq --arg` works. The `if` guards
+  # the assignment so a non-zero pipeline (gh blip, under `set -euo pipefail`)
+  # does NOT abort the script - we count it and keep polling to the timeout.
+  if verdict="$(gh pr view "$PR" --json comments | jq -r --arg w "$SINCE" -f "$MATCH_JQ")"; then
+    fails=0
+  else
+    verdict=""
+    fails=$(( fails + 1 ))
+    if [ "$fails" -ge "$MAX_CONSECUTIVE_FAILURES" ]; then
+      echo "poll_bot_review: $fails consecutive gh/jq failures polling PR #$PR; giving up (check auth / that the PR exists)." >&2
+      exit 4
+    fi
+  fi
   if [ -n "$verdict" ]; then
     echo "Bot review landed on PR #$PR:"
     echo "$verdict"

--- a/.agents/skills/awaiting-bot-review/scripts/poll_bot_review.sh
+++ b/.agents/skills/awaiting-bot-review/scripts/poll_bot_review.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Poll a PR for a landed bot code-review and print its verdict (Issue #864).
+#
+# Launch this as a BACKGROUND task right after posting `@claude review`, so the
+# harness re-invokes the agent when it exits and the verdict is surfaced without
+# the user having to notice the review landed. It never merges - relaying the
+# verdict (and any blocking findings) is the whole job.
+#
+# Usage:
+#   poll_bot_review.sh <PR> [--since ISO8601] [--timeout-min N] [--interval-sec N]
+#
+# Options:
+#   --since        Watermark; only a review newer than this counts. Defaults to
+#                  "now" (UTC), so a review already on the PR is ignored. Pass the
+#                  `@claude review` trigger comment's createdAt for a precise mark.
+#   --timeout-min  Give up after N minutes (default 25); exit 3 = notify-and-stop,
+#                  no auto re-ping (avoids double-review noise).
+#   --interval-sec Poll cadence in seconds (default 30).
+#
+# Exit codes: 0 = review landed (verdict on stdout); 2 = usage error;
+#             3 = timed out with no landed review.
+#
+# Detection lives in the sibling match_review.jq so it is unit-tested independently
+# of this polling shell (see tests/). The `gh ... | jq -f` form is deliberate: an
+# earlier inline `gh --jq --arg` poller was rejected by gh ("accepts at most 1
+# arg") and silently timed out every run - piping raw JSON to real jq avoids that
+# whole failure class.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MATCH_JQ="$SCRIPT_DIR/match_review.jq"
+
+PR=""
+SINCE=""
+TIMEOUT_MIN=25
+INTERVAL_SEC=30
+
+die() { echo "poll_bot_review: $1" >&2; exit 2; }
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --since)        SINCE="${2:-}"; shift 2 ;;
+    --timeout-min)  TIMEOUT_MIN="${2:-}"; shift 2 ;;
+    --interval-sec) INTERVAL_SEC="${2:-}"; shift 2 ;;
+    -h|--help)      awk 'NR==1{next} /^set -euo/{exit} /^#/{sub(/^# ?/,"");print}' "${BASH_SOURCE[0]}"; exit 0 ;;
+    -*)             die "unknown option: $1" ;;
+    *)              [ -z "$PR" ] || die "unexpected extra argument: $1"; PR="$1"; shift ;;
+  esac
+done
+
+[ -n "$PR" ] || die "missing required <PR> argument"
+[[ "$PR" =~ ^[0-9]+$ ]] || die "PR must be a number, got: $PR"
+[[ "$TIMEOUT_MIN" =~ ^[0-9]+$ ]] || die "--timeout-min must be a non-negative integer, got: $TIMEOUT_MIN"
+[[ "$INTERVAL_SEC" =~ ^[0-9]+$ ]] || die "--interval-sec must be a non-negative integer, got: $INTERVAL_SEC"
+[ -f "$MATCH_JQ" ] || die "detection predicate not found at $MATCH_JQ"
+
+if [ -z "$SINCE" ]; then
+  SINCE="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+fi
+
+deadline=$(( $(date +%s) + TIMEOUT_MIN * 60 ))
+
+while true; do
+  # Pipe raw JSON to real jq (NOT `gh --jq`) so `jq --arg` works.
+  verdict="$(gh pr view "$PR" --json comments | jq -r --arg w "$SINCE" -f "$MATCH_JQ")"
+  if [ -n "$verdict" ]; then
+    echo "Bot review landed on PR #$PR:"
+    echo "$verdict"
+    exit 0
+  fi
+  if [ "$(date +%s)" -ge "$deadline" ]; then
+    echo "poll_bot_review: no bot review on PR #$PR within ${TIMEOUT_MIN}m (watermark ${SINCE}); stopping." >&2
+    exit 3
+  fi
+  sleep "$INTERVAL_SEC"
+done

--- a/research/lab_notebook/pm.md
+++ b/research/lab_notebook/pm.md
@@ -8,6 +8,20 @@ Format and rules unchanged from the unified notebook — see `shared/feedback_la
 
 ## 2026-07-04
 
+### 03:15 UTC - Editor: PM
+
+#### `awaiting-bot-review` skill - auto-poll a PR for its review verdict ([PR #993](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/993) closes [#864](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/864))
+
+**Trigger.** Quick-win pull, and the most dogfood-motivated item on the board: after posting `@-claude review` the verdict lands ~5-7 min later, and until now someone had to notice and prompt me - which happened repeatedly earlier this same session. The design was pre-brainstormed/approved on the issue (2026-06-24) and #862 (its stated blocker) was already merged, so it was unblocked with the thinking already done.
+
+**What shipped.** First project-level skill (`.agents/skills/awaiting-bot-review/`): a `SKILL.md` with a trigger-shaped description, a bundled `poll_bot_review.sh <PR> [--since|--timeout-min|--interval-sec]`, and the detection predicate as a standalone `match_review.jq` (comment author `claude`, `createdAt > watermark`, body contains `"Claude finished"`). The poller is meant to run as a **background task** so the harness re-invokes on landing; it **never merges** (relaying the verdict is the whole job). Detection is a separate `.jq` file precisely so it is unit-tested independently of the polling shell. The `gh ... | jq -f` form is deliberate - an earlier inline `gh --jq --arg` poller (PR #862) was rejected by gh and silently timed out every run; `tools/ci/test_poll_bot_review.py` pins both the predicate and the arg parsing so that failure class can't regress.
+
+**Dogfood as the E2E.** Used the skill on its own PR: requested #993's review and launched the poller as a real background task. It detected the landed review and re-invoked me automatically - AC5 satisfied with the actual mechanism, not a simulation. (Aside caught live: the `@-claude review` mention-guard only allows the trigger as a *standalone* command, so it can't be bundled with the watermark capture in one shell call.)
+
+**Review (the bot reviewed its own poller).** `@-claude` review found two real issues, both taken: (1, medium) under `set -euo pipefail` a single transient `gh` blip made `verdict=$(gh|jq)` propagate a non-zero and `set -e` killed the whole 25-min background watch with an undocumented exit - the exact resilience the skill promises. Fixed by guarding the assignment (`if verdict=...`) + a consecutive-failure breaker that keeps polling through blips and gives up **loudly** (exit 4) only after 5 straight failures (bad auth / deleted PR), rather than masquerading as a clean timeout. (2, verify) detection hardcodes `author.login == "claude"` and the tests were self-referential - confirmed empirically that the real login IS `claude` on landed reviews (#985, #993) and pinned it with a comment so it can't be "fixed" to a `[bot]` form. Plus two nits (option-value swallow guard; a SKILL.md note that the watermark's `gh --jq` is safe only without `--arg`). Added 3 tests for the new paths; 16 skill / 490 full `tools/ci/` green.
+
+**Related board-hygiene find.** While shipping this, the user flagged a recurring cross-role slip: PRs stranded in *Ready for review*, never advanced to *In review*. Filed [#996](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/996) (a rung-3 mechanism: a PostToolUse hook that flips the linked issue to *In review* when a review is requested, mirroring `post_gh_pr_create.py`'s auto-board) and moved this very PR's card to *In review* by hand.
+
 ### 02:08 UTC - Editor: PM
 
 #### GitHub MCP server for board field updates - eval + decision ([#234](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/234))

--- a/tools/ci/test_poll_bot_review.py
+++ b/tools/ci/test_poll_bot_review.py
@@ -1,0 +1,167 @@
+"""Tests for the awaiting-bot-review skill's poller (Issue #864).
+
+Two layers, both hermetic (no live gh / no network):
+  * the detection predicate `match_review.jq` - piped fixtures through real `jq`,
+    which is the regression guard for the exact `gh --jq --arg` bug class that made
+    an earlier inline poller silently time out (Issue #864 "why a tested script").
+  * `poll_bot_review.sh` arg parsing + one-shot detection - driven with a fake `gh`
+    on PATH so the real script runs end-to-end deterministically.
+"""
+
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+SKILL = Path(__file__).parent.parent.parent / ".agents" / "skills" / "awaiting-bot-review"
+MATCH_JQ = SKILL / "scripts" / "match_review.jq"
+POLL_SH = SKILL / "scripts" / "poll_bot_review.sh"
+
+requires_jq = pytest.mark.skipif(shutil.which("jq") is None, reason="jq not on PATH")
+
+WATERMARK = "2026-07-04T01:49:00Z"
+
+
+def _finished(created="2026-07-04T01:49:26Z", login="claude"):
+    return {
+        "author": {"login": login},
+        "createdAt": created,
+        "body": "**Claude finished @Jin-HoMLee's task in 5m 18s**\n\n### PR Review\nLGTM.",
+    }
+
+
+def _working(created="2026-07-04T01:49:20Z", login="claude"):
+    return {
+        "author": {"login": login},
+        "createdAt": created,
+        "body": "**Claude is working...** [View job]",
+    }
+
+
+def _comments(*nodes):
+    return json.dumps({"comments": list(nodes)})
+
+
+# --------------------------------------------------------------------------
+# Layer 1: the jq detection predicate
+# --------------------------------------------------------------------------
+@requires_jq
+class TestMatchReviewPredicate:
+    def _run(self, comments_json, watermark=WATERMARK):
+        """Pipe fixture JSON through the real predicate, exactly as the script does."""
+        proc = subprocess.run(
+            ["jq", "-r", "--arg", "w", watermark, "-f", str(MATCH_JQ)],
+            input=comments_json, capture_output=True, text=True, timeout=15,
+        )
+        assert proc.returncode == 0, proc.stderr
+        return proc.stdout.strip()
+
+    def test_matches_finished_review_after_watermark(self):
+        out = self._run(_comments(_finished()))
+        assert "Claude finished" in out           # the verdict body is surfaced
+
+    def test_ignores_interim_working_state(self):
+        # A "working" comment is newer than the watermark and authored by the bot,
+        # but lacks "Claude finished", so it must NOT be treated as landed.
+        assert self._run(_comments(_working())) == ""
+
+    def test_ignores_review_at_or_before_watermark(self):
+        # A prior review on the same PR (createdAt <= watermark) must not re-match.
+        old = _finished(created="2026-07-04T01:48:00Z")
+        assert self._run(_comments(old)) == ""
+
+    def test_ignores_non_bot_author(self):
+        # A human quoting "Claude finished" must not trip detection.
+        human = _finished(login="Jin-HoMLee")
+        assert self._run(_comments(human)) == ""
+
+    def test_picks_newest_when_multiple_finished(self):
+        older = _finished(created="2026-07-04T01:49:26Z")
+        older["body"] = "**Claude finished** older verdict"
+        newer = _finished(created="2026-07-04T02:10:00Z")
+        newer["body"] = "**Claude finished** newer verdict"
+        out = self._run(_comments(older, newer))
+        assert "newer verdict" in out and "older verdict" not in out
+
+    def test_empty_comments_is_no_match(self):
+        assert self._run(_comments()) == ""
+
+
+# --------------------------------------------------------------------------
+# Layer 2: the poll_bot_review.sh wrapper (arg parsing + one-shot detection)
+# --------------------------------------------------------------------------
+_FAKE_GH = (
+    "#!/usr/bin/env python3\n"
+    "import os, sys\n"
+    "a = sys.argv[1:]\n"
+    "if a[:2] == ['pr', 'view']:\n"
+    "    sys.stdout.write(os.environ.get('FAKE_COMMENTS', '{\"comments\":[]}'))\n"
+    "    sys.exit(0)\n"
+    "sys.stderr.write('fake gh unmatched: %r\\n' % (a,)); sys.exit(1)\n"
+)
+
+
+@requires_jq
+class TestPollScript:
+    def _run(self, args, comments_json="", tmp_path=None):
+        gh = tmp_path / "gh"
+        gh.write_text(_FAKE_GH)
+        gh.chmod(0o755)
+        env = dict(os.environ)
+        env["PATH"] = f"{tmp_path}:{env['PATH']}"
+        if comments_json:
+            env["FAKE_COMMENTS"] = comments_json
+        return subprocess.run(
+            ["bash", str(POLL_SH), *args],
+            capture_output=True, text=True, timeout=30, env=env,
+        )
+
+    def test_detects_landed_review_exit_zero(self, tmp_path):
+        r = self._run(
+            [str(985), "--since", WATERMARK, "--timeout-min", "0", "--interval-sec", "0"],
+            comments_json=_comments(_finished()), tmp_path=tmp_path,
+        )
+        assert r.returncode == 0, r.stderr
+        assert "Bot review landed on PR #985" in r.stdout
+        assert "Claude finished" in r.stdout
+
+    def test_times_out_on_working_only(self, tmp_path):
+        # Only an interim "working" comment present, so no landed review: exit 3
+        # after one poll (timeout 0), notify-and-stop.
+        r = self._run(
+            [str(985), "--since", WATERMARK, "--timeout-min", "0", "--interval-sec", "0"],
+            comments_json=_comments(_working()), tmp_path=tmp_path,
+        )
+        assert r.returncode == 3
+        assert "no bot review" in r.stderr
+
+    def test_missing_pr_arg_is_usage_error(self, tmp_path):
+        r = self._run(["--since", WATERMARK], tmp_path=tmp_path)
+        assert r.returncode == 2
+        assert "missing required" in r.stderr
+
+    def test_non_numeric_pr_is_usage_error(self, tmp_path):
+        r = self._run(["not-a-number"], tmp_path=tmp_path)
+        assert r.returncode == 2
+        assert "must be a number" in r.stderr
+
+    def test_bad_timeout_is_usage_error(self, tmp_path):
+        r = self._run([str(985), "--timeout-min", "soon"], tmp_path=tmp_path)
+        assert r.returncode == 2
+        assert "timeout-min" in r.stderr
+
+    def test_unknown_option_is_usage_error(self, tmp_path):
+        r = self._run([str(985), "--merge-when-done"], tmp_path=tmp_path)
+        assert r.returncode == 2
+        assert "unknown option" in r.stderr
+
+    def test_help_renders_usage_and_exits_zero(self, tmp_path):
+        # The help printer parses the script's own header; a non-portable sed form
+        # broke it once, so pin exit 0 + real usage text (no shebang leakage).
+        r = self._run(["--help"], tmp_path=tmp_path)
+        assert r.returncode == 0, r.stderr
+        assert "Usage:" in r.stdout
+        assert not r.stdout.lstrip().startswith("!")   # shebang must not leak

--- a/tools/ci/test_poll_bot_review.py
+++ b/tools/ci/test_poll_bot_review.py
@@ -104,16 +104,45 @@ _FAKE_GH = (
 )
 
 
+# Fake gh that fails its first `pr view` call then serves FAKE_COMMENTS: models a
+# transient blip (network / rate-limit / 5xx) that the poller must survive.
+_FAKE_GH_FAIL_ONCE = (
+    "#!/usr/bin/env python3\n"
+    "import os, sys\n"
+    "a = sys.argv[1:]\n"
+    "if a[:2] != ['pr', 'view']:\n"
+    "    sys.stderr.write('unmatched\\n'); sys.exit(1)\n"
+    "c = os.environ['FAKE_COUNTER']\n"
+    "try:\n"
+    "    n = int(open(c).read())\n"
+    "except Exception:\n"
+    "    n = 0\n"
+    "open(c, 'w').write(str(n + 1))\n"
+    "if n == 0:\n"
+    "    sys.stderr.write('gh: simulated transient failure\\n'); sys.exit(1)\n"
+    "sys.stdout.write(os.environ.get('FAKE_COMMENTS', '{\"comments\":[]}')); sys.exit(0)\n"
+)
+
+# Fake gh that always fails: models a persistent error (bad auth / deleted PR).
+_FAKE_GH_ALWAYS_FAIL = (
+    "#!/usr/bin/env python3\n"
+    "import sys\n"
+    "sys.stderr.write('gh: simulated persistent failure\\n'); sys.exit(1)\n"
+)
+
+
 @requires_jq
 class TestPollScript:
-    def _run(self, args, comments_json="", tmp_path=None):
+    def _run(self, args, comments_json="", tmp_path=None, gh_body=_FAKE_GH, extra_env=None):
         gh = tmp_path / "gh"
-        gh.write_text(_FAKE_GH)
+        gh.write_text(gh_body)
         gh.chmod(0o755)
         env = dict(os.environ)
         env["PATH"] = f"{tmp_path}:{env['PATH']}"
         if comments_json:
             env["FAKE_COMMENTS"] = comments_json
+        if extra_env:
+            env.update(extra_env)
         return subprocess.run(
             ["bash", str(POLL_SH), *args],
             capture_output=True, text=True, timeout=30, env=env,
@@ -165,3 +194,35 @@ class TestPollScript:
         assert r.returncode == 0, r.stderr
         assert "Usage:" in r.stdout
         assert not r.stdout.lstrip().startswith("!")   # shebang must not leak
+
+    def test_survives_transient_gh_failure_then_detects(self, tmp_path):
+        # PR #993 review, finding 1: a single transient `gh` failure must NOT abort
+        # the poller (it would under `set -euo pipefail` without the guard). First
+        # poll fails, second succeeds with a landed review -> exit 0.
+        r = self._run(
+            [str(985), "--since", WATERMARK, "--timeout-min", "5", "--interval-sec", "0"],
+            comments_json=_comments(_finished()),
+            gh_body=_FAKE_GH_FAIL_ONCE,
+            extra_env={"FAKE_COUNTER": str(tmp_path / "count")},
+            tmp_path=tmp_path,
+        )
+        assert r.returncode == 0, r.stderr
+        assert "Claude finished" in r.stdout
+
+    def test_gives_up_after_consecutive_failures(self, tmp_path):
+        # A persistent failure surfaces loudly (exit 4) instead of masquerading as a
+        # clean 25-min timeout. timeout-min large so the failure breaker, not the
+        # deadline, is what stops it.
+        r = self._run(
+            [str(985), "--since", WATERMARK, "--timeout-min", "5", "--interval-sec", "0"],
+            gh_body=_FAKE_GH_ALWAYS_FAIL, tmp_path=tmp_path,
+        )
+        assert r.returncode == 4
+        assert "consecutive" in r.stderr
+
+    def test_option_value_swallow_is_guarded(self, tmp_path):
+        # PR #993 review, nit 1: `--since --timeout-min 5` must error, not take
+        # "--timeout-min" as the watermark.
+        r = self._run(["--since", "--timeout-min", "5", str(985)], tmp_path=tmp_path)
+        assert r.returncode == 2
+        assert "requires a value" in r.stderr


### PR DESCRIPTION
## Summary

Makes awaiting an `@claude` PR review **hands-free**. After the review is
requested, launch the bundled poller as a background task; the harness re-invokes
on landing so the verdict is surfaced without the user having to notice and prompt
("the review is back"). It **never merges** - relaying the verdict is the whole job.

Implements the design brainstormed + approved on the issue (2026-06-24).

- **`.agents/skills/awaiting-bot-review/SKILL.md`** - trigger-shaped `description`
  (fires on requesting/awaiting a bot review), documents launching the poller as a
  background task, surfacing the verdict + blocking findings, and the never-merge rule.
- **`scripts/poll_bot_review.sh <PR> [--since ISO] [--timeout-min N] [--interval-sec N]`**
  - polls via `gh pr view --json comments | jq -f` (raw JSON to real `jq`), the
  correct form that avoids the `gh --jq --arg` bug class which made an earlier inline
  poller error every iteration and silently time out (PR #862). Exit `0` = verdict on
  stdout, `2` = usage error, `3` = timed out (default 25 min, notify-and-stop, no auto re-ping).
- **`scripts/match_review.jq`** - detection predicate as a standalone, independently
  unit-tested file: comment authored by `claude`, `createdAt > watermark`, body contains
  `"Claude finished"` (finished, not the interim "working" state).
- **`tools/ci/test_poll_bot_review.py`** - 13 hermetic tests (no live gh): the jq
  predicate against fixtures, the script's arg parsing + one-shot detection via a fake
  `gh` on PATH, and a `--help` regression guard.

Scope is bot PR reviews only (YAGNI - not a general "wait for any CI" tool).

## Test plan

- [x] `pytest tools/ci/test_poll_bot_review.py` - 13 passed (predicate fixtures + arg parsing + help guard)
- [x] Full `pytest tools/ci/ -m "not live"` - 486 passed, no regressions
- [x] Live E2E: ran the real `poll_bot_review.sh 985 --since <before-its-review>` against PR #985 (which has a landed review) → detected it, surfaced the verdict, exit 0
- [x] `--help` renders usage cleanly (no shebang leak; portable `awk`, after fixing a macOS-`sed` form)
- [x] Dogfood: launched the skill's poller as a background task on this PR's own review request (see below)

Closes #864
