### PR TITLE
chore(tooling): tag item origin repo in board_open_items - board #9 collision guard (#999)

### DIFF
--- a/research/lab_notebook/pm.md
+++ b/research/lab_notebook/pm.md
@@ -8,6 +8,18 @@ Format and rules unchanged from the unified notebook — see `shared/feedback_la
 
 ## 2026-07-04
 
+### 17:15 UTC - Editor: PM
+
+#### Tag item origin repo in board_open_items - board #9 collision guard ([PR #1018](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/1018) closes [#999](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/999))
+
+**Trigger.** After re-scoping [#999](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/999) (its two original premises were both invalid - the MM-exemption framing overturned by #1006, and the "bucketing bug" a two-repo number-collision misread), the user asked whether we follow the 4 web-confirmed cross-repo best practices. Audit finding: we comply exactly where a **mechanism** exists (the auto-close gate; URL-keyed JSON) and slip exactly where it's **discipline-only** (ad-hoc `gh -R`, human-facing displays). The biggest mechanizable gap was the board tool's own text output showing bare numbers - the thing that caused #999's misfiling. Recommended fixing that one, skipping a noisy `gh -R` guard (negative ROI) and the mild prose gap. User approved.
+
+**What shipped.** `board_open_items.py`: an `origin` field per item (`project`/`personas`/`other`, from the URL - personas matched first since its repo name contains the project name), and an **asymmetric** `Ref` cell in the text table - `pers#71` for personas, bare `71` for project (project is the ~universal default, so only the collision partner is tagged). Docstring documents the two-repo aggregation + resolve-repo-from-URL rule. Live proof: the MM lane now shows `pers#73`/`pers#74` for personas items while its project items (`#978`, `#346`) stay bare.
+
+**The miss (worth recording).** My first test plan ran `scripts/tests/` + `test_check_ready_queue.py` (85 green) and I shipped - but `board_open_items` has a **second** test suite at `workflow/tests/test_board_open_items.py` (the one `pipeline-pytest` runs), which I never ran locally. Its alignment test asserted `header.index("#")`, which the `#`->`Ref` rename broke. The user caught the red check. **Lesson: a module with tests in two trees needs BOTH run before push** (`pytest workflow/tests/ scripts/tests/`) - the same silent-second-location class the CLAUDE.md dry-run gotchas warn about. Reproduced locally (blocked by a `joblib` local-venv gap on the *full* workflow suite, so ran the 4 `board_open_items` consumers directly: board_open_items, check_ready_queue, check_roadmap_health, dispatch_digest - all green), fixed via `header.index("Ref")` + simplifying `ref_cell` to tag only personas (so existing example-URL fixtures render bare, not `ext#`), pushed green.
+
+**Review (bot, on the pre-fix commit).** Independently flagged the same two-fold CI failure I'd just fixed (header rename + the `other`-classified fixture), plus 3 valid nits on the current code: no alignment guard for the *tagged* ref path (added `pers#71` + bare-`71` under-Ref assertions), a vacuous `or count>=2` disjunct (dropped), and a 5-digit overflow of the 9-wide Ref column (bumped to 10, matching the Kind-column's defensive sizing). Its `ext#`-vocabulary nit was moot post-simplification.
+
 ### 16:45 UTC - Editor: PM
 
 #### Fold MM into the Replenishment floor-5, remove the exemption ([PR #1016](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/1016) closes [#1006](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1006))

--- a/scripts/board_open_items.py
+++ b/scripts/board_open_items.py
@@ -367,12 +367,12 @@ def format_table(
     # Kind column is 8 wide to fit the longest marker "Issue/P" (parent); plain
     # "Issue" / draft "PR/D" are shorter. A narrower budget overflows and shifts
     # every column to its right out from under its header.
-    # Ref column (was "#") is 9 wide so a tagged personas ref ("pers#1234") fits
-    # without shifting the columns to its right; a bare project number is shorter
-    # (Issue #999 two-repo disambiguation).
+    # Ref column (was "#") is 10 wide so a tagged personas ref keeps its column
+    # even at 5 digits ("pers#12345") without shifting arc/title; a bare project
+    # number is shorter (Issue #999 two-repo disambiguation).
     lines = [
-        f"{'Status':<17} {'P':<3} {'Sz':<3} {'Age':<5} {'Role':<17} {'Kind':<8} {'Ref':<9} {arc_hdr}Title",
-        f"{'-' * 17} {'-' * 3} {'-' * 3} {'-' * 5} {'-' * 17} {'-' * 8} {'-' * 9} {arc_sep}{'-' * 60}",
+        f"{'Status':<17} {'P':<3} {'Sz':<3} {'Age':<5} {'Role':<17} {'Kind':<8} {'Ref':<10} {arc_hdr}Title",
+        f"{'-' * 17} {'-' * 3} {'-' * 3} {'-' * 5} {'-' * 17} {'-' * 8} {'-' * 10} {arc_sep}{'-' * 60}",
     ]
     for it in items:
         role = (it["role"] or "(none)").removeprefix("role:")[:16]
@@ -389,7 +389,7 @@ def format_table(
             arc_cell = ""
         lines.append(
             f"{it['status']:<17} {it['priority'] or '?':<3} {it['size'] or '?':<3} "
-            f"{age:<5} {role:<17} {kind:<8} {ref_cell(it):<9} {arc_cell}{title}"
+            f"{age:<5} {role:<17} {kind:<8} {ref_cell(it):<10} {arc_cell}{title}"
         )
     return "\n".join(lines) + "\n"
 

--- a/scripts/board_open_items.py
+++ b/scripts/board_open_items.py
@@ -15,6 +15,16 @@ Each item carries its issue/PR created/updated/closed timestamps; `--sort-update
 content-level field, NOT the board "Updated" column (which a bare field nudge bumps;
 see Issue #642).
 
+**Two-repo aggregation (Issue #999).** Board #9 aggregates items from BOTH the
+project repo and the personas repo (`claude-personas-splice-neoepitope-pipeline`),
+whose issue/PR numbers COLLIDE (both have a #29, #64, #71, ...). Each item's true
+identity is its `url`, never the bare number, so the text table disambiguates by
+tagging non-project rows (`pers#71` vs a bare project `71`), and `--json` carries
+both `url` and an `origin` field (`project` / `personas` / `other`). When acting on
+a listed item, resolve the repo from its `url` before any `gh ... -R` call: a bare
+`gh issue view 71` hits whichever repo your cwd defaults to and can silently return
+the wrong same-numbered issue.
+
 Usage:
   scripts/board_open_items.py
   scripts/board_open_items.py --role developer
@@ -36,6 +46,32 @@ from typing import Any
 
 OWNER = "Jin-HoMLee"
 PROJECT_NUMBER = 9
+
+# Board #9 aggregates two repos with colliding numbers (Issue #999). Personas is
+# checked first because its name CONTAINS the project name as a substring.
+PERSONAS_REPO = "claude-personas-splice-neoepitope-pipeline"
+PROJECT_REPO = "splice-neoepitope-pipeline"
+# Short tag rendered before a non-project item's number in the text table; the
+# project repo is the expected default and stays bare (asymmetric on purpose).
+_ORIGIN_TAG = {"personas": "pers", "other": "ext"}
+
+
+def origin_from_url(url: str) -> str:
+    """Classify a board item's origin repo from its URL: project / personas / other."""
+    url = url or ""
+    if f"/{PERSONAS_REPO}/" in url:
+        return "personas"
+    if f"/{PROJECT_REPO}/" in url:
+        return "project"
+    return "other"
+
+
+def ref_cell(item: dict) -> str:
+    """Disambiguated reference for the text table: bare `123` for a project item,
+    tagged `pers#123` for a personas (or `ext#123` for an unexpected) item."""
+    number = item.get("number")
+    tag = _ORIGIN_TAG.get(item.get("origin"))
+    return f"{tag}#{number}" if tag else str(number)
 
 QUERY = """
 query($owner: String!, $number: Int!, $after: String) {
@@ -194,6 +230,7 @@ def normalize(item: dict[str, Any]) -> dict[str, Any] | None:
         "number": content.get("number"),
         "title": content.get("title", ""),
         "url": content.get("url", ""),
+        "origin": origin_from_url(content.get("url", "")),
         "kind": "PR" if content.get("__typename") == "PullRequest" else "Issue",
         "is_draft": content.get("isDraft", False),
         "is_parent": is_parent,
@@ -327,9 +364,12 @@ def format_table(
     # Kind column is 8 wide to fit the longest marker "Issue/P" (parent); plain
     # "Issue" / draft "PR/D" are shorter. A narrower budget overflows and shifts
     # every column to its right out from under its header.
+    # Ref column (was "#") is 9 wide so a tagged personas ref ("pers#1234") fits
+    # without shifting the columns to its right; a bare project number is shorter
+    # (Issue #999 two-repo disambiguation).
     lines = [
-        f"{'Status':<17} {'P':<3} {'Sz':<3} {'Age':<5} {'Role':<17} {'Kind':<8} {'#':<5} {arc_hdr}Title",
-        f"{'-' * 17} {'-' * 3} {'-' * 3} {'-' * 5} {'-' * 17} {'-' * 8} {'-' * 5} {arc_sep}{'-' * 60}",
+        f"{'Status':<17} {'P':<3} {'Sz':<3} {'Age':<5} {'Role':<17} {'Kind':<8} {'Ref':<9} {arc_hdr}Title",
+        f"{'-' * 17} {'-' * 3} {'-' * 3} {'-' * 5} {'-' * 17} {'-' * 8} {'-' * 9} {arc_sep}{'-' * 60}",
     ]
     for it in items:
         role = (it["role"] or "(none)").removeprefix("role:")[:16]
@@ -346,7 +386,7 @@ def format_table(
             arc_cell = ""
         lines.append(
             f"{it['status']:<17} {it['priority'] or '?':<3} {it['size'] or '?':<3} "
-            f"{age:<5} {role:<17} {kind:<8} {it['number']:<5} {arc_cell}{title}"
+            f"{age:<5} {role:<17} {kind:<8} {ref_cell(it):<9} {arc_cell}{title}"
         )
     return "\n".join(lines) + "\n"
 

--- a/scripts/board_open_items.py
+++ b/scripts/board_open_items.py
@@ -19,8 +19,9 @@ see Issue #642).
 project repo and the personas repo (`claude-personas-splice-neoepitope-pipeline`),
 whose issue/PR numbers COLLIDE (both have a #29, #64, #71, ...). Each item's true
 identity is its `url`, never the bare number, so the text table disambiguates by
-tagging non-project rows (`pers#71` vs a bare project `71`), and `--json` carries
-both `url` and an `origin` field (`project` / `personas` / `other`). When acting on
+tagging the personas rows (`pers#71` vs a bare project `71` - the two collide),
+and `--json` carries both `url` and an `origin` field (`project` / `personas` /
+`other`). When acting on
 a listed item, resolve the repo from its `url` before any `gh ... -R` call: a bare
 `gh issue view 71` hits whichever repo your cwd defaults to and can silently return
 the wrong same-numbered issue.
@@ -51,11 +52,6 @@ PROJECT_NUMBER = 9
 # checked first because its name CONTAINS the project name as a substring.
 PERSONAS_REPO = "claude-personas-splice-neoepitope-pipeline"
 PROJECT_REPO = "splice-neoepitope-pipeline"
-# Short tag rendered before a non-project item's number in the text table; the
-# project repo is the expected default and stays bare (asymmetric on purpose).
-_ORIGIN_TAG = {"personas": "pers", "other": "ext"}
-
-
 def origin_from_url(url: str) -> str:
     """Classify a board item's origin repo from its URL: project / personas / other."""
     url = url or ""
@@ -67,11 +63,18 @@ def origin_from_url(url: str) -> str:
 
 
 def ref_cell(item: dict) -> str:
-    """Disambiguated reference for the text table: bare `123` for a project item,
-    tagged `pers#123` for a personas (or `ext#123` for an unexpected) item."""
+    """Disambiguated reference for the text table.
+
+    Board #9 aggregates exactly two repos, so tagging ONLY the personas rows fully
+    disambiguates them from the collision-partner project rows: a personas item
+    renders `pers#123`, everything else (project - the expected default - or an
+    unexpected/unknown origin) renders the bare `123`. Asymmetric on purpose: the
+    overwhelmingly-common project case stays uncluttered.
+    """
     number = item.get("number")
-    tag = _ORIGIN_TAG.get(item.get("origin"))
-    return f"{tag}#{number}" if tag else str(number)
+    if item.get("origin") == "personas":
+        return f"pers#{number}"
+    return str(number)
 
 QUERY = """
 query($owner: String!, $number: Int!, $after: String) {

--- a/scripts/tests/test_board_open_items_origin.py
+++ b/scripts/tests/test_board_open_items_origin.py
@@ -73,8 +73,14 @@ def test_format_table_tags_personas_row_only():
          "priority": "P2", "size": "S", "role": "role:memory_manager", "arc": None,
          "arc_phase": None, "updated_at": None},
     ]
-    out = b.format_table(items)
-    assert "pers#71" in out          # personas row tagged
-    assert " 71 " in out or out.count("71") >= 2  # project row keeps a bare 71
-    # header renamed # -> Ref
-    assert "Ref" in out.splitlines()[0]
+    table = b.format_table(items)
+    lines = table.splitlines()
+    header = lines[0]
+    assert "Ref" in header                 # header renamed # -> Ref
+    rows = lines[2:]                        # 0=header, 1=separator
+    pers_row = next(r for r in rows if "pers#71" in r)
+    proj_row = next(r for r in rows if "pers#71" not in r and "71" in r)
+    # both refs (bare project + tagged personas) start under the Ref header - the
+    # tagged path is exactly why the column was widened, so guard its alignment.
+    assert pers_row.index("pers#71") == header.index("Ref")
+    assert proj_row.index("71") == header.index("Ref")   # project row is bare

--- a/scripts/tests/test_board_open_items_origin.py
+++ b/scripts/tests/test_board_open_items_origin.py
@@ -42,8 +42,10 @@ class TestRefCell:
     def test_personas_is_tagged(self):
         assert b.ref_cell({"number": 71, "origin": "personas"}) == "pers#71"
 
-    def test_other_is_tagged(self):
-        assert b.ref_cell({"number": 71, "origin": "other"}) == "ext#71"
+    def test_other_renders_bare(self):
+        # Board #9 has exactly two repos, so only personas is tagged; an
+        # unexpected/unknown origin renders bare (never occurs in production).
+        assert b.ref_cell({"number": 71, "origin": "other"}) == "71"
 
     def test_missing_origin_falls_back_to_bare(self):
         # Defensive: an item dict without an origin key renders the bare number.

--- a/scripts/tests/test_board_open_items_origin.py
+++ b/scripts/tests/test_board_open_items_origin.py
@@ -1,0 +1,78 @@
+# scripts/tests/test_board_open_items_origin.py
+#
+# Issue #999 - board #9 aggregates the project repo AND the personas repo, whose
+# numbers collide. The text table must disambiguate a same-numbered project vs
+# personas item so a reader can't misattribute one (the misread that produced
+# this Issue's own original, incorrect filing).
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+import board_open_items as b  # noqa: E402
+
+PROJECT_URL = "https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/71"
+PERSONAS_URL = "https://github.com/Jin-HoMLee/claude-personas-splice-neoepitope-pipeline/issues/71"
+
+
+class TestOriginFromUrl:
+    def test_project(self):
+        assert b.origin_from_url(PROJECT_URL) == "project"
+
+    def test_personas_not_shadowed_by_substring(self):
+        # PERSONAS_REPO contains PROJECT_REPO as a substring; personas must win.
+        assert b.origin_from_url(PERSONAS_URL) == "personas"
+
+    def test_pr_url(self):
+        assert b.origin_from_url(
+            "https://github.com/Jin-HoMLee/claude-personas-splice-neoepitope-pipeline/pull/12"
+        ) == "personas"
+
+    def test_unknown_repo_is_other(self):
+        assert b.origin_from_url("https://github.com/someone/other-repo/issues/3") == "other"
+
+    def test_empty_or_none_is_other(self):
+        assert b.origin_from_url("") == "other"
+        assert b.origin_from_url(None) == "other"
+
+
+class TestRefCell:
+    def test_project_is_bare(self):
+        assert b.ref_cell({"number": 71, "origin": "project"}) == "71"
+
+    def test_personas_is_tagged(self):
+        assert b.ref_cell({"number": 71, "origin": "personas"}) == "pers#71"
+
+    def test_other_is_tagged(self):
+        assert b.ref_cell({"number": 71, "origin": "other"}) == "ext#71"
+
+    def test_missing_origin_falls_back_to_bare(self):
+        # Defensive: an item dict without an origin key renders the bare number.
+        assert b.ref_cell({"number": 71}) == "71"
+
+
+def test_same_number_project_and_personas_are_distinguishable():
+    """The core #999 guarantee: two items sharing #71 render distinct refs."""
+    proj = {"number": 71, "origin": b.origin_from_url(PROJECT_URL)}
+    pers = {"number": 71, "origin": b.origin_from_url(PERSONAS_URL)}
+    assert b.ref_cell(proj) != b.ref_cell(pers)
+    assert b.ref_cell(proj) == "71" and b.ref_cell(pers) == "pers#71"
+
+
+def test_format_table_tags_personas_row_only():
+    """End-to-end: the rendered table shows a bare project ref and a tagged
+    personas ref for two same-numbered items."""
+    items = [
+        {"number": 71, "url": PROJECT_URL, "origin": "project", "title": "project item",
+         "kind": "Issue", "is_draft": False, "is_parent": False, "status": "Ready",
+         "priority": "P2", "size": "S", "role": "role:developer", "arc": None,
+         "arc_phase": None, "updated_at": None},
+        {"number": 71, "url": PERSONAS_URL, "origin": "personas", "title": "personas item",
+         "kind": "Issue", "is_draft": False, "is_parent": False, "status": "Ready",
+         "priority": "P2", "size": "S", "role": "role:memory_manager", "arc": None,
+         "arc_phase": None, "updated_at": None},
+    ]
+    out = b.format_table(items)
+    assert "pers#71" in out          # personas row tagged
+    assert " 71 " in out or out.count("71") >= 2  # project row keeps a bare 71
+    # header renamed # -> Ref
+    assert "Ref" in out.splitlines()[0]

--- a/workflow/tests/test_board_open_items.py
+++ b/workflow/tests/test_board_open_items.py
@@ -369,11 +369,13 @@ def test_exclude_parents_filters_out_parents(monkeypatch, capsys):
 
 def test_format_table_parent_kind_keeps_column_alignment():
     # "Issue/P" is 7 chars and must not overflow the Kind column and shift the
-    # # column out from under its header (the first kind value to exceed the
-    # old 5-char budget; "Issue"=5 fit, drafts are "PR/D"=4).
+    # Ref column out from under its header (the first kind value to exceed the
+    # old 5-char budget; "Issue"=5 fit, drafts are "PR/D"=4). The Ref column was
+    # renamed from "#" in Issue #999 (two-repo disambiguation); a project item
+    # renders a bare number, so #547 stays "547".
     parent = boi.normalize(_board_item(547, sub_total=4))
     lines = boi.format_table([parent], now=NOW).splitlines()
     header, row = lines[0], lines[2]  # 0=header, 1=separator, 2=data
     assert "Issue/P" in row
-    # the issue number sits exactly under the '#' header label
-    assert row.index("547") == header.index("#")
+    # the issue number sits exactly under the 'Ref' header label
+    assert row.index("547") == header.index("Ref")


### PR DESCRIPTION
## Summary

Closes #999 (re-scoped). Board #9 aggregates the project repo AND the personas repo, whose issue/PR numbers **collide** (both have #29, #64, #71, ...). `board_open_items.py`'s text output showed only the bare number, so an item could be silently misattributed to the wrong repo - which is exactly what produced #999's own original (incorrect) filing, and a documented recurring analysis bite.

## Changes

- **`origin` field per item** (`project` / `personas` / `other`), derived from the item's `url`. Personas is matched first because its repo name *contains* the project name as a substring.
- **Asymmetric text-table disambiguation:** the `#` column becomes `Ref` and renders a bare `71` for a project item, a tagged `pers#71` for a personas one. Project is the expected default, so only the collision-prone (non-project) rows get a marker - keeps the common case uncluttered.
- **Docstring** documents the two-repo aggregation + the "resolve repo from URL before any `gh -R` call" rule.
- `--json` already carried `url`; it now also carries `origin`.

## Why asymmetric (not a symmetric repo column)

The project repo is where ~all interactive work happens, so bare numbers there are correct and expected; tagging only the personas rows (the one collision partner) flags precisely the items a bare number would misattribute, without widening every row. This directly addresses the misread class without changing how the (overwhelmingly project-repo) common case reads.

## Verification

- Live run: the MM lane now renders `pers#73` / `pers#74` / `pers#107` for personas items while the same lane's project items (`#978`, `#346`) stay bare - the exact project-vs-personas distinction that was invisible before and caused the misdiagnosis.

## Test plan

- [x] New tests in `scripts/tests/test_board_open_items_origin.py`: `origin_from_url` (project / personas-not-shadowed-by-substring / PR URL / other / empty), `ref_cell` (bare project / tagged personas / other-renders-bare / missing-origin fallback), a **same-number project-vs-personas distinguishability** guard, and a `format_table` render check asserting BOTH the tagged (`pers#71`) and bare (`71`) refs align under the `Ref` header.
- [x] All four `board_open_items` consumers green across BOTH test trees: `workflow/tests/{test_board_open_items,test_check_ready_queue,test_check_roadmap_health,test_dispatch_digest}.py` + `scripts/tests/` (the added `origin` field is JSON-additive, so the ready-queue consumer is unperturbed).
- [x] CI `pipeline-pytest` green after fixing a missed second test-location (`workflow/tests/test_board_open_items.py`'s alignment test asserted the renamed `#` header).

**Priority rationale:** P3 - a tooling-UX hardening that prevents a documented recurring misread class (it already produced one wrong Issue); blocks nothing, correct data was already in `--json`. Size S. arc:board-governance.

**Created by:** PM
