### PR TITLE
refactor(tooling): extract shared hardened gh() wrapper; migrate recheck_parent_status (#1017)

### DIFF
--- a/research/lab_notebook/developer.md
+++ b/research/lab_notebook/developer.md
@@ -8,6 +8,37 @@ Format and rules unchanged from the unified notebook — see `shared/feedback_la
 
 ## 2026-07-06 - stand up docs/adr + docs/design homes ([PR #1051](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/1051) closes [Issue #777](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/777))
 
+### 13:48 UTC - Editor: Developer - shared hardened gh() wrapper ([PR #1056](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/1056) closes [Issue #1017](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1017))
+
+**Context.**
+A `quick-win-burndown` for the Developer lane came up empty - the whole Ready queue was three genuine M-tasks and every Backlog S-item was pre-disqualified (blocked/stale-premise/gated/not-a-PR/wide).
+Rather than stuff a marginal item, surfaced that honestly and pulled the most tractable committed item, #1017, as a *proper* (non-quick) task on the user's go-ahead.
+PM had pre-approved the approach in the Issue thread.
+
+**Design decisions.**
+- **Wrapper home = `scripts/pm/gh_client.py`** (PM's open "scripts/pm vs tools/ common" question). All four hand-rolled copies + the priority-1 target live in `scripts/pm/`, and the established sibling-import convention is exactly `sys.path.insert(parent)` + bare-name import (as `board_open_items` is already consumed). No consumer lives elsewhere yet, so a neutral top-level home would be speculative.
+- **`GhError(subprocess.CalledProcessError)`** for the typed hard-failure (AC #1). Subclassing the base means every pre-existing `except subprocess.CalledProcessError` site keeps catching it unchanged (backward compatible) while new callers can isolate per-item. Ported the retry/backoff/`Retry-After` body verbatim-in-behavior from `recheck_milestone.py` (#711) - "do not reinvent."
+- **Scope discipline.** Kept PR1 to the wrapper + the one fully-unguarded copy (`recheck_parent_status.py`) per PM's stated boundary; filed follow-on [#1055](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1055) for the other three copies (AC #3's sanctioned branch). CLI contracts untouched.
+
+**Verification.**
+Drove real behavior, not just tests: a live `recheck_parent_status.py --issue 798` walk through the shared `gh()` (live REST + GraphQL) produced a correct audit. Full non-live `tools/ci` suite green.
+
+**Bot review (LGTM - ship it; fixes in `e8fb185`).**
+Four non-blocking observations, all technically sound and cheap, all taken:
+- **The strongest one:** the no-`--jq` house rule was documented but not *enforced*. Given this repo's mechanism-over-memory ladder (and that mode-(b) already bit once, #1011), moved it from convention to guarantee - `gh()` now raises `ValueError` on `--jq`/`-q` before any subprocess runs. This turns the whole argument *for* the refactor into something the wrapper upholds. +4 tests.
+- `run_all_mode()` now exits `1` when every parent was skipped on `gh` errors, so a `0` can't be misread as "clean board" when the sweep was blind - the exact silent-miss class this tool exists to catch. +1 test.
+- Documented `parse_json=False` for empty-stdout mutation calls (for the #1055 migrators) and recorded the deliberate `--issue`-vs-`--all` isolation asymmetry as an intentional choice.
+
+**Gotcha.**
+The em-dash guard fired on the *new* module - I'd ported `recheck_milestone.py`'s comments verbatim and they carried em-dashes. Normalized to hyphens in the added text rather than reach for the escape hatch (house style, and the delta-only guard then reads clean). Same class as the 2026-07-06 docs/adr entry below - a verbatim port carries the source's punctuation.
+
+**Incidental find (forwarded, not acted).**
+The live verification run flagged epic [#665](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/665) as `COMPLETION DRIFT` - open, but both native sub-issues (#798/#799) closed-completed. Pinged PM (To:PM comment on #665) with the evidence + the note that open #800 is a non-native, event-gated follow-up that doesn't block the close. PM's call.
+
+Card at In review; stopped at the merge gate.
+
+---
+
 ### 10:31 UTC - Editor: Developer - ADR/design extraction home + seed pass
 
 **Context.** Morning warm-up pull: [#777](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/777) was the oldest Ready item (17d) - stand up a technical decision-record home and start unloading the "why" content from the overloaded project-root `CLAUDE.md`. Technical sibling to [#769](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/769) (PM board-governance extraction from the same file); confirmed #769 not in progress / no branch, so no live collision on the file.

--- a/scripts/pm/gh_client.py
+++ b/scripts/pm/gh_client.py
@@ -86,9 +86,24 @@ def gh(*args: str, parse_json: bool = True, _runner=subprocess.run, _sleep=time.
     and a terminal failure raises :class:`GhError` - preserving the ``check=True``
     contract callers depend on. ``_runner`` / ``_sleep`` are injection seams for tests.
 
-    Do NOT pass ``--jq`` (mode (b) house rule above): fetch raw JSON and filter in
-    Python so a data-shape error cannot be misread as a transport failure.
+    ``--jq`` (mode (b) house rule above) is **rejected with ``ValueError``**: fetch
+    raw JSON and filter in Python so a data-shape error cannot be misread as a
+    transport failure. This enforces the rule at the single chokepoint rather than
+    leaving it a convention each call site could slip (mechanism over memory).
+
+    ``parse_json`` defaults to True (every board read expects JSON). For a mutation
+    call with empty stdout (``gh issue edit`` / ``gh pr comment``) pass
+    ``parse_json=False``, else a *successful* call raises ``json.JSONDecodeError`` on
+    the empty body - a confusing success-that-looks-like-failure.
     """
+    # Enforce the mode-(b) house rule at the chokepoint: gh's -q/--jq routes a jq
+    # data-shape error through the same non-zero exit as a transport failure, so it
+    # would be retried/swallowed. Reject it before any subprocess runs.
+    if any(a == "--jq" or a == "-q" or a.startswith("--jq=") for a in args):
+        raise ValueError(
+            "gh(): pass raw JSON and filter in Python; --jq/-q conflates a data-shape "
+            "error with a transport failure (mode b, #1011)"
+        )
     cmd = ["gh", *args]
     result = None
     for attempt in range(GH_MAX_ATTEMPTS):

--- a/scripts/pm/gh_client.py
+++ b/scripts/pm/gh_client.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Shared hardened ``gh`` subprocess wrapper for the board/hygiene tooling (Issue #1017).
+
+One home for the ``gh()`` helper that every board script re-rolled by hand. It bakes
+in the retry+backoff logic first proven in ``recheck_milestone.py`` (Issue #711 D4) so
+the same three-mode failure family is handled once, not re-patched per script.
+
+The three failure modes every ``gh`` call site faces (Issue #1017 body):
+
+- **(a) transient transport failure** (5xx / secondary-rate-limit 403 / replication
+  lag / network) -> a non-zero exit unrelated to the request. Retried here with
+  exponential backoff, honoring a ``Retry-After`` hint; a terminal failure raises
+  :class:`GhError`.
+- **(b) data-shape error routed through ``--jq``** -> jq exits non-zero and is
+  conflated with (a), so an over-broad ``except`` silently drops good data (a
+  deleted-account null ``.user`` once dropped *every* comment on an issue, #1011).
+  **House rule: keep ``jq`` out of ``gh``.** Do NOT pass ``--jq`` to this wrapper;
+  fetch raw JSON (``parse_json=True``, the default) and filter in Python, or pipe to
+  a separate ``jq`` process. Then a data-shape error can never masquerade as a
+  transport failure and be retried/swallowed.
+- **(c) wrong-but-successful response** -> no exception at all, a silent wrong answer.
+  The known instance: ``gh search "is:open is:blocked"`` returns 0 for genuinely
+  blocked issues (#745). **Caveat: prefer a bare ``is:blocked`` search or the
+  GraphQL ``blockedBy`` connection**; this wrapper cannot detect a 0-exit wrong body.
+
+Callers isolate a per-item failure by catching :class:`GhError` (or the base
+``subprocess.CalledProcessError`` it subclasses) around the per-item ``gh`` call, so
+one item's terminal failure skips that item instead of aborting the whole sweep
+(the #989/#1012 shape).
+
+Import from a sibling ``scripts/pm`` script via the established pattern::
+
+    import sys
+    from pathlib import Path
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+    from gh_client import gh, GhError
+"""
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import time
+
+GH_MAX_ATTEMPTS = 4
+assert GH_MAX_ATTEMPTS >= 1, "gh() runs the loop at least once; a terminal raise needs a result"
+GH_BACKOFF_BASE_SECONDS = 2.0
+# Clamp a Retry-After hint: GitHub can legally emit a large value (e.g. 3600s)
+# during sustained degradation, which would otherwise stall a live job for that
+# whole duration before raising (Issue #711 review).
+GH_RETRY_AFTER_CAP_SECONDS = 120.0
+
+# Deterministic client errors that won't fix themselves on retry - a bad request
+# stays bad. Everything else (5xx, 403/secondary-rate-limit, network/timeout, an
+# empty-stderr crash) is treated as transient and retried. We fail TOWARD retrying:
+# over-retrying a genuine bad arg only wastes a bounded few seconds, whereas
+# under-retrying a transient blip reds the whole job (Issue #711 D4).
+_DETERMINISTIC_HTTP_RE = re.compile(r"HTTP (400|401|404|410|422)\b")
+_RETRY_AFTER_RE = re.compile(r"retry[- ]after[:\s]+(\d+)", re.IGNORECASE)
+
+
+class GhError(subprocess.CalledProcessError):
+    """A terminal ``gh`` failure after retries are exhausted (Issue #1017).
+
+    Subclasses ``subprocess.CalledProcessError`` so a caller can catch the specific
+    type to isolate a per-item failure while every pre-existing
+    ``except subprocess.CalledProcessError`` site keeps catching it unchanged.
+    """
+
+
+def _is_transient_gh_error(stderr: str) -> bool:
+    return not _DETERMINISTIC_HTTP_RE.search(stderr or "")
+
+
+def _retry_after_seconds(stderr: str) -> float | None:
+    m = _RETRY_AFTER_RE.search(stderr or "")
+    return float(m.group(1)) if m else None
+
+
+def gh(*args: str, parse_json: bool = True, _runner=subprocess.run, _sleep=time.sleep) -> object:
+    """Run ``gh`` with retry + exponential backoff on transient failures.
+
+    A transient non-zero exit (mode (a)) is retried up to ``GH_MAX_ATTEMPTS`` with
+    exponential backoff, honoring a ``Retry-After`` hint when GitHub provides one
+    (clamped to ``GH_RETRY_AFTER_CAP_SECONDS``). A deterministic 4xx is not retried,
+    and a terminal failure raises :class:`GhError` - preserving the ``check=True``
+    contract callers depend on. ``_runner`` / ``_sleep`` are injection seams for tests.
+
+    Do NOT pass ``--jq`` (mode (b) house rule above): fetch raw JSON and filter in
+    Python so a data-shape error cannot be misread as a transport failure.
+    """
+    cmd = ["gh", *args]
+    result = None
+    for attempt in range(GH_MAX_ATTEMPTS):
+        result = _runner(cmd, capture_output=True, text=True)
+        if result.returncode == 0:
+            return json.loads(result.stdout) if parse_json else result.stdout
+        if not _is_transient_gh_error(result.stderr):
+            break
+        if attempt < GH_MAX_ATTEMPTS - 1:
+            delay = _retry_after_seconds(result.stderr)
+            if delay is None:
+                delay = GH_BACKOFF_BASE_SECONDS * (2 ** attempt)
+            _sleep(min(delay, GH_RETRY_AFTER_CAP_SECONDS))
+    raise GhError(result.returncode, cmd, output=result.stdout, stderr=result.stderr)

--- a/scripts/pm/recheck_parent_status.py
+++ b/scripts/pm/recheck_parent_status.py
@@ -219,6 +219,10 @@ def format_record(record: dict) -> str:
 
 
 def run_issue_mode(issue_number: int) -> int:
+    # Deliberate asymmetry with run_all_mode (Issue #1017 review): the single-chain
+    # --issue path has no per-item isolation - a terminal GhError propagates and
+    # fails hard (after the shared gh()'s retries). A one-target lookup should fail
+    # loudly rather than half-report; only the --all sweep isolates per parent.
     chain = audit_parent_chain(issue_number)
     if not chain:
         print(f"Issue #{issue_number} has no parent — nothing to audit.")
@@ -300,6 +304,12 @@ def run_all_mode() -> int:
     for block in drift_blocks:
         print(block)
         print()
+    # A sweep that skipped every parent on gh errors audited nothing - exit with the
+    # error code so a 0 can never be misread as "clean board" when it actually means
+    # "blind" (Issue #1017 review: the exact silent-miss class this tool exists to
+    # prevent). A partial skip keeps the 0/2 signal, surfaced by the suffix above.
+    if parents and skipped_count == len(parents):
+        return 1
     return 2 if drifted_count > 0 else 0
 
 

--- a/scripts/pm/recheck_parent_status.py
+++ b/scripts/pm/recheck_parent_status.py
@@ -12,9 +12,12 @@ Exits 0 if no drift, 2 if drift detected, 1 on error.
 from __future__ import annotations
 
 import argparse
-import json
-import subprocess
 import sys
+from pathlib import Path
+
+# Import the shared hardened gh() wrapper from the sibling module (Issue #1017).
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from gh_client import GhError, gh  # noqa: E402
 
 REPO = "Jin-HoMLee/splice-neoepitope-pipeline"
 PROJECT_NUMBER = 9
@@ -102,12 +105,6 @@ def classify_drift(
     if p_rank < c_rank:
         return "BACKWARD DRIFT"
     return None
-
-
-def gh(*args: str, parse_json: bool = True):
-    """Invoke `gh` and parse JSON output (or return raw text)."""
-    result = subprocess.run(["gh", *args], capture_output=True, text=True, check=True)
-    return json.loads(result.stdout) if parse_json else result.stdout
 
 
 def parent_issue_number(issue_number: int) -> int | None:
@@ -257,7 +254,13 @@ def all_parent_issues() -> list[int]:
     parents: list[int] = []
     for issue in data:
         n = issue["number"]
-        meta = gh("api", f"repos/{REPO}/issues/{n}")
+        try:
+            meta = gh("api", f"repos/{REPO}/issues/{n}")
+        except GhError as e:
+            # Per-item isolation (Issue #1017): a terminal gh failure on one issue's
+            # parent-probe must not abort the whole listing. Skip it and continue.
+            print(f"  [skipped #{n}: gh error probing sub-issues - {e}]", file=sys.stderr)
+            continue
         if (meta.get("sub_issues_summary") or {}).get("total", 0) > 0:
             parents.append(n)
     return parents
@@ -266,13 +269,21 @@ def all_parent_issues() -> list[int]:
 def run_all_mode() -> int:
     parents = all_parent_issues()
     drifted_count = 0
+    skipped_count = 0
     drift_blocks: list[str] = []
     for p in parents:
-        parent_status = status_for_issue(p)
-        children = open_sub_issues(p)
-        enriched = [{"number": c["number"], "status": status_for_issue(c["number"])}
-                    for c in children]
-        has_np = not enriched and has_not_planned_child(p)
+        try:
+            parent_status = status_for_issue(p)
+            children = open_sub_issues(p)
+            enriched = [{"number": c["number"], "status": status_for_issue(c["number"])}
+                        for c in children]
+            has_np = not enriched and has_not_planned_child(p)
+        except GhError as e:
+            # Per-item isolation (Issue #1017): one parent's terminal gh failure
+            # skips that parent, it does not abort the remaining audit.
+            skipped_count += 1
+            print(f"  [skipped #{p}: gh error during audit - {e}]", file=sys.stderr)
+            continue
         record = {
             "issue": p,
             "status": parent_status,
@@ -284,7 +295,8 @@ def run_all_mode() -> int:
             drifted_count += 1
             drift_blocks.append(format_record(record))
 
-    print(f"Audited {len(parents)} parent issues; {drifted_count} drifted.\n")
+    suffix = f" ({skipped_count} skipped on gh error)" if skipped_count else ""
+    print(f"Audited {len(parents)} parent issues; {drifted_count} drifted{suffix}.\n")
     for block in drift_blocks:
         print(block)
         print()

--- a/tools/ci/test_gh_client.py
+++ b/tools/ci/test_gh_client.py
@@ -1,0 +1,143 @@
+"""Unit tests for scripts/pm/gh_client.py (the shared hardened gh() wrapper, Issue #1017)."""
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+# Make the shared module importable as a module
+SCRIPT_DIR = Path(__file__).parent.parent.parent / "scripts" / "pm"
+sys.path.insert(0, str(SCRIPT_DIR))
+
+import gh_client as ghc
+
+
+class TestGhRetry:
+    """gh() retries transient non-zero exits with backoff, honoring Retry-After
+    (ported from recheck_milestone.py's #711 logic, Issue #1017).
+
+    GitHub secondary-rate-limit 403s, transient 5xx, and replication-lag errors
+    surface as a non-zero ``gh`` exit unrelated to the request. Deterministic 4xx
+    (404/422/…) must NOT be retried, and a terminal failure raises so the
+    check=True contract callers depend on is preserved.
+    """
+
+    @staticmethod
+    def _result(returncode, stdout="", stderr=""):
+        return subprocess.CompletedProcess(["gh"], returncode, stdout, stderr)
+
+    def _runner_seq(self, results):
+        """A fake subprocess.run yielding the given results in order; records calls."""
+        seq = list(results)
+        calls = []
+
+        def run(cmd, **kwargs):
+            calls.append(cmd)
+            return seq[len(calls) - 1]
+
+        run.calls = calls
+        return run
+
+    def test_retries_transient_then_succeeds(self):
+        runner = self._runner_seq([
+            self._result(1, stderr="HTTP 403: You have exceeded a secondary rate limit"),
+            self._result(0, stdout='{"ok": true}'),
+        ])
+        sleeps = []
+        out = ghc.gh("api", "x", _runner=runner, _sleep=sleeps.append)
+        assert out == {"ok": True}
+        assert len(runner.calls) == 2   # retried once
+        assert len(sleeps) == 1         # backed off once
+
+    def test_no_retry_on_deterministic_404(self):
+        runner = self._runner_seq([
+            self._result(1, stderr="gh: Not Found (HTTP 404)"),
+        ])
+        sleeps = []
+        with pytest.raises(ghc.GhError):
+            ghc.gh("api", "missing", _runner=runner, _sleep=sleeps.append)
+        assert len(runner.calls) == 1   # NOT retried
+        assert sleeps == []
+
+    def test_honors_retry_after_header(self):
+        runner = self._runner_seq([
+            self._result(1, stderr="HTTP 403: rate limited\nRetry-After: 7"),
+            self._result(0, stdout="[]"),
+        ])
+        sleeps = []
+        ghc.gh("api", "x", _runner=runner, _sleep=sleeps.append)
+        assert sleeps == [7.0]          # used the Retry-After hint, not exp backoff
+
+    def test_caps_excessive_retry_after(self):
+        # GitHub can legally emit a large Retry-After during sustained degradation;
+        # an uncapped hint would stall the nightly job. Cap it (Issue #711 review).
+        runner = self._runner_seq([
+            self._result(1, stderr="HTTP 403: rate limited\nRetry-After: 3600"),
+            self._result(0, stdout="[]"),
+        ])
+        sleeps = []
+        ghc.gh("api", "x", _runner=runner, _sleep=sleeps.append)
+        assert sleeps == [ghc.GH_RETRY_AFTER_CAP_SECONDS]   # 3600 clamped to the ceiling
+
+    def test_exhausts_attempts_then_raises(self):
+        runner = self._runner_seq(
+            [self._result(1, stderr="HTTP 503: server error")] * ghc.GH_MAX_ATTEMPTS
+        )
+        sleeps = []
+        with pytest.raises(ghc.GhError):
+            ghc.gh("api", "x", _runner=runner, _sleep=sleeps.append)
+        assert len(runner.calls) == ghc.GH_MAX_ATTEMPTS
+        assert len(sleeps) == ghc.GH_MAX_ATTEMPTS - 1  # no sleep after the last attempt
+
+    def test_success_first_try_no_sleep(self):
+        runner = self._runner_seq([self._result(0, stdout='{"a": 1}')])
+        sleeps = []
+        out = ghc.gh("api", "x", _runner=runner, _sleep=sleeps.append)
+        assert out == {"a": 1}
+        assert len(runner.calls) == 1
+        assert sleeps == []
+
+    def test_parse_json_false_returns_raw_stdout(self):
+        runner = self._runner_seq([self._result(0, stdout="raw text")])
+        out = ghc.gh("api", "x", parse_json=False, _runner=runner, _sleep=lambda _: None)
+        assert out == "raw text"
+
+
+class TestGhError:
+    """The typed hard-failure exception (Issue #1017 AC #1).
+
+    ``GhError`` subclasses ``subprocess.CalledProcessError`` so a caller can catch
+    the specific type to isolate a per-item failure (the #989/#1012 shape) while
+    every pre-existing ``except subprocess.CalledProcessError`` site keeps catching
+    it unchanged (backward compatible).
+    """
+
+    @staticmethod
+    def _result(returncode, stdout="", stderr=""):
+        return subprocess.CompletedProcess(["gh"], returncode, stdout, stderr)
+
+    def _runner_once(self, result):
+        def run(cmd, **kwargs):
+            return result
+        return run
+
+    def test_gherror_is_calledprocesserror_subclass(self):
+        assert issubclass(ghc.GhError, subprocess.CalledProcessError)
+
+    def test_terminal_failure_raises_gherror_caught_as_calledprocesserror(self):
+        runner = self._runner_once(self._result(1, stderr="gh: Not Found (HTTP 404)"))
+        # The specific type is GhError...
+        with pytest.raises(ghc.GhError):
+            ghc.gh("api", "missing", _runner=runner, _sleep=lambda _: None)
+        # ...and it is still caught by the legacy contract.
+        with pytest.raises(subprocess.CalledProcessError):
+            ghc.gh("api", "missing", _runner=runner, _sleep=lambda _: None)
+
+    def test_gherror_preserves_returncode_cmd_and_stderr(self):
+        runner = self._runner_once(self._result(422, stdout="out", stderr="HTTP 422: bad"))
+        with pytest.raises(ghc.GhError) as exc:
+            ghc.gh("api", "bad", _runner=runner, _sleep=lambda _: None)
+        assert exc.value.returncode == 422
+        assert exc.value.cmd == ["gh", "api", "bad"]
+        assert exc.value.stderr == "HTTP 422: bad"

--- a/tools/ci/test_gh_client.py
+++ b/tools/ci/test_gh_client.py
@@ -104,6 +104,38 @@ class TestGhRetry:
         assert out == "raw text"
 
 
+class TestNoJqGuard:
+    """The mode-(b) house rule is enforced at the chokepoint, not just documented
+    (Issue #1017 review): passing --jq to gh() raises before any subprocess runs, so
+    a data-shape error can never masquerade as a transport failure (the #1011 class).
+    """
+
+    def _boom_runner(self):
+        def run(cmd, **kwargs):  # must never be reached
+            raise AssertionError("subprocess should not run when --jq is rejected")
+        return run
+
+    def test_rejects_long_jq_flag(self):
+        with pytest.raises(ValueError, match="jq"):
+            ghc.gh("api", "x", "--jq", ".foo", _runner=self._boom_runner(), _sleep=lambda _: None)
+
+    def test_rejects_jq_equals_form(self):
+        with pytest.raises(ValueError, match="jq"):
+            ghc.gh("api", "x", "--jq=.foo", _runner=self._boom_runner(), _sleep=lambda _: None)
+
+    def test_rejects_short_q_flag(self):
+        with pytest.raises(ValueError, match="jq"):
+            ghc.gh("api", "x", "-q", ".foo", _runner=self._boom_runner(), _sleep=lambda _: None)
+
+    def test_allows_jq_substring_in_a_value(self):
+        # A query value that merely contains "jq" (not the flag) must pass through.
+        runner = TestGhRetry()._runner_seq([
+            subprocess.CompletedProcess(["gh"], 0, '{"ok": true}', ""),
+        ])
+        out = ghc.gh("api", "search?q=jq-parser", _runner=runner, _sleep=lambda _: None)
+        assert out == {"ok": True}
+
+
 class TestGhError:
     """The typed hard-failure exception (Issue #1017 AC #1).
 

--- a/tools/ci/test_recheck_parent_status.py
+++ b/tools/ci/test_recheck_parent_status.py
@@ -336,6 +336,32 @@ class TestAllMode:
         rc = rps.run_all_mode()
         assert rc == 0
 
+    @patch("recheck_parent_status.status_for_issue")
+    @patch("recheck_parent_status.open_sub_issues")
+    @patch("recheck_parent_status.all_parent_issues")
+    def test_terminal_gh_error_on_one_parent_does_not_abort_sweep(
+        self, mock_parents, mock_subs, mock_status, capsys
+    ):
+        # Issue #1017 AC #2: a terminal gh failure (retries exhausted -> GhError)
+        # on one parent must skip that parent, not abort the remaining audit.
+        mock_parents.return_value = [86, 24]
+
+        def status(n):
+            if n == 86:  # this parent's probe fails terminally
+                raise rps.GhError(1, ["gh"], stderr="HTTP 503: server error")
+            return {24: "In progress", 204: "Backlog"}.get(n)
+
+        mock_status.side_effect = status
+        mock_subs.side_effect = lambda n: {24: [{"number": 204}]}.get(n, [])
+
+        # If #86's GhError aborted the sweep this call would raise, not return.
+        rc = rps.run_all_mode()
+
+        # #24's In-progress-over-Backlog-child drift is still detected past the skip.
+        assert rc == 2
+        err = capsys.readouterr().err
+        assert "skipped #86" in err  # the skip was surfaced, not silently dropped
+
 
 class TestNotPlannedDrift:
     """Issue #632: a parent whose only remaining children are all closed must

--- a/tools/ci/test_recheck_parent_status.py
+++ b/tools/ci/test_recheck_parent_status.py
@@ -362,6 +362,24 @@ class TestAllMode:
         err = capsys.readouterr().err
         assert "skipped #86" in err  # the skip was surfaced, not silently dropped
 
+    @patch("recheck_parent_status.status_for_issue")
+    @patch("recheck_parent_status.open_sub_issues")
+    @patch("recheck_parent_status.all_parent_issues")
+    def test_all_parents_skipped_returns_error_not_zero(
+        self, mock_parents, mock_subs, mock_status
+    ):
+        # Issue #1017 review: a broad outage that skips EVERY parent audits nothing;
+        # exit 0 would be indistinguishable from a clean board. Must exit 1 instead.
+        mock_parents.return_value = [86, 24]
+
+        def boom(n):
+            raise rps.GhError(1, ["gh"], stderr="HTTP 503: server error")
+
+        mock_status.side_effect = boom
+        mock_subs.side_effect = lambda n: []
+        rc = rps.run_all_mode()
+        assert rc == 1  # audited nothing -> error, not a false "clean"
+
 
 class TestNotPlannedDrift:
     """Issue #632: a parent whose only remaining children are all closed must


### PR DESCRIPTION
## Summary

Extracts a single hardened `gh()` wrapper (`scripts/pm/gh_client.py`) to replace the four hand-rolled copies across the board tooling, and migrates the one **fully-unguarded** copy - `recheck_parent_status.py` (bare `check=True`, no try/except, per-item `gh` inside four loops) - onto it.

- **`scripts/pm/gh_client.py`** (new) - ports the retry + exponential-backoff + `Retry-After` logic proven in `recheck_milestone.py` (#711), and adds a typed `GhError(subprocess.CalledProcessError)` so callers can isolate a per-item failure while every pre-existing `except subprocess.CalledProcessError` site keeps catching it unchanged (backward-compatible). The module docstring documents the two non-transport failure modes as house rules: **keep `--jq` out of `gh`** (mode b, the #1011 null-`.user` class) and **prefer bare `is:blocked` / GraphQL `blockedBy`** over the silent-zero search (mode c, #745).
- **`recheck_parent_status.py`** - migrated to the shared wrapper; added **per-item isolation** to the `--all` sweep so one parent's terminal `gh` failure skips that parent (surfaced on stderr) instead of aborting the whole recheck.

**Scope** is the wrapper + this priority-1 migration, per the PM-coordinated plan in the Issue thread. The **CLI contract** of the session scripts is unchanged (internal-only). The remaining three copies (`recheck_milestone` re-point, `scan_prose_deps`, `scan_addressed_comments`) are tracked in the follow-on **#1055** (AC #3's sanctioned branch).

## Test plan

- [x] New `tools/ci/test_gh_client.py` - retry/backoff/`Retry-After`/cap/exhaustion/no-retry-on-4xx + `GhError` is a `CalledProcessError` subclass + preserves returncode/cmd/stderr (10 tests).
- [x] New `test_recheck_parent_status.py::test_terminal_gh_error_on_one_parent_does_not_abort_sweep` - AC #2: a `GhError` on one parent is skipped, the sweep continues and still detects the other parent's drift.
- [x] Full non-live `tools/ci` suite green: `639 passed, 2 deselected`.
- [x] Live drive: `recheck_parent_status.py --issue 798` walked the parent chain via the shared `gh()` (live REST + GraphQL) and produced a correct audit.

Closes #1017.
