### PR TITLE
docs(pm): lab notebook entry for #882 cross-repo memory-PR convention

### DIFF
--- a/research/lab_notebook/pm.md
+++ b/research/lab_notebook/pm.md
@@ -8,6 +8,20 @@ Format and rules unchanged from the unified notebook — see `shared/feedback_la
 
 ## 2026-07-07
 
+### 15:30 UTC - Editor: PM
+
+#### [Issue #882](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/882) — cross-repo PR convention for memory/Issue-closing drains
+
+**What.** Process rule: when an MM drain satisfies the last open AC of a project-repo `role:*` Issue, it ships as a personas-repo PR carrying a cross-repo `Closes Jin-HoMLee/splice-neoepitope-pipeline#N` keyword, not a direct drain-to-`main`. The existing `cross_repo_ac_gate.py` gate audits the target Issue's ACs before merge; the keyword auto-closes on merge. Routine/non-closing drains keep direct-to-`main`. Batched: carve the Issue-closing edit into its own PR.
+
+**Edits.** Two `shared/` memory edits:
+- `feedback_personas_governance.md`: new bullet under "PR vs direct-to-`main`" defining the trigger, scope boundary, and batched-drains rule.
+- `MEMORY.md`: Always-in-effect bullet referencing it.
+
+**Correction.** #882 body stated cross-repo auto-close does not work — it does. `Closes org/repo#N` auto-closes on merge; what `closingIssuesReferences` cannot surface is cross-repo refs, which is why `cross_repo_ac_gate.py` exists.
+
+**State.** Edits on disk in the personas-repo clone, uncommitted. Deliverable is memory-only — no project-repo PR. MM commits via a personas PR with a cross-repo forward-link; the project Issue closes on merge.
+
 ### 14:41 UTC - Editor: PM
 
 #### SPM-3.0 agentic-PM landscape entry to the merge gate ([PR #1075](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/1075); seeds [epic #1072](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1072))


### PR DESCRIPTION
**What.** Companion to [Issue #882](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/882) (all ACs ticked). Ships the lab notebook entry for the cross-repo memory-PR convention work.

**The convention (landed in two personas-repo `shared/` edits, uncommitted):**
- `shared/feedback_personas_governance.md`: new bullet under "PR vs direct-to-`main`" — when an MM drain satisfies the last open AC of a project-repo `role:*` Issue, it ships as a personas PR with a cross-repo closing keyword, not a direct drain-to-`main`.
- `shared/MEMORY.md`: Always-in-effect bullet referencing it.

**Close artifact.** The personas-repo PR (carrying the memory edits + `Closes Jin-HoMLee/splice-neoepitope-pipeline#882`) is the Issue-closing artifact. This project-repo PR ships only the lab notebook entry — intentionally no closing keyword.

**Test plan.**
- [x] Lab notebook entry reads correctly (correct date/timestamp, references #882 and both edited files)
- [x] Branch is based on clean `main` (fast-forwarded to `190a505`)
- [x] Only `research/lab_notebook/pm.md` is modified

**Created by:** PM