### PR TITLE
fix(pm): rewire the coordination scan board-wide + rename to /inbox (#1114)

### DIFF
--- a/.agents/commands/coordination.md
+++ b/.agents/commands/coordination.md
@@ -1,8 +1,0 @@
-Scan the two team-coordination channels and surface anything addressed to or relevant to your role; confirm with the user before acting on any request.
-
-1. **Board pings** — comments `**To:** <your role>` on your `role:*` Issues + recent comment activity, across **all open statuses** (a ping can land on a Backlog / Ready / No-Status Issue, not just active work): `python3 scripts/board_open_items.py --role <role> --sort-updated` (most-recent activity first; the Status column shows per row). Closed/Done items are excluded as resolved.
-2. **Open Discussions** — Team Coordination category (open = needs attention):
-   `gh api graphql -f query='{ repository(owner:"Jin-HoMLee", name:"splice-neoepitope-pipeline"){ discussions(first:30, categoryId:"DIC_kwDORwn9EM4C-Jo6", states:[OPEN]){ totalCount nodes{ number title author{login} } } } }'`
-   <!-- NOTE: first:30 is unpaginated — fine at 4-role scale, but add a hasNextPage/after cursor loop if open threads ever exceed 30 (totalCount surfaces the count to check). -->
-
-Bring any pending item to the user, summarize what it asks, and act only after confirmation. Close a Discussion / board thread when its ask is satisfied (open = live). Full protocol: `shared/feedback_team_coordination.md`.

--- a/.agents/commands/inbox.md
+++ b/.agents/commands/inbox.md
@@ -33,6 +33,11 @@ Two foot-guns, each of which broke this hand-rolled scan on 2026-06-29:
 1. The shell is **zsh**, which does **not** word-split an unquoted `$nums`. Use a `while read -r n` pipe, **never** `for n in $nums` (it iterates once over the whole blob).
 2. Match with jq `contains("To:** <Role>")` (literal substring), **not** a `test()` regex - the `\*` / `\b` escaping silently matches nothing.
 
+**The fallback is a strictly weaker net than the helper. Prefer the helper whenever it runs.** Two known gaps, both of which lose exactly the cross-role pings this command exists to catch:
+
+- **Only the first-listed addressee matches.** `contains("To:** PM")` is a raw substring, so `**To:** Scientist, PM` does **not** match PM (the text after the marker is ` Scientist, PM`). The helper's `_word_bounded` flattens punctuation and matches whole words, so it catches every recipient in a multi-addressee field.
+- **Issues only, no PRs.** `gh issue list` does not return PRs, so a `To:` ping on a PR comment is invisible here. The helper's `recently_updated()` makes a second `gh pr list` call precisely to cover them.
+
 ## 2. Open Discussions - Team Coordination category
 
 Open means it still needs attention.

--- a/.agents/commands/inbox.md
+++ b/.agents/commands/inbox.md
@@ -1,0 +1,43 @@
+Answer one question: **is anyone waiting on me?** Scan the two team-coordination channels, report what each one covered, and surface anything addressed to or relevant to your role. Confirm with the user before acting on any request.
+
+This is the single definition of the coordination scan. The morning routine (Beat 2) and the resume routine both delegate here - do not restate these mechanics in memory files, or the copies drift (they already did once: see the last section).
+
+## 1. Board pings - board-wide, NOT role-scoped
+
+A comment addressed `**To:** <your role>` can land on **any** Issue regardless of its `role:*` label (a Developer replies `To: PM` on a `role:developer` Issue). Scanning only your own `role:*` Issues therefore **structurally misses every cross-role ping**.
+
+```bash
+python3 scripts/pm/scan_addressed_comments.py --role <pm|scientist|developer|memory_manager>
+```
+
+It reads the session watermark itself (1-day overlap, 7-day floor when the marker is absent), scans board-wide, and prints pings grouped by Issue with author, timestamp, and snippet. A named `To:` addressee **acks on arrival**.
+
+Do **not** substitute `board_open_items.py --role <role>` here. That is the role-scoped scan this command used until [Issue #1114](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1114); it silently drops cross-role pings.
+
+## 2. Open Discussions - Team Coordination category
+
+Open means it still needs attention.
+
+```bash
+gh api graphql -f query='{ repository(owner:"Jin-HoMLee", name:"splice-neoepitope-pipeline"){ discussions(first:30, categoryId:"DIC_kwDORwn9EM4C-Jo6", states:[OPEN]){ totalCount nodes{ number title author{login} } } } }'
+```
+
+<!-- first:30 is unpaginated - fine at 4-role scale. Check totalCount; add a hasNextPage/after cursor loop if open threads ever exceed 30. -->
+
+## 3. Report coverage on every run - including when empty
+
+State what was actually scanned, so each run re-teaches its own scope:
+
+```
+Inbox: board pings (board-wide, since <floor>): N - open Discussions: N
+```
+
+An empty inbox is a result worth printing. Silence is indistinguishable from a scan that never ran.
+
+## Then
+
+Bring any pending item to the user, summarize what it asks, and act only after confirmation. Close a Discussion / board thread once its ask is satisfied (open = live). Full protocol: `shared/feedback_team_coordination.md`.
+
+## Why the board-wide scan is load-bearing
+
+`scan_addressed_comments.py` ([Issue #901](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/901)) landed board-wide precisely because the role-scoped scan had already lost a real ping: PM missed a Developer's `To: PM` reply on `role:developer` [Issue #887](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/887) (2026-06-29). The morning routine adopted the helper; this command was left on the old scan for three weeks and kept losing cross-role pings until [Issue #1114](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1114). One scan, one definition - that is what keeps this from happening a third time.

--- a/.agents/commands/inbox.md
+++ b/.agents/commands/inbox.md
@@ -14,6 +14,25 @@ It reads the session watermark itself (1-day overlap, 7-day floor when the marke
 
 Do **not** substitute `board_open_items.py --role <role>` here. That is the role-scoped scan this command used until [Issue #1114](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1114); it silently drops cross-role pings.
 
+### Fallback, only if the helper is unavailable
+
+Windowed by the last-session watermark ([Issue #886](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/886)), with a conservative 7-day floor when the marker is absent:
+
+```bash
+gh issue list --repo Jin-HoMLee/splice-neoepitope-pipeline --state all --search "updated:>=<floor>" --limit 80 --json number --jq '.[].number' \
+| while read -r n; do
+    gh issue view "$n" --repo Jin-HoMLee/splice-neoepitope-pipeline --json number,comments --jq '
+      .number as $n | .comments[] | select(.createdAt >= "<floor>T00:00:00Z")
+      | select(.body | contains("To:** <Role>"))
+      | "#\($n)  [\(.author.login) \(.createdAt[0:16])]  \(.body | gsub("\n";" ") | .[0:70])"'
+  done
+```
+
+Two foot-guns, each of which broke this hand-rolled scan on 2026-06-29:
+
+1. The shell is **zsh**, which does **not** word-split an unquoted `$nums`. Use a `while read -r n` pipe, **never** `for n in $nums` (it iterates once over the whole blob).
+2. Match with jq `contains("To:** <Role>")` (literal substring), **not** a `test()` regex - the `\*` / `\b` escaping silently matches nothing.
+
 ## 2. Open Discussions - Team Coordination category
 
 Open means it still needs attention.

--- a/.agents/skills/inbox/SKILL.md
+++ b/.agents/skills/inbox/SKILL.md
@@ -1,3 +1,10 @@
+---
+name: inbox
+description: Use to answer "is anyone waiting on me?" - the team-coordination scan. Scans both channels (board-wide `**To:** <role>` pings via scan_addressed_comments.py, plus open Team Coordination Discussions), reports what each covered, and surfaces anything addressed to your role. Run it at any session start, on a resume greeting, as morning-routine Beat 2, and whenever asked to "check my inbox", "check for pings", "is anything waiting on me", "any coordination items", "anything addressed to me", "check messages". This is the single definition of that scan - the morning and resume routines both delegate here rather than restating it.
+---
+
+# inbox
+
 Answer one question: **is anyone waiting on me?** Scan the two team-coordination channels, report what each one covered, and surface anything addressed to or relevant to your role. Confirm with the user before acting on any request.
 
 This is the single definition of the coordination scan. The morning routine (Beat 2) and the resume routine both delegate here - do not restate these mechanics in memory files, or the copies drift (they already did once: see the last section).

--- a/docs/superpowers/specs/2026-07-04-resume-routine-design.md
+++ b/docs/superpowers/specs/2026-07-04-resume-routine-design.md
@@ -5,6 +5,8 @@
 **Status:** Draft (for review)
 **Scope:** Shared (all roles: PM / Scientist / Developer / Memory Manager)
 
+> **Amendment 2026-07-11 ([Issue #1114](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1114)).** The `/coordination` command this spec names (items 4 and 5.2, section 6) has been **renamed to `/inbox`** and its ping scan rewired board-wide; the old command's role-scoped scan was structurally blind to cross-role pings. Read every `/coordination` below as `/inbox`. The design itself is unchanged - only the command's name and the correctness of its step-4 scan. The body is left as written, per the convention that a dated spec is a point-in-time record rather than a living document.
+
 ## 1. Problem
 
 A session opened with *"Good morning!"* reliably triggers the full morning routine - that habit works.

--- a/research/lab_notebook/pm.md
+++ b/research/lab_notebook/pm.md
@@ -8,6 +8,22 @@ Format and rules unchanged from the unified notebook — see `shared/feedback_la
 
 ## 2026-07-11
 
+### 13:55 UTC - Editor: PM
+
+#### Scope addition: `/inbox` command -> Agent Skill (vendor-agnosticism), [PR #1115](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/1115)
+
+Jin-Ho asked whether skills or commands are more vendor-agnostic. Web-verified against the primary source rather than answered from memory, and the answer was decisive enough to change the PR.
+
+**Finding.** `.claude/commands/*.md` is a **Claude-Code-proprietary** format (Claude Code's own docs: custom commands have been *"merged into skills"*). The **Agent Skills** format (`SKILL.md`) is an [open standard](https://agentskills.io) - verbatim, *"originally developed by Anthropic, released as an open standard"* - implemented by ~45 agents including OpenAI Codex, Gemini CLI, Cursor, GitHub Copilot, VS Code, OpenCode, Goose. Deliberately did **not** repeat the governance/adoption-timeline claims a web search surfaced (Linux Foundation stewardship, marketplace sizes): those came from secondary blogs I never fetched, and a search digest is zero sources.
+
+**Why it was load-bearing, not cosmetic.** Jin-Ho's global `CLAUDE.md` already instructs **Codex/OpenCode** to read the memory index, so both are *live* harnesses against these repos. As a command, `/inbox` would not exist in either - and with it, the entire board-wide-not-role-scoped discipline this PR exists to encode. `scan_addressed_comments.py` would still run; the rule around it would be invisible. **Encoding a hard-won correctness lesson in a single-vendor format is how you lose it a second time.** It also squared the last inconsistency with the [`.claude` -> `.agents` migration](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/861), itself a vendor-neutrality move. Repo now: **3 skills, 0 commands.**
+
+**It fixed the original complaint as a side effect.** A command's auto-invoke description is the *truncated first line of the file*. A skill has a real `description` field - so `/inbox` now advertises its actual trigger phrases ("check my inbox", "is anything waiting on me"). The harness re-registered it live with the full description the moment the frontmatter landed. The thing Jin-Ho could not remember now announces what it is for.
+
+**Naming: declined `github-inbox`** when asked. Reasons, in order of weight: (1) it names the *transport*, not the question - the same drift that made `/standup` and `/coordination` both fail at recall; (2) it disambiguates against nothing (there is exactly one inbox) - YAGNI; (3) a transport prefix quietly pre-authorizes `slack-inbox`/`email-inbox` siblings, i.e. one question with N implementations - **the exact shape of the bug this PR just killed.** If a channel is ever added, *widen the one inbox*. Division of labour: **the name carries the question, the description carries the medium** (and auto-invocation matches on the description anyway).
+
+**Second review: clean, mergeable.** Two takes: (a) the last live surface still calling the skill by its retired name (`dispatch_digest.py:38`, "the coordination skill") - fixed; (b) **my PR body was wrong** that the empty `.agents/commands/` dir was "left in place". Checked both layers because they disagreed: it is **absent from the git tree** (git cannot track an empty dir) and therefore gone for every other clone - what I saw was an empty husk on my local disk only. Corrected the body and `rmdir`'d it. That is twice in one PR that the reviewer caught me asserting a property of git instead of running the command (cf. the `git mv --follow` claim in the 13:30 entry). **The pattern is mine, not git's: I narrate tool behavior from expectation.**
+
 ### 13:30 UTC - Editor: PM
 
 #### A naming question turned out to be a blind coordination scan ([Issue #1114](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1114) / [PR #1115](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/1115))

--- a/research/lab_notebook/pm.md
+++ b/research/lab_notebook/pm.md
@@ -6,6 +6,47 @@ Format and rules unchanged from the unified notebook — see `shared/feedback_la
 
 ---
 
+## 2026-07-11
+
+### 13:30 UTC - Editor: PM
+
+#### A naming question turned out to be a blind coordination scan ([Issue #1114](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1114) / [PR #1115](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/1115))
+
+**What was asked.** Jin-Ho asked whether `/coordination` should be renamed, or modularized into smaller skills, because he could never remember what it did at session start.
+
+**Both proposals were wrong, and the second was actively wrong.** The command was 8 lines and 2 steps: there was nothing hidden inside to modularize, and splitting it would have added a *second* name to remember - worsening the exact complaint. Declining the user's own framing was the right call and it is what surfaced the real defect.
+
+**The real defect.** `/coordination` scanned board pings **role-scoped** (`board_open_items.py --role <role>`). A `**To:** <role>` comment lands on *any* Issue regardless of its `role:*` label, so the command could not see a cross-role ping *even in principle*. Measured on the live board: all six Issues carrying `To: PM` pings in the 7-day window (#547, #626, #665, #679, #1017, #1086) are labelled `role:scientist` or `role:developer` and **not one carries `role:pm`**. Miss rate on cross-role pings: **100%**. It was blind, not degraded.
+
+**Reproduced on myself.** I ran `/coordination` at session start and told Jin-Ho nothing was waiting on him. It held only because those six pings happened to be settled acks - luck, not correctness.
+
+**How it rotted - the transferable lesson.** `scan_addressed_comments.py` ([#901](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/901)) landed board-wide on 2026-07-04 *precisely* to fix this, after a real ping was lost on [#887](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/887). The morning routine adopted it. The command did not. **One scan, two implementations, one fix.** The duplication was in *prose* (memory files restating mechanics a command already owned), and prose duplication has no test to catch drift. `/inbox` is now the single definition and both routines delegate to it; the fix is the consolidation, not the rename.
+
+**Rename treated as cosmetic, on evidence.** `/coordination` was *already* a rename (`/standup` -> `/coordination`, [#740](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/740), 2026-06-13) and it still failed at recall. So a rename has demonstrably failed at this job once. `/inbox` names the *question* ("is anyone waiting on me?") rather than the domain, which is a different class of name - but I shipped it as a nicety and the structural fixes as the remedy.
+
+#### The bigger find: the resume routine has never fired ([Issue #1026](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1026))
+
+Jin-Ho's greeting was *"Hey :) let's continue"* - a **documented trigger** of `shared/feedback_resume_routine.md`, which I authored on 2026-07-04. It did not fire. I improvised instead.
+
+**Root cause (verified, not inferred).** The session-memory dir is a **symlink** to personas `pm/`, and `pm/MEMORY.md` is the same inode as the file injected into context. `shared/MEMORY.md` is reachable **only via a link** and is *never auto-loaded*. The greeting selector lived at `shared/MEMORY.md:50`; the *morning* trigger had been **inlined** into each role's always-loaded block. So "good morning" fires and "let's continue" reaches an agent that has never read the rule telling it to do anything. Chicken-and-egg: knowing to run the routine requires having read the file that is not loaded.
+
+**This is the mechanism-over-memory ladder failing at rung 0:** the rule was written at a tier that does not load. A rule's *tier* is part of its correctness, not a filing detail. #1026's first two ACs were already satisfied on disk; the one that failed was the behavioral one ("greeting classification routes correctly") - which is exactly why an AC should gate the behavior and not its documentation (`feedback_ac_gates_intent_not_proxy.md`, again).
+
+**Fix:** widened the existing "on good morning" bullet into a greeting *selector* in `pm|scientist|developer/MEMORY.md` - **widened, not added**, so the always-loaded rule count stays flat and does not cross the ~14-rule adherence cliff MM's own memory documents. MM excluded deliberately: it has no morning routine to mis-fire into, and already sits at 16 rules. Personas edits authored + left uncommitted for MM, per convention.
+
+#### Review + process notes
+
+Bot review: **LGTM, mergeable**, 4 minor findings, **all four verified against source before acting** and all four held.
+
+- Claimed `git mv` preserved history. **It does not** - `git log --follow` stops at this PR (8 to 62 lines is under the rename-similarity threshold). Claim **withdrawn** in the PR body rather than quietly dropped. I asserted a property of the tool instead of running it.
+- The hand-rolled fallback I *moved verbatim* carries a milder version of the same bug: `contains("To:** PM")` MISSES `**To:** Scientist, PM` (verified by running the predicate), and `gh issue list` returns no PRs. Both lose cross-role pings. **I moved that prose without auditing it** - the same reflex that caused the original drift. Now labelled a strictly weaker net with both gaps named.
+
+**Caught by my own guards, twice:** the no-`cd` hook blocked an out-of-tree `cd`, and the commit/push chain guard blocked a chained `git commit && git push`. Both fired correctly.
+
+**Footgun re-confirmed:** `new_branch.sh` wraps `gh issue develop`, whose dev-link auto-populates `closingIssuesReferences` - so #1115 **will** auto-close #1114 despite a body saying "Refs". I had written the body claiming otherwise; corrected. Here the coupling is *right* (the closure gate now forces MM's memory commit to land before merge), but the rule from `feedback_gh_develop_nonclosing_followup.md` holds: the body cannot make a dev-linked PR non-closing.
+
+**Flagged to Jin-Ho:** [#1092](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1092) (lab-notebook gate keys on *today's* UTC date, while entry-timing writes the entry post-review/pre-merge) is now false-blocking **three** PRs at the merge gate ([#1109](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/1109), [#1093](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/1093), and this one if held overnight). Its own priority rationale says "not expedite-class" - written when it had bitten once. I argued for a bump and said so explicitly rather than restating my read as fact.
+
 ## 2026-07-10
 
 ### 15:50 UTC - Editor: PM

--- a/scripts/pm/dispatch_digest.py
+++ b/scripts/pm/dispatch_digest.py
@@ -35,7 +35,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 import board_open_items as boi  # noqa: E402
 
 # The Team Coordination Discussions category on the project repo (constant id -
-# same one used in shared/feedback_team_coordination.md / the coordination skill).
+# same one used in shared/feedback_team_coordination.md / the /inbox skill).
 DISCUSSION_CATEGORY_ID = "DIC_kwDORwn9EM4C-Jo6"
 DISCUSSION_REPO_OWNER = "Jin-HoMLee"
 DISCUSSION_REPO_NAME = "splice-neoepitope-pipeline"


### PR DESCRIPTION
Closes [Issue #1114](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1114).

> **Merge prerequisite - read this first.** This branch was cut with `scripts/new_branch.sh`, which wraps `gh issue develop`; that Development-panel link auto-populates `closingIssuesReferences`, so this PR **will auto-close #1114 on merge** whether or not the body says "Refs". (An earlier draft of this body claimed it was non-closing. That was wrong - the dev-link overrides the body wording. See `feedback_gh_develop_nonclosing_followup.md`.)
> 
> Two of #1114's five ACs land in the **personas repo** (the memory wiring, committed by MM), not here. So the closure gate will - correctly - **refuse to merge this PR until MM has committed those edits** and all five ACs are ticked. That is the intended coupling, not an obstacle: it stops #1114 closing with its memory-wiring half undone. **MM's commit is a merge prerequisite for this PR.**

## What was broken

`/coordination` scanned board pings **role-scoped**:

```
python3 scripts/board_open_items.py --role <role> --sort-updated
```

A comment addressed `**To:** <role>` lands on **any** Issue regardless of its `role:*` label, so this could not see a cross-role ping even in principle.

## Evidence it was blind, not merely degraded

All six Issues carrying a `To: PM` ping in the current 7-day window:

| Issue | `role:` labels | Visible to the old scan? |
|---|---|---|
| #547 | `role:scientist`, `role:developer` | no |
| #626 | `role:developer` | no |
| #665 | `role:developer` | no |
| #679 | `role:scientist` | no |
| #1017 | `role:developer` | no |
| #1086 | `role:scientist` | no |

**Not one carries `role:pm`.** The miss rate on cross-role pings in that window was 100%. (Those particular pings were settled acks, so nothing was actually dropped - it held by luck, not by the scan being correct.)

Reproduced live this session: `/coordination` was run at session start and reported nothing addressed to PM.

## How it rotted

- **2026-06-13** ([#740](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/740) / [PR #741](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/741)) - `/standup` renamed to `/coordination`; the `board_open_items.py --role` scan baked in.
- **2026-06-29** - the blind spot bites for real (PM misses a Developer's `To: PM` reply on `role:developer` [#887](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/887)) and is documented in `shared/feedback_morning_routine.md`.
- **2026-07-04** ([#901](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/901) / [PR #1011](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/1011)) - `scan_addressed_comments.py` lands board-wide. **The morning routine adopts it. The command does not.**

One scan, two implementations, one fix. The prose duplication is the root cause, not the scan itself.

## Changes

- **Board-wide ping scan** via `scan_addressed_comments.py --role <role>`. The role-scoped scan is gone, with an explicit "do not substitute it back" note.
- **Coverage printed on every run**, including empty ones (`Inbox: board pings (board-wide, since <floor>): N - open Discussions: N`). An empty inbox is a result; silence is indistinguishable from a scan that never ran. This is the visibility gap that prompted the review.
- **Renamed `/coordination` to `/inbox`** - it names the question ("is anyone waiting on me?") rather than the domain. Tracked via `git mv`, so history follows.
- **Declared the single definition.** The hand-rolled fallback scan and its two zsh/jq foot-guns moved *into* the command from `shared/feedback_morning_routine.md`, so no knowledge is lost and the routines can delegate rather than restate.

## Companion personas-repo edits (authored, uncommitted, for MM)

Not in this PR (different repo; MM commits memory):

- `shared/feedback_morning_routine.md` - Beat 2 collapses to "run `/inbox`", mechanics removed.
- `shared/feedback_resume_routine.md` - item 4 delegates to `/inbox`.
- `shared/MEMORY.md` - index line repointed.
- `pm|scientist|developer/MEMORY.md` - the existing "on good morning" bullet is **widened into a greeting selector** so a resume greeting routes to the resume routine. This is the root cause of [#1026](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1026)'s failing AC: the selector lived only in `shared/MEMORY.md`, which is **not auto-loaded** (verified: the session-memory dir is a symlink to personas `pm/`, and only `pm/MEMORY.md` is injected), while the morning trigger *was* inlined. So "good morning" fired and "let's continue" silently ran nothing. Widening the existing bullet rather than adding one keeps the rule count flat, respecting the ~14-rule always-loaded cliff.
- **Memory Manager is deliberately out of scope** for the selector: MM has no morning routine to mis-fire into, and its Always-in-effect already sits at 16 rules, past that cliff. MM can opt in if wanted.

## Scope addition: `/inbox` is now an Agent Skill, not a command

Folded in mid-PR at Jin-Ho's request, after a vendor-agnosticism question.

`.claude/commands/*.md` is a **Claude-Code-proprietary** format; Claude Code's own docs say custom commands have been *"merged into skills"*. The **Agent Skills** format (`SKILL.md`) is an [open standard](https://agentskills.io) - *"originally developed by Anthropic, released as an open standard"* - implemented by ~45 agents including **OpenAI Codex, Gemini CLI, Cursor, GitHub Copilot, VS Code, OpenCode, Goose, Amp, Kiro**.

**Why it is load-bearing here, not cosmetic:** Jin-Ho's global `CLAUDE.md` already instructs **Codex/OpenCode** to read the memory index, so both are live harnesses against these repos. As a command, `/inbox` would not exist in either - and with it, the entire *board-wide, not role-scoped* procedure this PR exists to encode. `scan_addressed_comments.py` would still run; the discipline around it would be invisible. Encoding a hard-won correctness lesson in a single-vendor format is how you lose it again.

It also squares the last inconsistency with the [`.claude` -> `.agents` migration](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/861) (itself a vendor-neutrality move): the repo now carries **zero commands and three skills**.

- `git mv .agents/commands/inbox.md .agents/skills/inbox/SKILL.md`. **`.agents/commands/` is gone from the git tree entirely** (git does not track empty directories, and that was its last file), so every other clone simply stops having it. An earlier draft of this body said the dir was "left in place" - wrong: that was an empty husk lingering on my local disk only, since removed.
- Added `name` + `description` frontmatter in the house style (purpose + explicit trigger phrases), matching `awaiting-bot-review` / `quick-win-burndown`.
- `/inbox` invocation is unchanged, so every memory reference stays valid.
- **Discoverability improves as a side effect** - which was the user's original complaint. Auto-invocation now matches the real `description` field rather than the truncated first line of the file, which is all a command gets.

## Test plan

- [x] `scan_addressed_comments.py --role pm --days 7` surfaces the six cross-role pings the old scan could not see.
- [x] Verified all six carry no `role:pm` label, so the old scan's blindness is structural, not incidental.
- [x] Command exercised end-to-end: both channels run, coverage line renders (`board pings (board-wide, since 2026-07-10): 0 - open Discussions: 2`; watermark-windowed, so 0 is correct - those pings predate the marker).
- [x] No live `/coordination` reference remains in either repo (historical records - lab notebook, milestone reports, past specs - deliberately left untouched).
- [x] ~~`git mv` used, so the rename is tracked rather than an add/delete pair.~~ **Corrected (bot review, finding 1):** this is false. `git log --follow .agents/commands/inbox.md` stops at this PR's commits and does not trace into `coordination.md` - the file went 8 to 62 lines, so it falls under git's rename-similarity threshold and the diff genuinely is an add/delete pair. The old history remains under the old path. Claim withdrawn rather than quietly dropped.


**Created by:** PM




