### PR TITLE
test(alignment): unit-cover the HISAT2 paired-end (-1/-2) command branch

### DIFF
--- a/workflow/rules/alignment.smk
+++ b/workflow/rules/alignment.smk
@@ -78,6 +78,19 @@ if config.get("alignment", {}).get("aligner") == "hisat2":
     import sys
     sys.path.insert(0, os.path.join(workflow.basedir, "workflow", "scripts"))
     from strandness import get_strandness_from_row
+    from hisat2_command import build_read_args
+
+    def _get_hisat2_read_args(wildcards, input):
+        """Resolve the HISAT2 read-input args (`-U` vs `-1/-2`) for one sample.
+
+        Mirrors `_get_hisat2_strandness`: delegates the single-end / paired-end
+        selection to the pure `build_read_args` helper (unit-tested in
+        test_hisat2_command.py). Reads the already-resolved input paths so the
+        emitted command uses exactly the staged files. `input.fastq2` is a
+        (possibly empty) list from `_get_fastq2`.
+        """
+        fastq2 = input.fastq2[0] if input.fastq2 else ""
+        return build_read_args(input.fastq1, fastq2)
 
     def _get_hisat2_strandness(wildcards):
         """Resolve the HISAT2 --rna-strandness flag value for a single sample.
@@ -187,6 +200,7 @@ if config.get("alignment", {}).get("aligner") == "hisat2":
         params:
             index_prefix=_HISAT2_INDEX_PREFIX,
             strandness=_get_hisat2_strandness,
+            read_args=_get_hisat2_read_args,
         threads: config.get("alignment", {}).get("threads", 8)
         resources:
             mem_mb=20000,
@@ -205,12 +219,6 @@ if config.get("alignment", {}).get("aligner") == "hisat2":
                 exit 1
             fi
 
-            if [[ -n "{input.fastq2}" ]]; then
-                FASTQ_ARGS="-1 {input.fastq1} -2 {input.fastq2}"
-            else
-                FASTQ_ARGS="-U {input.fastq1}"
-            fi
-
             STRANDNESS_ARGS=""
             if [[ -n "{params.strandness}" ]]; then
                 STRANDNESS_ARGS="--rna-strandness {params.strandness}"
@@ -220,7 +228,7 @@ if config.get("alignment", {}).get("aligner") == "hisat2":
                 -p {threads} \\
                 -x {params.index_prefix} \\
                 $STRANDNESS_ARGS \\
-                $FASTQ_ARGS \\
+                {params.read_args} \\
                 2>> {log} | \\
                 samtools sort -@ {threads} -m 1G -o {output.bam} - 2>> {log}
 

--- a/workflow/scripts/hisat2_command.py
+++ b/workflow/scripts/hisat2_command.py
@@ -1,0 +1,28 @@
+"""Build HISAT2 read-input arguments (single-end vs paired-end).
+
+Used by `alignment.smk` to translate a sample's fastq paths into the HISAT2
+read-input flag form: `-U <r1>` for single-end, `-1 <r1> -2 <r2>` for
+paired-end. Extracted from the rule's inline shell so the single-end /
+paired-end selection is unit-testable (see `test_hisat2_command.py`),
+mirroring the `strandness.py` helper. Paired-end has no local end-to-end
+coverage otherwise (the chr22 smoke fixture is single-end only) and its only
+prior coverage (the GCP patient_002 runs) is gone with the decommissioned
+infra - see Issue #962.
+"""
+
+
+def build_read_args(fastq1, fastq2):
+    """Return the HISAT2 read-input args for a sample.
+
+    Paired-end (`-1 <r1> -2 <r2>`) when a non-empty `fastq2` is given, else
+    single-end (`-U <r1>`). `fastq2` may be `None`, an empty/whitespace-only
+    string, or a path; whitespace-only is treated as single-end, matching the
+    samples.tsv convention in `strandness.get_strandness_from_row`.
+    """
+    r1 = str(fastq1 or "").strip()
+    r2 = str(fastq2 or "").strip()
+    if not r1:
+        raise ValueError("fastq1 is required for HISAT2 alignment (got empty).")
+    if r2:
+        return f"-1 {r1} -2 {r2}"
+    return f"-U {r1}"

--- a/workflow/tests/test_alignment_hisat2_command.py
+++ b/workflow/tests/test_alignment_hisat2_command.py
@@ -1,0 +1,102 @@
+"""Snapshot test of the rendered hisat2_align read-input args.
+
+Complements the pure-helper test (test_hisat2_command.py) at the rule layer:
+it asserts the `hisat2_align` shell command actually wires `{params.read_args}`
+so a single-end sample renders `-U <r1>` and a paired-end sample renders
+`-1 <r1> -2 <r2>`. The pure test guards the helper's logic; this guards that
+the rule still calls it (a future edit dropping `{params.read_args}` from the
+shell would pass the unit test but fail here). Sibling of
+test_alignment_star_command.py. See Issue #962.
+
+Runs `snakemake --dry-run --printshellcmds` programmatically with an
+aligner=hisat2 override and stub inputs; skips where snakemake is unavailable.
+"""
+import shutil
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+@pytest.fixture(scope="module")
+def hisat2_dry_run_output(tmp_path_factory):
+    """Render hisat2_align for one SE and one PE sample; return captured stdout.
+
+    Both targets are rendered in a single dry-run so the SE (`-U`) and PE
+    (`-1/-2`) commands appear in one output; assertions key on the distinct
+    stub paths so the two samples can't be confused.
+    """
+    if shutil.which("snakemake") is None:
+        pytest.skip("snakemake not on PATH - activate the snakemake conda env")
+
+    tmp_path = tmp_path_factory.mktemp("hisat2_stub")
+    se_r1 = tmp_path / "se_R1.fq.gz"
+    pe_r1 = tmp_path / "pe_R1.fq.gz"
+    pe_r2 = tmp_path / "pe_R2.fq.gz"
+    for f in (se_r1, pe_r1, pe_r2):
+        f.touch()
+
+    index_dir = tmp_path / "hisat2_index"
+    index_dir.mkdir()
+    (index_dir / "index.done").touch()
+    (index_dir / "genome.1.ht2").touch()
+
+    samples = tmp_path / "samples.tsv"
+    samples.write_text(
+        "patient_id\tsample_id\tsample_type\tfastq1\tfastq2\tstrandness\n"
+        f"tp\tse_sample\tSolid Tissue Normal\t{se_r1}\t\t\n"
+        f"tp\tpe_sample\tPrimary Tumor\t{pe_r1}\t{pe_r2}\treverse\n"
+    )
+
+    override = tmp_path / "override.yaml"
+    override.write_text(textwrap.dedent(f"""\
+        samples_tsv: "{samples}"
+        alignment:
+          aligner: "hisat2"
+          hisat2_index_dir: "{index_dir}"
+          hisat2_prebuilt_url: ""
+    """))
+
+    result = subprocess.run(
+        [
+            "snakemake", "-n", "--printshellcmds",
+            "--configfile", "config/config.yaml", str(override),
+            "--",
+            "results/tp/alignment/se_sample/raw_junctions.tsv",
+            "results/tp/alignment/pe_sample/raw_junctions.tsv",
+        ],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        pytest.fail(
+            f"snakemake dry-run failed (exit {result.returncode}):\n"
+            f"STDOUT:\n{result.stdout}\n\nSTDERR:\n{result.stderr}"
+        )
+    return {"out": result.stdout, "se_r1": str(se_r1),
+            "pe_r1": str(pe_r1), "pe_r2": str(pe_r2)}
+
+
+def test_single_end_sample_uses_U(hisat2_dry_run_output):
+    o = hisat2_dry_run_output
+    assert f"-U {o['se_r1']}" in o["out"]
+
+
+def test_single_end_sample_not_rendered_paired(hisat2_dry_run_output):
+    o = hisat2_dry_run_output
+    assert f"-1 {o['se_r1']}" not in o["out"]
+
+
+def test_paired_end_sample_uses_1_2(hisat2_dry_run_output):
+    o = hisat2_dry_run_output
+    assert f"-1 {o['pe_r1']} -2 {o['pe_r2']}" in o["out"]
+
+
+def test_paired_end_sample_not_rendered_single(hisat2_dry_run_output):
+    o = hisat2_dry_run_output
+    assert f"-U {o['pe_r1']}" not in o["out"]

--- a/workflow/tests/test_alignment_hisat2_command.py
+++ b/workflow/tests/test_alignment_hisat2_command.py
@@ -100,3 +100,13 @@ def test_paired_end_sample_uses_1_2(hisat2_dry_run_output):
 def test_paired_end_sample_not_rendered_single(hisat2_dry_run_output):
     o = hisat2_dry_run_output
     assert f"-U {o['pe_r1']}" not in o["out"]
+
+
+def test_paired_end_sample_wires_strandness(hisat2_dry_run_output):
+    """The PE fixture sets strandness=reverse; the rendered command must carry
+    `--rna-strandness RF`, so the fixture's `reverse` value is load-bearing and
+    the PE path is asserted fully wired (read args + strandness), not just
+    -1/-2. The SE fixture leaves strandness empty, so RF can only come from PE.
+    """
+    o = hisat2_dry_run_output
+    assert "--rna-strandness RF" in o["out"]

--- a/workflow/tests/test_hisat2_command.py
+++ b/workflow/tests/test_hisat2_command.py
@@ -1,0 +1,42 @@
+"""Unit tests for the HISAT2 read-input arg helper used by hisat2_align.
+
+Guards the single-end (`-U`) vs paired-end (`-1/-2`) command selection. That
+branch was previously inline shell in `alignment.smk` (unreachable by a test);
+it is exercised in production but had no reproducible automated coverage after
+the GCP patient_002 runs were retired - see Issue #962.
+"""
+import pytest
+
+from hisat2_command import build_read_args
+
+
+class TestBuildReadArgs:
+    def test_single_end_uses_U(self):
+        assert build_read_args("r1.fq.gz", "") == "-U r1.fq.gz"
+
+    def test_single_end_none_fastq2(self):
+        assert build_read_args("r1.fq.gz", None) == "-U r1.fq.gz"
+
+    def test_whitespace_fastq2_is_single_end(self):
+        # Matches strandness.get_strandness_from_row: whitespace-only fastq2 is SE.
+        assert build_read_args("r1.fq.gz", "   ") == "-U r1.fq.gz"
+
+    def test_paired_end_uses_1_2(self):
+        assert build_read_args("r1.fq.gz", "r2.fq.gz") == "-1 r1.fq.gz -2 r2.fq.gz"
+
+    def test_paired_end_with_directory_paths(self):
+        # Realistic staged paths (mirrors the patient_002 BG003082_T0 PE case).
+        r1 = "data/patient_002/BG003082_T0_R1.fastq.gz"
+        r2 = "data/patient_002/BG003082_T0_R2.fastq.gz"
+        assert build_read_args(r1, r2) == f"-1 {r1} -2 {r2}"
+
+    def test_strips_surrounding_whitespace(self):
+        assert build_read_args("  r1.fq.gz  ", "  r2.fq.gz  ") == "-1 r1.fq.gz -2 r2.fq.gz"
+
+    def test_empty_fastq1_raises(self):
+        with pytest.raises(ValueError):
+            build_read_args("", "r2.fq.gz")
+
+    def test_none_fastq1_raises(self):
+        with pytest.raises(ValueError):
+            build_read_args(None, "")


### PR DESCRIPTION
## What

Adds reproducible unit coverage of the HISAT2 **paired-end (`-1/-2`) vs single-end (`-U`)** command selection, and refactors that selection out of `alignment.smk`'s inline shell (where it was untestable) into a pure `build_read_args` helper fed via a `params` function - mirroring the existing `strandness.py` / `_get_hisat2_strandness` pattern.

Behavior-preserving: single-end still renders `-U <r1>`, paired-end still renders `-1 <r1> -2 <r2>`, exactly as the old inline `if [[ -n fastq2 ]]` block did.

## Why (rescoped - see [Issue #962](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/962))

The Issue originally proposed a full paired-end **E2E smoke fixture** on real patient_002 data. During scoping that premise was falsified:

- **PE already ran in production** - patient_002's PE tumor (`BG003082_T0`) aligned end-to-end to a published `report.tsv`. The path is not unproven.
- **Most PE-specific logic is already unit-tested** - `test_strandness.py` covers PE `FR`/`RF`; `test_alignment_star_command.py` covers the STAR PE command; PE sample-sheet parsing is covered.

The one genuinely uncovered surface was the **HISAT2 `-1/-2` inline-shell branch**, whose only prior coverage (the GCP patient_002 runs) is gone with the decommissioned infra. Per the test pyramid (web-checked), the fix belongs at the lowest level that catches the risk - a unit test - not a heavy real-data E2E that would re-assert already-covered lower levels and drive layout-agnostic downstream steps the single-end chr22 fixture already covers.

## Changes

- `workflow/scripts/hisat2_command.py` - new pure `build_read_args(fastq1, fastq2)` helper.
- `workflow/rules/alignment.smk` - `_get_hisat2_read_args` params function; shell now uses `{params.read_args}` (inline `if` block removed).
- `workflow/tests/test_hisat2_command.py` - pure-helper unit tests (SE / PE / whitespace / empty).
- `workflow/tests/test_alignment_hisat2_command.py` - dry-run snapshot asserting the rule still wires `{params.read_args}` (sibling of `test_alignment_star_command.py`).

## Test plan

- [x] `pytest workflow/tests/` (snakemake on PATH so the dry-run snapshots run, not skip): **707 passed, 1 skipped**.
- [x] New pure-helper tests pass: `test_hisat2_command.py` (8 cases).
- [x] New wiring test passes: `test_alignment_hisat2_command.py` (4 cases, with snakemake active).
- [x] Hermetic dry-run verified end-to-end: a single-end sample renders `-U <r1>`; a paired-end sample renders `-1 <r1> -2 <r2>` **and** `--rna-strandness RF`.
- [x] Behavior-preserving: the single-end chr22 command is unchanged (renders `-U` exactly as before the refactor).

Closes #962

**Created by:** Developer



<!-- skip-lab-notebook: routine -->
