### PR TITLE
feat(pm): routine-only watermark for morning-routine recap

### DIFF
--- a/.agents/hooks/write_session_watermark.py
+++ b/.agents/hooks/write_session_watermark.py
@@ -79,25 +79,25 @@ def write_watermark(root, timestamp=None, marker=DEFAULT_MARKER):
     never observes a partially written file. Raises KeyError on an unknown name.
     """
     spec = MARKERS[marker]
-    marker = Path(root).joinpath(*spec["relpath"])
-    marker.parent.mkdir(parents=True, exist_ok=True)
+    marker_path = Path(root).joinpath(*spec["relpath"])
+    marker_path.parent.mkdir(parents=True, exist_ok=True)
     body = {
         spec["key"]: timestamp or _utc_now_iso(),
         "schema": SCHEMA,
     }
-    fd, tmp = tempfile.mkstemp(dir=str(marker.parent), prefix=".lsm-", suffix=".tmp")
+    fd, tmp = tempfile.mkstemp(dir=str(marker_path.parent), prefix=".lsm-", suffix=".tmp")
     try:
         with os.fdopen(fd, "w") as fh:
             json.dump(body, fh)
             fh.write("\n")
-        os.replace(tmp, marker)
+        os.replace(tmp, marker_path)
     except Exception:
         try:
             os.unlink(tmp)
         except OSError:
             pass
         raise
-    return marker
+    return marker_path
 
 
 def _parse_args(argv):
@@ -114,7 +114,16 @@ def _parse_args(argv):
 
 
 def main(argv=None):
-    args = _parse_args(argv)
+    try:
+        marker = _parse_args(argv).marker
+    except SystemExit:
+        # argparse calls sys.exit() on an unrecognized/invalid arg. As a Stop
+        # hook, a non-zero exit is the "block the stop" signal - which this hook
+        # must never emit (see module docstring). Swallow it, fall back to the
+        # default marker, and continue to a clean exit 0. On the CLI path a typo
+        # thus writes the session marker rather than erroring: a fail-wide, not
+        # fail-closed, outcome consistent with the rest of this writer.
+        marker = DEFAULT_MARKER
     payload = {}
     # As a Stop hook, stdin carries the hook JSON (used only for cwd fallback).
     # As a CLI (`--marker routine`), skip the read when stdin is a TTY so we
@@ -127,7 +136,7 @@ def main(argv=None):
             # stdin): an absent payload just falls back to env/cwd resolution.
             payload = {}
     try:
-        write_watermark(_project_root(payload), marker=args.marker)
+        write_watermark(_project_root(payload), marker=marker)
     except Exception:
         # Fail open: a watermark failure must never block session stop.
         pass

--- a/.agents/hooks/write_session_watermark.py
+++ b/.agents/hooks/write_session_watermark.py
@@ -20,7 +20,16 @@ on any error (a watermark write must never break a session).
 
 The marker (`.agents/last_session_marker.json`) is a gitignored per-clone local
 artifact, mirroring `.agents/hook_fires.jsonl`.
+
+Two watermarks, one writer (Issue #1002). The Stop hook (no args) writes the
+`session` marker every turn-end. The morning-routine recap beat invokes this
+same script as a CLI with `--marker routine` to stamp a distinct
+`.agents/last_routine_marker.json`, so the recap/closure-audit lookback can
+anchor on "last routine" instead of "last session-end" (which advances after
+*any* session, including a non-recap one). The two markers live in separate
+files with separate timestamp keys and never disturb each other.
 """
+import argparse
 import json
 import os
 import sys
@@ -29,7 +38,21 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 SCHEMA = 1
-MARKER_RELPATH = (".agents", "last_session_marker.json")
+
+# Named watermarks. Each selects its own file + timestamp key so the session
+# marker (Stop hook) and the routine marker (recap beat, Issue #1002) are
+# independent: writing one never clobbers the other.
+MARKERS = {
+    "session": {
+        "relpath": (".agents", "last_session_marker.json"),
+        "key": "last_session_end_utc",
+    },
+    "routine": {
+        "relpath": (".agents", "last_routine_marker.json"),
+        "key": "last_routine_end_utc",
+    },
+}
+DEFAULT_MARKER = "session"
 
 
 def _project_root(payload):
@@ -47,16 +70,19 @@ def _utc_now_iso():
     return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
-def write_watermark(root, timestamp=None):
-    """Atomically write the watermark JSON under `root`; return the marker path.
+def write_watermark(root, timestamp=None, marker=DEFAULT_MARKER):
+    """Atomically write the named watermark JSON under `root`; return its path.
 
-    Uses a temp file in the marker's own directory + os.replace so a concurrent
-    reader never observes a partially written file.
+    `marker` selects which watermark (see MARKERS): "session" (default, the
+    Stop-hook marker) or "routine" (the recap-beat marker, Issue #1002). Uses a
+    temp file in the marker's own directory + os.replace so a concurrent reader
+    never observes a partially written file. Raises KeyError on an unknown name.
     """
-    marker = Path(root).joinpath(*MARKER_RELPATH)
+    spec = MARKERS[marker]
+    marker = Path(root).joinpath(*spec["relpath"])
     marker.parent.mkdir(parents=True, exist_ok=True)
     body = {
-        "last_session_end_utc": timestamp or _utc_now_iso(),
+        spec["key"]: timestamp or _utc_now_iso(),
         "schema": SCHEMA,
     }
     fd, tmp = tempfile.mkstemp(dir=str(marker.parent), prefix=".lsm-", suffix=".tmp")
@@ -74,15 +100,34 @@ def write_watermark(root, timestamp=None):
     return marker
 
 
-def main():
+def _parse_args(argv):
+    parser = argparse.ArgumentParser(
+        description="Write a session/routine watermark marker (Issues #820, #1002).",
+    )
+    parser.add_argument(
+        "--marker",
+        choices=sorted(MARKERS),
+        default=DEFAULT_MARKER,
+        help="which watermark to write (default: session, the Stop-hook marker)",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv=None):
+    args = _parse_args(argv)
+    payload = {}
+    # As a Stop hook, stdin carries the hook JSON (used only for cwd fallback).
+    # As a CLI (`--marker routine`), skip the read when stdin is a TTY so we
+    # never block waiting for input. A closed/piped-empty stdin parses to {}.
+    if not sys.stdin.isatty():
+        try:
+            payload = json.load(sys.stdin)
+        except Exception:
+            # Fail open on ANY read/parse error (malformed JSON, OSError on
+            # stdin): an absent payload just falls back to env/cwd resolution.
+            payload = {}
     try:
-        payload = json.load(sys.stdin)
-    except Exception:
-        # Fail open on ANY read/parse error (malformed JSON, OSError on stdin):
-        # an absent payload just falls back to env/cwd root resolution.
-        payload = {}
-    try:
-        write_watermark(_project_root(payload))
+        write_watermark(_project_root(payload), marker=args.marker)
     except Exception:
         # Fail open: a watermark failure must never block session stop.
         pass

--- a/.gitignore
+++ b/.gitignore
@@ -327,6 +327,9 @@ CLAUDE.local.md
 # Last-session watermark — deterministic morning-routine window floor (Issue #820)
 .agents/last_session_marker.json
 .claude/last_session_marker.json
+# Last-routine watermark - recap-beat window floor, distinct from last-session (Issue #1002)
+.agents/last_routine_marker.json
+.claude/last_routine_marker.json
 
 # Codex CLI - per-user local harness config (local experiment; not team tooling yet).
 # Canonical hooks live in .agents/hooks/; promote to a committed config only if Codex

--- a/research/lab_notebook/pm.md
+++ b/research/lab_notebook/pm.md
@@ -8,6 +8,20 @@ Format and rules unchanged from the unified notebook — see `shared/feedback_la
 
 ## 2026-07-06
 
+### 13:58 UTC - Editor: PM
+
+#### Routine-only watermark for the morning-routine recap ([Issue #1002](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1002) -> [PR #1057](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/1057))
+
+**Trigger.** Resume-session pull off the burn-down; Jin-Ho asked to settle #1002's open approach question first, then take it forward. #1002: the recap (beat 1a/1b) anchored on `last_session_marker.json`, which the `Stop` hook advances at *every* turn-end, so a non-recap session (quick-wins, overnight) narrowed the recap window and could skip closures a human never saw recapped.
+
+**The decision - option A, and why the "how" was the only open question.** The *what* was already user-approved (a separate routine-only marker). The unresolved piece was *how a marker gets written only when a routine runs*. The key realization: **"a routine ran" is not a hook-observable event** - hooks fire on tool calls (Pre/Post/Stop), not on the agent rendering a routine - so a pure-hook solution is impossible without the agent first emitting a signal. That collapsed the choice to (A) the recap beat stamps the marker itself vs (B) a flag-file + Stop-hook stamp (which still relies on the agent setting the flag). Decider: a **missed** routine stamp fails *wide* (the recap over-includes, hides nothing), strictly safer than today's fail-*narrow* bug, so the reliability tax of a hook is not earned. Chose A, reusing `write_session_watermark.py`'s tested atomic writer via a `MARKERS` registry + `--marker` CLI so only the *trigger* lives in memory, the durable write stays deterministic.
+
+**Cross-repo split (same as #973).** Code (writer registry + CLI + tests + gitignore) ships in the project [PR #1057](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/1057); the read-side + trigger are a personas-repo memory edit (`pm/feedback_morning_routine.md`, MM-committed). The coordination scan (`scan_addressed_comments.py`) deliberately keeps the session marker - "since I last looked" is the right window for pings, distinct from "since my last recap."
+
+**Review lesson - argparse `exit(2)` breaks the Stop-hook contract.** The bot review (clean/mergeable) caught a real regression I'd introduced: I moved `_parse_args` ahead of `main()`'s fail-open `try`, and argparse calls `sys.exit(2)` on a bad arg. For a Claude Code **Stop** hook, **exit code 2 is specifically the "block the stop" signal** the module docstring forbids - so a malformed argv could block the agent from stopping. Latent (the wiring passes no args) but a genuine break of the file's invariant. Fixed by catching `SystemExit` around `_parse_args` and falling back to the default marker (restoring "robust to any argv"), plus a regression test. **Reusable gotcha: adding argparse to a Stop/PreToolUse hook silently arms an exit-2 that the harness reads as a block - keep argument parsing inside the fail-open guard.**
+
+**State at entry.** [PR #1057](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/1057) review-clean, CI green, 21 tests pass. Merging on Jin-Ho's go; the personas memory half is still in MM's drain queue (fail-safe either merge order, per the bot's coordination note).
+
 ### 11:28 UTC - Editor: PM
 
 #### i6-S3 Data Preparation milestone closure report to the merge gate ([PR #1046](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/1046); milestone [i6 - S3 - Data Preparation](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/milestone/30))

--- a/tools/ci/test_write_session_watermark.py
+++ b/tools/ci/test_write_session_watermark.py
@@ -24,6 +24,7 @@ import pytest
 
 HOOK = Path(__file__).parent.parent.parent / ".agents" / "hooks" / "write_session_watermark.py"
 MARKER_RELPATH = Path(".agents") / "last_session_marker.json"
+ROUTINE_MARKER_RELPATH = Path(".agents") / "last_routine_marker.json"
 ISO_Z = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$")
 
 
@@ -169,3 +170,76 @@ class TestWriteWatermark:
         mod = _load_module()
         root = mod._project_root({"cwd": "/some/other/path"})
         assert root == tmp_path
+
+
+class TestRoutineMarker:
+    """Issue #1002: a second, routine-only watermark distinct from the session
+    marker. The Stop hook keeps writing the session marker every turn-end; the
+    morning-routine recap beat writes the routine marker via `--marker routine`,
+    and the recap/closure-audit lookback anchors on that one instead."""
+
+    def test_default_marker_is_session(self, tmp_path):
+        # Backward compat: no marker arg == the session marker the Stop hook writes.
+        mod = _load_module()
+        path = mod.write_watermark(tmp_path, timestamp="2026-07-06T12:00:00Z")
+        assert path == tmp_path / MARKER_RELPATH
+        assert json.loads(path.read_text()) == {
+            "last_session_end_utc": "2026-07-06T12:00:00Z",
+            "schema": 1,
+        }
+
+    def test_routine_marker_path_and_key(self, tmp_path):
+        mod = _load_module()
+        path = mod.write_watermark(tmp_path, timestamp="2026-07-06T12:00:00Z", marker="routine")
+        assert path == tmp_path / ROUTINE_MARKER_RELPATH
+        assert json.loads(path.read_text()) == {
+            "last_routine_end_utc": "2026-07-06T12:00:00Z",
+            "schema": 1,
+        }
+
+    def test_session_and_routine_markers_are_independent(self, tmp_path):
+        # Writing one marker must never disturb the other (distinct files).
+        mod = _load_module()
+        mod.write_watermark(tmp_path, timestamp="2026-07-01T00:00:00Z", marker="session")
+        mod.write_watermark(tmp_path, timestamp="2026-07-06T00:00:00Z", marker="routine")
+        session = json.loads((tmp_path / MARKER_RELPATH).read_text())
+        routine = json.loads((tmp_path / ROUTINE_MARKER_RELPATH).read_text())
+        assert session["last_session_end_utc"] == "2026-07-01T00:00:00Z"
+        assert routine["last_routine_end_utc"] == "2026-07-06T00:00:00Z"
+
+    def test_unknown_marker_raises(self, tmp_path):
+        mod = _load_module()
+        with pytest.raises(KeyError):
+            mod.write_watermark(tmp_path, marker="nope")
+
+    def test_cli_marker_routine_writes_only_routine_file(self, tmp_path):
+        (tmp_path / ".agents").mkdir()
+        proc = subprocess.run(
+            [sys.executable, str(HOOK), "--marker", "routine"],
+            input=_stop_payload(),
+            capture_output=True,
+            text=True,
+            timeout=5,
+            env={"CLAUDE_PROJECT_DIR": str(tmp_path), "PATH": ""},
+        )
+        assert proc.returncode == 0
+        assert proc.stdout.strip() == ""
+        assert (tmp_path / ROUTINE_MARKER_RELPATH).exists()
+        assert not (tmp_path / MARKER_RELPATH).exists()
+        ts = json.loads((tmp_path / ROUTINE_MARKER_RELPATH).read_text())["last_routine_end_utc"]
+        assert ISO_Z.match(ts)
+
+    def test_cli_default_writes_only_session_file(self, tmp_path):
+        # No --marker == the Stop-hook path == session marker only.
+        (tmp_path / ".agents").mkdir()
+        proc = subprocess.run(
+            [sys.executable, str(HOOK)],
+            input=_stop_payload(),
+            capture_output=True,
+            text=True,
+            timeout=5,
+            env={"CLAUDE_PROJECT_DIR": str(tmp_path), "PATH": ""},
+        )
+        assert proc.returncode == 0
+        assert (tmp_path / MARKER_RELPATH).exists()
+        assert not (tmp_path / ROUTINE_MARKER_RELPATH).exists()

--- a/tools/ci/test_write_session_watermark.py
+++ b/tools/ci/test_write_session_watermark.py
@@ -229,6 +229,24 @@ class TestRoutineMarker:
         ts = json.loads((tmp_path / ROUTINE_MARKER_RELPATH).read_text())["last_routine_end_utc"]
         assert ISO_Z.match(ts)
 
+    def test_bad_marker_arg_exits_zero_and_falls_back_to_session(self, tmp_path):
+        # Stop-hook safety (review finding, PR #1057): argparse exits 2 on a bad
+        # arg, and exit 2 is the "block the stop" signal a Stop hook must never
+        # emit. main() must swallow it, write the default (session) marker, and
+        # exit 0 - never propagate the non-zero.
+        (tmp_path / ".agents").mkdir()
+        proc = subprocess.run(
+            [sys.executable, str(HOOK), "--marker", "bogus"],
+            input=_stop_payload(),
+            capture_output=True,
+            text=True,
+            timeout=5,
+            env={"CLAUDE_PROJECT_DIR": str(tmp_path), "PATH": ""},
+        )
+        assert proc.returncode == 0
+        assert (tmp_path / MARKER_RELPATH).exists()
+        assert not (tmp_path / ROUTINE_MARKER_RELPATH).exists()
+
     def test_cli_default_writes_only_session_file(self, tmp_path):
         # No --marker == the Stop-hook path == session marker only.
         (tmp_path / ".agents").mkdir()


### PR DESCRIPTION
Closes #1002.

## Summary

The morning-routine recap (beat 1a/1b) anchored its lookback on `last_session_marker.json`, which the `Stop` hook advances at **every** turn-end. So a non-recap session (a quick-wins run, an overnight autonomous session) narrowed the recap window and could skip closures a human never saw recapped.

This adds a second, **routine-only** watermark written only by the recap beat, per the approach settled on the Issue (option A, 2026-07-04 + 2026-07-06): the recap beat writes the marker itself, reusing the existing tested atomic writer. "A routine ran" is not a hook-observable event, and a missed stamp fails *wide* (the next recap over-includes, hides nothing), so a memory-side trigger is safe and the hook machinery of the alternative is not earned.

## What is in this PR (project repo)

- `write_session_watermark.py`: a `MARKERS` registry parameterizes the writer by name (`session` default = the Stop hook; `routine` = the recap beat), each with its own file + timestamp key so the two markers never collide. A `--marker` CLI selects the routine file; the no-arg Stop-hook path is byte-for-byte unchanged.
- `tools/ci/test_write_session_watermark.py`: 6 new tests (routine path/key, session default preserved, independence, unknown-marker guard, CLI routine vs default).
- `.gitignore`: routine marker ignored alongside the session marker.

## Landed separately (personas repo, committed by MM)

The **read-side + trigger** live in the morning-routine memory (`pm/feedback_morning_routine.md`), edited in this session and pending MM's commit (same split as [Issue #973](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/973)'s AC4 memory half):
- beat 1a/1b now anchor on the routine marker (`.agents/last_routine_marker.json`), same schema-gate / 1-day overlap / 7-day-absent fallback semantics (AC-2, AC-3, AC-4);
- the recap beat stamps the routine marker at the end via `write_session_watermark.py --marker routine` (AC-1 trigger);
- the coordination scan (`scan_addressed_comments.py`) deliberately keeps the **session** marker.

## Test plan

- [x] `workflow/tests/.venv/bin/python -m pytest tools/ci/test_write_session_watermark.py -q` -> 20 passed (14 existing + 6 new).
- [x] Smoke: `write_session_watermark.py --marker routine` writes `.agents/last_routine_marker.json` = `{last_routine_end_utc, schema:1}`; the session marker is untouched by the same call.
- [x] Smoke: no-arg (Stop-hook path) writes only `last_session_marker.json` (routine file absent).
- [x] `git check-ignore` confirms the routine marker is not tracked; `git status` shows no stray marker file.
- [x] `py_compile` clean; no external importer of the removed `MARKER_RELPATH` module constant.

**Created by:** PM
