### PR TITLE
fix(pm): SDR trend buckets lose issues at the span edges; align window grid to whole UTC days (#1099)

### DIFF
--- a/research/lab_notebook/pm.md
+++ b/research/lab_notebook/pm.md
@@ -8,6 +8,38 @@ Format and rules unchanged from the unified notebook — see `shared/feedback_la
 
 ## 2026-07-11
 
+### 21:30 UTC - Editor: PM
+
+#### The SDR trend bug was real, but the Issue I filed about it was wrong ([Issue #1099](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1099) / [PR #1128](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/1128))
+
+**The headline finding is not the fix. It is that my own measurement was more wrong than the code I filed it against.**
+
+[#1099](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1099) reported the weekly-SDR trend under-counting history against a "direct count" reference (9/7/19/68 vs 10/13/28/68), and argued the skew would corrupt the WIP-limit retune the SDR is supposed to inform. AC1 - deliberately - asked whoever picked it up to **discriminate displacement from loss before fixing**. That instruction is the only reason this landed correctly.
+
+**The reference was the broken instrument.** I had built it by querying `closed:A..B` per week with consecutive weeks sharing a boundary day. GitHub's `closed:` range is **inclusive on both endpoints**, so every boundary day was counted twice. Proof, not inference: [Issue #798](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/798) (closed 06-19T22:29) is returned by *both* `closed:2026-06-12..2026-06-19` and `closed:2026-06-19..2026-06-26`.
+
+| Series | Weeks | Sum |
+|---|---|---|
+| My "direct count" (overlapping, inflated) | 10 / 13 / 28 / 68 | 119 |
+| True disjoint day-granular count | 6 / 12 / 22 / 61 | 101 |
+| Old script | 8 / 10 / 19 / 65 | 102 |
+| Fixed script | **6 / 12 / 22 / 61** | **101** |
+
+**The old script was already far closer to the truth than the yardstick I measured it against.** Had I done the obvious thing - "make the trend match the direct count" - I would have shipped double-counting into the governance metric. The Issue's "why it matters" section does not survive either: it claimed the trend implied a 3.5x jump where reality was a smooth ramp; the true ramp (6 to 61) is *steeper* than the buggy one.
+
+**A real defect did exist underneath, and it is two.** (1) `_run_window_mode` normalized an explicit `--until` to end-of-day but left the live `datetime.now()` path mid-day, so every bucket edge sat at a time-of-day the day-granular source data cannot resolve. (2) Buckets are half-open at the start, so the `span_start` edge is the *last instant* of its day and that whole day belongs to no bucket - yet the fetch started at `span_start.date()`, pulling a day nothing could count. Pinned by a **matched-pair control**: flipping only the fetch-span rule, the old drops exactly 24 hourly synthetic issues, the new drops 0. Both could not have passed.
+
+**What I make of it.** This is the day's rule - *a check must be able to fail* - biting on its author, twice more, inside the very session that promoted it:
+
+- The `closed:A..B` reference: I never asked whether my measuring stick could be the thing that was wrong.
+- Then, in the fix itself, I wrote "milestone_report.py has **zero** test coverage" - from a grep scoped to `workflow/tests/` and `scripts/`. The suite lives in `tools/ci/` (**39 tests**, already covering `week_windows`/`closed_in_window`/`weekly_series`). A search that could not have found it can only ever confirm what I already believed. The bot caught it by casually citing the file.
+
+Sightings **7** and **8**, both today, both after writing the rule down. That settles the open question from this morning's episode: **the memory rule does not bite at claim time.** It fires at reflection, which is too late - the claim is already in a commit message, a PR body, an Issue comment. The escalation signal is met; the next move is a mechanism, not a ninth bullet. Candidate shape: assert against `HEAD`/the real search space, never the convenient sample.
+
+**Ship state.** Bot review: no blocking findings, boundary math independently traced, conservation test confirmed a genuine regression lock. 3 of 4 polish items taken (shared `_first_covered_day`, a naive-datetime **raise** on `normalize_until`, help-text); declined deduping a pure list-comp. Full suite **746 passed, 0 failed**; the pre-existing 39 still green. Every rendered row now returns its own number when cross-checked with the query its label implies. Corrections are on the record in the PR body (which becomes the squash commit), the Issue, and the follow-up commit - not quietly patched out.
+
+---
+
 ### 16:05 UTC - Editor: PM
 
 #### Relax one-arc-per-issue at the parent tier ([Issue #1103](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1103) / [PR #1123](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/1123))

--- a/scripts/pm/milestone_report.py
+++ b/scripts/pm/milestone_report.py
@@ -30,7 +30,7 @@ import re
 import statistics
 import subprocess
 import sys
-from datetime import datetime, timedelta, timezone
+from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Optional
 
@@ -186,10 +186,30 @@ def normalize_until(until: datetime) -> datetime:
     adjacent buckets and strands those past the final edge. Snapping the anchor to
     the day boundary makes the bucket grid agree with the granularity of the data
     it buckets. Idempotent. Issue #1099.
+
+    ``until`` must be timezone-aware. A naive datetime would be read as *local*
+    time by ``astimezone``, silently shifting every bucket edge by the host's UTC
+    offset - the exact class of bug this function exists to remove.
     """
+    if until.tzinfo is None:
+        raise ValueError(
+            "normalize_until requires a timezone-aware datetime; a naive one would "
+            "be interpreted as local time and shift every bucket edge."
+        )
     return until.astimezone(timezone.utc).replace(
         hour=23, minute=59, second=59, microsecond=999999
     )
+
+
+def _first_covered_day(span_start: datetime) -> date:
+    """The first whole day a ``(span_start, ...]`` bucket actually holds.
+
+    ``span_start`` is an **exclusive** edge sitting at the last instant of its own
+    day, so that day belongs to no bucket. Both the fetch range and the rendered
+    row label must key off the day *after* it, and they must agree - hence one
+    helper rather than the same ``+ 1 day`` written twice. Issue #1099.
+    """
+    return (span_start + timedelta(days=1)).date()
 
 
 def week_windows(until: datetime, n_weeks: int) -> list[tuple[datetime, datetime]]:
@@ -217,8 +237,7 @@ def fetch_span(until: datetime, n_weeks: int) -> tuple[str, str]:
     the fetch returns lands in exactly one bucket (conservation).
     """
     span_start = week_windows(until, n_weeks)[0][0]
-    since = (span_start + timedelta(days=1)).date()
-    return since.isoformat(), until.date().isoformat()
+    return _first_covered_day(span_start).isoformat(), until.date().isoformat()
 
 
 def closed_in_window(issues: list[dict], start: datetime, end: datetime) -> list[dict]:
@@ -252,7 +271,7 @@ def weekly_series(issues: list[dict], until: datetime, n_weeks: int) -> list[dic
     for start, end in week_windows(until, n_weeks):
         delivered = delivered_issues(closed_in_window(issues, start, end))
         series.append({
-            "week_start": (start + timedelta(days=1)).date().isoformat(),
+            "week_start": _first_covered_day(start).isoformat(),
             "week_end": end.date().isoformat(),
             "n_delivered": len(delivered),
             "median_cycle_time_days": median_cycle_time(delivered),
@@ -702,8 +721,12 @@ def main() -> int:
     ap.add_argument("--weekly", action="store_true",
                     help="force weekly SDR window mode even if a milestone arg is present")
     ap.add_argument("--since", help="SDR trend-span start (YYYY-MM-DD); sets the trend length "
-                                    "from since..until, overriding --trend-weeks")
-    ap.add_argument("--until", help="SDR window end (YYYY-MM-DD); default = today")
+                                    "from since..until, overriding --trend-weeks. Reaches back AT "
+                                    "LEAST this far, rounded outward to whole 7-day weeks, so the "
+                                    "first row may begin a few days before this date")
+    ap.add_argument("--until", help="SDR window end (YYYY-MM-DD); default = today. Anchored to the "
+                                    "end of that UTC day, matching the day-granular `closed:` search "
+                                    "the trend is sourced from")
     ap.add_argument("--trend-weeks", type=int, default=DEFAULT_TREND_WEEKS,
                     help=f"SDR trailing weeks shown in the trend (default {DEFAULT_TREND_WEEKS})")
     ap.add_argument("--out-dir", type=Path, default=None,

--- a/scripts/pm/milestone_report.py
+++ b/scripts/pm/milestone_report.py
@@ -176,6 +176,22 @@ def throughput_per_week(n_delivered: int, duration_days: Optional[float]) -> Opt
 # pure functions bucket delivered issues into trailing weeks so the report can
 # show a throughput + cycle-time TREND, not just a single-window snapshot.
 
+def normalize_until(until: datetime) -> datetime:
+    """Anchor a window end on the last instant of its UTC day.
+
+    The trend is bucketed with datetime precision but *sourced* from GitHub's
+    ``closed:A..B`` search operator, which is day-granular. A mid-day anchor (what
+    ``datetime.now()`` yields in a live run) therefore puts every bucket edge at a
+    time-of-day the source data cannot resolve, which both displaces issues into
+    adjacent buckets and strands those past the final edge. Snapping the anchor to
+    the day boundary makes the bucket grid agree with the granularity of the data
+    it buckets. Idempotent. Issue #1099.
+    """
+    return until.astimezone(timezone.utc).replace(
+        hour=23, minute=59, second=59, microsecond=999999
+    )
+
+
 def week_windows(until: datetime, n_weeks: int) -> list[tuple[datetime, datetime]]:
     """``n_weeks`` trailing 7-day ``(start, end]`` windows ending at ``until``.
 
@@ -188,6 +204,21 @@ def week_windows(until: datetime, n_weeks: int) -> list[tuple[datetime, datetime
         for i in range(max(n_weeks, 1))
     ]
     return list(reversed(windows))
+
+
+def fetch_span(until: datetime, n_weeks: int) -> tuple[str, str]:
+    """ISO date range whose whole-day coverage exactly matches ``week_windows``.
+
+    Buckets are **half-open at the start** (``(span_start, end]``), and with a
+    normalized ``until`` the ``span_start`` edge sits at the *last instant* of its
+    own day - so that day belongs to no bucket. Fetching from ``span_start.date()``
+    would pull a full day of issues that nothing can count, which is the bottom-edge
+    leak behind Issue #1099. Start the fetch the day after instead, so every issue
+    the fetch returns lands in exactly one bucket (conservation).
+    """
+    span_start = week_windows(until, n_weeks)[0][0]
+    since = (span_start + timedelta(days=1)).date()
+    return since.isoformat(), until.date().isoformat()
 
 
 def closed_in_window(issues: list[dict], start: datetime, end: datetime) -> list[dict]:
@@ -207,12 +238,21 @@ def weekly_series(issues: list[dict], until: datetime, n_weeks: int) -> list[dic
     (dates as ISO ``YYYY-MM-DD``), chronological. Throughput + cycle time key off
     *delivered* issues (a descoped close is not shipped work), consistent with
     the milestone-mode metrics.
+
+    ``week_start`` names the **first day the bucket actually covers**, not the
+    half-open ``(start`` edge - which, with a normalized ``until``, is the last
+    instant of the *preceding* day. Rendered as ``week_start..week_end`` the pair
+    reads as an inclusive day range, so it must be one: a reader who cross-checks a
+    row with ``closed:<week_start>..<week_end>`` has to get that row's number back.
+    Naming the raw edge instead put a day the bucket does not hold into the label,
+    and that mismatch is precisely what produced the bogus reference counts in
+    Issue #1099.
     """
     series = []
     for start, end in week_windows(until, n_weeks):
         delivered = delivered_issues(closed_in_window(issues, start, end))
         series.append({
-            "week_start": start.date().isoformat(),
+            "week_start": (start + timedelta(days=1)).date().isoformat(),
             "week_end": end.date().isoformat(),
             "n_delivered": len(delivered),
             "median_cycle_time_days": median_cycle_time(delivered),
@@ -610,8 +650,12 @@ def _run_window_mode(ap: argparse.ArgumentParser, since: Optional[str], until: O
                      trend_weeks: int, out_dir: Optional[Path], dry_run: bool) -> int:
     """Weekly meta-work SDR. Reporting week = the most recent 7-day window; the
     trend spans ``n_weeks`` back. Skips a reporting week with nothing closed."""
-    until_dt = (_parse_date_arg(ap, "--until", until).replace(hour=23, minute=59, second=59)
-                if until else datetime.now(timezone.utc))
+    # Normalize BOTH paths to the end of the UTC day. The explicit --until already
+    # did; the default (live `now()`) path did not, so a real run bucketed on
+    # mid-day edges the day-granular source data cannot resolve (Issue #1099).
+    until_dt = normalize_until(
+        _parse_date_arg(ap, "--until", until) if until else datetime.now(timezone.utc)
+    )
     # --since sets the TREND SPAN: derive the week count from since..until so the
     # trend actually reaches back to --since (overriding --trend-weeks). Deriving
     # a single span-start without this would only clip the fetch and could
@@ -627,7 +671,7 @@ def _run_window_mode(ap: argparse.ArgumentParser, since: Optional[str], until: O
     windows = week_windows(until_dt, n_weeks)
     report_start, report_end = windows[-1]
 
-    all_issues = fetch_window_issues(windows[0][0].date().isoformat(), until_dt.date().isoformat())
+    all_issues = fetch_window_issues(*fetch_span(until_dt, n_weeks))
     week_issues = closed_in_window(all_issues, report_start, report_end)
     metrics = compute_window_metrics(week_issues, all_issues, until_dt, n_weeks)
 

--- a/workflow/tests/test_milestone_report_windows.py
+++ b/workflow/tests/test_milestone_report_windows.py
@@ -49,6 +49,13 @@ def test_normalize_until_is_idempotent():
     assert mr.normalize_until(once) == once
 
 
+def test_normalize_until_rejects_a_naive_datetime():
+    """A naive datetime would be read as *local* time and shift every bucket edge by
+    the host's UTC offset - the same class of silent grid drift this helper removes."""
+    with pytest.raises(ValueError, match="timezone-aware"):
+        mr.normalize_until(datetime(2026, 7, 10, 14, 30, 0))
+
+
 # --- fetch_span must match what the buckets actually cover -------------------
 
 def test_fetch_span_starts_the_day_after_the_first_bucket_opens():

--- a/workflow/tests/test_milestone_report_windows.py
+++ b/workflow/tests/test_milestone_report_windows.py
@@ -1,0 +1,163 @@
+"""Window/bucket boundary semantics for scripts/pm/milestone_report.py (Issue #1099).
+
+The weekly SDR sources its data from GitHub's ``closed:A..B`` search operator, which
+is **day-granular and inclusive on both endpoints**. The trend buckets, by contrast,
+are ``(start, end]`` datetime intervals. When the two granularities disagree, issues
+fall through the gap: they are fetched but land in no bucket at all.
+
+The load-bearing property is **conservation**: every issue the fetch returns must be
+counted in exactly one bucket. A count that silently drops issues corrupts the trend
+series that CLAUDE.md designates as the input to the WIP-limit retune.
+
+Pure functions only - no network.
+"""
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+_PM_DIR = Path(__file__).resolve().parents[2] / "scripts" / "pm"
+sys.path.insert(0, str(_PM_DIR))
+
+import milestone_report as mr  # noqa: E402
+
+UTC = timezone.utc
+
+
+def _issue(number: int, closed_at: str) -> dict:
+    """A delivered (COMPLETED) closed issue, in the shape _normalize_issue emits."""
+    return {
+        "number": number,
+        "state": "CLOSED",
+        "state_reason": "COMPLETED",
+        "created_at": "2026-01-01T00:00:00Z",
+        "closed_at": closed_at,
+    }
+
+
+# --- normalize_until ---------------------------------------------------------
+
+def test_normalize_until_anchors_a_mid_day_time_to_end_of_utc_day():
+    """A live run's datetime.now() is mid-day; the data it buckets is day-granular."""
+    got = mr.normalize_until(datetime(2026, 7, 10, 14, 30, 0, tzinfo=UTC))
+    assert got == datetime(2026, 7, 10, 23, 59, 59, 999999, tzinfo=UTC)
+
+
+def test_normalize_until_is_idempotent():
+    once = mr.normalize_until(datetime(2026, 7, 10, 14, 30, 0, tzinfo=UTC))
+    assert mr.normalize_until(once) == once
+
+
+# --- fetch_span must match what the buckets actually cover -------------------
+
+def test_fetch_span_starts_the_day_after_the_first_bucket_opens():
+    """Buckets are half-open at the start: ``(span_start, ...]``.
+
+    ``span_start`` is the last instant of its own day, so that day is NOT covered by
+    any bucket. Fetching from ``span_start.date()`` therefore pulls a whole day of
+    issues that no bucket can hold - the bottom-edge leak.
+    """
+    until = mr.normalize_until(datetime(2026, 7, 10, 12, 0, 0, tzinfo=UTC))
+    since_iso, until_iso = mr.fetch_span(until, 4)
+
+    windows = mr.week_windows(until, 4)
+    span_start = windows[0][0]
+
+    assert since_iso == (span_start + timedelta(days=1)).date().isoformat()
+    assert since_iso == "2026-06-13"        # NOT 2026-06-12
+    assert until_iso == "2026-07-10"
+
+
+# --- the load-bearing property: conservation ---------------------------------
+
+@pytest.mark.parametrize("n_weeks", [1, 4, 6])
+def test_every_fetched_issue_lands_in_exactly_one_bucket(n_weeks):
+    """Conservation. Synthesize an issue closed at *every hour* of the fetch span and
+    assert each is bucketed exactly once.
+
+    This is the regression lock for Issue #1099: before the fix, issues closed on the
+    fetch's first day (and, on a mid-day anchor, after the last bucket's edge) were
+    returned by the fetch and counted by nothing.
+    """
+    until = mr.normalize_until(datetime(2026, 7, 10, 14, 30, 0, tzinfo=UTC))
+    windows = mr.week_windows(until, n_weeks)
+    since_iso, until_iso = mr.fetch_span(until, n_weeks)
+
+    # Every hour the day-granular fetch `closed:since..until` would return.
+    start = datetime.fromisoformat(since_iso).replace(tzinfo=UTC)
+    end = datetime.fromisoformat(until_iso).replace(hour=23, minute=59, second=59, tzinfo=UTC)
+    issues, t, n = [], start, 0
+    while t <= end:
+        issues.append(_issue(n, t.strftime("%Y-%m-%dT%H:%M:%SZ")))
+        t += timedelta(hours=1)
+        n += 1
+
+    hits = {i["number"]: 0 for i in issues}
+    for w_start, w_end in windows:
+        for i in mr.closed_in_window(issues, w_start, w_end):
+            hits[i["number"]] += 1
+
+    dropped = [n for n, c in hits.items() if c == 0]
+    doubled = [n for n, c in hits.items() if c > 1]
+    assert not dropped, (
+        f"{len(dropped)}/{len(issues)} fetched issues landed in NO bucket "
+        f"(first dropped closed_at={issues[dropped[0]]['closed_at']})"
+    )
+    assert not doubled, f"{len(doubled)} fetched issues were double-counted"
+
+
+def test_bucket_edge_instant_lands_in_exactly_one_bucket():
+    """An issue closed at the exact shared edge of two buckets belongs to the earlier
+    one (intervals are ``(start, end]``), never to both and never to neither."""
+    until = mr.normalize_until(datetime(2026, 7, 10, 9, 0, 0, tzinfo=UTC))
+    windows = mr.week_windows(until, 4)
+    edge = windows[0][1]  # boundary shared by bucket 0 (as `end`) and bucket 1 (as `start`)
+
+    issue = _issue(1, edge.strftime("%Y-%m-%dT%H:%M:%S.%fZ"))
+    hits = [k for k, (s, e) in enumerate(windows) if mr.closed_in_window([issue], s, e)]
+    assert hits == [0], f"edge instant {edge.isoformat()} landed in buckets {hits}, expected [0]"
+
+
+def test_week_label_names_the_days_the_bucket_actually_covers():
+    """``week_start..week_end`` renders as an inclusive day range, so it must be one.
+
+    A reader cross-checking a trend row runs ``closed:<week_start>..<week_end>`` (a
+    both-ends-inclusive GitHub search). If the label named the raw half-open ``(start``
+    edge, that query would span an extra day and return a bigger number than the row.
+    Mislabelling this way is what produced the bogus reference counts in Issue #1099.
+    """
+    until = mr.normalize_until(datetime(2026, 7, 10, 14, 30, 0, tzinfo=UTC))
+    series = mr.weekly_series([], until, 4)
+
+    # Each row covers exactly 7 whole days, inclusive of both labelled endpoints.
+    for w in series:
+        start = datetime.fromisoformat(w["week_start"])
+        end = datetime.fromisoformat(w["week_end"])
+        assert (end - start).days == 6, f"{w['week_start']}..{w['week_end']} is not 7 whole days"
+
+    # Consecutive rows must not share a day (that overlap is the double-count trap).
+    for earlier, later in zip(series, series[1:]):
+        assert earlier["week_end"] < later["week_start"], (
+            f"weeks overlap on {earlier['week_end']}: rows would double-count it"
+        )
+
+    assert series[0]["week_start"] == "2026-06-13"   # NOT 2026-06-12
+    assert series[-1]["week_end"] == "2026-07-10"
+
+
+def test_weekly_series_totals_match_the_fetched_population():
+    """The rendered trend series must sum to the delivered population it was given."""
+    until = mr.normalize_until(datetime(2026, 7, 10, 14, 30, 0, tzinfo=UTC))
+    since_iso, until_iso = mr.fetch_span(until, 4)
+
+    start = datetime.fromisoformat(since_iso).replace(tzinfo=UTC)
+    end = datetime.fromisoformat(until_iso).replace(hour=23, minute=59, second=59, tzinfo=UTC)
+    issues, t, n = [], start, 0
+    while t <= end:
+        issues.append(_issue(n, t.strftime("%Y-%m-%dT%H:%M:%SZ")))
+        t += timedelta(hours=6)
+        n += 1
+
+    series = mr.weekly_series(issues, until, 4)
+    assert sum(w["n_delivered"] for w in series) == len(mr.delivered_issues(issues))


### PR DESCRIPTION
Closes [Issue #1099](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1099).

## What was wrong

The weekly SDR buckets issues with **datetime** precision but sources them from GitHub's `closed:A..B` search, which is **day-granular and inclusive on both endpoints**. The two granularities disagreed, and issues fell through the gap.

The Issue asked whether the trend gap was **displacement** (items land in an adjacent bucket; totals conserve) or **loss** (items dropped; totals do not conserve). The answer is **both**, from two distinct defects:

1. **Mid-day anchoring.** `_run_window_mode` normalized an explicit `--until` to end-of-day but left the default `datetime.now()` path at a mid-day timestamp. So in a *live* run every bucket edge sat at a time-of-day the source data cannot resolve. This **displaces** issues across internal edges and **strands** those closed after the final edge.
2. **Bottom-edge leak.** Buckets are half-open at the start, so with a normalized `until` the `span_start` edge is the **last instant of its own day** - meaning that whole day belongs to no bucket. The fetch nonetheless started at `span_start.date()`, pulling a full day of issues that nothing could count.

## The correction that matters most: the Issue's own reference counts were wrong

**The gap reported in the Issue was mostly an artifact of a broken check, not of the script.** The "direct count" column was produced by running `closed:A..B` per week with the weeks sharing a boundary day - and since that operator is inclusive on **both** ends, consecutive queries **double-count the shared day**. Demonstrated: [Issue #798](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/798) (closed 06-19T22:29) is returned by **both** `closed:2026-06-12..2026-06-19` and `closed:2026-06-19..2026-06-26`.

| Series | Weeks | Sum |
|---|---|---|
| Issue's "direct count" (overlapping, **inflated**) | 10 / 13 / 28 / 68 | 119 |
| True disjoint day-granular count | 6 / 12 / 22 / 61 | 101 |
| Old script (mid-day buckets) | 8 / 10 / 19 / 65 | 102 |
| **Fixed script** | **6 / 12 / 22 / 61** | **101** |

So the old script was *already much closer to the truth* than the reference I measured it against. The Issue's "Why it matters" claim - that the trend implies a 3.5x jump where reality is a smooth ramp - **does not hold**: the true ramp (6 to 61) is steeper than the one the buggy trend showed. The real defect is smaller than advertised, but it is real, and the fix makes the series exact.

Had I "fixed" the script to match that reference, I would have introduced double-counting. Recording this because it is the second time today the same failure shape - a check that could not come back red - nearly landed a wrong change.

## The fix

- **`normalize_until(dt)`** - snaps the window anchor to the last instant of the UTC day, on **both** paths. Makes the bucket grid agree with the granularity of the data it buckets. Idempotent.
- **`fetch_span(until, n_weeks)`** - returns the ISO date range whose whole-day coverage **exactly matches** what the buckets cover, starting the day after the first bucket opens. Conservation now holds: every fetched issue lands in exactly one bucket.
- **Trend row labels** - `week_start` now names the first day the bucket **actually covers**, not the raw half-open `(start` edge. Rendered as `week_start..week_end` the pair reads as an inclusive day range, so it must be one: a reader cross-checking a row must get that row's number back. The old label put a day the bucket does not hold into the range - the very trap that produced the bogus reference counts above.

## Test plan

Adds `workflow/tests/test_milestone_report_windows.py` (10 tests, pure, no network), covering the window/bucket grid that the pre-existing `tools/ci/test_milestone_report.py` (39 tests) does not exercise. The two are complementary: that suite anchors on a midnight `UNTIL` and asserts on `week_end`, so the `week_start` relabel leaves it untouched (still 39/39 green).

> **Correction.** An earlier revision of this PR body and of commit `e7cc597` claimed `milestone_report.py` had *zero* test coverage. That was false - I grepped only `workflow/tests/` and `scripts/`, a search that could not have found the suite in `tools/ci/`, so it could only confirm what I already believed. Same could-only-confirm failure shape as the broken reference count above. Recorded rather than quietly fixed.

- [x] **Matched-pair control on the defect** (identical inputs, one variable flipped, opposite outcomes - both could not pass): old fetch-span rule drops exactly **24** hourly synthetic issues; new rule drops **0**.
- [x] **Conservation lock** - an issue synthesized at every hour of the fetch span lands in **exactly one** bucket, parametrized over 1 / 4 / 6 week spans. This is the regression lock: it fails loudly on the old code.
- [x] **Edge-instant test** - an issue closed at the exact shared edge of two buckets lands in exactly one (the earlier), never both, never neither.
- [x] **Label contract test** - each row spans exactly 7 whole days and consecutive rows share no day (the double-count trap).
- [x] **Live smoke** - the fixed run's rows each return their own number when cross-checked with the `closed:` query their label implies: `6 / 12 / 22 / 61`, reconciling exactly.
- [x] Full suite green: **746 passed, 46 skipped, 0 failed**; pre-existing `tools/ci/test_milestone_report.py` **39/39** green.
- [x] Bot review returned **no blocking findings**; 3 of 4 optional polish items taken (shared `_first_covered_day` helper, naive-datetime guard on `normalize_until` + test, `--since`/`--until` help text). Declined the 4th (deduping a pure list-comp) as coupling for no gain.

## Out of scope

The narrative-seed over-collection in the same script is [Issue #1005](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1005) - a distinct code path, deliberately not touched here.

**Created by:** PM
