### PR TITLE
chore(env): adopt uv for the test + research pyenv venvs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,8 +69,8 @@ The project has **4 functional Python environments**, each with a different use 
 
 | Use case | Canonical path | Setup recipe | Documented at |
 |---|---|---|---|
-| Pytest test suite | `workflow/tests/.venv` | `pyenv local 3.13.5 && uv venv --python 3.13.5 workflow/tests/.venv && uv pip install --python workflow/tests/.venv/bin/python -r workflow/tests/requirements-test.txt` | [workflow/tests/README.md](workflow/tests/README.md) |
-| Research / Jupyter notebooks | `research/.venv` | `cd research/ && pyenv local 3.14.4 && uv venv --python 3.14.4 .venv && uv pip install --python .venv/bin/python -r requirements.txt` | [research/README.md](research/README.md) |
+| Pytest test suite | `workflow/tests/.venv` | `pyenv local 3.13.5 && uv venv --seed --python 3.13.5 workflow/tests/.venv && uv pip install --python workflow/tests/.venv/bin/python -r workflow/tests/requirements-test.txt` | [workflow/tests/README.md](workflow/tests/README.md) |
+| Research / Jupyter notebooks | `research/.venv` | `cd research/ && pyenv local 3.14.4 && uv venv --seed --python 3.14.4 .venv && uv pip install --python .venv/bin/python -r requirements.txt` | [research/README.md](research/README.md) |
 | Snakemake orchestration (and ad-hoc `python -c` quick checks) | `conda activate snakemake` | `bash scripts/setup_local.sh` | "Snakemake Conda Activation" above |
 | Per-rule Python (`workflow/scripts/*.py` invoked by Snakemake rules) | rule's own `--use-conda` env | auto-created from `workflow/envs/*.yaml` on first `snakemake --use-conda` run | implicit; each rule declares `conda: "envs/<env>.yaml"` |
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,8 +69,8 @@ The project has **4 functional Python environments**, each with a different use 
 
 | Use case | Canonical path | Setup recipe | Documented at |
 |---|---|---|---|
-| Pytest test suite | `workflow/tests/.venv` | `pyenv local 3.13.5 && python -m venv workflow/tests/.venv && workflow/tests/.venv/bin/pip install -r workflow/tests/requirements-test.txt` | [workflow/tests/README.md](workflow/tests/README.md) |
-| Research / Jupyter notebooks | `research/.venv` | `cd research/ && pyenv local 3.14.4 && python -m venv .venv && .venv/bin/pip install -r requirements.txt` | [research/README.md](research/README.md) |
+| Pytest test suite | `workflow/tests/.venv` | `pyenv local 3.13.5 && uv venv --python 3.13.5 workflow/tests/.venv && uv pip install --python workflow/tests/.venv/bin/python -r workflow/tests/requirements-test.txt` | [workflow/tests/README.md](workflow/tests/README.md) |
+| Research / Jupyter notebooks | `research/.venv` | `cd research/ && pyenv local 3.14.4 && uv venv --python 3.14.4 .venv && uv pip install --python .venv/bin/python -r requirements.txt` | [research/README.md](research/README.md) |
 | Snakemake orchestration (and ad-hoc `python -c` quick checks) | `conda activate snakemake` | `bash scripts/setup_local.sh` | "Snakemake Conda Activation" above |
 | Per-rule Python (`workflow/scripts/*.py` invoked by Snakemake rules) | rule's own `--use-conda` env | auto-created from `workflow/envs/*.yaml` on first `snakemake --use-conda` run | implicit; each rule declares `conda: "envs/<env>.yaml"` |
 

--- a/research/README.md
+++ b/research/README.md
@@ -12,14 +12,14 @@ Scientific work associated with the splice neoepitope pipeline project.
 
 Per-patient result interpretation notebooks. Each patient run gets its own notebook (`patient_NNN_results.ipynb`). Cross-patient comparisons go in `results_comparison.ipynb`.
 
-**Setup (one-time):**
+**Setup (one-time):** requires [`uv`](https://docs.astral.sh/uv/) (`brew install uv` or `curl -LsSf https://astral.sh/uv/install.sh | sh`).
 ```bash
 cd research/
 pyenv local 3.14.4            # sets .python-version (gitignored, per-clone)
-python -m venv .venv
-source .venv/bin/activate
-pip install -r requirements.txt
+uv venv --python 3.14.4 .venv                              # fast venv creation
+uv pip install --python .venv/bin/python -r requirements.txt  # 10-100x faster than pip
 ```
+Only the two per-clone pyenv venvs use `uv`; the `snakemake` conda env and per-rule `--use-conda` envs are unchanged (`uv` is pip-side only, never touches conda's solver).
 
 **Usage:** Open any `.ipynb` in VSCode and select `research/.venv` as the kernel (Python 3.14.4).
 

--- a/research/README.md
+++ b/research/README.md
@@ -16,7 +16,7 @@ Per-patient result interpretation notebooks. Each patient run gets its own noteb
 ```bash
 cd research/
 pyenv local 3.14.4            # sets .python-version (gitignored, per-clone)
-uv venv --python 3.14.4 .venv                              # fast venv creation
+uv venv --seed --python 3.14.4 .venv                       # --seed keeps pip in the venv (uv omits it by default)
 uv pip install --python .venv/bin/python -r requirements.txt  # 10-100x faster than pip
 ```
 Only the two per-clone pyenv venvs use `uv`; the `snakemake` conda env and per-rule `--use-conda` envs are unchanged (`uv` is pip-side only, never touches conda's solver).

--- a/research/lab_notebook/developer.md
+++ b/research/lab_notebook/developer.md
@@ -22,6 +22,18 @@ Format and rules unchanged from the unified notebook — see `shared/feedback_la
 
 **Process note.** Stopping at the merge command per the cadence the skill itself documents; card at In review. Content-based review poll via the `awaiting-bot-review` skill (dogfooded).
 
+### 17:25 UTC - Editor: Developer - adopt uv for the test + research pyenv venvs ([PR #1020](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/1020) closes [Issue #570](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/570))
+
+**Context.** Third quick-win of the burn-down session. [Issue #570](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/570): swap the two per-clone pyenv venv setup recipes (`workflow/tests/.venv`, `research/.venv`) from `python -m venv` + `pip install` to `uv venv` + `uv pip install`. Docs-only; the `snakemake` conda env + per-rule `--use-conda` envs are explicitly out of scope (`uv` is pip-side only, never touches conda's binary solver where our env pain lives).
+
+**Change.** Recipes updated on three surfaces - `workflow/tests/README.md`, `research/README.md`, and the AGENTS.md (=CLAUDE.md symlink target) Python-environments table - with `uv` documented as a prerequisite and a retained note that conda envs are unchanged. Design choice: **kept `pyenv`** for interpreter provisioning/pinning so the `.python-version` per-clone-independence story is untouched; only the two commands the Issue named moved to `uv`. Lowest-risk faithful swap.
+
+**Verification (the part a dry-run/pytest can't cover).** Built **both** venvs with the exact new commands to a scratch path (non-destructive - left the canonical gitignored venvs intact): tests venv -> `pytest workflow/tests/ -q` = 667 passed, 6 skipped; research venv -> all notebook imports resolve (jupyterlab/pandas/matplotlib/openpyxl/numpy/scipy/sklearn/joblib/boto3/pytest; pandas 3.0.3, numpy 2.5.1).
+
+**Bot review (LGTM) - two minor, both fixed in `a28f051`.** (1) `uv venv` omits pip by default (unlike `python -m venv`, which seeds it), so an ad-hoc `<venv>/bin/pip install <pkg>` would break - added `--seed` to both recipes to reinstate pip (the faithful match to the old behavior; verified a `--seed` venv has a working `bin/pip`). (2) The "CI parity" note ("CI runs tests via pip, local mirrors that") went stale since local now uses `uv` while CI still uses pip - reworded to note both resolve the shared `>=`-pinned requirements to the same package set, and flagged `astral-sh/setup-uv` in CI as a possible follow-up. Lesson: a docs change that alters one side of a stated *parity* invariant must re-check the other side's wording - the inaccuracy was one I introduced.
+
+**Process note.** Stopping at the merge command per the standing autonomy cadence ([[shared/feedback_autonomy_merge_gate_cadence]]); card at In review for the user's final look.
+
 ### 16:17 UTC - Editor: Developer - extend scan_prose_deps resilience to the blocker-meta lookup + --check exit code ([PR #1014](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/1014) closes [Issue #1012](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1012))
 
 **Context.** [Issue #1012](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1012) was the follow-up I filed from the #1010 (#989) review below: that review flagged two adjacent same-class gaps as out of scope. Picked it as the next quick win right after #989 merged. This is the second-order follow-up chain in one session ([[feedback_communicate_next_steps]]).

--- a/workflow/tests/README.md
+++ b/workflow/tests/README.md
@@ -6,6 +6,8 @@ Unit + snapshot tests for the pipeline's Python helpers and Snakemake rule shell
 
 The test runner is a pyenv-managed Python venv separate from the workflow's `snakemake` conda env. The two envs cooperate at run time: the venv provides `pytest` + test deps, and the activated conda env puts the `snakemake` binary on PATH for tests that invoke it via subprocess (e.g. [test_alignment_star_command.py](test_alignment_star_command.py)).
 
+Prerequisite: [`uv`](https://docs.astral.sh/uv/) (Astral's fast installer/resolver) - `brew install uv` or the standalone installer `curl -LsSf https://astral.sh/uv/install.sh | sh`.
+
 ```bash
 # 1. Pin the Python version used by this clone (writes .python-version, gitignored).
 #    Any stable Python >=3.10 works; 3.13.5 is recommended (recent, widely
@@ -13,13 +15,15 @@ The test runner is a pyenv-managed Python venv separate from the workflow's `sna
 #    have no upper Python bound.
 pyenv local 3.13.5
 
-# 2. Create the test venv inside workflow/tests/ (also gitignored)
-python -m venv workflow/tests/.venv
+# 2. Create the test venv inside workflow/tests/ (also gitignored) with uv.
+uv venv --python 3.13.5 workflow/tests/.venv
 
-# 3. Install test dependencies
-workflow/tests/.venv/bin/pip install --upgrade pip
-workflow/tests/.venv/bin/pip install -r workflow/tests/requirements-test.txt
+# 3. Install test dependencies with uv (10-100x faster than pip; no separate
+#    pip-upgrade step needed).
+uv pip install --python workflow/tests/.venv/bin/python -r workflow/tests/requirements-test.txt
 ```
+
+Only the two per-clone pyenv venvs move to `uv`. The `snakemake` conda env and the per-rule `--use-conda` envs (`workflow/envs/*.yaml`) are unchanged - `uv` operates on the pip/PyPI side and does not touch conda's binary solver.
 
 ## Running tests
 

--- a/workflow/tests/README.md
+++ b/workflow/tests/README.md
@@ -16,7 +16,9 @@ Prerequisite: [`uv`](https://docs.astral.sh/uv/) (Astral's fast installer/resolv
 pyenv local 3.13.5
 
 # 2. Create the test venv inside workflow/tests/ (also gitignored) with uv.
-uv venv --python 3.13.5 workflow/tests/.venv
+#    --seed keeps pip/setuptools in the venv (uv omits them by default), so an
+#    ad-hoc `workflow/tests/.venv/bin/pip install <pkg>` still works.
+uv venv --seed --python 3.13.5 workflow/tests/.venv
 
 # 3. Install test dependencies with uv (10-100x faster than pip; no separate
 #    pip-upgrade step needed).
@@ -63,6 +65,6 @@ Last measurement (non-RAM-pressured run): full collection of 287 tests in ~20s; 
 
 - **`snakemake` conda env = workflow runner.** Snakemake + solver. Keep pristine; adding test deps risks dep drift in the workhorse env.
 - **`.venv` = test runner.** Pinned via [requirements-test.txt](requirements-test.txt). Fast to recreate. Isolated.
-- **CI parity.** CI runs tests via pip in a clean venv, not a conda env — local mirrors that.
+- **CI parity.** CI installs `requirements-test.txt` into a clean venv (via pip), not a conda env; local now uses `uv` for that same install, and the shared `>=`-pinned requirements keep both on the same package set. (Resolver-identical parity would need `uv` in CI too via `astral-sh/setup-uv` - a possible follow-up.)
 
 The migration from git worktrees to separate clones (2026-05-14) means each clone needs its own one-time `.venv` setup; no sharing across clones.


### PR DESCRIPTION
## Summary

Closes #570. Swap the two per-clone pyenv venv setup recipes from `python -m venv` + `pip install -r` to `uv venv` + `uv pip install` (Astral's `uv`: 10-100x faster resolution/install, standalone interpreter provisioning). **Scope is strictly** the two pip-managed pyenv venvs - `workflow/tests/.venv` and `research/.venv`.

**Explicitly out of scope:** the `snakemake` conda env and the per-rule `--use-conda` envs (`workflow/envs/*.yaml`). `uv` operates on the pip/PyPI side and never touches conda's binary solver - which is where all our documented env pain lives (libdeflate vs regtools/samtools, cuDNN/JAX/openmm, torch Pascal binary resolution).

## What changed

- **`workflow/tests/README.md`** - recipe now `uv venv --python 3.13.5 workflow/tests/.venv` + `uv pip install --python .../bin/python -r requirements-test.txt`; `uv` documented as a prerequisite; a note that conda envs are unchanged.
- **`research/README.md`** - recipe now `uv venv --python 3.14.4 .venv` + `uv pip install`; `uv` prerequisite + conda-unchanged note.
- **`AGENTS.md`** (the `CLAUDE.md` symlink target) - the two pyenv-venv rows in the Python-environments table updated to match.

Design choice: **`pyenv` is kept** for interpreter provisioning/pinning (so the `.python-version` per-clone-independence story is untouched); only the two commands the Issue named (`python -m venv`, `pip install`) move to `uv`. Lowest-risk faithful "recipe swap".

## AC disposition

- [x] `workflow/tests/README.md` recipe updated to the `uv venv` + `uv pip install` form, keeping the Python 3.13.5 pin.
- [x] `research/README.md` recipe updated to the `uv` equivalent, keeping the Python 3.14.4 pin.
- [x] `CLAUDE.md`/`AGENTS.md` Python-environments table setup-recipe cells updated to match both.
- [x] `uv` install step documented as a prerequisite (`brew install uv` / standalone installer) in both READMEs.
- [x] Both venvs verified to build + run (pytest green; research notebook imports resolve) - see Test plan.
- [x] Explicit note retained that conda envs are unchanged (no `uv` in `workflow/envs/*.yaml` or the `snakemake` env).

## Test plan

Built both venvs with the **exact new commands** to a scratch path (non-destructive; the canonical gitignored venvs left intact):

- [x] **Tests venv** - `uv venv --python 3.13.5` + `uv pip install -r requirements-test.txt` built clean; `python -m pytest workflow/tests/ -q` → **667 passed, 6 skipped**.
- [x] **Research venv** - `uv venv --python 3.14.4` + `uv pip install -r requirements.txt` built clean; all notebook imports resolve (`jupyterlab, pandas, matplotlib, openpyxl, numpy, scipy, sklearn, joblib, boto3, pytest`; pandas 3.0.3, numpy 2.5.1).
- [x] Docs-only change to production paths (no code touched); the uv recipes reproduce the same dependency sets from the unchanged `requirements*.txt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)