### PR TITLE
chore(security): best-practice gh auth setup runbook (Dev half of Issue 971)

### DIFF
--- a/docs/gh_auth_setup.md
+++ b/docs/gh_auth_setup.md
@@ -41,7 +41,8 @@ gh auth login --hostname github.com --git-protocol https --web
 ```
 
 The web flow stores the OAuth token in the macOS Keychain.
-Its default scopes do not include `project`, and our board is a user Projects v2 board (user project 9), so add the two scopes the board operations need:
+Its default scopes do not include `project`, and our board is a user Projects v2 board (user project 9).
+Add `project` (which alone grants Projects v2 read/write on user- or org-owned boards) plus `read:org` (a `gh auth login` default that AC-4 mandates; it covers org membership, not the board ops themselves):
 
 ```bash
 gh auth refresh --hostname github.com --scopes project,read:org
@@ -77,8 +78,9 @@ So the fine-grained token belongs in `GH_TOKEN`, but injected at runtime, not wr
 Store the fine-grained token once in the Keychain:
 
 ```bash
-security add-generic-password -a "$USER" -s gh-automation-token -w
+security add-generic-password -U -a "$USER" -s gh-automation-token -w
 # (paste the token at the prompt; it is not echoed and not stored on disk in plaintext)
+# -U updates the item in place if it already exists, so this same command is safe to re-run on rotation
 ```
 
 Then, in an automation shell only, inject it at runtime instead of exporting a literal:
@@ -88,7 +90,7 @@ Then, in an automation shell only, inject it at runtime instead of exporting a l
 export GH_TOKEN="$(security find-generic-password -a "$USER" -s gh-automation-token -w)"
 ```
 
-Rotate by re-running `security add-generic-password` with the new token after the old one is revoked; nothing in version control or dotfiles needs to change.
+Rotate by re-running the same `security add-generic-password -U ...` command with the new token after the old one is revoked (the `-U` flag updates the existing item in place); nothing in version control or dotfiles needs to change.
 
 ## Verification
 
@@ -103,8 +105,8 @@ scripts/board_open_items.py --role developer   # a paginated board query that ex
 
 An agent cannot perform these; they are account-level or local-machine actions.
 
-- [ ] **Rotate the two exposed tokens first (time-sensitive).**
-  Revoke `ghp_YniY...` (already dead) and the current `ghp_jCNBGr4...` at <https://github.com/settings/tokens>.
+- [ ] **Rotate the two exposed classic PATs first (time-sensitive).**
+  Revoke both at <https://github.com/settings/tokens>: the one that already expired on 2026-07-03, and the classic `ghp_` token still active as the current `gh` credential. Identify them by their name/note and creation date on that page; no token value is reproduced here.
 - [ ] Run the `gh auth login --web` browser flow to store an OAuth token in the Keychain.
 - [ ] Run `gh auth refresh --scopes project,read:org` to add the board scopes.
 - [ ] Remove the `export GH_TOKEN=...` line from `~/.zshenv`.

--- a/docs/gh_auth_setup.md
+++ b/docs/gh_auth_setup.md
@@ -1,0 +1,120 @@
+# Local GitHub CLI Authentication Setup
+
+Best-practice setup for `gh` authentication on a local development machine.
+
+The goal is to stop relying on a long-lived classic PAT hardcoded in a plaintext dotfile, and instead make the system keyring (macOS Keychain) the primary interactive credential.
+
+This document is the Developer-side advisory artifact for [Issue #971](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/971).
+The account-level actions it points to (the browser OAuth flow, editing `~/.zshenv`, revoking tokens) are **human-only** and are listed as a checklist at the end.
+
+## Why change the current setup
+
+The prior setup is the anti-pattern on three counts, each confirmed against GitHub's own guidance (sourced below):
+
+1. **Long-lived classic PAT with broad `repo` scope.**
+   GitHub recommends fine-grained, minimally-scoped, expiring tokens.
+   A leaked broad classic token can touch every repo the account owns.
+2. **Plaintext in a dotfile** (`export GH_TOKEN=...` in `~/.zshenv`).
+   Readable by any process running as the user; the Keychain avoids on-disk plaintext.
+3. **`GH_TOKEN` always-on for interactive use.**
+   The `GH_TOKEN` env var shadows the Keychain on every `gh` call and is intended for headless automation, not day-to-day interactive work.
+
+This is not theoretical: the token expired mid-session on 2026-07-03 and broke all `gh` operations with 401s partway through a board restructure, and two token values appeared in that session's command output.
+
+## Target setup
+
+Two credential paths, used for different purposes:
+
+| Use | Credential | Storage |
+|-----|-----------|---------|
+| **Interactive** (day-to-day `gh` in a terminal) | OAuth token from `gh auth login` web flow | macOS Keychain (managed by `gh`) |
+| **Automation only** (headless scripts, CI-like local runs) | fine-grained, expiring PAT | injected into `GH_TOKEN` at runtime from the Keychain, never a plaintext dotfile |
+
+Key point: do **not** keep a plaintext `GH_TOKEN` in `~/.zshenv` for interactive use.
+When `GH_TOKEN` is set, it overrides the Keychain credential for every `gh` invocation, which is exactly the shadowing that caused the mid-session breakage.
+
+### Interactive: Keychain OAuth via `gh auth login`
+
+```bash
+# Remove the always-on env token first (see the human checklist), then:
+gh auth login --hostname github.com --git-protocol https --web
+```
+
+The web flow stores the OAuth token in the macOS Keychain.
+Its default scopes do not include `project`, and our board is a user Projects v2 board (user project 9), so add the two scopes the board operations need:
+
+```bash
+gh auth refresh --hostname github.com --scopes project,read:org
+```
+
+Verify (should show `project`, `read:org`, `repo`, and no missing-scope warning):
+
+```bash
+gh auth status
+```
+
+### Automation: fine-grained expiring PAT (only if genuinely needed)
+
+Create the token at <https://github.com/settings/personal-access-tokens> with:
+
+- **Resource owner:** `Jin-HoMLee`
+- **Repository access:** only the repos automation touches (at minimum `splice-neoepitope-pipeline`; add the personas repo if a routine drafts there)
+- **Expiration:** set an expiry (e.g. 90 days); a non-expiring token is the anti-pattern being removed
+- **Repository permissions:**
+  - Contents: Read and write
+  - Issues: Read and write
+  - Pull requests: Read and write
+  - Metadata: Read-only (mandatory, auto-selected)
+  - Workflows: Read and write (only if a routine edits `.github/workflows/`)
+- **Account permissions:**
+  - Projects: Read and write (this is what drives board operations on the user project; the classic `project` scope equivalent for fine-grained tokens)
+
+Note: GitHub's own `gh` guidance favors supplying a fine-grained PAT via `GH_TOKEN` rather than storing it through `gh auth login`, because a fine-grained token's resource scoping can produce confusing behavior when the Keychain path assumes a broadly-scoped credential.
+So the fine-grained token belongs in `GH_TOKEN`, but injected at runtime, not written to a dotfile.
+
+### Keychain-lookup snippet (for a retained automation token)
+
+Store the fine-grained token once in the Keychain:
+
+```bash
+security add-generic-password -a "$USER" -s gh-automation-token -w
+# (paste the token at the prompt; it is not echoed and not stored on disk in plaintext)
+```
+
+Then, in an automation shell only, inject it at runtime instead of exporting a literal:
+
+```bash
+# put in the automation script, NOT in ~/.zshenv:
+export GH_TOKEN="$(security find-generic-password -a "$USER" -s gh-automation-token -w)"
+```
+
+Rotate by re-running `security add-generic-password` with the new token after the old one is revoked; nothing in version control or dotfiles needs to change.
+
+## Verification
+
+After the interactive setup, both of these should succeed with the Keychain credential (no `GH_TOKEN` in the environment):
+
+```bash
+gh auth status                      # shows project, read:org, repo; no missing-scope warning
+scripts/board_open_items.py --role developer   # a paginated board query that exercises the project scope
+```
+
+## Human-only checklist (Jin-Ho)
+
+An agent cannot perform these; they are account-level or local-machine actions.
+
+- [ ] **Rotate the two exposed tokens first (time-sensitive).**
+  Revoke `ghp_YniY...` (already dead) and the current `ghp_jCNBGr4...` at <https://github.com/settings/tokens>.
+- [ ] Run the `gh auth login --web` browser flow to store an OAuth token in the Keychain.
+- [ ] Run `gh auth refresh --scopes project,read:org` to add the board scopes.
+- [ ] Remove the `export GH_TOKEN=...` line from `~/.zshenv`.
+- [ ] If automation genuinely needs a token, create the fine-grained PAT per the spec above and store it in the Keychain (not a dotfile).
+- [ ] Confirm `gh auth status` shows `project`, `read:org`, `repo` with no missing-scope warning.
+
+## Sources
+
+- [Managing your personal access tokens](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens)
+- [Introducing fine-grained personal access tokens (GitHub Blog)](https://github.blog/security/application-security/introducing-fine-grained-personal-access-tokens-for-github/)
+- [`gh` environment manual](https://cli.github.com/manual/gh_help_environment)
+- [`gh auth login` manual](https://cli.github.com/manual/gh_auth_login)
+- [cli/cli #9461 - minimum required v2 fine-grained PAT scopes](https://github.com/cli/cli/issues/9461)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -11,6 +11,8 @@
 | Python | 3.11+ | Managed automatically via conda |
 | Git | any | For cloning the repository |
 
+> For contributors: best-practice local GitHub CLI authentication (Keychain-primary, fine-grained tokens) is documented in [gh auth setup](gh_auth_setup.md).
+
 ---
 
 ## 1. Install Conda (Miniforge — recommended)

--- a/research/lab_notebook/developer.md
+++ b/research/lab_notebook/developer.md
@@ -8,6 +8,24 @@ Format and rules unchanged from the unified notebook — see `shared/feedback_la
 
 ## 2026-07-04 - CCR sandbox gh re-probe: native issue-dependency fields still unavailable in-sandbox ([PR #974](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/974) closes [Issue #941](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/941))
 
+### 14:02 UTC - Editor: Developer - gh auth keyring migration: Dev-half runbook + collaborative human migration ([PR #1000](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/1000) closes [Issue #971](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/971))
+
+**Context.** [Issue #971](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/971) (dual `role:human` + `role:developer`, the morning warm-up pick): migrate local `gh` off a long-lived classic PAT hardcoded in `~/.zshenv` to a Keychain-primary OAuth credential, and rotate two tokens exposed in the 2026-07-03 session. The gating ACs are human-only (browser OAuth, dotfile edit, token revocation at github.com); the Dev half is advisory runbook + live verification + docs.
+
+**Dev deliverable.** `docs/gh_auth_setup.md`: interactive Keychain path (`gh auth login --web` -> `gh auth refresh -s project,read:org`), a fine-grained expiring automation-token spec, a Keychain runtime-injection snippet, verification commands, and the human checklist. Plus a discoverability pointer from `docs/installation.md`.
+
+**Live audit finding.** Pre-migration `gh auth status` confirmed all three anti-patterns (GH_TOKEN env var, classic `ghp_` PAT, plaintext `~/.zshenv`) plus a scope gap: the token had `project, repo, workflow` but was **missing `read:org`** (AC-4). The post-migration keyring `gho_` token carries all five (`gist, project, read:org, repo, workflow`).
+
+**Collaborative migration (human half, walked live).** Keychain login + refresh landed the `gho_` token; a fresh login shell confirmed GH_TOKEN gone (a stale-shell intermediate state re-shadowed it until a truly new login shell). Token-inventory disambiguation at the tokens page (3 classic PATs): revoked the exposed `gh CLI (global, ~/.zshenv)` PAT; **kept** two purpose-built automation PATs (`ADD_TO_PROJECT_PAT` = board auto-add Action, `splice-pipeline-ci-projects-read` = CI `read:project`) - neither exposed, and revoking either would break automation. Identify-before-revoke mattered: 2 of 3 classic tokens were live automation secrets.
+
+**Two lessons (candidate memories).**
+1. **Never put even a fragment of a live credential in tracked text.** My first doc draft hardcoded a 7-char prefix of the *live* token in the checklist (the Issue body carried the same). Bot review caught it: a truncated `ghp_` prefix evades GitHub secret-scanning yet persists in git history forever - in a doc whose whole thesis is "stop leaking credentials." Disambiguate tokens by name + creation date instead; no secret bytes. Scrubbed both the doc and the Issue body.
+2. **A live GH_TOKEN rotation strands the agent's own Bash shell.** Revoking the classic PAT 401'd *my* agent shell (it still held the pre-revocation GH_TOKEN in env from session start), while the user's interactive terminals were fine on the keyring. Workaround for the rest of the session: prefix `env -u GH_TOKEN gh ...` so the shell falls back to the Keychain `gho_` token (the Bash tool re-inits from profile, but the exported var persisted).
+
+**Review.** Bot review LGTM-in-shape, 3 findings, all addressed in `f66b43d`: (1) removed the live-token fragment; (2) added `-U` to `security add-generic-password` so store + rotation are idempotent (bare re-run errors `errSecDuplicateItem`); (3) reworded the `read:org` rationale - `project` scope alone drives Projects v2, `read:org` is a `gh` default AC-4 mandates. Content-based poll caught the verdict at 3m50s.
+
+**Process note.** Warm-up pick that became a live collaborative migration; closure routed through the doc PR since the machine-state work produced no repo diff (the entry above is that record). Stopped at the merge command per the standing autonomy cadence.
+
 ### 02:58 UTC - Editor: Developer - namespace shared-step logs under logs/_shared/ ([PR #991](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/991) closes [Issue #673](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/673))
 
 **Context.** [Issue #673](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/673): shared reference/index/model-build logs (no `{patient_id}`) wrote to `logs/<step>/` at the top level while per-patient jobs wrote to `logs/<patient_id>/<step>/`, so five step names (alignment, download, filter_junctions, mhc_affinity, proteome_filter) appeared at two depths. Next quick win of the session.


### PR DESCRIPTION
## Summary

Closes #971. Developer-half artifact: a best-practice `gh` auth setup runbook at `docs/gh_auth_setup.md`, plus a lab-notebook entry recording the collaborative migration.

The doc is the committable Developer deliverable; the Issue's acceptance criteria are human machine/account actions (browser OAuth flow, `~/.zshenv` edit, token revocation) that were completed collaboratively on 2026-07-04, so all five ACs on [Issue #971](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/971) are now ticked. This PR carries the close because the migration itself produced no repo diff; the lab-notebook entry captures what happened.

## What the doc covers

- Interactive auth via the macOS Keychain (`gh auth login` web flow) as the primary credential
- Fine-grained, expiring automation-token spec (repo-scoped; Contents/Issues/PRs RW + Projects account permission for board ops)
- Keychain runtime-injection snippet, so any retained `GH_TOKEN` is never a plaintext dotfile literal
- Scope verification commands
- The human-only checklist, with token rotation flagged as time-sensitive

## Migration outcome (human half, completed 2026-07-04)

- Local `gh` now authenticates via the Keychain (`gho_` OAuth token); scopes include `read:org` (the audit gap) + `project`.
- `export GH_TOKEN=...` removed from `~/.zshenv`.
- The exposed `gh CLI (global, ~/.zshenv)` classic PAT revoked; the two purpose-built automation PATs (`ADD_TO_PROJECT_PAT`, `splice-pipeline-ci-projects-read`) identified and kept.

## Review findings addressed (`f66b43d`)

- Removed the live-token fragment from the checklist (bot-review finding 1)
- Added `-U` to `security add-generic-password` so store + rotation are idempotent (finding 2)
- Reworded the `read:org` rationale (finding 3)
- Added a discoverability pointer from `docs/installation.md`

## Test plan

- [x] Doc renders and internal/external links are well-formed; em-dash-guard clean
- [x] The verification commands in the doc were run live (`gh auth status` confirmed the final keyring scope set)
- [x] Migration verified end-to-end this session: fresh login shell shows the keyring credential only, exposed token revoked, `gh` still authenticates

**Created by:** Developer
