### PR TITLE
tooling(pm): scan_addressed_comments.py - board-wide To:<role> ping scan (#901)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -74,19 +74,24 @@ jobs:
         run: python -m pip install --upgrade pip pytest pyyaml
 
       - name: Run CI-tooling tests
-        # Collection scope: every tools/<dir>/ with a test suite must be listed
-        # here explicitly — pytest does NOT recurse into tools/ as a whole, so a
-        # new tools/<x>/ test home is silently skipped until added below.
-        # Separate invocations so each dir is collected in isolation — tools/ci
+        # Collection scope: every tools/<dir>/ AND scripts/tests/ with a test
+        # suite must be listed here explicitly - pytest does NOT recurse into
+        # tools/ (or scripts/) as a whole, so a new test home is silently skipped
+        # until added below.
+        # Separate invocations so each dir is collected in isolation - tools/ci
         # and tools/news carry their own pytest.ini for marker registration
         # (tools/project_map has none; isolation still keeps collection scopes
         # clean). tools/news is the morning-news poller (Issue #639);
-        # tools/project_map is the project-map atlas extractor (Issue #713 —
+        # tools/project_map is the project-map atlas extractor (Issue #713 -
         # the invariant suite was CI-invisible under tools/, regressions
         # ungated). project_map's extractor discovers files via `git ls-files`
         # (Issue #780), so the atlas is reproducible across working-tree states
         # (a populated local clone matches a clean checkout); it needs git on
-        # PATH, which the actions/checkout step provides.
+        # PATH, which the actions/checkout step provides. scripts/tests holds the
+        # PM board-tooling suites (board_open_items, arc labels, and the
+        # scan_addressed_comments Beat-2 scanner, Issue #901) - it was
+        # CI-invisible until #901 added it here, the same regression class #713
+        # fixed for tools/project_map.
         #
         # `-m "not live"` deselects the live-API smoke (Issue #711): a transient
         # GitHub-API blip must not red this per-PR job (or poison the hermetic
@@ -97,6 +102,7 @@ jobs:
           pytest tools/ci/ -v -m "not live"
           pytest tools/news/ -v
           pytest tools/project_map/ -v
+          pytest scripts/tests/ -v
         env:
           # PAT with `read:project` scope; integration tests that resolve
           # project items via GraphQL need this scope (the default

--- a/research/lab_notebook/pm.md
+++ b/research/lab_notebook/pm.md
@@ -8,6 +8,22 @@ Format and rules unchanged from the unified notebook — see `shared/feedback_la
 
 ## 2026-07-04
 
+### 16:00 UTC - Editor: PM
+
+#### `scan_addressed_comments.py` - board-wide `To:<role>` ping scanner ([PR #1011](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/1011) closes [#901](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/901))
+
+**Trigger.** Second quick-win of the session (after [#996](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/996)). The Daily Stand-up Beat 2 ping scan was a daily hand-roll that broke 3x in five minutes on 2026-06-29 (zsh word-split; jq `test()` escaping) and, worse, was role-scoped - so it structurally missed every cross-role `**To:** <you>` ping, which is how PM missed the Developer's `To: PM` reply on `role:developer` #887. Deterministic-first: a tested script.
+
+**What shipped.** `scripts/pm/scan_addressed_comments.py --role <role>`: board-wide (two `gh {issue,pr} list --search "updated:>=..."` calls, sidestepping the Done-first project-query pagination trap and covering PRs), windowed by the `.agents/last_session_marker.json` watermark (#886) minus a 1-day overlap with a 7-day floor fallback, matching the `**To:**` field with a word-bounded literal-substring test (no `test()` regex - the exact footgun that broke the hand-roll), grouped by Issue with author + timestamp + snippet. 29 unit tests. **Also closed a latent CI gap:** `scripts/tests/` ran in *no* CI job (the `board_open_items` + arc-label suites were ungated) - wired it into `ci-tools-pytest`, the same regression class #713 fixed for `tools/project_map`.
+
+**Live smoke as the real E2E.** Ran `--role pm --days 6` and `--role developer --days 4` against the live board: both surfaced real, correctly-grouped `**To:**` pings (multi-recipient `To: PM, Developer`, both `->`/arrow forms), confirming the whole pipeline works, not just the mocked units.
+
+**Dogfood of the #996 hook.** Requesting this PR's review auto-flipped #901's card `Ready` -> *In review* via the hook shipped ~1h earlier - the mechanism working on the very next PR unprompted.
+
+**Review (bot, "ready to merge", all non-blocking).** Four taken: (1) the `fetch_comments` jq crashed on a null `.user` (deleted account), and because `--jq` errors exit gh non-zero, the `except` dropped *every* comment on that issue - null-guarded `(.user.login? // "?")`; (2) softened the "exit 0 always" docstring to be honest that a hard `gh`-listing failure surfaces loudly (the intended behavior) rather than as a false "(none)"; (4) dropped a fetched-but-unused `updatedAt`; (5) fail-fast on negative `--days`. One nit left with reasoning: (3) trailing prose on a same-line `To:` can over-match, but over-surfacing is the *safe* direction for a coordination scan (the harm was under-surfacing, #887). 3 new CLI-guard tests.
+
+**Cross-repo residual (AC 5).** The Beat 2 repoint edits `shared/feedback_morning_routine.md`, which lives in the **personas repo**, not here - so it is NOT in this pipeline PR. Authored + staged in the personas working tree (script now primary, hand-rolled scan demoted to documented fallback) for the Memory Manager to commit, per the "memory is committed for you" model.
+
 ### 15:30 UTC - Editor: PM
 
 #### Review-request board-advance hook - `Ready for review` -> `In review` auto-flip ([PR #1008](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/1008) closes [#996](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/996))

--- a/scripts/pm/scan_addressed_comments.py
+++ b/scripts/pm/scan_addressed_comments.py
@@ -1,0 +1,273 @@
+#!/usr/bin/env python3
+"""Board-wide scan for comments addressed `**To:** <role>` (Daily Stand-up Beat 2).
+
+A team-coordination comment opens `**From:** <Role> -> **To:** <Role(s)>`. A ping
+`To:` your role can land on ANY Issue/PR regardless of its `role:*` label (e.g. a
+Developer replies `To: PM` on a `role:developer` Issue), so a role-scoped scan of
+only your own `role:*` Issues structurally misses every cross-role ping - which is
+exactly how PM missed the Developer's `To: PM` reply on `role:developer`
+[Issue #887] (2026-06-29). There is no @mention/notification for cross-role pings
+(all roles are one GitHub user), so detection depends entirely on scanning the
+right surface board-wide.
+
+This replaces the error-prone daily hand-roll (the inline jq/zsh form broke 3x in
+five minutes on 2026-06-29). Usage:
+
+  scripts/pm/scan_addressed_comments.py --role pm
+  scripts/pm/scan_addressed_comments.py --role developer --days 3
+  scripts/pm/scan_addressed_comments.py --role memory_manager --since 2026-07-01T00:00:00Z
+
+Window: the last-session watermark (`.agents/last_session_marker.json`, written by
+the Stop hook) minus a 1-day backward overlap; a conservative 7-day floor when the
+marker is absent (fresh clone / first run). `--since` / `--days` override it.
+
+Exit 0 always (a scan surfaces, it never gates). Issue #901.
+
+[Issue #887]: https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/887
+"""
+import argparse
+import json
+import subprocess
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+REPO = "Jin-HoMLee/splice-neoepitope-pipeline"
+MARKER_PATH = Path(__file__).resolve().parent.parent.parent / ".agents" / "last_session_marker.json"
+
+# Backward overlap on the watermark + the floor when no marker exists.
+OVERLAP_DAYS = 1
+FLOOR_DAYS = 7
+
+# Role -> display aliases as they appear in a `**To:** <Role>` field. Full names
+# plus the short forms the team uses on the board (Sci / Dev / MM). A `To: all` /
+# `To: team` broadcast is deliberately NOT matched: only a *named* addressee owes
+# an ack (per feedback_team_coordination.md), and surfacing every broadcast to
+# every role would be noise.
+ROLE_ALIASES = {
+    "pm": ["PM"],
+    "scientist": ["Scientist", "Sci"],
+    "developer": ["Developer", "Dev"],
+    "memory_manager": ["Memory Manager", "MM"],
+}
+
+# The literal marker after which the addressee list appears. Mirrors the proven
+# jq predicate `contains("To:** <Role>")`: the addressing convention bolds the
+# label (`**To:** PM`), so the tail after `To:**` is the recipient list. We match
+# on this literal (no `test()` regex) because the regex form's `\*` / `\b`
+# escaping silently matched nothing when hand-rolled (2026-06-29).
+_TO_MARKER = "To:**"
+
+
+# --- pure helpers (unit-tested, no I/O) ---
+
+
+def display_names(role):
+    """Aliases to look for in a `To:` field for `role`. Raises on unknown role."""
+    if role not in ROLE_ALIASES:
+        raise ValueError(f"unknown role: {role!r} (choices: {', '.join(ROLE_ALIASES)})")
+    return ROLE_ALIASES[role]
+
+
+def _to_field_tails(body):
+    """Yield the text after each `To:**` marker, one per line that carries it.
+
+    Only the recipient list (the tail of the `**To:**` line) is searched, so a
+    role name mentioned elsewhere in the comment body never false-matches.
+    """
+    for line in (body or "").splitlines():
+        idx = line.find(_TO_MARKER)
+        if idx != -1:
+            yield line[idx + len(_TO_MARKER):]
+
+
+def _word_bounded(alias_lower, tail):
+    """True if `alias_lower` appears as a whole word/phrase in `tail`.
+
+    Punctuation (commas between multiple recipients, arrows, emphasis) is
+    flattened to spaces so `**To:** Scientist, PM` matches `pm`, while `PMx` or a
+    substring hit inside another word does not. Pure string ops - no regex
+    predicate, so the jq `test()` escaping footgun cannot recur.
+    """
+    flat = "".join(c if c.isalnum() else " " for c in tail.lower())
+    padded = f" {' '.join(flat.split())} "
+    return f" {alias_lower} " in padded
+
+
+def body_addresses_role(body, names):
+    """True if any `To:` field in `body` names one of `names` (the role aliases)."""
+    aliases = [n.lower() for n in names]
+    return any(
+        _word_bounded(a, tail) for tail in _to_field_tails(body) for a in aliases
+    )
+
+
+def compute_since(marker, now):
+    """Window floor as an aware UTC datetime.
+
+    `marker` is the parsed `.agents/last_session_marker.json` dict (or None). Uses
+    `last_session_end_utc` minus OVERLAP_DAYS when present + parseable, else a
+    FLOOR_DAYS floor before `now`.
+    """
+    ts = (marker or {}).get("last_session_end_utc")
+    if ts:
+        try:
+            end = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+            if end.tzinfo is None:
+                end = end.replace(tzinfo=timezone.utc)
+            return end - timedelta(days=OVERLAP_DAYS)
+        except (ValueError, TypeError):
+            pass
+    return now - timedelta(days=FLOOR_DAYS)
+
+
+def snippet(body, maxlen=140):
+    """One-line preview of a comment body, whitespace-collapsed and truncated."""
+    flat = " ".join((body or "").split())
+    return flat if len(flat) <= maxlen else flat[: maxlen - 3] + "..."
+
+
+def parse_ts(ts):
+    """Parse a GitHub ISO-8601 timestamp to an aware UTC datetime (or None)."""
+    if not ts:
+        return None
+    try:
+        dt = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+        return dt if dt.tzinfo else dt.replace(tzinfo=timezone.utc)
+    except (ValueError, TypeError):
+        return None
+
+
+def select_pings(comments, names, since):
+    """Filter raw REST comments to those created >= `since` AND addressing the role.
+
+    Returns [(login, created_at, snippet)], oldest first. A comment with an
+    unparseable/absent timestamp is kept (fail-open: better a stray line than a
+    dropped ping).
+    """
+    out = []
+    for c in comments or []:
+        created = parse_ts(c.get("created_at"))
+        if created is not None and created < since:
+            continue
+        if not body_addresses_role(c.get("body"), names):
+            continue
+        login = ((c.get("user") or {}).get("login")) or "?"
+        out.append((login, c.get("created_at") or "?", snippet(c.get("body"))))
+    return out
+
+
+# --- gh I/O ---
+
+
+def gh(*args, parse_json=True):
+    result = subprocess.run(["gh", *args], capture_output=True, text=True, check=True)
+    return json.loads(result.stdout) if parse_json else result.stdout
+
+
+def read_marker(path=MARKER_PATH):
+    """Parse the session watermark file, or None if absent/malformed."""
+    try:
+        return json.loads(Path(path).read_text())
+    except (OSError, json.JSONDecodeError, ValueError):
+        return None
+
+
+def recently_updated(since_date):
+    """Board-wide Issues + PRs updated on/after `since_date` (YYYY-MM-DD).
+
+    Two calls (issues + PRs) rather than the board's Done-first project query, so
+    the pagination trap does not apply and PRs are covered.
+    """
+    search = f"updated:>={since_date}"
+    items = {}
+    for kind, sub in (("Issue", "issue"), ("PR", "pr")):
+        rows = gh(
+            sub, "list", "--repo", REPO, "--state", "all", "--limit", "1000",
+            "--search", search, "--json", "number,title,updatedAt",
+        )
+        for r in rows:
+            items[r["number"]] = {**r, "kind": kind}
+    return [items[n] for n in sorted(items)]
+
+
+def fetch_comments(number):
+    """All REST comments on Issue/PR `number` (REST serves both). Empty on error."""
+    try:
+        return gh(
+            "api", f"repos/{REPO}/issues/{number}/comments", "--paginate",
+            "--jq", ".[] | {body, created_at, user: {login: .user.login}}",
+            parse_json=False,
+        ).strip()
+    except subprocess.CalledProcessError:
+        return ""
+
+
+def _parse_jsonl(text):
+    """Parse newline-delimited JSON objects (gh --jq streams one per line)."""
+    rows = []
+    for line in (text or "").splitlines():
+        line = line.strip()
+        if line:
+            try:
+                rows.append(json.loads(line))
+            except json.JSONDecodeError:
+                pass
+    return rows
+
+
+# --- orchestration ---
+
+
+def render(role, groups, since):
+    lines = [
+        f"Board pings **To:** {role} since {since.strftime('%Y-%m-%d %H:%MZ')} "
+        f"(board-wide, all recently-updated Issues/PRs):"
+    ]
+    if not groups:
+        lines.append("  (none)")
+        return "\n".join(lines) + "\n"
+    for item, pings in groups:
+        lines.append(f"\n#{item['number']} [{item['kind']}] {item['title']}")
+        for login, ts, snip in pings:
+            lines.append(f"  - @{login} {ts}: {snip}")
+    return "\n".join(lines) + "\n"
+
+
+def scan(role, since):
+    names = display_names(role)
+    since_date = since.strftime("%Y-%m-%d")
+    groups = []
+    for item in recently_updated(since_date):
+        comments = _parse_jsonl(fetch_comments(item["number"]))
+        pings = select_pings(comments, names, since)
+        if pings:
+            groups.append((item, pings))
+    return groups
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--role", required=True, choices=sorted(ROLE_ALIASES),
+                        help="scan for comments addressed To: this role")
+    parser.add_argument("--since", help="ISO-8601 window floor (overrides the watermark)")
+    parser.add_argument("--days", type=int, help="window = last N days (overrides the watermark)")
+    args = parser.parse_args()
+
+    now = datetime.now(timezone.utc)
+    if args.since:
+        since = parse_ts(args.since)
+        if since is None:
+            parser.error(f"unparseable --since: {args.since!r}")
+    elif args.days is not None:
+        since = now - timedelta(days=args.days)
+    else:
+        since = compute_since(read_marker(), now)
+
+    print(render(args.role, scan(args.role, since), since), end="")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/pm/scan_addressed_comments.py
+++ b/scripts/pm/scan_addressed_comments.py
@@ -21,7 +21,9 @@ Window: the last-session watermark (`.agents/last_session_marker.json`, written 
 the Stop hook) minus a 1-day backward overlap; a conservative 7-day floor when the
 marker is absent (fresh clone / first run). `--since` / `--days` override it.
 
-Exit 0 always (a scan surfaces, it never gates). Issue #901.
+Exit 0 on a completed scan - finding nothing is not a failure. A hard `gh` /
+network failure on the board-listing call surfaces loudly (non-zero traceback)
+rather than as a false empty result. Issue #901.
 
 [Issue #887]: https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/887
 """
@@ -184,7 +186,7 @@ def recently_updated(since_date):
     for kind, sub in (("Issue", "issue"), ("PR", "pr")):
         rows = gh(
             sub, "list", "--repo", REPO, "--state", "all", "--limit", "1000",
-            "--search", search, "--json", "number,title,updatedAt",
+            "--search", search, "--json", "number,title",
         )
         for r in rows:
             items[r["number"]] = {**r, "kind": kind}
@@ -196,7 +198,10 @@ def fetch_comments(number):
     try:
         return gh(
             "api", f"repos/{REPO}/issues/{number}/comments", "--paginate",
-            "--jq", ".[] | {body, created_at, user: {login: .user.login}}",
+            # `.user` is null for a fully-deleted account; guard it so a single
+            # such comment doesn't error the whole `--jq` page (which would exit
+            # gh non-zero and silently drop EVERY comment on this issue).
+            "--jq", '.[] | {body, created_at, user: {login: (.user.login? // "?")}}',
             parse_json=False,
         ).strip()
     except subprocess.CalledProcessError:
@@ -261,6 +266,8 @@ def main():
         if since is None:
             parser.error(f"unparseable --since: {args.since!r}")
     elif args.days is not None:
+        if args.days < 0:
+            parser.error(f"--days must be non-negative, got {args.days}")
         since = now - timedelta(days=args.days)
     else:
         since = compute_since(read_marker(), now)

--- a/scripts/tests/test_scan_addressed_comments.py
+++ b/scripts/tests/test_scan_addressed_comments.py
@@ -1,0 +1,176 @@
+"""Tests for `scripts/pm/scan_addressed_comments.py` (Issue #901).
+
+Pure-helper unit tests + a network-free orchestration test that monkeypatches the
+two `gh` I/O functions with fixtures. No live `gh` is reached.
+"""
+
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+SCRIPTS_PM = Path(__file__).parent.parent / "pm"
+sys.path.insert(0, str(SCRIPTS_PM))
+
+import scan_addressed_comments as s  # noqa: E402
+
+UTC = timezone.utc
+
+
+class TestDisplayNames:
+    def test_known_roles(self):
+        assert s.display_names("pm") == ["PM"]
+        assert "Developer" in s.display_names("developer")
+        assert "MM" in s.display_names("memory_manager")
+
+    def test_unknown_role_raises(self):
+        try:
+            s.display_names("nobody")
+            assert False, "expected ValueError"
+        except ValueError:
+            pass
+
+
+class TestBodyAddressesRole:
+    def test_simple_bold_to(self):
+        body = "**From:** Developer -> **To:** PM\n\nplease review."
+        assert s.body_addresses_role(body, s.display_names("pm")) is True
+
+    def test_multi_recipient_list_matches_each(self):
+        body = "**From:** PM -> **To:** Scientist, Developer\n\nheads up."
+        assert s.body_addresses_role(body, s.display_names("scientist")) is True
+        assert s.body_addresses_role(body, s.display_names("developer")) is True
+        assert s.body_addresses_role(body, s.display_names("pm")) is False
+
+    def test_short_alias_dev(self):
+        body = "**From:** PM -> **To:** Dev\n\nlook at this."
+        assert s.body_addresses_role(body, s.display_names("developer")) is True
+
+    def test_memory_manager_two_word_phrase(self):
+        body = "**From:** PM -> **To:** Memory Manager\n\ncommit please."
+        assert s.body_addresses_role(body, s.display_names("memory_manager")) is True
+
+    def test_role_mentioned_off_the_to_line_not_matched(self):
+        # "PM" appears in the body but NOT in a To: field -> not a ping.
+        body = "**From:** Developer -> **To:** Scientist\n\nask the PM later."
+        assert s.body_addresses_role(body, s.display_names("pm")) is False
+
+    def test_substring_inside_word_not_matched(self):
+        body = "**From:** X -> **To:** PMgroup\n\nnope."
+        assert s.body_addresses_role(body, s.display_names("pm")) is False
+
+    def test_broadcast_all_not_matched(self):
+        # `To: all` is a broadcast; a named addressee owes an ack, a broadcast
+        # does not, so it is deliberately not surfaced per role.
+        body = "**From:** PM -> **To:** all\n\nconvention is live."
+        assert s.body_addresses_role(body, s.display_names("pm")) is False
+
+    def test_no_to_line(self):
+        assert s.body_addresses_role("just a normal comment about PM stuff", s.display_names("pm")) is False
+
+    def test_none_body_safe(self):
+        assert s.body_addresses_role(None, s.display_names("pm")) is False
+
+
+class TestComputeSince:
+    def test_marker_present_applies_overlap(self):
+        marker = {"last_session_end_utc": "2026-07-04T12:00:00Z"}
+        now = datetime(2026, 7, 4, 15, 0, tzinfo=UTC)
+        got = s.compute_since(marker, now)
+        assert got == datetime(2026, 7, 3, 12, 0, tzinfo=UTC)  # minus 1-day overlap
+
+    def test_marker_absent_uses_floor(self):
+        now = datetime(2026, 7, 4, 15, 0, tzinfo=UTC)
+        assert s.compute_since(None, now) == now - timedelta(days=s.FLOOR_DAYS)
+
+    def test_marker_malformed_ts_uses_floor(self):
+        now = datetime(2026, 7, 4, 15, 0, tzinfo=UTC)
+        got = s.compute_since({"last_session_end_utc": "not-a-date"}, now)
+        assert got == now - timedelta(days=s.FLOOR_DAYS)
+
+    def test_marker_missing_key_uses_floor(self):
+        now = datetime(2026, 7, 4, 15, 0, tzinfo=UTC)
+        assert s.compute_since({"schema": 1}, now) == now - timedelta(days=s.FLOOR_DAYS)
+
+
+class TestSelectPings:
+    def _c(self, body, created, login="dev"):
+        return {"body": body, "created_at": created, "user": {"login": login}}
+
+    def test_filters_by_since_and_role(self):
+        since = datetime(2026, 7, 3, 0, 0, tzinfo=UTC)
+        comments = [
+            self._c("**To:** PM\n\nnew ping", "2026-07-04T10:00:00Z", "alice"),
+            self._c("**To:** PM\n\nold ping", "2026-07-01T10:00:00Z", "bob"),      # too old
+            self._c("**To:** Scientist\n\nnot for pm", "2026-07-04T11:00:00Z"),    # wrong role
+        ]
+        pings = s.select_pings(comments, s.display_names("pm"), since)
+        assert len(pings) == 1
+        assert pings[0][0] == "alice"
+
+    def test_unparseable_timestamp_kept(self):
+        since = datetime(2026, 7, 3, 0, 0, tzinfo=UTC)
+        comments = [self._c("**To:** PM\n\nkeep me", None, "carol")]
+        pings = s.select_pings(comments, s.display_names("pm"), since)
+        assert len(pings) == 1 and pings[0][0] == "carol"
+
+    def test_empty_comments_safe(self):
+        since = datetime(2026, 7, 3, 0, 0, tzinfo=UTC)
+        assert s.select_pings([], s.display_names("pm"), since) == []
+        assert s.select_pings(None, s.display_names("pm"), since) == []
+
+
+class TestSnippet:
+    def test_short_untouched(self):
+        assert s.snippet("hello world") == "hello world"
+
+    def test_collapses_whitespace(self):
+        assert s.snippet("a\n\n  b   c") == "a b c"
+
+    def test_truncates_long(self):
+        out = s.snippet("x" * 200, maxlen=50)
+        assert len(out) == 50 and out.endswith("...")
+
+
+class TestParseJsonl:
+    def test_parses_and_skips_bad(self):
+        text = '{"a": 1}\n\nnot json\n{"b": 2}\n'
+        assert s._parse_jsonl(text) == [{"a": 1}, {"b": 2}]
+
+    def test_empty(self):
+        assert s._parse_jsonl("") == []
+        assert s._parse_jsonl(None) == []
+
+
+class TestOrchestrationNoNetwork:
+    def test_scan_groups_pings(self, monkeypatch):
+        since = datetime(2026, 7, 3, 0, 0, tzinfo=UTC)
+        monkeypatch.setattr(s, "recently_updated", lambda d: [
+            {"number": 10, "title": "Alpha", "kind": "Issue"},
+            {"number": 11, "title": "Beta", "kind": "PR"},
+            {"number": 12, "title": "Gamma", "kind": "Issue"},
+        ])
+
+        def fake_comments(number):
+            data = {
+                10: '{"body": "**To:** PM\\n\\nreview", "created_at": "2026-07-04T10:00:00Z", "user": {"login": "dev"}}',
+                11: '{"body": "**To:** Scientist\\n\\nnot pm", "created_at": "2026-07-04T10:00:00Z", "user": {"login": "sci"}}',
+                12: "",  # comment-less issue
+            }
+            return data[number]
+
+        monkeypatch.setattr(s, "fetch_comments", fake_comments)
+        groups = s.scan("pm", since)
+        assert [g[0]["number"] for g in groups] == [10]
+        assert groups[0][1][0][0] == "dev"
+
+    def test_render_none(self):
+        since = datetime(2026, 7, 4, 15, 0, tzinfo=UTC)
+        out = s.render("pm", [], since)
+        assert "(none)" in out
+
+    def test_render_groups(self):
+        since = datetime(2026, 7, 4, 15, 0, tzinfo=UTC)
+        groups = [({"number": 10, "title": "Alpha", "kind": "Issue"},
+                   [("dev", "2026-07-04T10:00:00Z", "review please")])]
+        out = s.render("pm", groups, since)
+        assert "#10 [Issue] Alpha" in out and "@dev" in out

--- a/scripts/tests/test_scan_addressed_comments.py
+++ b/scripts/tests/test_scan_addressed_comments.py
@@ -174,3 +174,24 @@ class TestOrchestrationNoNetwork:
                    [("dev", "2026-07-04T10:00:00Z", "review please")])]
         out = s.render("pm", groups, since)
         assert "#10 [Issue] Alpha" in out and "@dev" in out
+
+
+class TestCliGuards:
+    def _run(self, *args):
+        import subprocess
+        return subprocess.run(
+            [sys.executable, str(SCRIPTS_PM / "scan_addressed_comments.py"), *args],
+            capture_output=True, text=True, timeout=10,
+        )
+
+    def test_negative_days_rejected(self):
+        r = self._run("--role", "pm", "--days", "-3")
+        assert r.returncode == 2 and "non-negative" in r.stderr
+
+    def test_unknown_role_rejected(self):
+        r = self._run("--role", "nobody")
+        assert r.returncode == 2
+
+    def test_missing_role_rejected(self):
+        r = self._run("--days", "1")
+        assert r.returncode == 2


### PR DESCRIPTION
## Summary

Closes #901. Replaces the error-prone daily hand-roll of the Daily Stand-up Beat 2 ping scan with a tested script.

A `**To:** <role>` coordination ping can land on **any** Issue/PR regardless of its `role:*` label, so the old role-scoped scan structurally missed every cross-role ping - which is how PM missed the Developer's `To: PM` reply on `role:developer` #887. The inline jq/zsh replacement broke 3x in five minutes on 2026-06-29 (zsh word-split, jq `test()` escaping). Deterministic-first: a tested script, not a daily hand-roll.

## What shipped

`scripts/pm/scan_addressed_comments.py --role <pm|scientist|developer|memory_manager>`:
- **Board-wide:** lists all Issues + PRs updated since the window (two `gh {issue,pr} list --search "updated:>=..."` calls, not the Done-first project query), then scans each one's comments.
- **Window:** reads `.agents/last_session_marker.json` (`last_session_end_utc`, the Stop-hook watermark from #886) minus a 1-day backward overlap; a conservative 7-day floor when the marker is absent. `--since` / `--days` override.
- **Match:** literal-substring on the `**To:**` field only (no `test()` regex - the escaping footgun that broke the hand-roll), word-bounded so a multi-recipient `To: PM, Developer` and short aliases (`Dev`/`MM`) match, while a substring inside another word (`PMgroup`) or a broadcast `To: all` does not.
- **Output:** pings grouped by Issue with author + timestamp + snippet. Exit 0 always (a scan surfaces, never gates). Handles PRs + comment-less Issues without erroring.

**Also:** wired `scripts/tests/` into the `ci-tools-pytest` job. It was CI-invisible - the existing `board_open_items` + arc-label suites ran nowhere - the same regression class #713 fixed for `tools/project_map`.

## Cross-repo companion (personas repo)

AC 5 (repoint shared morning-routine Beat 2) edits `shared/feedback_morning_routine.md`, which lives in the **personas repo** (`claude-personas-splice-neoepitope-pipeline`), not here. The repoint (script is now primary; the hand-rolled scan is the documented fallback) is authored and staged in the personas working tree for the Memory Manager to commit, per the "memory is committed for you" model.

## Test plan

- [x] 26 new unit tests in `scripts/tests/test_scan_addressed_comments.py` (role aliases, `To:`-field matching incl. multi-recipient / short-alias / off-line / substring / broadcast / no-`To:` / None, window computation with marker present/absent/malformed, ping selection + since-filter, snippet, JSONL parse, network-free orchestration via monkeypatched `gh`).
- [x] Full `scripts/tests/` green (53 passed) - no pre-existing suite reddened by the new CI wiring.
- [x] Live end-to-end smoke: `--role pm --days 6` against the real board surfaced real `**To:** PM` pings board-wide, correctly grouped, including multi-recipient `To: PM, Developer` and both `->`/arrow forms.
- [x] Dogfood: this PR's own `@-claude review` request fired the #996 hook and flipped #901's card `Ready` -> `In review` (confirmed via the hook's `additionalContext`).

**Priority rationale:** P2 - a real cross-role coordination reliability gap (caused a missed Dev reply), but advisory: the manual board-wide scan is the working stopgap and no delivery is blocked.

**Created by:** PM
