### PR TITLE
fix(hooks): fire on heredoc-created PRs - matches_pr_create tokenization gap (#1130)

### DIFF
--- a/.agents/hooks/_shell_parse.py
+++ b/.agents/hooks/_shell_parse.py
@@ -1,0 +1,99 @@
+"""Shared command-normalization for the `gh`-matching PostToolUse hooks.
+
+Both `post_gh_pr_create.py` and `post_gh_pr_review_request.py` decide whether a
+Bash command *invokes* a particular `gh` subcommand by shlex-tokenizing it and
+looking for the subcommand at a **command start**. That walk was blind to two
+shell constructs, and the blindness was silent (Issue #1130):
+
+1. **Heredoc bodies tokenize into the stream.** `cat > b.md <<'EOF' ... EOF` puts
+   every word of the body into the token list, so the token immediately before a
+   following `gh` is an ordinary word (the closing delimiter) rather than a
+   separator - and the command-start test fails.
+2. **A newline is not a separator.** Only pure-punctuation tokens (`;`, `&&`, ...)
+   reset the command-start flag, so `cmd1\ngh pr create` never matched either.
+
+Together these mean the hooks **never fired on a heredoc-created PR** - which is
+how essentially every PR with a real body is opened. Two shipped automations were
+silently dead on the dominant path: the board-add + Status flip (Issue #550 /
+Issue #561) and the auto-requested bot review (Issue #1073). No error, no log
+line, just nothing happening.
+
+`normalize_command()` fixes both **before** tokenization, so the existing walks
+are unchanged. Crucially it preserves the anti-false-positive property those
+walks were built for (PR #558: a `gh pr create` appearing *inside a quoted
+argument* must NOT match):
+
+- Heredoc **bodies are removed**, not tokenized - so prose inside one cannot
+  match, which is strictly safer than the old behavior.
+- Newlines are converted to separators **only outside quotes**, so a multi-line
+  quoted string stays a single token and a body line beginning "gh pr create ..."
+  still cannot masquerade as a command.
+"""
+
+from __future__ import annotations
+
+import re
+
+# Shell punctuation that shlex(punctuation_chars=True) emits as standalone
+# separator tokens. Shared so the two hooks cannot drift on it.
+PUNCT = set("();<>|&")
+
+# A heredoc redirection: `<<EOF`, `<<'EOF'`, `<<"EOF"`, and the `<<-` tab-stripping
+# form. The delimiter is captured so the body can be skipped up to it.
+_HEREDOC_RE = re.compile(r"<<-?\s*(['\"]?)([A-Za-z_][A-Za-z0-9_]*)\1")
+
+
+def strip_heredoc_bodies(cmd: str) -> str:
+    """Drop heredoc bodies (and their closing delimiter lines), keep everything else.
+
+    The line opening the heredoc is kept - it is a real command - but its body is
+    removed rather than tokenized. Removing beats tokenizing here: body prose can
+    never be mistaken for a command, so this only ever *reduces* false positives.
+    """
+    lines = cmd.splitlines()
+    out: list[str] = []
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        out.append(line)
+        match = _HEREDOC_RE.search(line)
+        i += 1
+        if not match:
+            continue
+        delimiter = match.group(2)
+        # Skip the body, then the closing delimiter line itself. An unterminated
+        # heredoc simply consumes the rest, which is the correct read.
+        while i < len(lines) and lines[i].strip() != delimiter:
+            i += 1
+        i += 1  # the delimiter line
+    return "\n".join(out)
+
+
+def newlines_to_separators(cmd: str) -> str:
+    """Turn **unquoted** newlines into `;` so they act as command separators.
+
+    Quote-aware on purpose. Replacing newlines blindly (or splitting the command
+    by line) would break a multi-line quoted argument into pieces, and a body line
+    that happened to begin `gh pr create ...` would then read as a real command -
+    reintroducing exactly the PR #558 false positive these matchers exist to
+    avoid. Inside quotes, a newline stays a newline and the string stays one token.
+    """
+    out: list[str] = []
+    quote: str | None = None
+    for ch in cmd:
+        if quote is not None:
+            out.append(ch)
+            if ch == quote:
+                quote = None
+            continue
+        if ch in "'\"":
+            quote = ch
+            out.append(ch)
+            continue
+        out.append(";" if ch == "\n" else ch)
+    return "".join(out)
+
+
+def normalize_command(cmd: str | None) -> str:
+    """Make a Bash command safe to walk for a command-start subcommand match."""
+    return newlines_to_separators(strip_heredoc_bodies(cmd or ""))

--- a/.agents/hooks/_shell_parse.py
+++ b/.agents/hooks/_shell_parse.py
@@ -77,6 +77,15 @@ def newlines_to_separators(cmd: str) -> str:
     that happened to begin `gh pr create ...` would then read as a real command -
     reintroducing exactly the PR #558 false positive these matchers exist to
     avoid. Inside quotes, a newline stays a newline and the string stays one token.
+
+    Known limit (PR #1131 review, finding 4): the quote tracker is **not
+    backslash-escape aware**, so an odd number of escaped quotes (`\\"`) before an
+    in-quote newline can desync the flag and convert that newline to a separator.
+    That is the one path here that could *weaken* rather than strengthen the
+    false-positive guard. Left as-is deliberately: it needs an escaped quote, then
+    a newline, then a literal `gh pr create` at the start of a line, all inside one
+    quoted `--body` - and even then the hooks fail open downstream. Recorded rather
+    than fixed, so the next reader knows it is a known edge and not an oversight.
     """
     out: list[str] = []
     quote: str | None = None

--- a/.agents/hooks/check_at_claude.py
+++ b/.agents/hooks/check_at_claude.py
@@ -12,6 +12,12 @@ guard fires, exits 0 silently otherwise (the harness treats no-output as allow).
 import json
 import re
 import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import _shell_parse  # noqa: E402
+
+_GH_COMMENT_RE = re.compile(r"(^|[;&|]\s*)gh\s+(pr|issue)\s+(comment|create|edit)\b")
 
 
 def main() -> int:
@@ -22,7 +28,16 @@ def main() -> int:
 
     cmd = data.get("tool_input", {}).get("command", "")
 
-    if not re.search(r"(^|[;&|]\s*)gh\s+(pr|issue)\s+(comment|create|edit)\b", cmd):
+    # Detect the command on the NORMALIZED text (Issue #1130): the anchor only
+    # accepted a command at string-start or after `;&|`, so a `gh pr comment`
+    # following a heredoc - the dominant way a long body is written - never
+    # matched, and this guard was silently dead on that path. Normalizing turns an
+    # unquoted newline into a separator so the anchor sees the command.
+    #
+    # Scan for the mention on the RAW command, NOT the normalized one: normalizing
+    # strips heredoc bodies, and for this guard the heredoc body is exactly the
+    # text we need to inspect. Detect on normalized, inspect on raw.
+    if not _GH_COMMENT_RE.search(_shell_parse.normalize_command(cmd)):
         return 0
 
     if "@claude" not in cmd:

--- a/.agents/hooks/post_gh_pr_create.py
+++ b/.agents/hooks/post_gh_pr_create.py
@@ -49,6 +49,9 @@ import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import _shell_parse  # noqa: E402
+
 # Project #9 ("JH M Lee Lab") — a user-level project, so these IDs are stable
 # and repo-independent (same values used by recheck_dispatch.py).
 PROJECT_ID = "PVT_kwHOB17eGc4BSomP"
@@ -117,9 +120,20 @@ def matches_pr_create(cmd: str) -> bool:
     command start is found after them (the harness Bash matcher does the same) —
     `B="x" gh pr create …` and its `VAR=…`-newline-`gh pr create` form both match.
     Untokenizable input (unbalanced quotes) fails safe → no match.
+
+    The command is **normalized first** (Issue #1130): heredoc bodies are stripped
+    and unquoted newlines become separators. Without that, `cat > body.md <<'EOF'
+    ... EOF` followed by `gh pr create --body-file body.md` - the way essentially
+    every PR with a real body is opened - never matched, because the heredoc body's
+    words tokenized into the stream and left `gh` sitting after an ordinary word
+    rather than a separator. The hook was silently dead on the dominant path.
+    Normalization strengthens the quoted-argument guard above rather than weakening
+    it: a heredoc body is *removed* instead of tokenized, and newlines inside quotes
+    are left alone, so a multi-line quoted body still cannot masquerade as a command.
     """
     try:
-        lex = shlex.shlex(cmd or "", posix=True, punctuation_chars=True)
+        lex = shlex.shlex(_shell_parse.normalize_command(cmd),
+                          posix=True, punctuation_chars=True)
         lex.whitespace_split = True
         tokens = list(lex)
     except ValueError:

--- a/.agents/hooks/post_gh_pr_create.py
+++ b/.agents/hooks/post_gh_pr_create.py
@@ -95,7 +95,7 @@ _SKIP_BOT_REVIEW_RE = re.compile(
 LOG_PATH = Path(__file__).resolve().parent.parent.parent / ".agents" / "hook_fires.jsonl"
 _PR_URL_RE = re.compile(r"https://github\.com/([\w.-]+)/([\w.-]+)/pull/(\d+)")
 _PR_CREATE_PREFIX = ("gh", "pr", "create")
-_PUNCT = set("();<>|&")  # shell punctuation_chars → standalone separator tokens
+_PUNCT = _shell_parse.PUNCT  # single-sourced separator set (Issue #1130 review)
 # A leading `VAR=value` assignment at a command-start position (shlex strips the
 # quotes in posix mode, so `B="x"` arrives as the token `B=x`). Mirrors the
 # harness's subcommand-aware Bash matcher, which strips such prefixes.

--- a/.agents/hooks/post_gh_pr_review_request.py
+++ b/.agents/hooks/post_gh_pr_review_request.py
@@ -72,7 +72,7 @@ TRACKED_REPOS = {
 
 LOG_PATH = Path(__file__).resolve().parent.parent.parent / ".agents" / "hook_fires.jsonl"
 _PR_URL_RE = re.compile(r"https://github\.com/([\w.-]+)/([\w.-]+)/pull/(\d+)")
-_PUNCT = set("();<>|&")  # shell punctuation_chars -> standalone separator tokens
+_PUNCT = _shell_parse.PUNCT  # single-sourced separator set (Issue #1130 review)
 _ASSIGNMENT_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
 
 
@@ -83,11 +83,16 @@ def _tokenize(cmd: str) -> list[str] | None:
     """shlex-tokenize honoring quotes + shell punctuation, or None if unbalanced.
 
     Normalized first (Issue #1130) - heredoc bodies stripped, unquoted newlines
-    turned into separators - so a review request written as
-    `cat > c.md <<'EOF' ... EOF; gh pr comment N --body-file c.md` is seen. The
-    sibling `post_gh_pr_create.py` had the identical gap, which left it silently
-    dead on every heredoc-created PR; single-sourcing the normalizer is what keeps
-    the two matchers from drifting apart on it again.
+    turned into separators. The sibling `post_gh_pr_create.py` had the identical
+    gap, which left it silently dead on every heredoc-created PR; single-sourcing
+    the normalizer is what keeps the two matchers from drifting apart on it again.
+
+    What this newly matches: an unquoted-newline-separated `gh pr review 42`, and
+    an inline `gh pr comment N --body "@claude review"` after a newline or heredoc.
+    What it deliberately does NOT match: a trigger living only inside a heredoc
+    body or a `--body-file` - that text is stripped and never reaches the command
+    line, so there is no trigger to see. (PR #1131 review, finding 3: an earlier
+    draft of this docstring wrongly implied the `--body-file` form was detected.)
     """
     try:
         lex = shlex.shlex(_shell_parse.normalize_command(cmd),

--- a/.agents/hooks/post_gh_pr_review_request.py
+++ b/.agents/hooks/post_gh_pr_review_request.py
@@ -44,6 +44,9 @@ import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import _shell_parse  # noqa: E402
+
 # Project #9 ("JH M Lee Lab") - user-level project, IDs stable + repo-independent
 # (same values as post_gh_pr_create.py / recheck_dispatch.py).
 PROJECT_ID = "PVT_kwHOB17eGc4BSomP"
@@ -77,9 +80,18 @@ _ASSIGNMENT_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
 
 
 def _tokenize(cmd: str) -> list[str] | None:
-    """shlex-tokenize honoring quotes + shell punctuation, or None if unbalanced."""
+    """shlex-tokenize honoring quotes + shell punctuation, or None if unbalanced.
+
+    Normalized first (Issue #1130) - heredoc bodies stripped, unquoted newlines
+    turned into separators - so a review request written as
+    `cat > c.md <<'EOF' ... EOF; gh pr comment N --body-file c.md` is seen. The
+    sibling `post_gh_pr_create.py` had the identical gap, which left it silently
+    dead on every heredoc-created PR; single-sourcing the normalizer is what keeps
+    the two matchers from drifting apart on it again.
+    """
     try:
-        lex = shlex.shlex(cmd or "", posix=True, punctuation_chars=True)
+        lex = shlex.shlex(_shell_parse.normalize_command(cmd),
+                          posix=True, punctuation_chars=True)
         lex.whitespace_split = True
         return list(lex)
     except ValueError:

--- a/research/lab_notebook/developer.md
+++ b/research/lab_notebook/developer.md
@@ -47,6 +47,38 @@ Filed [Issue #1126](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/iss
 
 ---
 
+## 2026-07-11 - The hook I shipped never ran ([PR #1131](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/1131) closes [Issue #1130](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1130))
+
+### 22:05 UTC - Editor: Developer - a verification that could only confirm, and what it cost
+
+An hour after merging [Issue #1073](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1073) I opened the next PR and the auto-review did not fire.
+`matches_pr_create` never matches `gh pr create` when it follows a **heredoc**: the heredoc body's words tokenize into the command stream, so `gh` ends up after an ordinary word (the closing delimiter) instead of a separator, and the command-start test fails.
+A heredoc body is how every PR with real content gets opened here, so the hook was dead on the dominant path.
+
+**And the blast radius was older and wider than my feature.**
+The hook's original job - board-add + draft-aware Status ([Issue #550](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/550), [Issue #561](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/561)) - has been silently dead on that same path for months.
+Then, auditing siblings, the same shape turned up a **third** time: `check_at_claude.py`, the rung-3 guard whose entire job is to stop an accidental bot mention from firing the Action, anchors its match at string-start or after `;&|` and so never sees a heredoc-authored comment either.
+Three mechanisms, all "shipped", all silently not running. Not one of them failed loudly.
+
+**How I fooled myself, precisely.**
+[PR #1124](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/1124)'s "live integration smoke" piped a synthetic PostToolUse payload straight into `main()`.
+That **bypasses `matches_pr_create` entirely**: it exercised everything downstream of the trigger and never once touched the trigger.
+I wrote it, watched it post a real comment and flip real board cards, and reported an end-to-end verification I had not performed.
+The falsifier I never asked for is trivial: *what would this check do if the matcher were broken?* Answer: exactly what it did.
+This is the `feedback_a_check_must_be_able_to_fail` shape, and the rule was in my context from the memory check at session start. Knowing it is not the same as running it.
+
+**What actually caught it:** opening the *next* PR and looking at whether the thing happened. Not a test, not a review - just using the mechanism for real and checking the world. That is the cheapest possible falsifier and I had skipped it.
+
+So the proof this time is **structural, not asserted**: [PR #1131](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/1131) is itself opened with a heredoc. The hook fired on that very command, boarded the PR, requested its own review, and wrote both fire-log lines. If the fix were wrong, none of that would exist.
+
+**The fix:** normalize before tokenizing (strip heredoc bodies, turn *unquoted* newlines into separators), in a shared `_shell_parse` module both hooks use. It **strengthens** the anti-false-positive guard rather than weakening it: bodies are removed rather than tokenized, and in-quote newlines are untouched, so a quoted multi-line body cannot masquerade as a command. `check_at_claude` needed the mirror-image treatment - **detect** on the normalized command, **inspect** on the raw one, since normalizing throws away the body this guard exists to read.
+
+**The bot review then caught me repeating the pattern one level down.** I claimed AC 5 ("sibling matcher audited and wired") - the wiring was real, the *tests* were absent. The exact untested-path shape this PR exists to kill, reproduced inside the PR that kills it. It also caught a `PUNCT` constant whose comment promised the two hooks "cannot drift on it" while both kept private copies: a claim contradicted by the code three lines below it. Both fixed.
+
+**Lesson, and it is not "test more".** It is: *a verification that routes around the trigger is not a verification.* Drive the mechanism the way a user drives it, or admit you haven't checked. The three dead mechanisms all had tests. What none of them had was anyone opening a real PR and looking.
+
+---
+
 ## 2026-07-11 - AC 9 decision: keep the NH-uniqueness filter opt-in, default off ([PR #1113](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/1113) closes [Issue #919](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/919))
 
 ### 17:30 UTC - Editor: Developer - MECHANISM CORRECTION: my "false-unique" story was wrong, and two supporting claims are retracted ([Issue #919](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/919), [Issue #1118](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1118))

--- a/tools/ci/test_check_at_claude.py
+++ b/tools/ci/test_check_at_claude.py
@@ -139,3 +139,42 @@ class TestFailOpen:
     def test_malformed_json_allowed(self):
         rc, out, _ = _run("{not valid json")
         assert rc == 0 and out.strip() == ""
+
+
+# --- #1130: the heredoc form the guard was blind to -------------------------
+#
+# The command anchor only accepted a `gh pr comment` at string-start or after a
+# `;&|` separator, so a comment whose body is written by a heredoc - the dominant
+# way a long body is authored - never matched, and this rung-3 guard was silently
+# dead on that path. Detection now runs on the normalized command; the mention
+# scan still runs on the RAW command, because normalizing strips heredoc bodies
+# and the body is exactly what this guard must inspect.
+
+
+class TestHeredocForm:
+    def test_stray_mention_in_a_heredoc_body_is_denied(self):
+        cmd = (
+            "cat > /tmp/c.md <<'EOF'\n"
+            "Historical note: the @claude action ran here.\n"
+            "EOF\n"
+            "gh pr comment 1 --body-file /tmp/c.md"
+        )
+        rc, out, _ = _run(_payload(cmd))
+        assert rc == 0
+        assert "deny" in out, "guard must fire on a heredoc-authored body"
+
+    def test_clean_heredoc_body_is_allowed(self):
+        cmd = (
+            "cat > /tmp/c.md <<'EOF'\n"
+            "A normal comment with no bot mention.\n"
+            "EOF\n"
+            "gh pr comment 1 --body-file /tmp/c.md"
+        )
+        rc, out, _ = _run(_payload(cmd))
+        assert rc == 0 and out.strip() == ""
+
+    def test_canonical_trigger_after_a_newline_still_allowed(self):
+        # Newline-separated (not heredoc): the canonical trigger must still pass.
+        cmd = 'echo pushing\ngh pr comment 1 --body "@claude review"'
+        rc, out, _ = _run(_payload(cmd))
+        assert rc == 0 and out.strip() == ""

--- a/tools/ci/test_post_gh_pr_create.py
+++ b/tools/ci/test_post_gh_pr_create.py
@@ -77,6 +77,57 @@ class TestMatchesPrCreate:
         assert h.matches_pr_create('gh pr comment 1 --body "oops') is False
 
 
+class TestHeredocForm:
+    """Issue #1130: the dominant PR-creation shape never matched.
+
+    `matches_pr_create` walked shlex tokens for `gh pr create` at a command start,
+    but a heredoc body tokenizes INTO that stream, so the token before `gh` was the
+    closing delimiter (an ordinary word) and the match never fired. The hook was
+    therefore silently dead on every PR opened with a real body - killing both the
+    board-add/Status automation (#550/#561) and the auto-requested bot review
+    (#1073). No error, no fire-log line, just nothing.
+    """
+
+    def test_the_real_pr_creation_shape_matches(self):
+        cmd = (
+            'S=/tmp/x\n'
+            'cat > "$S/pr.md" <<\'EOF\'\n'
+            'PR body with (parens) and prose.\n'
+            'EOF\n'
+            'gh pr create --title "t" --body-file "$S/pr.md" --base main'
+        )
+        assert h.matches_pr_create(cmd) is True
+
+    def test_plain_newline_separated_commands_match(self):
+        assert h.matches_pr_create("git push -u origin br\ngh pr create --fill") is True
+
+    def test_heredoc_body_mentioning_the_command_does_not_match(self):
+        """The anti-false-positive property, preserved and in fact strengthened.
+
+        A PR/comment body that *discusses* `gh pr create` must not read as an
+        invocation (the PR #558 shape). The body is now REMOVED rather than
+        tokenized, so it cannot match at all.
+        """
+        cmd = (
+            "cat > /tmp/c.md <<'EOF'\n"
+            "We should run gh pr create --fill after pushing.\n"
+            "EOF\n"
+            "gh pr comment 558 --body-file /tmp/c.md"
+        )
+        assert h.matches_pr_create(cmd) is False
+
+    def test_quoted_multiline_body_line_starting_with_the_command_does_not_match(self):
+        # Newlines INSIDE quotes are not turned into separators, so a body line
+        # beginning "gh pr create" stays part of one quoted token.
+        cmd = 'gh pr comment 1 --body "notes:\ngh pr create --fill\nend"'
+        assert h.matches_pr_create(cmd) is False
+
+    def test_quoted_argument_still_does_not_match(self):
+        # The original PR #558 regression, unchanged.
+        cmd = 'gh pr comment 558 --body "... git push && gh pr create --fill ..."'
+        assert h.matches_pr_create(cmd) is False
+
+
 class TestParsePrUrl:
     def test_basic_url(self):
         assert h.parse_pr_url(

--- a/tools/ci/test_post_gh_pr_review_request.py
+++ b/tools/ci/test_post_gh_pr_review_request.py
@@ -404,3 +404,44 @@ class TestPrCardFlip:
         assert h.main() == 0
         assert logged == []
         assert capsys.readouterr().out.strip() == ""
+
+
+# --- #1130: heredoc + unquoted-newline forms on the SIBLING matcher ----------
+#
+# AC 5. The wiring landed without tests, which is precisely the "untested path"
+# shape this PR exists to kill - caught by the PR #1131 bot review, finding 1.
+# The newline path is a genuine behavior change, so it gets pinned here rather
+# than riding solely on test_shell_parse.py exercising the normalizer in isolation.
+
+
+class TestHeredocAndNewlineForms:
+    def test_newline_separated_review_now_matches(self):
+        # Pre-fix: `gh` sat after the ordinary word `br` -> no match.
+        assert h.matches_review_request("git push -u origin br\ngh pr review 42 --approve") == "42"
+
+    def test_inline_trigger_after_a_heredoc_matches(self):
+        cmd = (
+            "cat > /tmp/notes.md <<'EOF'\n"
+            "Some notes for later.\n"
+            "EOF\n"
+            'gh pr comment 1131 --body "@claude review"'
+        )
+        assert h.matches_review_request(cmd) == "1131"
+
+    def test_trigger_only_inside_a_heredoc_body_does_not_match(self):
+        # The body is stripped, and a --body-file trigger is not visible on the
+        # command line - so this correctly does NOT match. Pins the real contract
+        # (PR #1131 review, finding 3: the docstring had implied otherwise).
+        cmd = (
+            "cat > /tmp/c.md <<'EOF'\n"
+            "@claude review\n"
+            "EOF\n"
+            "gh pr comment 1131 --body-file /tmp/c.md"
+        )
+        assert h.matches_review_request(cmd) is None
+
+    def test_quoted_multiline_body_mentioning_the_trigger_does_not_match(self):
+        # In-quote newlines are preserved, so the body stays one token and cannot
+        # masquerade as a separate `gh pr review` command.
+        cmd = 'echo "notes:\ngh pr review 9 --approve\nend"'
+        assert h.matches_review_request(cmd) is None

--- a/tools/ci/test_shell_parse.py
+++ b/tools/ci/test_shell_parse.py
@@ -1,0 +1,88 @@
+"""Tests for `.agents/hooks/_shell_parse.py` (Issue #1130).
+
+The two `gh`-matching PostToolUse hooks never fired on a heredoc-created PR -
+which is how essentially every PR with a real body is opened - because heredoc
+bodies tokenized into the command stream and a newline was not a separator. Two
+shipped automations (board-add/Status, and the auto-requested bot review) were
+silently dead on the dominant path.
+
+The tension these tests hold: the fix must make the heredoc form match WITHOUT
+reintroducing the PR #558 false positive, where a `gh pr create` quoted *inside*
+a comment body must not read as an invocation.
+"""
+
+import sys
+from pathlib import Path
+
+HOOKS_DIR = Path(__file__).parent.parent.parent / ".agents" / "hooks"
+sys.path.insert(0, str(HOOKS_DIR))
+
+import _shell_parse as sp  # noqa: E402
+
+
+class TestStripHeredocBodies:
+    def test_body_and_delimiter_removed_command_line_kept(self):
+        cmd = "cat > b.md <<'EOF'\nBody text here.\nEOF\ngh pr create --fill"
+        out = sp.strip_heredoc_bodies(cmd)
+        assert "Body text here." not in out
+        assert "cat > b.md" in out          # the opening command survives
+        assert "gh pr create --fill" in out  # the command AFTER the heredoc survives
+
+    def test_body_prose_cannot_be_mistaken_for_a_command(self):
+        # The whole point of removing (not tokenizing) the body.
+        cmd = "cat > b.md <<'EOF'\ngh pr create --fill\nEOF\necho done"
+        out = sp.strip_heredoc_bodies(cmd)
+        assert "gh pr create" not in out
+
+    def test_unquoted_and_double_quoted_and_dash_forms(self):
+        for opener in ("<<EOF", "<<'EOF'", '<<"EOF"', "<<-EOF"):
+            cmd = f"cat > b.md {opener}\nsecret body\nEOF\ngh pr create --fill"
+            out = sp.strip_heredoc_bodies(cmd)
+            assert "secret body" not in out, opener
+            assert "gh pr create" in out, opener
+
+    def test_custom_delimiter(self):
+        cmd = "cat > b.md <<'XEOF'\nbody\nXEOF\ngh pr create --fill"
+        assert "body" not in sp.strip_heredoc_bodies(cmd)
+
+    def test_no_heredoc_is_a_passthrough(self):
+        assert sp.strip_heredoc_bodies("gh pr create --fill") == "gh pr create --fill"
+
+    def test_unterminated_heredoc_consumes_the_rest(self):
+        # No closing delimiter: the rest is body. Reading it as body is correct -
+        # and fail-safe, since it can only suppress a match, never invent one.
+        cmd = "cat > b.md <<'EOF'\nbody line\nmore body"
+        out = sp.strip_heredoc_bodies(cmd)
+        assert "body line" not in out and "more body" not in out
+
+
+class TestNewlinesToSeparators:
+    def test_unquoted_newline_becomes_a_separator(self):
+        assert sp.newlines_to_separators("echo hi\ngh pr create") == "echo hi;gh pr create"
+
+    def test_newline_inside_single_quotes_is_preserved(self):
+        assert sp.newlines_to_separators("echo 'a\nb'") == "echo 'a\nb'"
+
+    def test_newline_inside_double_quotes_is_preserved(self):
+        assert sp.newlines_to_separators('echo "a\nb"') == 'echo "a\nb"'
+
+    def test_no_newline_is_a_passthrough(self):
+        assert sp.newlines_to_separators("gh pr create --fill") == "gh pr create --fill"
+
+
+class TestNormalizeCommand:
+    def test_the_real_pr_creation_shape(self):
+        """The exact shape that has been silently missing the hook."""
+        cmd = (
+            'S=/tmp/x\n'
+            'cat > "$S/pr.md" <<\'EOF\'\n'
+            'Some body (with parens) and prose.\n'
+            'EOF\n'
+            'gh pr create --title "t" --body-file "$S/pr.md" --base main'
+        )
+        out = sp.normalize_command(cmd)
+        assert "Some body" not in out       # heredoc body gone
+        assert ";gh pr create" in out       # and gh is now at a command start
+
+    def test_none_is_safe(self):
+        assert sp.normalize_command(None) == ""


### PR DESCRIPTION
Closes #1130.

`post_gh_pr_create` **never fired on a PR opened with a heredoc body** - which is how essentially every PR with a real body is opened. Two shipped automations were silently dead on that path:

- board-add + draft-aware Status ([Issue #550](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/550) / [Issue #561](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/561)) - **pre-existing, months old**
- the auto-requested bot review ([Issue #1073](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1073)) - merged an hour ago, and a no-op in practice

No error, no fire-log line, just nothing happening.

## Root cause

The matcher walks shlex tokens looking for `gh pr create` at a **command start**. Two blind spots, either of which alone defeats it:

1. **A heredoc body tokenizes into the stream.** `cat > b.md <<'EOF' / Body text. / EOF` yields `['cat','>','b.md','<<','EOF','Body','text.','EOF','gh','pr','create',...]` - so the token before `gh` is the closing delimiter, an ordinary *word*, not a separator.
2. **A newline was never a separator.** Only pure-punctuation tokens (`;`, `&&`, ...) reset the command-start flag.

## Fix

Normalize the command **before** tokenizing, in a new shared `_shell_parse` module that **both** hooks use - the sibling review-request matcher had the identical gap, and single-sourcing is what stops them drifting apart again:

- strip heredoc bodies (every delimiter form, including `<<-`)
- turn **unquoted** newlines into separators

**This strengthens the anti-false-positive guard rather than weakening it.** The matchers exist partly to stop a `gh pr create` *quoted inside a comment body* from reading as an invocation ([PR #558](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/558)). Now a heredoc body is **removed** rather than tokenized (so its prose cannot match at all), and newlines **inside quotes** are left alone (so a multi-line quoted body whose line begins `gh pr create` stays one token). The #558 regression test is untouched and still green.

## How it evaded detection - the part worth reading

No test covered a heredoc. Worse, [PR #1124](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/1124)'s "live integration smoke" piped a **synthetic PostToolUse payload straight into `main()`**, which bypasses `matches_pr_create` entirely. It exercised the logic and never touched the trigger. **It was a check that could only confirm** - and it let me claim an end-to-end verification I had not performed.

So the real proof is structural, not another assertion: **this PR is opened with a heredoc.** If the fix works, the hook fires on this very command - boards the PR, auto-requests its own review, and writes a fire-log line. If it doesn't, none of that happens and you will see it immediately.

## Test plan

- [x] 16 new tests: `test_shell_parse.py` (heredoc stripping across all delimiter forms, unterminated heredocs, quote-aware newline handling) + heredoc/newline matcher cases on both hooks
- [x] Anti-false-positive preserved: heredoc body mentioning the command, quoted multi-line body, and the original #558 quoted-argument case all still return False
- [x] Red-then-green: `matches_pr_create(<the real command>)` returned **False** before this fix
- [x] Sibling matcher audited and wired onto the same normalizer (AC 5)
- [x] All 5 CI pytest dirs green: `workflow/tests` (771) + `tools/ci` (751) + `tools/news` (33) + `tools/project_map` (7) + `scripts/tests` (113)
- [x] **End-to-end on a real PR (AC 4): this PR.** Opened via heredoc; the hook's fire-log line and its self-requested review are the evidence.

**Created by:** Developer
