### PR TITLE
docs(dev): stand up docs/adr + docs/design homes; migrate 2 exemplars (#777)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,20 +17,10 @@ Modernised reimplementation of a 2015 cancer neoepitope prediction pipeline (Jin
 ## Pipeline Design Decisions
 
 ### Junction origin classification
-Normal samples are used to filter tumor junctions at the junction level, not at the prediction level. The hierarchy:
-```
-all junctions
-  └─ annotated        (in GENCODE)            → discard
-  └─ unannotated      (not in GENCODE)
-       ├─ normal_shared  (also in normal)  → discard (kept in TSV for reference)
-       └─ tumor_exclusive    (absent in normal) → neoepitope prediction
-```
-This is the clinically correct approach: a junction present in matched normal tissue is not tumor-specific and should not be a neoepitope target. The Fisher's exact test (end-of-pipeline statistical comparison) was removed in favour of this upstream filtering step.
-
-When no normal sample is present, all unannotated junctions are labeled `tumor_exclusive` with a warning — the pipeline still runs.
+Tumor junctions are filtered against matched normal at the **junction** level, not the prediction level. Labels used in code/TSVs: `annotated` (in GENCODE) and `normal_shared` (also in normal) are discarded; `tumor_exclusive` (unannotated, absent in normal) goes to neoepitope prediction. With no normal sample, all unannotated junctions fall back to `tumor_exclusive` with a warning. How/why (the clinical rationale + the removed Fisher's exact test): [`docs/design/junction-origin-classification.md`](docs/design/junction-origin-classification.md).
 
 ### TCRdock via Docker
-TCRdock runs inside a Docker container (`docker/Dockerfile.pipeline`) rather than a conda env. The conda approach failed due to irreconcilable cuDNN/JAX/openmm version conflicts. The Docker image bundles CUDA 11.8, cuDNN 8, Python 3.10, JAX 0.3.25, AlphaFold params, and BLAST — the host only needs the NVIDIA Container Toolkit. Running CUDA 11.8 inside the container on a host with a newer driver (e.g. 12.8) is supported by NVIDIA's forward-compatibility guarantee.
+TCRdock runs in a Docker container (`docker/Dockerfile.pipeline`), not a conda env; the image bundles CUDA 11.8, cuDNN 8, Python 3.10, JAX 0.3.25, AlphaFold params, and BLAST, so the host needs only the NVIDIA Container Toolkit. Rationale (the conda-conflict history + forward-compatibility guarantee): [`docs/adr/0001-tcrdock-via-docker.md`](docs/adr/0001-tcrdock-via-docker.md).
 
 ### PDB chain relabelling
 AlphaFold outputs all residues as a single chain (A). `relabel_pdb_chains()` in `run_tcrdock.py` reassigns chain IDs (A=MHC, B=peptide, C=TCR-α, D=TCR-β) using per-chain sequence lengths from TCRdock's `alphafold_setup/targets.tsv`. The report injects PDB COMPND records so Mol* displays meaningful chain names in the sequence panel instead of "Polymer 1/2/3/4".

--- a/docs/adr/0000-adr-template.md
+++ b/docs/adr/0000-adr-template.md
@@ -1,6 +1,6 @@
 # ADR-NNNN: <short decision title, imperative>
 
-- **Status:** Proposed | Accepted | Superseded by [ADR-XXXX](XXXX-slug.md) | Deprecated
+- **Status:** Proposed | Accepted | Superseded by ADR-XXXX | Deprecated
 - **Date:** YYYY-MM-DD
 - **Deciders:** <role(s)>
 

--- a/docs/adr/0000-adr-template.md
+++ b/docs/adr/0000-adr-template.md
@@ -1,0 +1,23 @@
+# ADR-NNNN: <short decision title, imperative>
+
+- **Status:** Proposed | Accepted | Superseded by [ADR-XXXX](XXXX-slug.md) | Deprecated
+- **Date:** YYYY-MM-DD
+- **Deciders:** <role(s)>
+
+## Context
+
+The problem, force, or constraint that made a decision necessary.
+State it neutrally: the facts a reader needs to understand why a choice had to be made, not the choice itself.
+
+## Decision
+
+What we chose, as a complete sentence in active voice ("We run X in Y because ...").
+One decision per ADR.
+
+## Consequences
+
+What becomes easier or harder as a result: the trade-offs accepted, any follow-on obligations, and anything a future reader should not undo without re-opening this decision.
+
+## Alternatives considered
+
+- **<option>** - why it was rejected.

--- a/docs/adr/0001-tcrdock-via-docker.md
+++ b/docs/adr/0001-tcrdock-via-docker.md
@@ -6,8 +6,8 @@
 
 ## Context
 
-TCRdock needs CUDA, cuDNN, JAX, OpenMM, AlphaFold params, and BLAST at mutually compatible versions.
-Provisioning that stack as a conda env failed due to irreconcilable cuDNN/JAX/openmm version conflicts.
+TCRdock's full stack needs CUDA, cuDNN, and JAX, plus OpenMM/pdbfixer for Amber relaxation, AlphaFold params, and BLAST.
+Provisioning that stack as a conda env failed: the cuDNN/JAX/openmm version constraints were irreconcilable.
 
 ## Decision
 
@@ -16,6 +16,7 @@ The image bundles CUDA 11.8, cuDNN 8, Python 3.10, JAX 0.3.25, AlphaFold params,
 
 ## Consequences
 
+- The image deliberately omits OpenMM/pdbfixer: Amber relaxation is not used by `run_prediction.py`, so dropping it sidesteps the primary conda conflict without affecting structure prediction (see `docker/Dockerfile.pipeline`).
 - The host needs only the NVIDIA Container Toolkit, not a matched CUDA/cuDNN/JAX toolchain.
 - Running CUDA 11.8 inside the container on a host with a newer driver (e.g. 12.8) is supported by NVIDIA's forward-compatibility guarantee.
 - TCRdock is decoupled from the conda-managed per-rule envs: it is invoked as a container, not a Snakemake `--use-conda` rule.

--- a/docs/adr/0001-tcrdock-via-docker.md
+++ b/docs/adr/0001-tcrdock-via-docker.md
@@ -1,0 +1,25 @@
+# ADR-0001: Run TCRdock in a Docker container, not a conda env
+
+- **Status:** Accepted
+- **Date:** 2026-07-06 (migrated from `CLAUDE.md`; the decision itself predates this record)
+- **Deciders:** Developer
+
+## Context
+
+TCRdock needs CUDA, cuDNN, JAX, OpenMM, AlphaFold params, and BLAST at mutually compatible versions.
+Provisioning that stack as a conda env failed due to irreconcilable cuDNN/JAX/openmm version conflicts.
+
+## Decision
+
+TCRdock runs inside a Docker container (`docker/Dockerfile.pipeline`) rather than a conda env.
+The image bundles CUDA 11.8, cuDNN 8, Python 3.10, JAX 0.3.25, AlphaFold params, and BLAST; the host only needs the NVIDIA Container Toolkit.
+
+## Consequences
+
+- The host needs only the NVIDIA Container Toolkit, not a matched CUDA/cuDNN/JAX toolchain.
+- Running CUDA 11.8 inside the container on a host with a newer driver (e.g. 12.8) is supported by NVIDIA's forward-compatibility guarantee.
+- TCRdock is decoupled from the conda-managed per-rule envs: it is invoked as a container, not a Snakemake `--use-conda` rule.
+
+## Alternatives considered
+
+- **conda env for the whole TCRdock stack** - rejected: irreconcilable cuDNN/JAX/openmm version conflicts.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,43 @@
+# Architecture Decision Records (`docs/adr/`)
+
+This directory holds **technical decision records**: point-in-time "we chose X because Y"
+decisions about the pipeline's architecture, infrastructure, and tooling.
+
+An ADR captures *why* a choice was made so a future reader (or agent) does not silently
+undo it. Each ADR is a numbered, mostly-immutable file: once Accepted, a decision is
+changed by writing a *new* ADR that supersedes the old one (mark the old one
+`Superseded by [ADR-XXXX]`), not by editing history.
+
+## Format
+
+Lightweight [MADR](https://adr.github.io/madr/)-style: **Context / Decision / Consequences**
+(+ optional *Alternatives considered*). Copy [`0000-adr-template.md`](0000-adr-template.md)
+and give it the next free number: `NNNN-short-slug.md`.
+
+## Index
+
+| ADR | Title | Status |
+|-----|-------|--------|
+| [0001](0001-tcrdock-via-docker.md) | Run TCRdock in a Docker container, not a conda env | Accepted |
+
+## Why this home exists (and the routing rule)
+
+This directory and its sibling [`docs/design/`](../design/) exist to unload the project-root
+`CLAUDE.md`, which had grown to mix three [Diátaxis](https://diataxis.fr/) content types in
+one file. The cut is **by audience and content type**:
+
+| Content type | Home | Examples |
+|--------------|------|----------|
+| **Decision** ("we chose X because Y") | `docs/adr/` | TCRdock-via-Docker, torch `cu126`/P100 pin, GCP zone migration, regtools/libdeflate `samtools` workaround, `assembly:` config removal |
+| **Explanation** ("here is how/why this works") | [`docs/design/`](../design/) | junction-origin classification, PDB chain relabelling, Snakemake-8 gotchas (conceptual), BED12 / STAR `SJ.out.tab` semantics |
+| **Agent reference** (commands, env matrix, hook behavior, "do X not Y" gotchas) | **stays in `CLAUDE.md`** | the env matrix, GitHub safety-wrapper hooks, merge workflow |
+
+When a decision block moves here, `CLAUDE.md` keeps a **terse one-line pointer** back to
+the ADR so an agent reading the reference file still finds the rationale.
+
+This is the technical sibling of the board-governance-prose extraction tracked in
+[Issue #769](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/769) (PM-owned,
+`arc:board-governance`). To avoid the two extractions re-overlapping: **board / project /
+Kanban governance prose is #769's territory (its own canonical home); technical design
+rationale is this directory's.** A block about *how the board works* goes to #769's home,
+not here.

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -1,0 +1,21 @@
+# Design explanation docs (`docs/design/`)
+
+This directory holds **design explanation**: narrative "here is how/why this part of the
+pipeline works" documents. Unlike an [ADR](../adr/) (a point-in-time decision, mostly
+immutable), a design doc is **editable** and evolves with the code it describes.
+
+These are the [Diátaxis](https://diataxis.fr/) *explanation* type: understanding-oriented
+prose, not a command reference and not a single dated decision.
+
+## Index
+
+| Doc | Topic |
+|-----|-------|
+| [junction-origin-classification.md](junction-origin-classification.md) | How tumor-vs-normal junction filtering classifies each junction |
+
+## Relationship to `docs/adr/` and `CLAUDE.md`
+
+See [`docs/adr/README.md`](../adr/README.md) for the full routing rule. In short: a crisp
+*decision* ("we chose X because Y") is an ADR; ongoing *explanation* of how something works
+is a design doc; operational *agent reference* (commands, env matrix, hooks) stays in the
+project-root `CLAUDE.md`.

--- a/docs/design/junction-origin-classification.md
+++ b/docs/design/junction-origin-classification.md
@@ -1,0 +1,17 @@
+# Junction origin classification
+
+*Design explanation. Migrated verbatim (punctuation normalized to house style) from `CLAUDE.md` for [Issue #777](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/777).*
+
+Normal samples are used to filter tumor junctions at the junction level, not at the prediction level. The hierarchy:
+
+```
+all junctions
+  └─ annotated        (in GENCODE)            → discard
+  └─ unannotated      (not in GENCODE)
+       ├─ normal_shared  (also in normal)  → discard (kept in TSV for reference)
+       └─ tumor_exclusive    (absent in normal) → neoepitope prediction
+```
+
+This is the clinically correct approach: a junction present in matched normal tissue is not tumor-specific and should not be a neoepitope target. The Fisher's exact test (end-of-pipeline statistical comparison) was removed in favour of this upstream filtering step.
+
+When no normal sample is present, all unannotated junctions are labeled `tumor_exclusive` with a warning - the pipeline still runs.

--- a/research/lab_notebook/developer.md
+++ b/research/lab_notebook/developer.md
@@ -6,7 +6,27 @@ Format and rules unchanged from the unified notebook — see `shared/feedback_la
 
 ---
 
-## 2026-07-05 - quick-win burn-down: set_status.sh board-status wrapper ([PR #1039](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/1039) closes [Issue #1024](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1024))
+## 2026-07-06 - stand up docs/adr + docs/design homes ([PR #1051](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/1051) closes [Issue #777](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/777))
+
+### 10:31 UTC - Editor: Developer - ADR/design extraction home + seed pass
+
+**Context.** Morning warm-up pull: [#777](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/777) was the oldest Ready item (17d) - stand up a technical decision-record home and start unloading the "why" content from the overloaded project-root `CLAUDE.md`. Technical sibling to [#769](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/769) (PM board-governance extraction from the same file); confirmed #769 not in progress / no branch, so no live collision on the file.
+
+**Design decisions (brainstormed, M-size).** Two genuine user calls surfaced:
+- **Scope:** scaffold + seed (this PR) vs full migration in one PR. Chose scaffold + seed - stand up both homes, the ADR template, the READMEs (recorded rationale + routing rule + #769 boundary note), and one migrated exemplar each; carve the ~7-block bulk migration to follow-up [#1050](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1050). Load-bearing deliverable (home + routing rule + pattern) ships here; the rest is mechanical.
+- **Format:** user picked the Diataxis-purer **two-home split** (`docs/adr/` for point-in-time decisions, `docs/design/` for ongoing explanation) over my ADR-only recommendation. Routing rule recorded in `docs/adr/README.md` so the #1050 pass is deterministic. Seeded ADR-0001 (TCRdock-via-Docker) + design/junction-origin-classification to validate both homes.
+
+**Closure shape.** Followed `feedback_close_issue_with_pr`: PR ticks AC1/3/4/5 fully + AC2 partial (2 exemplars), remaining AC2 carved to [#1050](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1050); AC2 box ticked with the deferral link so the merge gate passes. `Closes #777`.
+
+**Bot review (LGTM - ship it; fixes in `5a6ca2d`).** One 🟡 non-blocking accuracy nit worth taking: ADR-0001 Context listed OpenMM as a TCRdock *need*, but `docker/Dockerfile.pipeline:3-4` deliberately omits openmm/pdbfixer (Amber relaxation unused by `run_prediction.py`). Verified the Dockerfile claim, then corrected the Context (OpenMM is a conda-conflict *source*, not a runtime need) and added a Consequences bullet recording the deliberate omission - the "what is explicitly not done" an ADR should carry. Also de-linked the template's non-resolving `Superseded by` placeholder (trivia). Routing-judgment trivia (regtools/samtools + `assembly:` read more like gotchas than decisions) forwarded to [#1050](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1050) to settle per-block at migration time.
+
+**Process notes / gotchas.**
+- **`CLAUDE.md` is a symlink to `AGENTS.md`.** The Edit tool refuses to write through a symlink ("Resolve the symlink and pass the real target path") - had to target `AGENTS.md` directly. Same bytes, but any future `CLAUDE.md` edit hits this; `readlink CLAUDE.md` -> `AGENTS.md` (CLAUDE.md is the link).
+- **Em-dash guard vs verbatim migration.** Migrated content carried em-dashes; rather than reach for the `CLAUDE_ALLOW_EMDASH=1` escape hatch, normalized em -> hyphen in the migrated text. This both honors house style AND satisfies AC4 "no semantic change" (punctuation-only is not semantic), and keeps the guard clean with zero net-added dashes. The right call for a verbatim-relocation task under this house style.
+
+**No memory writes this session** - the symlink gotcha is self-correcting (the Edit error names the fix); will escalate to a memory only if it bites a second time.
+
+---
 
 ### 17:10 UTC - Editor: Developer - regression cover + a second review round (same PR #1039)
 


### PR DESCRIPTION
**Created by:** Developer

Seed pass for [Issue #777](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/777): stand up a technical decision-record home and start unloading the "why" content from `CLAUDE.md` (symlinked to `AGENTS.md`).

## What changed

- **Two Diátaxis-split homes:**
  - `docs/adr/` - numbered, mostly-immutable **decision** records (MADR-lite: Context / Decision / Consequences). Includes [`0000-adr-template.md`](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/blob/docs/developer/issue-777-adr-home/docs/adr/0000-adr-template.md).
  - `docs/design/` - editable **explanation** docs (Diátaxis "explanation").
- **Recorded rationale + routing rule** in [`docs/adr/README.md`](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/blob/docs/developer/issue-777-adr-home/docs/adr/README.md): a table routing each candidate block to `adr` / `design` / stays-in-`CLAUDE.md`, plus the [Issue #769](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/769) board-governance boundary note (AC1, AC5).
- **Two exemplars migrated verbatim** (punctuation normalized to house style, no semantic change): ADR-0001 TCRdock-via-Docker; `design/junction-origin-classification`. Each block in `AGENTS.md` collapsed to a terse reference + pointer (AC2 partial, AC3, AC4).

## AC status

AC1 / AC3 / AC4 / AC5 fully satisfied this PR. **AC2** (migrate *the* why content) is partially met - 2 exemplars prove the pattern; the remaining ~7 blocks are pure mechanical migration, carved to [Issue #1050](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1050) (per `feedback_close_issue_with_pr`). The load-bearing deliverable (home + routing rule + pattern) ships here.

Closes #777

## Test plan

- [x] All 5 new files present; relative links resolve (`adr/README` <-> `design/README`, template + exemplar links)
- [x] No em/en dashes net-added (grep scan clean)
- [x] Migrated content faithful to originals - TCRdock version/toolkit facts + junction-origin labels (`annotated`/`normal_shared`/`tumor_exclusive`) preserved
- [x] `AGENTS.md` pointer lines link to the new homes; each block reduced to reference + rationale pointer