### PR TITLE
fix(scripts): board_open_items --role must match every role label, not just the first (#1153)

### DIFF
--- a/research/lab_notebook/developer.md
+++ b/research/lab_notebook/developer.md
@@ -6,6 +6,26 @@ Format and rules unchanged from the unified notebook — see `shared/feedback_la
 
 ---
 
+## 2026-07-14 - The queue was lying, and it had been for months ([Issue #1153](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1153))
+
+### 13:10 UTC - Editor: Developer - found by a contradiction, not by a search
+
+`board_open_items.py --role X` kept only the **first** `role:` label on an item, so a dual-role Issue was invisible in the queue of whichever role was not listed first. Measured against the live board: **12 open Issues hidden from `--role developer`**, including [Issue #1112](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1112) - an Issue on which **I am the Lead/DRI**. This script backs the morning routine's right-side sweep, `/inbox`, and the quick-win burndown, so the under-count propagated into every board scan I run.
+
+**Nobody went looking for this.** It surfaced in a routine Beat 2 as a *contradiction*: PM's comment said they had committed #1112 to `Ready` with me as Lead, and my own `Ready` queue did not contain it. Two instruments disagreed. The only reason I caught it is that I checked the board directly instead of trusting the scan that had just told me my queue was complete - and the scan had returned exit 0, no warning, a clean short list. **An under-count reads exactly like a small backlog.**
+
+**The corrective pattern already existed, one line away.** The `arc` axis had this identical bug and it was already corrected in [Issue #1103](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1103): `arcs` carries the full label set alongside first-only `arc`, and the filter matches membership. Its code comment even spells out the reason - GitHub returns labels in an **unstable order**, so first-only matching hides an item *nondeterministically*, not merely "the second one". The `role` axis never got the same treatment because the dual-role convention post-dates the single-role assumption baked into the parse. So the fix is not invention, it is **applying a fix we already made to the axis we forgot**.
+
+**The falsifier, and why the matched pair mattered.** Against the pre-fix code the *first-role* test passes and the *second-role* test fails. A test that checked only the first role would have gone green and certified the bug. I also ran the integration check against stashed pre-fix code: **12 hidden before, 0 after**, same command, same board, one variable flipped. Without that control I would have had a green table proving nothing.
+
+**And my verification script had the bug I have already written down.** My first live-board reconciliation used `printf '%s\n' $SEEN` on a space-separated blob. **zsh does not word-split** - the whole blob printed as one line, every count came back `1`, and the table looked plausible enough to read past. Then I fed numerically-sorted input to `comm`, which needs lexicographic order, and got a "hidden" list that was pure garbage. Two silent-wrong-answer bugs, in the eleven lines I wrote to *check* for a silent-wrong-answer bug. Both are already in my memory as rules. Knowing them did not stop me writing them; the only thing that caught them was that the numbers were internally inconsistent (`scan=1` for every role; `hidden` items on a role whose scan count *exceeded* its labelled count) and I refused to let that stand.
+
+**The lesson is not new, it is just newly specific.** The check I write to validate a fix is written by the same person who wrote the fix, out of the same model of the world. It needs a falsifier as much as the code does. Today the tool under test and the tool doing the testing both silently returned a clean, empty, exit-0 answer - and *that shape* is the actual adversary here, not any particular line of code.
+
+**Shipped:** `roles[]` alongside first-only `role` (mirroring `arcs`/`arc`), membership matching in `matches_filter`, a `+N` marker in the Role column so a dual-role row reads as dual, and 8 tests including the matched pair. Verified by driving the real tool against the live board: all four roles now reconcile exactly against `gh issue list --label role:<r>` - zero hidden, zero extra. Suite green (1736 passed).
+
+---
+
 ## 2026-07-13 - I blamed the wrong layer, and the fix was one level in ([PR #1145](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/1145) closes [Issue #1142](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1142))
 
 ### 15:45 UTC - Editor: Developer - a probe that varies two things cannot tell you which one moved

--- a/research/lab_notebook/developer.md
+++ b/research/lab_notebook/developer.md
@@ -8,6 +8,20 @@ Format and rules unchanged from the unified notebook — see `shared/feedback_la
 
 ## 2026-07-14 - The queue was lying, and it had been for months ([Issue #1153](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1153))
 
+### 15:05 UTC - Editor: Developer - I fixed the instance and missed the class. Again.
+
+The bot review on [PR #1154](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/1154) found the **identical bug one file over**: `check_roadmap_health.py:108` imports `board_open_items`, reuses its `normalize()`, and then re-implements its own first-role-only `--role` filter. Character for character the same silent drop. My PR's own thesis was *"apply the fix we already made to the axis we forgot"* - and I shipped it with the axis still forgotten in the second consumer. Shipping it would have made *"the role axis is fixed"* look true while the undercount that hid work from a Lead kept running in the roadmap sweep.
+
+**This is the third consecutive session with the same shape.** 2026-07-12: fixed the flag in `audit_parent_chain`, missed `run_all_mode`. 2026-07-13: fixed the hook I probed, missed the three the probe couldn't see. Today: fixed the axis in the file I was looking at, missed the file that imports it. I have now written "I fix the instance and miss the class" in this notebook three times, and writing it a fourth time is not a plan.
+
+**What actually caught it, all three times, was an external reviewer with a different probe.** Never my own re-read. So the operational lesson is not "look harder" - it is: **when you fix a bug, grep for the *shape* before you open the PR.** I did that afterwards this time, and the sweep found a third site (`dispatch_digest._role_slug`) the bot had only mentioned in passing. That grep cost thirty seconds and would have caught everything the review did. It belongs *before* the PR, not after it.
+
+**And the fix for the review's finding contained the same bug class again.** My first cut read `it.get("roles")` alone, which silently bucketed every legacy-shaped dict (`role` present, `roles` absent) into `(none)`. A pre-existing test in `workflow/tests/` caught it - a directory my "sweep for all consumers" grep had not searched, because I searched `scripts/` and `tools/` and forgot the suite spans five directories. That is *also* a rule already in my memory ([[ci-pytest-runs-five-dirs-not-just-tools-ci]]). Two rules I have written down, both violated inside the fix for a bug about silently-wrong queries.
+
+**Honest limit on what I verified.** `board_open_items` is confirmed against the live board with a matched-pair control (12 hidden -> 0). `check_roadmap_health` is **not** - the board carries exactly one Target-dated item out of 164 open, and it is single-role, so no live dual-role overdue item exists to exercise. Its evidence is the red-first unit pair alone. Writing that down rather than letting "verified" cover both.
+
+**Shipped after review:** `matches_role()` membership matching + `group_by_role()` bucketing under both roles + `_roles_of()` legacy fallback in `check_roadmap_health`; the two `+N` rendering tests the review asked for (verified red against pre-fix code - they had passed on first write only because the fix was already in, which proves nothing); [Issue #1158](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1158) filed for the third site. Suite: 1748 passed.
+
 ### 13:10 UTC - Editor: Developer - found by a contradiction, not by a search
 
 `board_open_items.py --role X` kept only the **first** `role:` label on an item, so a dual-role Issue was invisible in the queue of whichever role was not listed first. Measured against the live board: **12 open Issues hidden from `--role developer`**, including [Issue #1112](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1112) - an Issue on which **I am the Lead/DRI**. This script backs the morning routine's right-side sweep, `/inbox`, and the quick-win burndown, so the under-count propagated into every board scan I run.

--- a/scripts/board_open_items.py
+++ b/scripts/board_open_items.py
@@ -212,7 +212,16 @@ def normalize(item: dict[str, Any]) -> dict[str, Any] | None:
     if status == "Done":
         return None
     labels = [l["name"] for l in content.get("labels", {}).get("nodes", [])]
-    role = next((l for l in labels if l.startswith("role:")), None)
+    # An Issue may carry several `role:` labels - the dual-role convention gives one
+    # role the Lead/DRI and scopes individual ACs to the other. Keep the FULL set, for
+    # the same reason `arcs` does (#1103): GitHub returns labels in an unstable order,
+    # so filtering on the first one alone hides a dual-role item under a role that
+    # varies between calls. #1153: that hid 12 open Issues from `--role developer`,
+    # including one where Developer was the Lead.
+    role_labels = [l for l in labels if l.startswith("role:")]
+    # `role` keeps the first for single-value consumers (the Role column, --json
+    # readers); `roles` carries the full set so the filter cannot silently truncate.
+    role = role_labels[0] if role_labels else None
     arc_labels = [l for l in labels if l.startswith("arc:")]
     # A parent/epic has >=1 sub-issue. PRs (and the rare node the query returned
     # no summary for) have no subIssuesSummary block -> treated as a leaf. Mirrors
@@ -255,6 +264,7 @@ def normalize(item: dict[str, Any]) -> dict[str, Any] | None:
         "size": size,
         "target_date": target_date,
         "role": role,
+        "roles": role_labels,
         "arc": arc,
         "arc_phase": arc_phase,
         "labels": labels,
@@ -340,7 +350,12 @@ def apply_recency(
 def matches_filter(it: dict[str, Any], args: argparse.Namespace) -> bool:
     if args.role:
         want = args.role if args.role.startswith("role:") else f"role:{args.role}"
-        if it["role"] != want:
+        # Membership in the FULL set, not equality with the first role - same reason
+        # as the arc filter below (#1153 / #1103). A dual-role Issue must surface in
+        # BOTH lanes; matching `it["role"]` alone made it appear under one role and
+        # vanish under the other, nondeterministically (GitHub label order is
+        # unstable). A Lead could not see the work they were DRI for.
+        if want not in it["roles"]:
             return False
     if args.status and it["status"] != args.status:
         return False
@@ -388,7 +403,13 @@ def format_table(
         f"{'-' * 17} {'-' * 3} {'-' * 3} {'-' * 5} {'-' * 17} {'-' * 8} {'-' * 10} {arc_sep}{'-' * 60}",
     ]
     for it in items:
-        role = (it["role"] or "(none)").removeprefix("role:")[:16]
+        # A dual-role Issue (#1153) gets a `+N` marker, mirroring the multi-arc cell
+        # below. `--role <r>` matches membership in the FULL set, so without this a
+        # row matched via its SECOND role would display only its first and read as
+        # though it did not match the filter that returned it.
+        role_extra = max(len(it.get("roles") or []) - 1, 0)
+        role_suffix = f" +{role_extra}" if role_extra else ""
+        role = (it["role"] or "(none)").removeprefix("role:")[: 16 - len(role_suffix)] + role_suffix
         # "/D" = draft PR; "/P" = parent/epic Issue (mutually exclusive — a parent
         # is always an Issue, never a draft).
         kind = it["kind"] + ("/D" if it["is_draft"] else "") + ("/P" if it["is_parent"] else "")

--- a/scripts/check_roadmap_health.py
+++ b/scripts/check_roadmap_health.py
@@ -59,11 +59,46 @@ def find_overdue(items: list[dict[str, Any]], today: date) -> list[dict[str, Any
     return [it for _, it in overdue]
 
 
+def _roles_of(it: dict[str, Any]) -> list[str]:
+    """Every `role:` label on an item, tolerating a legacy first-role-only dict.
+
+    Falls back to `[role]` when `roles` is absent rather than treating the item as
+    role-less. Reading `roles` alone would silently bucket every legacy-shaped item
+    into '(none)' - which is the same silent-wrong-answer class #1153 is about, so
+    the fix must not reintroduce it one level down.
+    """
+    roles = it.get("roles")
+    if roles:
+        return list(roles)
+    role = it.get("role")
+    return [role] if role else []
+
+
+def matches_role(it: dict[str, Any], want: str) -> bool:
+    """True if `want` is ANY of the item's role: labels, not merely the first.
+
+    Membership, not equality (#1153). An Issue may carry several `role:` labels
+    (the dual-role convention: one role Leads, the other owns scoped ACs), and
+    GitHub returns labels in an unstable order - so matching `it["role"]`
+    (= labels[0]) drops a dual-role item from one of its owners' views
+    nondeterministically. Mirrors `board_open_items.matches_filter`.
+    """
+    want = want if want.startswith("role:") else f"role:{want}"
+    return want in _roles_of(it)
+
+
 def group_by_role(items: list[dict[str, Any]]) -> dict[str, list[dict[str, Any]]]:
-    """Bucket items by their role:* label; a missing role goes to '(none)'."""
+    """Bucket items by role:* label; a missing role goes to '(none)'.
+
+    An item with two roles appears under BOTH headings (#1153) - an overdue item
+    owned jointly by Sci and Dev is overdue for both of them, and bucketing it
+    under whichever label GitHub happened to return first means one of its owners
+    never sees it in this report.
+    """
     groups: dict[str, list[dict[str, Any]]] = {}
     for it in items:
-        groups.setdefault(it.get("role") or "(none)", []).append(it)
+        for role in _roles_of(it) or ["(none)"]:
+            groups.setdefault(role, []).append(it)
     return groups
 
 
@@ -104,8 +139,7 @@ def main() -> int:
     normalized = [n for it in raw if (n := boi.normalize(it)) is not None]
 
     if args.role:
-        want = args.role if args.role.startswith("role:") else f"role:{args.role}"
-        normalized = [it for it in normalized if it.get("role") == want]
+        normalized = [it for it in normalized if matches_role(it, args.role)]
 
     overdue = find_overdue(normalized, today)
 

--- a/scripts/tests/test_board_open_items_role.py
+++ b/scripts/tests/test_board_open_items_role.py
@@ -84,3 +84,22 @@ def test_role_filter_still_excludes_an_unrelated_role():
 def test_role_filter_accepts_the_prefixed_form():
     n = b.normalize(_item(["role:scientist", "role:developer"]))
     assert b.matches_filter(n, _args(role="role:developer")) is True
+
+
+# --- the Role column must SHOW that a row is dual-role -----------------------
+#
+# Mirrors the arc axis's own rendering pair (test_board_open_items_arc.py:
+# test_arc_column_marks_a_multi_arc_parent / ..._unmarked_for_a_single_arc_item).
+# Without the marker, a row matched via its SECOND role displays only its first
+# and reads as though it did not match the filter that returned it.
+
+def test_role_column_marks_a_dual_role_item():
+    n = b.normalize(_item(["role:scientist", "role:developer"]))
+    out = b.format_table([n])
+    assert "+1" in out
+
+
+def test_role_column_unmarked_for_a_single_role_item():
+    n = b.normalize(_item(["role:developer"]))
+    out = b.format_table([n])
+    assert "+1" not in out

--- a/scripts/tests/test_board_open_items_role.py
+++ b/scripts/tests/test_board_open_items_role.py
@@ -1,0 +1,86 @@
+# scripts/tests/test_board_open_items_role.py
+#
+# Issue #1153: `--role X` kept only the FIRST `role:` label, so a dual-role Issue
+# was invisible in the queue of whichever role was not listed first. Measured on
+# the live board 2026-07-14: 12 open Issues hidden from `--role developer`,
+# including #1112 - an Issue on which Developer is the Lead/DRI.
+#
+# This mirrors the arc axis, which already carries the full label set (#1103) for
+# exactly this reason. GitHub returns labels in an UNSTABLE order, so first-only
+# matching does not merely hide the second role - it hides a *nondeterministic*
+# one, which is why this cannot be worked around by "just label it in the right
+# order".
+import argparse
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+import board_open_items as b  # noqa: E402
+
+
+def _item(labels):
+    return {
+        "content": {
+            "__typename": "Issue", "number": 1112, "title": "t", "url": "u",
+            "state": "OPEN", "createdAt": None, "updatedAt": None, "closedAt": None,
+            "labels": {"nodes": [{"name": n} for n in labels]},
+        },
+        "fieldValues": {"nodes": [{"name": "Ready", "field": {"name": "Status"}}]},
+    }
+
+
+def _args(**kw):
+    base = dict(role=None, status=None, priority=None, size=None, arc=None, arc_phase=None)
+    base.update(kw)
+    return argparse.Namespace(**base)
+
+
+def test_normalize_collects_every_role_label():
+    n = b.normalize(_item(["role:scientist", "role:developer"]))
+    assert n["roles"] == ["role:scientist", "role:developer"]
+
+
+def test_role_key_retains_first_label_for_existing_consumers():
+    """`role` keeps its old first-only meaning so the --json shape does not break."""
+    n = b.normalize(_item(["role:scientist", "role:developer"]))
+    assert n["role"] == "role:scientist"
+
+
+def test_single_role_item_unchanged():
+    n = b.normalize(_item(["role:developer"]))
+    assert n["role"] == "role:developer"
+    assert n["roles"] == ["role:developer"]
+
+
+def test_no_role_labels():
+    n = b.normalize(_item(["arc:board-governance"]))
+    assert n["role"] is None
+    assert n["roles"] == []
+
+
+# --- the matched pair: identical item, one variable flipped, BOTH must match ---
+#
+# This is the falsifier. Against the pre-fix code the `developer` half goes red
+# (the item is filtered out because `role:developer` is not the first label),
+# while the `scientist` half passes - so a test that only checked the first role
+# would have certified the bug as correct behavior.
+
+def test_dual_role_item_matches_under_its_first_role():
+    n = b.normalize(_item(["role:scientist", "role:developer"]))
+    assert b.matches_filter(n, _args(role="scientist")) is True
+
+
+def test_dual_role_item_matches_under_its_second_role():
+    n = b.normalize(_item(["role:scientist", "role:developer"]))
+    assert b.matches_filter(n, _args(role="developer")) is True
+
+
+def test_role_filter_still_excludes_an_unrelated_role():
+    """The guard must still be able to say no, or it is not a filter."""
+    n = b.normalize(_item(["role:scientist", "role:developer"]))
+    assert b.matches_filter(n, _args(role="pm")) is False
+
+
+def test_role_filter_accepts_the_prefixed_form():
+    n = b.normalize(_item(["role:scientist", "role:developer"]))
+    assert b.matches_filter(n, _args(role="role:developer")) is True

--- a/scripts/tests/test_check_roadmap_health_role.py
+++ b/scripts/tests/test_check_roadmap_health_role.py
@@ -1,0 +1,88 @@
+# scripts/tests/test_check_roadmap_health_role.py
+#
+# Issue #1153, second instance. `board_open_items` was fixed to match --role against
+# EVERY role label, but `check_roadmap_health` reuses that same `normalize()` output
+# and re-implemented its own first-role-only filter - so the identical silent drop
+# survived one file over. Caught by the PR #1154 bot review, not by me: I fixed the
+# instance and missed the class, which is the failure mode this repo keeps hitting.
+#
+# The filter is the blocking one (a dual-role overdue Issue vanishes from
+# `--role <r>` for whichever role is not listed first). `group_by_role` is the
+# softer sibling in the same file: an overdue item owned by two roles must appear
+# under BOTH headings, or one of its owners never sees it.
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+import check_roadmap_health as crh  # noqa: E402
+
+
+def _it(roles, number=1112):
+    """A normalize()-shaped item: `role` = first label, `roles` = the full set."""
+    labels = [f"role:{r}" for r in roles]
+    return {"number": number, "role": labels[0] if labels else None, "roles": labels}
+
+
+# --- the blocking one: the --role filter must not silently drop a dual-role item ---
+
+def test_role_filter_matches_dual_role_under_its_second_role():
+    it = _it(["scientist", "developer"])
+    assert crh.matches_role(it, "developer") is True
+
+
+def test_role_filter_matches_dual_role_under_its_first_role():
+    it = _it(["scientist", "developer"])
+    assert crh.matches_role(it, "scientist") is True
+
+
+def test_role_filter_still_says_no_to_an_unrelated_role():
+    """It must still be able to fail, or it is not a filter."""
+    it = _it(["scientist", "developer"])
+    assert crh.matches_role(it, "pm") is False
+
+
+def test_role_filter_accepts_the_prefixed_form():
+    it = _it(["scientist", "developer"])
+    assert crh.matches_role(it, "role:developer") is True
+
+
+def test_role_filter_on_a_single_role_item():
+    it = _it(["developer"])
+    assert crh.matches_role(it, "developer") is True
+    assert crh.matches_role(it, "scientist") is False
+
+
+# --- the softer sibling: grouping must surface a dual-role item to BOTH owners ---
+
+def test_group_by_role_buckets_a_dual_role_item_under_both_roles():
+    groups = crh.group_by_role([_it(["scientist", "developer"])])
+    assert set(groups) == {"role:scientist", "role:developer"}
+    assert groups["role:developer"][0]["number"] == 1112
+    assert groups["role:scientist"][0]["number"] == 1112
+
+
+def test_group_by_role_single_role_unchanged():
+    groups = crh.group_by_role([_it(["developer"])])
+    assert set(groups) == {"role:developer"}
+
+
+def test_group_by_role_roleless_item_goes_to_none_bucket():
+    groups = crh.group_by_role([{"number": 7, "role": None, "roles": []}])
+    assert set(groups) == {"(none)"}
+
+
+# --- legacy shape: an item with `role` but no `roles` must NOT vanish ---------
+#
+# Reading `roles` alone would bucket every first-role-only dict into '(none)' and
+# make `--role X` match nothing - the same silent-wrong-answer class this Issue is
+# about, reintroduced one level down by its own fix. Caught by a pre-existing test
+# in workflow/tests/ (a directory my first grep did not search).
+
+def test_legacy_item_without_roles_key_still_groups_under_its_role():
+    groups = crh.group_by_role([{"number": 1, "role": "role:pm"}])
+    assert set(groups) == {"role:pm"}
+
+
+def test_legacy_item_without_roles_key_still_matches_the_filter():
+    assert crh.matches_role({"number": 1, "role": "role:pm"}, "pm") is True
+    assert crh.matches_role({"number": 1, "role": "role:pm"}, "developer") is False


### PR DESCRIPTION
Closes [Issue #1153](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1153).

`board_open_items.py --role X` kept only the **first** `role:` label, so a dual-role Issue was
invisible in the queue of whichever role was not listed first. Silently: exit 0, no warning, just
a short list that reads like a small backlog.

**Measured on the live board:** 12 open Issues hidden from `--role developer` - including
[Issue #1112](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1112), where Developer
is the **Lead/DRI**. A Lead could not see the work they own. This script backs the morning routine's
right-side sweep, the `/inbox` skill and the `quick-win-burndown` skill, so the under-count
propagated into every board scan.

**It was nondeterministic, not just "the second label".** GitHub returns labels in an unstable
order. The `arc` axis already carries the full label set for exactly this reason
([Issue #1103](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1103)) and its code
comment says so. The `role` axis, one line up, never got the same treatment - the dual-role
convention post-dates the single-role assumption baked into the parse. This applies the fix we
already made, to the axis we forgot.

## What changed

- `roles[]` carries every `role:` label, mirroring `arcs`/`arc`. First-only `role` is **retained**
  with unchanged meaning, so the `--json` shape and existing single-value consumers do not break.
- `matches_filter` matches **membership** in `roles`, not equality with the first.
- The Role column renders a `+N` marker (same convention as the multi-arc cell), so a row matched
  via its second role does not display as though it did not match the filter that returned it.

## Test plan

- [x] 8 new tests in `scripts/tests/test_board_open_items_role.py`, including a **matched-pair
      control**: the same dual-role item must match under **both** its roles.
- [x] **Verified red before the fix** (5 failed / 3 passed). The pair is load-bearing: against the
      pre-fix code the *first*-role half passes and the *second*-role half fails, so a test checking
      only the first role would have gone green and certified the bug.
- [x] Full suite green: **1736 passed**, 21 skipped, across all five CI pytest directories
      (`workflow/tests`, `tools/ci`, `tools/news`, `tools/project_map`, `scripts/tests`).
- [x] **Driven against the live board, not a fixture.** All four roles now reconcile exactly against
      `gh issue list --label role:<r>`: zero hidden, zero extra.
- [x] **Integration-level matched pair:** same check re-run against stashed pre-fix code - **12
      hidden before, 0 after**. Same command, same board, one variable flipped, opposite outcomes.

**Created by:** Developer


---

## Review round 2 (added after the bot's first pass)

The review found the **identical bug in a second consumer** - `check_roadmap_health.py` reuses the
same `normalize()` output and re-implemented its own first-role-only filter. Leaving it would have
made this PR's own thesis ("the role axis is fixed") false while the undercount kept running in the
roadmap sweep. Fixed here rather than deferred.

- [x] `check_roadmap_health.matches_role` matches membership over the full role set (the same silent drop).
- [x] `check_roadmap_health.group_by_role` buckets a dual-role item under **both** headings.
- [x] `_roles_of()` falls back to `[role]` when `roles` is absent - my first cut silently bucketed every
      legacy-shaped dict into `(none)`, reintroducing the very class this PR fixes. A pre-existing test in
      `workflow/tests/` caught it.
- [x] The two `+N` rendering tests the review asked for, completing the mirror of the arc axis to the test
      layer. **Verified red against pre-fix code** - they passed on first write only because the fix was
      already in, which proves nothing.
- [x] Full suite green: **1748 passed**, 21 skipped, all five CI pytest directories.
- [x] Third site (`scripts/pm/dispatch_digest._role_slug` - mis-grouping, no drop) carried on
      [Issue #1158](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1158) rather than growing this PR past its stated scope.

### Known limitation (stated, not hidden)

`board_open_items` is verified against the **live board** with a matched-pair control (12 hidden -> 0;
all four roles reconcile exactly against `gh issue list --label role:<r>`). **`check_roadmap_health` is
not.** The board currently holds exactly **one** Target-dated item out of 164 open, and it is single-role -
so there is no live dual-role overdue item to exercise and the end-to-end path is genuinely unexercised.
Its evidence is the red-first unit matched-pair alone.
