### PR TITLE
docs(research): refresh stale GCS/GCP glossary entries post-R2 migration (#998)

### DIFF
--- a/research/glossary.md
+++ b/research/glossary.md
@@ -76,9 +76,9 @@ Project-relevant abbreviations and acronyms. The pipeline mixes biology, ML, bio
 
 **GBM** - Glioblastoma (Multiforme). WHO grade 4 astrocytoma; most aggressive primary adult brain tumor (~15-mo median OS post standard-of-care surgery + radiation + temozolomide). MGMT-unmethylated subset has the worst prognosis (resistant to temozolomide); subject of the GNOS-PV01 personalized DNA vaccine Phase 1 ([Garfinkle et al. 2026](https://www.nature.com/articles/s43018-026-01163-w)). *Domain: bio.*
 
-**GCP** - Google Cloud Platform. The cloud provider hosting this pipeline's VMs and storage bucket (zone `europe-west4-a`). *Domain: cloud.*
+**GCP** - Google Cloud Platform. Formerly hosted this pipeline's VMs and storage bucket (zone `europe-west4-a`); the GCP stack was decommissioned 2026-06-26 ([Issue #854](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/854)) to stop charges before the free-trial lapse. Current compute is a local CPU-only core; the funded revival path targets a paid GPU provider (RunPod, see `docs/migration_runbook.md`). *Domain: cloud.*
 
-**GCS** - Google Cloud Storage. GCP's object store; pipeline results, logs, and reference data live in `gs://splice-neoepitope-project`. *Domain: cloud.*
+**GCS** - Google Cloud Storage. GCP's object store; formerly held this pipeline's results, logs, and reference data in `gs://splice-neoepitope-project`. Decommissioned with the GCP stack 2026-06-26 ([Issue #854](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/854)) after project data was preserved on Cloudflare R2 - see **[R2](#r)**. *Domain: cloud.*
 
 **GKE** - Google Kubernetes Engine. Managed Kubernetes on GCP. *Domain: cloud.*
 
@@ -188,9 +188,13 @@ Project-relevant abbreviations and acronyms. The pipeline mixes biology, ML, bio
 
 ## R
 
+**R2** - Cloudflare R2. S3-compatible object store; the current home for this pipeline's results, logs, and reference data after the GCP/**[GCS](#g)** decommission (2026-06-26, [Issue #854](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/854)). Accessed via the s3v4 API with `region=auto`. *Domain: cloud.*
+
 **RCE** - Remote Code Execution. Vulnerability class where an attacker runs arbitrary code on a remote system, typically via input-validation or memory-safety bugs (e.g. CVE-2026-3854's crafted git push trigger). *Domain: security.*
 
 **RMSD** - Root Mean Square Deviation. Average distance (in Å) between corresponding atoms after optimal superposition; the standard structural-similarity metric. Variants used in DockQ: backbone-only, all-atom, interface-only (iRMSD), ligand-only (LRMSD). *Domain: bio.*
+
+**RunPod** - GPU cloud provider (per-second billing on L4 / Ada-class GPUs). The forward paid-provider target for reviving GPU workloads (TCRdock structural validation, GPU MHCflurry) post-GCP; migration plan in `docs/migration_runbook.md`. *Domain: cloud.*
 
 ## S
 

--- a/research/glossary.md
+++ b/research/glossary.md
@@ -98,7 +98,7 @@ Project-relevant abbreviations and acronyms. The pipeline mixes biology, ML, bio
 
 **HLA-LOH** - HLA Loss of Heterozygosity. Tumor immune-escape mechanism: somatic deletion or copy-neutral loss of one HLA allele, narrowing the peptide-presentation repertoire and shielding the tumor from neoantigen-specific T cells. Detected from WES (e.g. LOHHLA); candidates predicted on a lost allele are no longer presented. *Domain: bio.*
 
-**HPC** - High-Performance Computing. Cluster compute systems with job schedulers (SLURM, LSF, HTCondor); distinct from cloud "on-demand" compute models (GCP, AWS Batch). Pipeline currently runs on cloud, not HPC. *Domain: cloud.*
+**HPC** - High-Performance Computing. Cluster compute systems with job schedulers (SLURM, LSF, HTCondor); distinct from cloud "on-demand" compute models (GCP, AWS Batch). The pipeline core currently runs on a local CPU-only host (neither cloud nor HPC) post-GCP-decommission; the funded GPU-revival path targets cloud (RunPod), not HPC. *Domain: cloud.*
 
 **HTCondor** - High-Throughput Condor. Distributed batch scheduler from UW-Madison's CHTC; dominant in physics/astronomy (e.g. CERN ATLAS). Supports no-shared-FS topologies natively - relevant precedent for cloud-executor design. *Domain: cloud.*
 


### PR DESCRIPTION
## Summary

`research/glossary.md` still described the GCP/GCS stack (decommissioned 2026-06-26, [#854](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/854)) as **live** infrastructure. This refreshes the two stale entries and documents the current + forward infra.

- **GCP** entry → past tense (stack decommissioned #854; current compute = local CPU-only core; funded revival targets RunPod).
- **GCS** entry → past tense (`gs://splice-neoepitope-project` marked former; points at R2).
- **New R2** entry (Cloudflare R2, s3v4 / `region=auto`) — the current object store.
- **New RunPod** entry — the funded GPU-revival target (`docs/migration_runbook.md`).
- **HPC** entry → dropped the stale "Pipeline currently runs on cloud" claim (local CPU-only core now); caught by the bot review as a sibling of the same staleness class.

Term definitions themselves are unchanged (they appear in immutable historical lab-notebook entries); only the "live" assertions moved. GKE (line 83) is a generic term definition, not an our-infra assertion, so it stays per the issue scope.

## Test plan

- [x] AC-3 sweep for stale live-infra assertions: three entries carried them - GCP (79), GCS (81), and HPC (101, caught in bot review by a broadened grep `currently runs|runs on cloud|hosted on|...`). All three now past-tense/local; re-swept clean. GKE (83) is a generic definition, not an our-infra claim, so left as-is.
- [x] R2/RunPod facts cross-checked against the infra record (#854, `reference_r2_data_access.md`, `docs/migration_runbook.md`): R2 = s3v4/`region=auto`; RunPod = L4/Ada.
- [x] Markdown renders (bold entries + intra-doc `#g`/`#r` section links resolve to the G/R headings).

<!-- skip-lab-notebook: routine -->

Closes #998
