### PR TITLE
docs(research): correct notebook data-read path from decommissioned GCS to R2 (#995)

### DIFF
--- a/research/README.md
+++ b/research/README.md
@@ -38,6 +38,8 @@ from r2_io import r2_read_tsv_cached
 report = r2_read_tsv_cached("results/patient_001/reports/report.tsv")
 ```
 
+The bare `import r2_io` resolves because notebooks run with `research/notebooks/` as the cwd (Jupyter's default); adjust the import path if you run the snippet from elsewhere.
+
 ---
 
 ## scripts/zotero_add.py

--- a/research/README.md
+++ b/research/README.md
@@ -31,7 +31,12 @@ research/.venv/bin/python -m ipykernel install --user \
 ```
 This is a machine-local registration (`~/Library/Jupyter/kernels/` on macOS, `~/.local/share/jupyter/kernels/` on Linux for the GPU-revival path), not tracked in git - like the `.venv` itself, each clone runs it once. The kernelspec name is global, so the last clone to run it becomes the canonical execution clone; run it from whichever clone you execute notebooks in. After registration, run notebooks from this venv's jupyter (`research/.venv/bin/jupyter nbconvert --to notebook --execute <nb>`) with no `--ExecutePreprocessor.kernel_name` override needed.
 
-The notebooks read pipeline results directly from GCS (`gs://splice-neoepitope-project/results/<patient_id>/`) via `gsutil` — no local data download needed. Make sure `gsutil` is authenticated (`gcloud auth application-default login`).
+The notebooks read pipeline results from **Cloudflare R2** (`results/<patient_id>/` on the project bucket) via the [`r2_io.py`](notebooks/r2_io.py) helper, which replaced the decommissioned GCS/`gsutil` loader at the GCP exit ([#854](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/854)). Credentials come from the project-root `.env` (gitignored): `R2_ENDPOINT`, `R2_BUCKET`, `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`. Reads are locally cached (`$R2_CACHE_DIR`, default `~/.cache/splice-neoepitope-r2`) and ETag-validated, so a re-run is cache-backed and offline-tolerant:
+
+```python
+from r2_io import r2_read_tsv_cached
+report = r2_read_tsv_cached("results/patient_001/reports/report.tsv")
+```
 
 ---
 

--- a/research/lab_notebook/scientist.md
+++ b/research/lab_notebook/scientist.md
@@ -10,6 +10,12 @@ Format and rules unchanged from the unified notebook — see `shared/feedback_la
 
 ### Editor: Scientist
 
+#### [PR #997](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/997) - correct the notebook data-read instruction from decommissioned GCS to R2. Closes [Issue #995](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/995).
+
+**What.** `research/README.md` still told notebooks to read results from `gs://splice-neoepitope-project/` via `gsutil`; GCP was decommissioned 2026-06-26 (#854). Verified the as-shipped path against the codebase (not recall): the notebooks already read from Cloudflare R2 via `research/notebooks/r2_io.py` (`r2_read_tsv_cached`, creds from project-root `.env`, local cache + ETag validation; `boto3>=1.34` in requirements). Corrected the instruction to that helper with a usage example matching the shipped notebooks verbatim, and dropped the line's pre-existing em-dash.
+
+**Review.** Bot review LGTM - every factual claim (API signature, env-var names, cache-dir default, boto3 dep) verified against source. Applied its one usability nit (noted the bare import resolves because notebooks run from `research/notebooks/`). It also confirmed the glossary staleness I flagged extends to a sibling GCP entry → filed [#998](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/998) for the `research/glossary.md` GCS+GCP refresh. This was surfaced originally by the [#990](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/990) kernelspec review; the `research/lab_notebook*.md` `gs://` mentions are immutable historical entries and correctly left untouched.
+
 #### [PR #994](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/994) - TEtrans out-of-registry provenance + `outputs/` commit-vs-gitignore policy. Closes [Issue #832](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/832) + [Issue #774](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/774).
 
 **#832 - TEtrans (Li 2025) as a transcript-level exon-TE source, no registry row.**


### PR DESCRIPTION
Closes #995. Surfaced by the [PR #990](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/990) review (nit 3), deferred out of the kernelspec fix to keep that PR focused.

## What

`research/README.md` still told notebooks to read pipeline results from `gs://splice-neoepitope-project/results/<patient_id>/` via `gsutil`. GCP was decommissioned 2026-06-26 ([#854](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/854)); the notebooks now read from **Cloudflare R2** via the shipped [`research/notebooks/r2_io.py`](research/notebooks/r2_io.py) helper (boto3, creds from project-root `.env`, local cache + ETag validation). The instruction is corrected to that as-shipped path, with a minimal usage example.

Verified against the codebase rather than recall: `r2_io.py` exists with `r2_read_tsv_cached(key, ...)`; `boto3` is in `research/requirements.txt`; the patient_001 notebook was already migrated onto it (#854 fold).

## Acceptance criteria

- [x] Replace the GCS/`gsutil` read instruction with the R2 fetch path (points at `r2_io.py`, the shipped reader)
- [x] Fix the line's pre-existing em-dash to a plain hyphen (guard-clean)
- [x] Confirm no other GCS/`gsutil` references remain stale in `research/README.md`

## Test plan

- [x] `grep -niE 'gcs|gsutil|gs://|gcloud' research/README.md` returns only the historical "decommissioned GCS/gsutil loader" reference in the correction text
- [x] the usage example matches `r2_io.py`'s public API (`r2_read_tsv_cached(key)`)
- [x] no em/en dashes introduced (guard-clean)

## Note (out of scope, spotted)

`research/glossary.md:81` defines **GCS** and asserts "pipeline results, logs, and reference data live in `gs://splice-neoepitope-project`" - also stale post-R2. Left out to keep this README-scoped; can fold into a glossary pass or a small follow-up. (The many `gs://` mentions in `research/lab_notebook*.md` are immutable historical entries and are correctly left untouched.)