### PR TITLE
tooling(pm): mechanize closure-recap query - check_closed_recent.py (#784)

### DIFF
--- a/scripts/pm/check_closed_recent.py
+++ b/scripts/pm/check_closed_recent.py
@@ -28,7 +28,6 @@ import json
 import subprocess
 import sys
 from datetime import datetime, timedelta, timezone
-from pathlib import Path
 
 REPO = "Jin-HoMLee/splice-neoepitope-pipeline"
 UTC = timezone.utc
@@ -76,6 +75,15 @@ def parse_ts(ts):
         return None
 
 
+def filter_merged(rows):
+    """Keep only merged PRs (mergedAt present); drop closed-unmerged (mergedAt null).
+
+    Pulled out of the `gh` I/O layer so the merged-vs-closed selection rule - the
+    one real business rule on the PR side - is unit-testable without a live `gh`.
+    """
+    return [r for r in rows if r.get("mergedAt")]
+
+
 def is_within(when_ts, floor):
     """True if `when_ts` (ISO-8601) is at/after `floor`.
 
@@ -117,7 +125,7 @@ def list_merged_prs(search):
         "--search", search, "--limit", "1000",
         "--json", "number,title,mergedAt",
     )
-    return [r for r in rows if r.get("mergedAt")]
+    return filter_merged(rows)
 
 
 # --- orchestration ---
@@ -139,7 +147,11 @@ def collect(floor, issues, prs):
         if is_within(pr.get("mergedAt"), floor):
             rows.append({"number": pr["number"], "kind": "PR",
                          "when": pr.get("mergedAt") or "?", "title": pr.get("title") or ""})
-    rows.sort(key=lambda r: r["when"], reverse=True)
+    # Sort on the parsed timestamp, not the raw string: a fail-open placeholder
+    # ("?") sorts above digits and would jump a malformed row to the top of a
+    # newest-first list. Unparseable rows sink to the bottom instead.
+    rows.sort(key=lambda r: parse_ts(r["when"]) or datetime.min.replace(tzinfo=UTC),
+              reverse=True)
     return rows
 
 

--- a/scripts/pm/check_closed_recent.py
+++ b/scripts/pm/check_closed_recent.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""Recap of recently closed Issues + merged PRs (morning-routine Beat 1a/1b).
+
+The Service Delivery Review closure-recap was a hand-typed query each morning:
+`gh issue list --state closed --search "closed:>YYYY-MM-DD"`. The `>` operator
+excludes the whole boundary day, so `closed:>2026-06-18` returns only items closed
+06-19 onward - silently reporting "nothing closed" when items merged *during* the
+boundary day. That off-by-one slipped 2026-06-19 (caught by the user). This script
+makes the boundary deterministic (`>=`) and covers both closed Issues AND merged
+PRs in one place - the closed-side companion to `board_open_items.py`'s open scan.
+
+Usage:
+
+  scripts/pm/check_closed_recent.py                 # default: since the start of yesterday (UTC)
+  scripts/pm/check_closed_recent.py --days 3        # since the start of the day 3 days ago
+  scripts/pm/check_closed_recent.py --since 2026-07-01
+
+Window floor is a whole day (00:00 UTC): the recap is day-granular, matching how
+GitHub's `closed:` search operator works. `--since YYYY-MM-DD` / `--days N`
+override the default.
+
+Exit 0 on a completed scan - finding nothing closed is not a failure. A hard `gh`
+/ network error on a listing call surfaces loudly (non-zero traceback) rather than
+as a false "nothing closed". Issue #784.
+"""
+import argparse
+import json
+import subprocess
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+REPO = "Jin-HoMLee/splice-neoepitope-pipeline"
+UTC = timezone.utc
+
+
+# --- pure helpers (unit-tested, no I/O) ---
+
+
+def compute_floor(now, days=1):
+    """Window floor as an aware UTC datetime at 00:00 of the day `days` days ago.
+
+    `days=1` (default) -> the start of yesterday, so the recap includes everything
+    closed yesterday and today. The floor is truncated to midnight because the
+    `closed:` search operator is day-granular; a sub-day floor would imply a
+    precision the query cannot honor.
+    """
+    if days < 0:
+        raise ValueError(f"days must be non-negative, got {days}")
+    floor_date = (now.astimezone(UTC) - timedelta(days=days)).date()
+    return datetime(floor_date.year, floor_date.month, floor_date.day, tzinfo=UTC)
+
+
+def floor_date_str(floor):
+    """The `YYYY-MM-DD` string used in the search operator."""
+    return floor.astimezone(UTC).strftime("%Y-%m-%d")
+
+
+def build_search(floor):
+    """The GitHub search fragment - `>=` (inclusive), never bare `>`.
+
+    Using `>=` includes items closed *during* the boundary day; the bare `>` this
+    replaces excluded the whole boundary day, which is the exact bug (Issue #784).
+    """
+    return f"closed:>={floor_date_str(floor)}"
+
+
+def parse_ts(ts):
+    """Parse a GitHub ISO-8601 timestamp to an aware UTC datetime (or None)."""
+    if not ts:
+        return None
+    try:
+        dt = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+        return dt if dt.tzinfo else dt.replace(tzinfo=UTC)
+    except (ValueError, TypeError):
+        return None
+
+
+def is_within(when_ts, floor):
+    """True if `when_ts` (ISO-8601) is at/after `floor`.
+
+    A client-side belt-and-suspenders on top of the `>=` search: pins that an item
+    closed at the very start of the boundary day (00:00:00Z) is *included*, so the
+    off-by-one cannot silently return. An absent/unparseable timestamp is kept
+    (fail-open: better a stray row than a dropped closure).
+    """
+    dt = parse_ts(when_ts)
+    return True if dt is None else dt >= floor
+
+
+# --- gh I/O ---
+
+
+def gh_json(*args):
+    result = subprocess.run(["gh", *args], capture_output=True, text=True, check=True)
+    return json.loads(result.stdout)
+
+
+def list_closed_issues(search):
+    """Closed Issues matching `search` (number, title, closedAt)."""
+    return gh_json(
+        "issue", "list", "--repo", REPO, "--state", "closed",
+        "--search", search, "--limit", "1000",
+        "--json", "number,title,closedAt",
+    )
+
+
+def list_merged_prs(search):
+    """PRs matching `search`, filtered to the *merged* ones (mergedAt present).
+
+    `--state all --search "closed:>=…"` returns both merged and closed-unmerged
+    PRs; only merged PRs belong in a shipped-work recap, so the unmerged ones
+    (mergedAt is null) are dropped.
+    """
+    rows = gh_json(
+        "pr", "list", "--repo", REPO, "--state", "all",
+        "--search", search, "--limit", "1000",
+        "--json", "number,title,mergedAt",
+    )
+    return [r for r in rows if r.get("mergedAt")]
+
+
+# --- orchestration ---
+
+
+def collect(floor, issues, prs):
+    """Merge closed Issues + merged PRs into recap rows, newest first.
+
+    `issues` / `prs` are the raw `gh` result lists (injected, so this is testable
+    without network). Each is re-filtered client-side via `is_within` so the
+    boundary is enforced here too, not only by the search string.
+    """
+    rows = []
+    for it in issues:
+        if is_within(it.get("closedAt"), floor):
+            rows.append({"number": it["number"], "kind": "Issue",
+                         "when": it.get("closedAt") or "?", "title": it.get("title") or ""})
+    for pr in prs:
+        if is_within(pr.get("mergedAt"), floor):
+            rows.append({"number": pr["number"], "kind": "PR",
+                         "when": pr.get("mergedAt") or "?", "title": pr.get("title") or ""})
+    rows.sort(key=lambda r: r["when"], reverse=True)
+    return rows
+
+
+def render(rows, floor):
+    header = f"Closed Issues + merged PRs since {floor_date_str(floor)} (00:00 UTC):"
+    if not rows:
+        return header + "\n  (nothing closed in window)\n"
+    lines = [header]
+    for r in rows:
+        when = r["when"][:16].replace("T", " ")
+        lines.append(f"  #{r['number']:<5} {r['kind']:<5} {when}  {r['title']}")
+    lines.append(f"\n  {len(rows)} item(s).")
+    return "\n".join(lines) + "\n"
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument("--since", help="window floor YYYY-MM-DD (overrides --days)")
+    group.add_argument("--days", type=int, default=1,
+                       help="window = since the start of the day N days ago (default 1 = yesterday)")
+    args = parser.parse_args()
+
+    now = datetime.now(UTC)
+    if args.since:
+        floor = parse_ts(args.since + "T00:00:00Z")
+        if floor is None:
+            parser.error(f"unparseable --since (want YYYY-MM-DD): {args.since!r}")
+    else:
+        if args.days < 0:
+            parser.error(f"--days must be non-negative, got {args.days}")
+        floor = compute_floor(now, args.days)
+
+    search = build_search(floor)
+    rows = collect(floor, list_closed_issues(search), list_merged_prs(search))
+    print(render(rows, floor), end="")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_check_closed_recent.py
+++ b/scripts/tests/test_check_closed_recent.py
@@ -69,6 +69,16 @@ class TestIsWithin:
         assert c.is_within("", floor) is True
 
 
+class TestFilterMerged:
+    def test_keeps_merged_drops_unmerged(self):
+        rows = [
+            {"number": 1, "mergedAt": "2026-07-04T09:00:00Z"},
+            {"number": 2, "mergedAt": None},   # closed-unmerged -> dropped
+            {"number": 3},                       # no mergedAt key -> dropped
+        ]
+        assert [r["number"] for r in c.filter_merged(rows)] == [1]
+
+
 class TestCollect:
     FLOOR = datetime(2026, 7, 3, 0, 0, tzinfo=UTC)
 
@@ -88,6 +98,16 @@ class TestCollect:
         issues = [{"number": 5, "title": "edge", "closedAt": "2026-07-03T00:00:00Z"}]
         rows = c.collect(self.FLOOR, issues, [])
         assert len(rows) == 1 and rows[0]["number"] == 5
+
+    def test_fail_open_placeholder_sorts_last_not_first(self):
+        # A row whose timestamp is unparseable (kept fail-open, when="?") must not
+        # jump to the top of a newest-first list on raw-string sort.
+        issues = [
+            {"number": 1, "title": "real", "closedAt": "2026-07-04T09:00:00Z"},
+            {"number": 2, "title": "malformed", "closedAt": "not-a-date"},
+        ]
+        rows = c.collect(self.FLOOR, issues, [])
+        assert [r["number"] for r in rows] == [1, 2]  # real first, placeholder last
 
 
 class TestRender:

--- a/scripts/tests/test_check_closed_recent.py
+++ b/scripts/tests/test_check_closed_recent.py
@@ -1,0 +1,107 @@
+"""Tests for `scripts/pm/check_closed_recent.py` (Issue #784).
+
+Pure-helper unit tests (window floor, the `>=` boundary, inclusion predicate) plus
+a network-free orchestration test with injected `gh` result lists. No live `gh`.
+"""
+
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+SCRIPTS_PM = Path(__file__).parent.parent / "pm"
+sys.path.insert(0, str(SCRIPTS_PM))
+
+import check_closed_recent as c  # noqa: E402
+
+UTC = timezone.utc
+
+
+class TestComputeFloor:
+    def test_default_days_1_is_start_of_yesterday(self):
+        now = datetime(2026, 7, 4, 20, 30, tzinfo=UTC)
+        assert c.compute_floor(now, 1) == datetime(2026, 7, 3, 0, 0, tzinfo=UTC)
+
+    def test_days_0_is_start_of_today(self):
+        now = datetime(2026, 7, 4, 20, 30, tzinfo=UTC)
+        assert c.compute_floor(now, 0) == datetime(2026, 7, 4, 0, 0, tzinfo=UTC)
+
+    def test_crosses_month_boundary(self):
+        now = datetime(2026, 7, 1, 3, 0, tzinfo=UTC)
+        assert c.compute_floor(now, 1) == datetime(2026, 6, 30, 0, 0, tzinfo=UTC)
+
+    def test_negative_days_raises(self):
+        try:
+            c.compute_floor(datetime(2026, 7, 4, tzinfo=UTC), -1)
+            assert False, "expected ValueError"
+        except ValueError:
+            pass
+
+
+class TestBuildSearch:
+    def test_uses_inclusive_boundary(self):
+        floor = datetime(2026, 6, 18, 0, 0, tzinfo=UTC)
+        assert c.build_search(floor) == "closed:>=2026-06-18"
+
+    def test_is_not_the_exclusive_operator(self):
+        # The whole point of #784: the bare `>` dropped the boundary day.
+        floor = datetime(2026, 6, 18, 0, 0, tzinfo=UTC)
+        assert ">=" in c.build_search(floor)
+        assert ">2026" not in c.build_search(floor).replace(">=", "")
+
+
+class TestIsWithin:
+    def test_item_at_boundary_day_start_is_included(self):
+        # AC2: an item closed at 00:00:00 of the boundary day must be INCLUDED.
+        floor = datetime(2026, 6, 18, 0, 0, tzinfo=UTC)
+        assert c.is_within("2026-06-18T00:00:00Z", floor) is True
+
+    def test_item_during_boundary_day_included(self):
+        floor = datetime(2026, 6, 18, 0, 0, tzinfo=UTC)
+        assert c.is_within("2026-06-18T09:30:00Z", floor) is True
+
+    def test_item_just_before_floor_excluded(self):
+        floor = datetime(2026, 6, 18, 0, 0, tzinfo=UTC)
+        assert c.is_within("2026-06-17T23:59:59Z", floor) is False
+
+    def test_unparseable_timestamp_kept(self):
+        floor = datetime(2026, 6, 18, 0, 0, tzinfo=UTC)
+        assert c.is_within(None, floor) is True
+        assert c.is_within("", floor) is True
+
+
+class TestCollect:
+    FLOOR = datetime(2026, 7, 3, 0, 0, tzinfo=UTC)
+
+    def test_merges_and_sorts_newest_first(self):
+        issues = [{"number": 10, "title": "issue ten", "closedAt": "2026-07-03T08:00:00Z"}]
+        prs = [{"number": 20, "title": "pr twenty", "mergedAt": "2026-07-04T09:00:00Z"}]
+        rows = c.collect(self.FLOOR, issues, prs)
+        assert [r["number"] for r in rows] == [20, 10]  # PR is newer -> first
+        assert [r["kind"] for r in rows] == ["PR", "Issue"]
+
+    def test_reapplies_boundary_clientside(self):
+        # An item before the floor slips through even if the search returned it.
+        issues = [{"number": 1, "title": "stale", "closedAt": "2026-07-02T23:00:00Z"}]
+        assert c.collect(self.FLOOR, issues, []) == []
+
+    def test_boundary_start_kept(self):
+        issues = [{"number": 5, "title": "edge", "closedAt": "2026-07-03T00:00:00Z"}]
+        rows = c.collect(self.FLOOR, issues, [])
+        assert len(rows) == 1 and rows[0]["number"] == 5
+
+
+class TestRender:
+    FLOOR = datetime(2026, 7, 3, 0, 0, tzinfo=UTC)
+
+    def test_empty_says_nothing_closed(self):
+        out = c.render([], self.FLOOR)
+        assert "nothing closed" in out
+
+    def test_lists_rows_and_count(self):
+        rows = [
+            {"number": 20, "kind": "PR", "when": "2026-07-04T09:00:00Z", "title": "pr twenty"},
+            {"number": 10, "kind": "Issue", "when": "2026-07-03T08:00:00Z", "title": "issue ten"},
+        ]
+        out = c.render(rows, self.FLOOR)
+        assert "#20" in out and "#10" in out
+        assert "2 item(s)." in out


### PR DESCRIPTION
Mechanizes the morning-routine closure-recap (Service Delivery Review, Beat 1a/1b), killing the `closed:>` off-by-one that silently dropped a whole boundary day.

Closes #784.

## What

`scripts/pm/check_closed_recent.py` - the closed-side companion to `board_open_items.py`'s open-momentum scan:

- Scans **both** closed Issues and merged PRs over a window (default: since the start of yesterday UTC; `--since YYYY-MM-DD` / `--days N` override).
- Boundary is **`>=`-correct** and enforced twice - in the search string (`closed:>=DATE`) and client-side via a `is_within()` predicate - so an item closed at the very start of the boundary day (00:00:00Z) is included, not silently dropped.
- Prints a newest-first recap table (Issues + PRs interleaved).

Pure helpers (`compute_floor`, `build_search`, `is_within`, `collect`, `render`) are unit-tested with no live `gh`; the thin `gh` I/O layer mirrors the sibling `scan_addressed_comments.py`.

## AC3 (morning-routine reference) - staged for MM

AC3 points the Beat 1a/1b query at the script; that edit is in the personas repo (`pm/feedback_morning_routine.md`), authored this session and staged for the Memory Manager to commit (PM does not commit the personas repo). This project PR carries AC1 + AC2.

## Test plan

- [x] `pytest scripts/tests/` (full suite, the CI-collected home) - 82 passed, incl. the new `test_check_closed_recent.py` (window floor, `>=` boundary, boundary-start inclusion, orchestration, render).
- [x] Driven live: default window recaps today + yesterday's closures (Issues + merged PRs, newest-first); `--since 2026-07-03` confirms items closed *on* 07-03 are included (the old `>` would have dropped them).

**Created by:** PM



<!-- skip-lab-notebook: routine -->
