### PR TITLE
feat(hooks): guard relative memory-path ops while cwd drifted out of clone (#1053)

### DIFF
--- a/.agents/hooks/check_memory_path_cwd_drift.py
+++ b/.agents/hooks/check_memory_path_cwd_drift.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""Pre-flight hook: refuse a memory-path operation while the cwd has drifted.
+
+House rule "cwd IS the role's own clone root": the main-session Bash cwd persists
+across tool calls, so a `cd` into a scratch/temp dir that is never undone leaves
+the shell standing outside the clone. A *later* command that uses a clone-root-
+relative memory path (`grep .agents/memory/...`, an Edit of `.agents/memory/x`)
+then resolves against the wrong directory - silent wrong-file memory I/O.
+
+This is the narrow residual gap NOT covered by `check_no_cd_outside_cwd.py`,
+which deliberately ALLOWS `cd` into temp roots (the scratchpad) - exactly the door
+the drift walks through. This guard catches the one high-harm moment: a relative
+memory path used while the persisted cwd is outside the clone.
+
+SCOPE (deliberately narrow, so a false-positive deny is unlikely): fires ONLY when
+BOTH hold -
+  1. the session `cwd` (from the PreToolUse JSON) resolves OUTSIDE the clone
+     subtree (not the root, not a subdir), AND
+  2. the tool references a RELATIVE path under `.agents/memory/` or
+     `.claude/memory/` (Bash: any command token; Edit/Write/MultiEdit: file_path).
+An ABSOLUTE memory path is always safe (it does not depend on cwd) -> allowed.
+A cwd inside the clone (root or subdir) -> allowed. Non-memory paths -> allowed.
+
+WHY A HOOK, NOT `permissions.deny`: a static rule cannot see the runtime cwd or
+resolve absolute-vs-relative. Sibling of `check_no_cd_outside_cwd.py`.
+
+BEST-PRACTICE FRAMING: persistent-shell agent harnesses accept cwd drift as a
+known tradeoff and mitigate it by preferring absolute paths / `git -C` and by
+making drift LOUD rather than silent. This guard makes the single high-harm drift
+moment loud, and its deny message nudges to the real fix.
+
+FAILS OPEN (allows) on: an unresolvable / missing cwd, a dynamic path (`$VAR`,
+backticks, command substitution), a tokenization failure, or an unexpected JSON
+shape. A guard must never break a legitimate command on ambiguity.
+
+ESCAPE HATCH: set env `CLAUDE_ALLOW_CWD_DRIFT=1` for a deliberate memory op from a
+drifted cwd the user authorized (prefer an absolute path / `cd` back instead).
+
+Reads PreToolUse hook JSON on stdin, prints a deny decision on stdout when the
+guard fires, exits 0 silently otherwise. Fires are appended to
+`.agents/hook_fires.jsonl` (Issue #453 infra).
+
+See https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1053.
+"""
+from __future__ import annotations
+
+import json
+import os
+import shlex
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+PROJECT_ROOT = str(Path(__file__).resolve().parent.parent.parent)
+LOG_PATH = Path(PROJECT_ROOT) / ".agents" / "hook_fires.jsonl"
+
+_TRUTHY = {"1", "true", "yes", "on"}
+# The clone-root-relative memory directories a drifted cwd would mis-resolve.
+_MEMORY_SEGMENTS = (".agents/memory", ".claude/memory")
+_PATH_TOOLS = {"Edit", "MultiEdit", "Write"}
+
+
+# --- pure helpers (unit-tested, no I/O) ---
+
+
+def cwd_outside_clone(cwd, project_root: str) -> bool:
+    """True iff `cwd` resolves OUTSIDE the clone subtree (not root, not a subdir).
+
+    A missing / empty / unresolvable cwd returns False (cannot tell -> the caller
+    fails open and does not fire). Both paths are realpath-normalized so a
+    symlinked clone component does not spuriously read as "outside".
+    """
+    if not cwd:
+        return False
+    try:
+        c = os.path.realpath(cwd)
+        r = os.path.realpath(project_root)
+    except (OSError, ValueError):
+        return False
+    if c == r or c.startswith(r + os.sep):
+        return False
+    return True
+
+
+def is_relative_memory_token(token: str) -> bool:
+    """True iff `token` is a RELATIVE path into a memory dir (so it resolves
+    against cwd). Absolute paths and dynamic tokens are not relative memory refs.
+    """
+    if not token or "$" in token or "`" in token:
+        return False  # dynamic -> unresolvable -> fail open
+    if token.startswith("/") or token.startswith("~"):
+        return False  # absolute / home-anchored -> cwd-independent -> safe
+    stripped = token[2:] if token.startswith("./") else token
+    return any(stripped.startswith(seg) for seg in _MEMORY_SEGMENTS)
+
+
+def command_has_relative_memory_ref(cmd: str):
+    """For a Bash command, return the first relative-memory-path token, or None.
+
+    Returns None on a tokenization failure (caller fails open). Quoted strings
+    survive as single tokens.
+    """
+    try:
+        tokens = shlex.split(cmd or "", posix=True)
+    except ValueError:
+        return None
+    for tok in tokens:
+        if is_relative_memory_token(tok):
+            return tok
+    return None
+
+
+def offending_ref(tool_name: str, tool_input: dict):
+    """Return the relative-memory-path reference that would mis-resolve, or None.
+
+    Bash -> scan the command tokens. Edit/Write/MultiEdit -> the `file_path`.
+    """
+    tool_input = tool_input or {}
+    if tool_name == "Bash":
+        return command_has_relative_memory_ref(tool_input.get("command", ""))
+    if tool_name in _PATH_TOOLS:
+        fp = tool_input.get("file_path", "")
+        return fp if is_relative_memory_token(fp) else None
+    return None
+
+
+def is_allowed(env=None) -> bool:
+    """True when the user has set the CLAUDE_ALLOW_CWD_DRIFT escape hatch."""
+    env = os.environ if env is None else env
+    return (env.get("CLAUDE_ALLOW_CWD_DRIFT") or "").strip().lower() in _TRUTHY
+
+
+def deny_payload(ref: str, cwd: str, project_root: str) -> dict:
+    """The PreToolUse deny decision for a drifted-cwd memory operation."""
+    return {
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "deny",
+            "permissionDecisionReason": (
+                f"Refusing a relative memory path (`{ref}`) while the shell cwd has "
+                f"drifted OUT of the clone root.\n  cwd:   {cwd}\n  clone: {project_root}\n"
+                "A clone-root-relative memory path resolves against the wrong "
+                "directory from here (silent wrong-file memory I/O). Fix: `cd` back "
+                "to the clone root, or use an absolute path (the cwd persists across "
+                "tool calls - don't rely on where the shell is standing). Deliberate "
+                "drifted memory op the user authorized: set CLAUDE_ALLOW_CWD_DRIFT=1."
+            ),
+        }
+    }
+
+
+# --- I/O ---
+
+
+def _log_fire(ref: str, cwd: str, snippet: str) -> None:
+    """Append one fire-log line on a deny (Issue #453 infra). Never raises."""
+    payload = {
+        "ts": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "hook": "check_memory_path_cwd_drift",
+        "action": "refused-memory-path-cwd-drift",
+        "ref": ref[:120],
+        "cwd": (cwd or "")[:200],
+        "snippet": snippet[:200],
+    }
+    line = json.dumps(payload, separators=(",", ":")) + "\n"
+    try:
+        LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+        with open(LOG_PATH, "a", encoding="utf-8") as f:
+            f.write(line)
+    except OSError:
+        pass
+
+
+# --- orchestration ---
+
+
+def main() -> int:
+    try:
+        data = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError):
+        return 0  # fail open
+
+    tool_name = data.get("tool_name")
+    if tool_name != "Bash" and tool_name not in _PATH_TOOLS:
+        return 0
+
+    if is_allowed():
+        return 0
+
+    cwd = data.get("cwd")
+    if not cwd_outside_clone(cwd, PROJECT_ROOT):
+        return 0  # cwd is fine (or unknown) -> nothing to guard
+
+    tool_input = data.get("tool_input") or {}
+    ref = offending_ref(tool_name, tool_input)
+    if ref is None:
+        return 0
+
+    snippet = tool_input.get("command", "") or tool_input.get("file_path", "")
+    _log_fire(ref, cwd, snippet)
+    print(json.dumps(deny_payload(ref, cwd, PROJECT_ROOT)))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.agents/hooks/check_memory_path_cwd_drift.py
+++ b/.agents/hooks/check_memory_path_cwd_drift.py
@@ -90,8 +90,13 @@ def is_relative_memory_token(token: str) -> bool:
         return False  # dynamic -> unresolvable -> fail open
     if token.startswith("/") or token.startswith("~"):
         return False  # absolute / home-anchored -> cwd-independent -> safe
+    # A leading `./` is the memory dir itself; a leading `../` is NOT matched -
+    # a parent-relative escape (`../.agents/memory`) is a deliberate fail-open gap
+    # (not the recorded incident shape; erring toward allow on the deny path).
     stripped = token[2:] if token.startswith("./") else token
-    return any(stripped.startswith(seg) for seg in _MEMORY_SEGMENTS)
+    # Anchor at a path boundary so a sibling like `.agents/memory-archive/` does
+    # NOT over-match - a false-positive deny is the costly direction here.
+    return any(stripped == seg or stripped.startswith(seg + "/") for seg in _MEMORY_SEGMENTS)
 
 
 def command_has_relative_memory_ref(cmd: str):

--- a/.agents/settings.json
+++ b/.agents/settings.json
@@ -34,6 +34,11 @@
             "command": "${CLAUDE_PROJECT_DIR}/.agents/hooks/check_no_cd_outside_cwd.py",
             "if": "Bash(cd*)",
             "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "${CLAUDE_PROJECT_DIR}/.agents/hooks/check_memory_path_cwd_drift.py",
+            "timeout": 5
           }
         ]
       },
@@ -43,6 +48,11 @@
           {
             "type": "command",
             "command": "${CLAUDE_PROJECT_DIR}/.agents/hooks/check_no_emdash.py",
+            "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "${CLAUDE_PROJECT_DIR}/.agents/hooks/check_memory_path_cwd_drift.py",
             "timeout": 5
           }
         ]

--- a/docs/superpowers/specs/2026-07-08-memory-path-cwd-drift-guard-design.md
+++ b/docs/superpowers/specs/2026-07-08-memory-path-cwd-drift-guard-design.md
@@ -1,0 +1,91 @@
+# Memory-path cwd-drift guard (Issue #1053)
+
+Design spec, 2026-07-08. Developer.
+
+## Problem
+
+The four role agents each work from their own clone. The main-session Bash shell
+persists its working directory across tool calls (the standard persistent-shell
+model), so the cwd can silently drift out of the clone root - most commonly via a
+legitimate `cd` into the scratchpad temp root that is never undone. A later
+command that uses a **clone-root-relative** path (e.g. `grep .agents/memory/...`)
+then resolves against the wrong directory.
+
+## Premise audit (AC#1)
+
+Auditing the three recorded drift incidents (esp. the 2026-07-04 PM episode)
+resolves the failure shape the issue left open ("persisted cwd vs realpath
+mis-resolution vs both"):
+
+- **The recurring shape is persisted cwd drift, not wrong-clone memory writes.**
+  On 2026-07-04 a `cd .../scratchpad` persisted and made a later bare-relative
+  `grep .agents/memory/shared` resolve wrong. The PM's own clone-realpath check
+  that session confirmed edits still landed in the *right* clone.
+- **The "silent wrong-file memory I/O" class has never actually fired** - it is a
+  latent risk warned about by the bare-path memory convention, with zero observed
+  occurrences.
+- **The existing `check_no_cd_outside_cwd` hook (PR #1029) does not cover this.**
+  It denies `cd` into another repo / sibling clone / `$HOME`, but *deliberately
+  allows* `cd` into `/private/tmp` (the scratchpad root) - exactly the door the
+  drift walks through. It landed hours after the last incident.
+- **PreToolUse JSON carries `cwd`**, which is the lever a residual guard needs.
+
+## Decision
+
+Build a narrow residual guard as cheap insurance against the latent-but-serious
+wrong-file memory-write class, complementing (not duplicating) the existing
+cd-guard. Grounded in agentic-coding best practice: persistent-shell harnesses
+accept cwd drift as a known tradeoff and mitigate it by (a) preferring absolute
+paths / `git -C` and (b) making drift *loud* rather than silent. This guard makes
+the one high-harm drift moment loud.
+
+Rejected: a blanket "warn on any command while cwd drifted" guard - it would fight
+the existing hook's deliberate temp-root allowance and generate noise. Rejected:
+closing the issue - the wrong-file class, though never fired, is a genuine
+memory-corruption hazard and the guard is cheap.
+
+## Design
+
+New `PreToolUse` hook `.agents/hooks/check_memory_path_cwd_drift.py`.
+
+**Registered on** the `Bash` matcher and the `Edit|MultiEdit|Write` matcher (two
+settings entries, one script).
+
+**Denies** iff *both* hold:
+1. `cwd` from the hook JSON resolves **outside the clone root** (reuse the
+   existing hook's root-derivation: `Path(__file__).resolve().parent.parent.parent`,
+   symlink-safe, no env var). A cwd inside the clone root or unresolvable → allowed.
+2. The tool references a **relative** path under `.agents/memory/` or
+   `.claude/memory/`:
+   - `Bash`: scan the command string for those segments as a relative token.
+   - `Edit`/`MultiEdit`/`Write`: inspect `file_path` (and for `Bash`, the whole
+     command). An **absolute** memory path is always safe → allowed.
+
+**Fails open** (allow) on: unresolvable cwd, dynamic paths (`$VAR`, backticks,
+command substitution), tokenization failure, unexpected JSON shape, missing
+fields. A guard must never break a legitimate command on ambiguity.
+
+**Escape hatch**: `CLAUDE_ALLOW_CWD_DRIFT=1`.
+
+**Fire log**: one line per deny to `.agents/hook_fires.jsonl` (Issue #453 infra),
+`hook: "check_memory_path_cwd_drift"`.
+
+**Deny message**: names the drift, shows the drifted cwd vs clone root, and nudges
+to the real fix - `cd` back to the clone root or use an absolute path / `git -C`.
+
+## Testing
+
+Unit tests in `tools/ci/test_check_memory_path_cwd_drift.py`, mirroring
+`test_check_no_cd_outside_cwd.py`: pure helpers (path classification, memory-path
+detection, cwd-inside-clone) plus `main()` end-to-end via stdin JSON. Cover:
+drift + relative memory path (deny), drift + absolute memory path (allow), drift +
+non-memory path (allow), no-drift + relative memory path (allow), dynamic path
+(allow / fail-open), escape hatch, each tool type, fire-log line shape, and an
+`os.access(HOOK, os.X_OK)` regression assertion (the exec-bit lesson from #1032).
+
+## Acceptance criteria mapping
+
+- AC1 (confirm premise) → this spec's Premise audit section + a comment on #1053.
+- AC2 (guard fires on a probe) → live-fire probe in the wiring step.
+- AC3 (fail-open + fire-log) → design + tests above.
+- AC4 (strip stopgap bullet) → same PR, cross-repo edit to personas `pm/MEMORY.md`.

--- a/research/lab_notebook/developer.md
+++ b/research/lab_notebook/developer.md
@@ -6,6 +6,22 @@ Format and rules unchanged from the unified notebook — see `shared/feedback_la
 
 ---
 
+## 2026-07-09 - ship the cwd-drift guard pair ([PR #1088](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/1088) closes [Issue #1053](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1053))
+
+### 12:06 UTC - Editor: Developer - merge-gate pass, cross-repo companion, and a proxy-shaped gate
+
+**Ship.**
+[PR #1088](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/1088) cleared the gate with all four CI checks green (`ci-tools-pytest`, `pipeline-pytest`, `pipeline-conda-env-solve`, `pipeline-snakemake-dry-run`), `mergeStateStatus: CLEAN`, bot review addressed in `99414ea`, and no unticked boxes on either the PR test plan or #1053's acceptance criteria. Its cross-repo companion [personas PR #126](https://github.com/Jin-HoMLee/claude-personas-splice-neoepitope-pipeline/pull/126) (strip the now-obsolete `pm/MEMORY.md` stopgap bullet) merges alongside, per AC#4 - the stopgap says "guard not yet landed", so it must not outlive the guard.
+
+**The lab-notebook gate is keyed on a proxy, and today it bit.**
+Yesterday's entry for this exact PR was written post-review, pre-merge - textbook adherence to `shared/feedback_lab_notebook.md` "Entry timing". But the merge slipped past midnight UTC, and `check_lab_notebook` demands a `## <merge-date>` header, so a correctly-written entry read as a *missing* one. The two escapes were both bad: re-date the committed 07-08 entry (violates this notebook's own "entries are immutable once committed" rule, line 5) or stamp a hollow bypass marker on a PR that is anything but routine. So this entry exists partly because the gate asked for a header, which is the tell.
+
+The gate is checking *"was an entry written on the merge date"* when the intent is *"does an entry exist for this unit of work, written after review and before merge."* Any PR whose review straddles a UTC midnight - i.e. any overnight review, which is the normal case for a bot review requested late - hits this. The fix is to accept an entry in a small window ending at the merge date, or to key on the `#PR`/`#Issue` reference across recent date blocks rather than on one exact header. Filed as a follow-up; not fixed inline, because a gate change wants its own tests and its own review rather than riding a merge it is currently blocking.
+
+**Lesson.** A gate that forces you to choose between violating a second rule and faking a bypass is not enforcing its intent - it is enforcing its proxy. Same shape as the AC-heading lint (`ac_section_lint.py`), which stayed keyed to one canonical heading precisely to avoid guessing. The tell that you are on the wrong side of it: the artifact you are creating exists to satisfy the check, not the reader.
+
+---
+
 ## 2026-07-08 - memory-path cwd-drift guard ([PR #1088](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/1088) closes [Issue #1053](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1053))
 
 ### Editor: Developer - narrow PreToolUse guard for relative memory ops under a drifted cwd

--- a/research/lab_notebook/developer.md
+++ b/research/lab_notebook/developer.md
@@ -6,6 +6,31 @@ Format and rules unchanged from the unified notebook — see `shared/feedback_la
 
 ---
 
+## 2026-07-08 - memory-path cwd-drift guard ([PR #1088](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/1088) closes [Issue #1053](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1053))
+
+### Editor: Developer - narrow PreToolUse guard for relative memory ops under a drifted cwd
+
+**The audit-first step earned its keep - again.**
+AC#1 asked to "confirm the premise first" before building. Doing so materially reshaped the issue. The three recorded drift incidents (esp. the 2026-07-04 PM episode) show the recurring shape is **persisted cwd drift** (a `cd .../scratchpad` that persists, then a bare-relative `grep .agents/memory/shared` resolving wrong), not the scary **wrong-clone memory write** the issue was framed around - the PM's own realpath check that session confirmed writes landed in the right clone. So the dangerous class has **fired zero times**; it's latent. And the existing `check_no_cd_outside_cwd` hook (PR #1029, landed hours after the last incident) **deliberately allows** `cd` into `/private/tmp` - exactly the door the drift walks through - so it never covered this.
+
+**Surfaced the honest disposition, let the user decide.**
+Given the dangerous class never fired and the observed drift self-corrects (a failed relative command is loud, not silent corruption), this narrowly misses our "mechanism only after the *specific* defect recurs" bar. I said so plainly and offered close-vs-build. The user asked what actual agentic-coding best practice says about `cd` handling, so I web-cross-checked: persistent-shell harnesses accept cwd drift as a known tradeoff and mitigate by (a) preferring absolute paths / `git -C` and (b) making drift **loud** not silent (Claude Code even resets cwd per-command *for subagents*, but not the main session). User chose to build the narrow guard as cheap insurance. The guard's job, framed by that research: make the one high-harm drift moment loud.
+
+**Build.**
+`check_memory_path_cwd_drift.py` denies a Bash/Edit/Write iff BOTH (a) `cwd` (from PreToolUse JSON - the lever) resolves outside the clone subtree, and (b) a **relative** `.agents/memory`/`.claude/memory` path is used. Absolute paths and in-clone cwd pass; fails open on unresolvable cwd / dynamic tokens. Mirrors the sibling cd-guard's pure-helper structure; committed `100755` (the #1032 exec-bit lesson, with an `os.access` regression test). 37 tests, live-fire probed.
+
+**Bot review (LGTM, non-blocking nits; fixes in `99414ea`).**
+- **Took #1 (real):** `startswith(".agents/memory")` over-matched a sibling like `.agents/memory-archive/` and would *deny* it - a false positive on the **costly deny direction**. Anchored to `== seg or startswith(seg + "/")`. +tests.
+- **Took #3:** documented the `../.agents/memory` parent-relative gap as an *intentional* fail-open with a comment + test.
+- **Declined #2 (perf `if:` gate) with rationale:** a leading-wildcard `Bash(*memory*)` whose match support is unverified could silently fail and **disable the guard** - a silent-guard-failure is exactly the class we're guarding against, so correctness beats a micro-perf spawn. **Declined #4:** MM cross-cwd is already escape-hatched + forced onto `git -C` by the cd-guard.
+
+**Cross-repo companion (AC#4).**
+The transient stopgap bullet lives in the personas repo (`pm/MEMORY.md`), so the strip ships as forward-linked companion [personas PR #126](https://github.com/Jin-HoMLee/claude-personas-splice-neoepitope-pipeline/pull/126), to merge alongside this one.
+
+**Lesson.** On a deny-direction guard, an unanchored `startswith` on a path segment is a latent false-positive - anchor at the path boundary. And the premise-audit-before-building step keeps paying: it turned a "thrice-recurring correctness hazard" framing into an honest "latent, never-fired; here's the real narrow residual." Both PRs at the merge gate.
+
+---
+
 ## 2026-07-06 - stand up docs/adr + docs/design homes ([PR #1051](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/1051) closes [Issue #777](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/777))
 
 ### 14:37 UTC - Editor: Developer - converge the remaining 3 gh() copies ([PR #1061](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/1061) closes [Issue #1055](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1055))

--- a/tools/ci/test_check_memory_path_cwd_drift.py
+++ b/tools/ci/test_check_memory_path_cwd_drift.py
@@ -79,6 +79,20 @@ class TestIsRelativeMemoryToken:
         # a token that merely contains the segment deeper in is not a root-relative ref
         assert h.is_relative_memory_token("foo/.agents/memory/x") is False
 
+    def test_exact_segment_matches(self):
+        # a bare `.agents/memory` reference (e.g. `ls .agents/memory`) is caught
+        assert h.is_relative_memory_token(".agents/memory") is True
+        assert h.is_relative_memory_token(".claude/memory") is True
+
+    def test_sibling_dir_not_over_matched(self):
+        # anchored at a path boundary: a sibling dir must NOT match (deny direction)
+        assert h.is_relative_memory_token(".agents/memory-archive/x") is False
+        assert h.is_relative_memory_token(".claude/memory-old/y") is False
+
+    def test_parent_relative_intentional_gap(self):
+        # `../.agents/memory` is a deliberate fail-open gap (not the incident shape)
+        assert h.is_relative_memory_token("../.agents/memory/x") is False
+
 
 # --- command_has_relative_memory_ref ---
 

--- a/tools/ci/test_check_memory_path_cwd_drift.py
+++ b/tools/ci/test_check_memory_path_cwd_drift.py
@@ -1,0 +1,200 @@
+"""Tests for `.agents/hooks/check_memory_path_cwd_drift.py` (Issue #1053).
+
+Pure-function unit tests pass an explicit project_root / token so they don't
+depend on the real clone location. Subprocess tests pipe PreToolUse JSON to stdin
+against the real hook (which derives PROJECT_ROOT from its own path) and exercise
+deny / allow / escape-hatch / fail-open end-to-end.
+"""
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+HOOKS_DIR = Path(__file__).parent.parent.parent / ".agents" / "hooks"
+HOOK = HOOKS_DIR / "check_memory_path_cwd_drift.py"
+REAL_ROOT = str(HOOKS_DIR.parent.parent)  # the actual project clone root
+sys.path.insert(0, str(HOOKS_DIR))
+
+import check_memory_path_cwd_drift as h  # noqa: E402
+
+ROOT = "/proj"
+
+
+# --- cwd_outside_clone ---
+
+
+class TestCwdOutsideClone:
+    def test_exact_root_inside(self):
+        assert h.cwd_outside_clone("/proj", "/proj") is False
+
+    def test_subdir_inside(self):
+        assert h.cwd_outside_clone("/proj/workflow", "/proj") is False
+
+    def test_temp_root_outside(self):
+        assert h.cwd_outside_clone("/private/tmp/claude/scratch", "/proj") is True
+
+    def test_sibling_clone_outside(self):
+        assert h.cwd_outside_clone("/proj-developer", "/proj") is True  # prefix but not subdir
+
+    def test_missing_cwd_not_outside(self):
+        assert h.cwd_outside_clone(None, "/proj") is False
+        assert h.cwd_outside_clone("", "/proj") is False
+
+    def test_trailing_slash_normalized(self):
+        assert h.cwd_outside_clone("/proj/", "/proj") is False
+
+
+# --- is_relative_memory_token ---
+
+
+class TestIsRelativeMemoryToken:
+    def test_relative_agents_memory(self):
+        assert h.is_relative_memory_token(".agents/memory/shared/MEMORY.md") is True
+
+    def test_relative_claude_memory(self):
+        assert h.is_relative_memory_token(".claude/memory/foo.md") is True
+
+    def test_dot_slash_prefix(self):
+        assert h.is_relative_memory_token("./.agents/memory/x") is True
+
+    def test_absolute_memory_safe(self):
+        assert h.is_relative_memory_token("/Users/x/.agents/memory/y") is False
+
+    def test_home_anchored_safe(self):
+        assert h.is_relative_memory_token("~/.claude/memory/y") is False
+
+    def test_non_memory_relative(self):
+        assert h.is_relative_memory_token("workflow/scripts/x.py") is False
+
+    def test_dynamic_fails_open(self):
+        assert h.is_relative_memory_token("$HOME/.agents/memory/x") is False
+        assert h.is_relative_memory_token("`pwd`/.agents/memory/x") is False
+
+    def test_empty(self):
+        assert h.is_relative_memory_token("") is False
+
+    def test_memory_mid_path_not_at_start(self):
+        # a token that merely contains the segment deeper in is not a root-relative ref
+        assert h.is_relative_memory_token("foo/.agents/memory/x") is False
+
+
+# --- command_has_relative_memory_ref ---
+
+
+class TestCommandScan:
+    def test_grep_relative_memory(self):
+        assert h.command_has_relative_memory_ref("grep -r foo .agents/memory/shared") == ".agents/memory/shared"
+
+    def test_absolute_memory_command_safe(self):
+        assert h.command_has_relative_memory_ref("cat /abs/.agents/memory/x") is None
+
+    def test_no_memory_ref(self):
+        assert h.command_has_relative_memory_ref("git status && ls workflow") is None
+
+    def test_quoted_token(self):
+        assert h.command_has_relative_memory_ref("cat '.claude/memory/a b.md'") == ".claude/memory/a b.md"
+
+    def test_tokenization_failure_fails_open(self):
+        assert h.command_has_relative_memory_ref("cat '.agents/memory/x") is None  # unbalanced quote
+
+
+# --- offending_ref (per tool) ---
+
+
+class TestOffendingRef:
+    def test_bash(self):
+        assert h.offending_ref("Bash", {"command": "cat .agents/memory/x"}) == ".agents/memory/x"
+
+    def test_edit_relative_filepath(self):
+        assert h.offending_ref("Edit", {"file_path": ".agents/memory/x"}) == ".agents/memory/x"
+
+    def test_edit_absolute_filepath_safe(self):
+        assert h.offending_ref("Edit", {"file_path": "/abs/.agents/memory/x"}) is None
+
+    def test_write_relative(self):
+        assert h.offending_ref("Write", {"file_path": ".claude/memory/x"}) == ".claude/memory/x"
+
+    def test_unknown_tool(self):
+        assert h.offending_ref("Read", {"file_path": ".agents/memory/x"}) is None
+
+
+# --- is_allowed ---
+
+
+class TestIsAllowed:
+    def test_set(self):
+        assert h.is_allowed({"CLAUDE_ALLOW_CWD_DRIFT": "1"}) is True
+        assert h.is_allowed({"CLAUDE_ALLOW_CWD_DRIFT": "true"}) is True
+
+    def test_unset(self):
+        assert h.is_allowed({}) is False
+        assert h.is_allowed({"CLAUDE_ALLOW_CWD_DRIFT": "0"}) is False
+
+
+# --- end-to-end via stdin (uses the real project root) ---
+
+
+def _run(payload: dict, env=None):
+    return subprocess.run(
+        [sys.executable, str(HOOK)],
+        input=json.dumps(payload),
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+def _bash(cmd: str, cwd: str) -> dict:
+    return {"tool_name": "Bash", "tool_input": {"command": cmd}, "cwd": cwd}
+
+
+DRIFTED = "/private/tmp/claude-scratch"
+
+
+class TestEndToEnd:
+    def test_drift_plus_relative_memory_denied(self):
+        proc = _run(_bash("grep foo .agents/memory/shared/MEMORY.md", DRIFTED))
+        assert proc.returncode == 0
+        out = json.loads(proc.stdout)
+        assert out["hookSpecificOutput"]["permissionDecision"] == "deny"
+
+    def test_drift_plus_absolute_memory_allowed(self):
+        assert _run(_bash(f"grep foo {REAL_ROOT}/.agents/memory/x", DRIFTED)).stdout.strip() == ""
+
+    def test_drift_plus_non_memory_allowed(self):
+        assert _run(_bash("ls workflow", DRIFTED)).stdout.strip() == ""
+
+    def test_no_drift_plus_relative_memory_allowed(self):
+        assert _run(_bash("grep foo .agents/memory/x", REAL_ROOT)).stdout.strip() == ""
+
+    def test_edit_relative_memory_from_drift_denied(self):
+        payload = {"tool_name": "Edit", "tool_input": {"file_path": ".agents/memory/x"}, "cwd": DRIFTED}
+        out = json.loads(_run(payload).stdout)
+        assert out["hookSpecificOutput"]["permissionDecision"] == "deny"
+
+    def test_escape_hatch(self):
+        env = dict(os.environ, CLAUDE_ALLOW_CWD_DRIFT="1")
+        assert _run(_bash("cat .agents/memory/x", DRIFTED), env=env).stdout.strip() == ""
+
+    def test_missing_cwd_fails_open(self):
+        payload = {"tool_name": "Bash", "tool_input": {"command": "cat .agents/memory/x"}}
+        assert _run(payload).stdout.strip() == ""
+
+    def test_bad_json_fails_open(self):
+        proc = subprocess.run(
+            [sys.executable, str(HOOK)], input="not json", capture_output=True, text=True
+        )
+        assert proc.returncode == 0
+        assert proc.stdout.strip() == ""
+
+    def test_non_guarded_tool_ignored(self):
+        payload = {"tool_name": "Read", "tool_input": {"file_path": ".agents/memory/x"}, "cwd": DRIFTED}
+        assert _run(payload).stdout.strip() == ""
+
+
+def test_hook_is_executable():
+    # The harness execs the hook by bare path; a non-executable file EACCESes
+    # before the shebang (the blocker caught on PR #1029 / lesson #1032).
+    assert os.access(HOOK, os.X_OK), f"{HOOK} must be committed executable (100755)"


### PR DESCRIPTION
**Created by:** Developer

Closes #1053.

## Premise audit first (AC#1)
Auditing the 3 recorded drift incidents pinned the failure shape the issue left open:
- The recurring shape is **persisted cwd drift**, not wrong-clone memory writes - that dangerous class has **never actually fired** (the 2026-07-04 PM episode's own realpath check confirmed writes landed in the right clone).
- The existing `check_no_cd_outside_cwd` hook (PR #1029) **deliberately allows** `cd` into `/private/tmp` (the scratchpad) - exactly the door the drift walks through - so it does not cover this.
- Surfaced to the user that this narrowly misses our "mechanism only after the specific defect recurs" bar; user chose to **build the narrow guard as cheap insurance**.

Full audit: [issue comment](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1053#issuecomment-4916799894) + design spec `docs/superpowers/specs/2026-07-08-memory-path-cwd-drift-guard-design.md`.

## What this does
New PreToolUse hook `check_memory_path_cwd_drift.py`. **Denies** a `Bash`/`Edit`/`MultiEdit`/`Write` iff **both**: (a) session `cwd` (from hook JSON) resolves **outside the clone subtree**, and (b) the tool uses a **relative** `.agents/memory` or `.claude/memory` path. Absolute memory paths and an in-clone cwd pass untouched. Fails open on unresolvable cwd / dynamic paths (`$VAR`, backticks) / parse misses. Escape hatch `CLAUDE_ALLOW_CWD_DRIFT=1`; logs to `.agents/hook_fires.jsonl`. Wired on the `Bash` and `Edit|MultiEdit|Write` matchers.

Best-practice grounded (web cross-checked): persistent-shell harnesses accept cwd drift as a known tradeoff and mitigate by preferring absolute paths / `git -C` and making drift **loud**; this guard makes the one high-harm drift moment loud.

## Companion PR (AC#4)
The transient stopgap bullet lives in the **personas repo** (`pm/MEMORY.md`), so it's stripped in a forward-linked companion PR: Jin-HoMLee/claude-personas-splice-neoepitope-pipeline#126 - **merge alongside this PR**.

## Test plan
- [x] 37 unit + e2e tests (`tools/ci/test_check_memory_path_cwd_drift.py`): drift+relative-memory (deny), drift+absolute (allow), drift+non-memory (allow), no-drift+relative (allow), each tool type, escape hatch, fail-open, fire-log shape, exec-bit assertion
- [x] Full `tools/ci/` suite green (683 passed)
- [x] Live-fire probe: denies on drift, silent when clean, fire logged, ran by bare path (exec bit)
- [x] Hook committed executable (100755)