### PR TITLE
fix(pm): the SDR printed a fabricated 0% unplanned - render it as unclassifiable (#1180)

### DIFF
--- a/research/lab_notebook/pm.md
+++ b/research/lab_notebook/pm.md
@@ -8,6 +8,28 @@ Format and rules unchanged from the unified notebook — see `shared/feedback_la
 
 ## 2026-07-14
 
+### 21:45 UTC - Editor: PM
+
+**The SDR has been printing a number that was never a measurement.** [Issue #1180](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1180) -> [PR #1181](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/1181), carved as the first slice of [#1144](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1144).
+
+`gh issue list --label unplanned --state all` returns **zero issues repo-wide.** The label has never been applied to anything. And yet last week's SDR printed a clean, confident `25 / 0 (0% unplanned)` and `[n+0]` on **every** weekly trend row. `throughput_breakdown` guarded the *empty-window* case but not the *marker-never-used* case, which returned `0.0` - and `0.0` is indistinguishable from a real, hard-won zero. Three different worlds (we absorbed no unplanned work / nobody applied the label / the reading code is broken) collapsed into one output. **The number could only ever come back one way** - the exact property [PR #1143](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/1143) built a matched-pair control to escape, reproduced **one layer up, in its own input.**
+
+**The design call I most want to remember: `n_committed` had to become `None` too.** The tempting fix is to null the percentage and leave the counts. But "25 committed" is the **same false assertion** as "0% unplanned", one column over - it asserts an arrival classification we cannot make. So when the marker is unused, *nothing* delivered is classifiable, and the count surfaces as `n_unclassifiable`. A degraded input has to be **visible**, not quietly absorbed. And `marker_in_use` is a **required** keyword, because a default is just a slower way of letting a future call site fabricate.
+
+**Then the same disease bit me twice more inside the fix itself, and neither was caught by care.**
+
+**(a) The em-dash cleanup had four emitting sites; I found three by grep and was ready to ship.** The fourth - a Jinja `pct` filter - surfaced only when my new test ran against a **live render**. Grep found what I thought to look for.
+
+**(b) The bot found `[None+None]` printing on every console trend row** - in the exact mode this PR exists to fix. My PR body claimed *"card, pills, trend column, and text summary all render unclassifiable."* **Only the headline did.** I had described the fix I intended, not the fix I shipped.
+
+**And the way (b) survived is the thing worth writing down.** I *did* run the real command against the real board. Then I **grepped the output for `arrival`** - the line I had just fixed. **My verification could only ever confirm the change I already knew about.** A check aimed at what you changed cannot show you what you missed.
+
+So: **three layers of one disease in a single Issue.** A metric that could only come back one way. A test that only checked the doubt I already had. A live verification that only looked where I had already looked. The fix for a check-that-cannot-fail was itself verified by a check that could not fail. I don't think I get to call that ironic anymore; it looks more like the default state, and the only reliable escape has been an instrument I did not build - the reviewer, or Jin-Ho asking why.
+
+**Also worth keeping:** the reviewer's nit was that my em-dash test skipped the `lstrip` char-class by matching the string's *prefix* - a **value heuristic**. Correct, and I took it: shipping an approximate match **inside a test written to reject approximate matching** would have been a poor joke. Replaced with an AST **context** check.
+
+**Board:** #1144 gained a sub-issue and is therefore now a parent, so it moved to `Epic` with Priority/Size cleared (Pattern A2) - a parent never sits in a workflow column. Its remaining scope (the marker's *slip rate*, once the marker is actually in use) genuinely needs [#1138](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1138)'s `Backlog -> Ready` transition history, which is exactly why the slice was carved rather than blocked behind it. Also filed [#1179](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1179) (P3): the two PM sweeps' `--check` exit codes are **inverted**, which would silently misread if a future routine shelled both.
+
 ### 20:40 UTC - Editor: PM
 
 **A question from Jin-Ho found a worse bug than the code review did.** Amending nothing below (entries are immutable) - this supersedes the design described in the 19:05 entry.

--- a/scripts/pm/milestone_report.py
+++ b/scripts/pm/milestone_report.py
@@ -129,23 +129,76 @@ def committed_issues(issues: list[dict]) -> list[dict]:
     return [i for i in issues if not is_unplanned(i)]
 
 
-def throughput_breakdown(issues: list[dict]) -> dict[str, Any]:
+def is_marker_in_use(repo_label_count: int) -> bool:
+    """Is the arrival marker actually in use, repo-wide? Pure given the count.
+
+    The whole point of the arrival axis is to be falsifiable, and this is the fact
+    that makes it so. Split out as a pure function over an injected count (rather than
+    doing the ``gh`` call inline) so the fabricating case is unit-testable without a
+    network, which is exactly the property the metric was missing.
+
+    A count of 0 means the label has never been applied to anything - so the arrival
+    axis is **not in use**, and no delivered item can be classified by it. See
+    ``throughput_breakdown`` for why that must not render as 0%.
+    """
+    return repo_label_count > 0
+
+
+def throughput_breakdown(issues: list[dict], *, marker_in_use: bool) -> dict[str, Any]:
     """Split *delivered* work by arrival: committed vs unplanned.
 
     The Kanban Throughput Breakdown Chart, reduced to the one split we actually
     need. Keyed off delivered (not raw closed) for the same reason throughput and
     cycle time are: a descoped issue is not shipped work.
 
-    ``pct_unplanned`` is None (not 0.0) on an empty delivered set, so a zero-ship
-    week reads as "no data" rather than as a truthful-looking 0% unplanned.
+    **Two degenerate cases, both of which must NOT print a confident zero.**
+
+    1. *Empty window* - no delivered issues at all. ``pct_unplanned`` is None (not
+       0.0), so a zero-ship week reads as "no data". This guard already existed.
+
+    2. *The marker is not in use* (``marker_in_use=False``) - i.e. the ``unplanned``
+       label has never been applied to anything, repo-wide. This returned **0.0**,
+       and 0.0 is indistinguishable from a real, hard-won, measured zero:
+
+           | we genuinely absorbed no unplanned work | -> 0% |
+           | nobody ever applied the label           | -> 0% |
+           | the label-reading code is broken        | -> 0% |
+
+       Three different worlds, one confident output. The number could only ever come
+       back one way. That is not a measurement, it is a fabrication wearing a
+       measurement's clothes - the most dangerous state for a metric (Issue #1180).
+
+       When the marker is not in use, **nothing delivered can be classified by
+       arrival at all**, so ``n_committed`` is None too. Printing "25 committed"
+       would be exactly the same false assertion as "0% unplanned", one column over.
+       The delivered count is reported as ``n_unclassifiable`` instead, so a degraded
+       input is *visible* rather than silently absorbed.
+
+    ``marker_in_use`` is a **required keyword**, deliberately: it cannot be derived
+    from ``issues`` (from that list alone, "no delivered issue carries the label" is
+    information-theoretically identical in both worlds), and a default would let a
+    caller silently fall back into the fabricating behavior. Making it required means
+    a new call site must *decide*.
     """
     delivered = delivered_issues(issues)
-    n_unplanned = len(unplanned_issues(delivered))
     n_delivered = len(delivered)
+
+    if not marker_in_use:
+        return {
+            "n_committed": None,
+            "n_unplanned": None,
+            "n_unclassifiable": n_delivered,
+            "pct_unplanned": None,
+            "marker_in_use": False,
+        }
+
+    n_unplanned = len(unplanned_issues(delivered))
     return {
         "n_committed": n_delivered - n_unplanned,
         "n_unplanned": n_unplanned,
+        "n_unclassifiable": 0,
         "pct_unplanned": (100.0 * n_unplanned / n_delivered) if n_delivered else None,
+        "marker_in_use": True,
     }
 
 
@@ -292,7 +345,8 @@ def closed_in_window(issues: list[dict], start: datetime, end: datetime) -> list
     return out
 
 
-def weekly_series(issues: list[dict], until: datetime, n_weeks: int) -> list[dict]:
+def weekly_series(issues: list[dict], until: datetime, n_weeks: int,
+                  *, marker_in_use: bool) -> list[dict]:
     """Per-week throughput + median cycle-time trend over the trailing weeks.
 
     Each entry: ``{week_start, week_end, n_delivered, median_cycle_time_days}``
@@ -317,7 +371,7 @@ def weekly_series(issues: list[dict], until: datetime, n_weeks: int) -> list[dic
         series.append({
             "week_start": _first_covered_day(start).isoformat(),
             "week_end": end.date().isoformat(),
-            **throughput_breakdown(in_window),
+            **throughput_breakdown(in_window, marker_in_use=marker_in_use),
             "n_delivered": len(delivered),
             "median_cycle_time_days": median_cycle_time(delivered),
         })
@@ -325,7 +379,8 @@ def weekly_series(issues: list[dict], until: datetime, n_weeks: int) -> list[dic
 
 
 def compute_window_metrics(
-    week_issues: list[dict], all_issues: list[dict], until: datetime, n_weeks: int
+    week_issues: list[dict], all_issues: list[dict], until: datetime, n_weeks: int,
+    *, marker_in_use: bool
 ) -> dict[str, Any]:
     """Headline (reporting-week) metrics + the weekly trend for SDR window mode.
 
@@ -347,12 +402,14 @@ def compute_window_metrics(
         "avg_cycle_time_days": avg_cycle_time(delivered),
         "median_cycle_time_days": median_cycle_time(delivered),
         "per_role_counts": per_role_counts(week_issues),
-        **throughput_breakdown(week_issues),
-        "weekly_series": weekly_series(all_issues, until, n_weeks),
+        **throughput_breakdown(week_issues, marker_in_use=marker_in_use),
+        "weekly_series": weekly_series(all_issues, until, n_weeks,
+                                       marker_in_use=marker_in_use),
     }
 
 
-def compute_metrics(issues: list[dict], milestone: dict) -> dict[str, Any]:
+def compute_metrics(issues: list[dict], milestone: dict,
+                    *, marker_in_use: bool) -> dict[str, Any]:
     """Assemble the headline metrics block from the data layer."""
     closed = closed_issues(issues)
     delivered = delivered_issues(issues)
@@ -374,7 +431,7 @@ def compute_metrics(issues: list[dict], milestone: dict) -> dict[str, Any]:
         "avg_cycle_time_days": avg_cycle_time(delivered),
         "median_cycle_time_days": median_cycle_time(delivered),
         "per_role_counts": per_role_counts(issues),
-        **throughput_breakdown(issues),
+        **throughput_breakdown(issues, marker_in_use=marker_in_use),
     }
 
 
@@ -469,14 +526,35 @@ def _normalize_issue(it: dict, board: dict[int, dict]) -> dict:
         "labels": labels,
         "roles": [l for l in labels if l.startswith("role:")],
         "arcs": [l for l in labels if l.startswith("arc:")],
-        "status": b.get("status") or ("Done" if it["state"].upper() == "CLOSED" else "—"),
-        "priority": b.get("priority") or "—",
-        "size": b.get("size") or "—",
+        "status": b.get("status") or ("Done" if it["state"].upper() == "CLOSED" else "n/a"),
+        # "n/a", not an em-dash: this string is emitted into the generated HTML,
+        # where the house no-em-dash rule applies and no guard can see it (the
+        # PreToolUse guard scans Claude's edits, not a script's output). Issue #1180.
+        "priority": b.get("priority") or "n/a",
+        "size": b.get("size") or "n/a",
     }
     # Single-source the descoped flag for the inventory badge (covers
     # NOT_PLANNED + DUPLICATE without the template hardcoding the set).
     issue["is_descoped"] = is_descoped(issue)
     return issue
+
+
+def fetch_marker_in_use() -> bool:
+    """Has the ``unplanned`` label EVER been applied, repo-wide?
+
+    The falsifier the arrival metric was missing. Deliberately repo-wide and
+    all-states: the question is not "did this window have unplanned work" (which the
+    issue list already answers, ambiguously) but "is the marker being used at all" -
+    a fact that no window of issues can supply about itself.
+
+    ``--limit 1`` because the count is irrelevant; only zero-vs-nonzero matters.
+    """
+    raw = _gh([
+        "issue", "list", "--repo", f"{OWNER}/{REPO}",
+        "--label", UNPLANNED_LABEL, "--state", "all", "--limit", "1",
+        "--json", "number",
+    ])
+    return is_marker_in_use(len(json.loads(raw)))
 
 
 def fetch_milestone_issues(name: str) -> list[dict]:
@@ -576,9 +654,9 @@ def seed_narrative(milestone: dict, issues: list[dict], metrics: dict) -> str:
         "",
         "<!-- Lead role: what shipped, grouped by deliverable, with PR + slide links.",
         f"     The {len(delivered)} delivered issues are listed in the Inventory appendix",
-        "     below — narrate the highlights here, don't re-list them. -->",
+        "     below - narrate the highlights here, don't re-list them. -->",
         "",
-        "_Seeded from the lead role's lab-notebook entries in the milestone window — "
+        "_Seeded from the lead role's lab-notebook entries in the milestone window - "
         "replace with the deliverables narrative._",
         "",
     ]
@@ -589,11 +667,11 @@ def seed_narrative(milestone: dict, issues: list[dict], metrics: dict) -> str:
             "## Descoped (closed NOT_PLANNED)",
             "",
             "<!-- These closed WITHOUT shipping (superseded / YAGNI / wontfix). They are",
-            "     excluded from the delivered count — record why each was dropped + where",
+            "     excluded from the delivered count - record why each was dropped + where",
             "     the need (if any) was routed, so the descope isn't silently masked. -->",
             "",
         ]
-        lines += [f"- [#{i['number']}]({i['url']}) {i['title']} — _why descoped: TBD_" for i in descoped]
+        lines += [f"- [#{i['number']}]({i['url']}) {i['title']} - _why descoped: TBD_" for i in descoped]
     lines += [
         "",
         "## Carried-forward & routing",
@@ -602,7 +680,7 @@ def seed_narrative(milestone: dict, issues: list[dict], metrics: dict) -> str:
         "     closure-routing decision (a/b/c/d). -->",
         "",
     ]
-    lines += [f"- [#{i['number']}]({i['url']}) {i['title']} — _route: TBD_" for i in carried] or ["- _(none carried forward)_"]
+    lines += [f"- [#{i['number']}]({i['url']}) {i['title']} - _route: TBD_" for i in carried] or ["- _(none carried forward)_"]
     lines += [
         "",
         "## Retrospective (process/health)",
@@ -630,7 +708,7 @@ def render_html(
         loader=FileSystemLoader(str(TEMPLATE_PATH.parent)),
         autoescape=select_autoescape(["html", "j2"]),
     )
-    env.filters["pct"] = lambda v: f"{v:.0%}" if v is not None else "—"
+    env.filters["pct"] = lambda v: f"{v:.0%}" if v is not None else "n/a"
     template = env.get_template(TEMPLATE_PATH.name)
     # Milestone-level arc(s) = the distinct arc labels across its issues (arc is
     # a per-issue label under the three-axis model, not a milestone property).
@@ -649,7 +727,7 @@ def render_html(
 
 
 def _fmt(v: Optional[float], unit: str = "") -> str:
-    return "—" if v is None else f"{v:.1f}{unit}"
+    return "n/a" if v is None else f"{v:.1f}{unit}"
 
 
 def print_metrics(milestone: dict, metrics: dict) -> None:
@@ -663,9 +741,17 @@ def print_metrics(milestone: dict, metrics: dict) -> None:
     print(f"  delivered / descoped (closed)    : "
           f"{metrics['n_delivered']} / {metrics['n_descoped']}")
     pct = metrics.get("pct_unplanned")
-    print(f"  arrival: committed / unplanned   : "
-          f"{metrics['n_committed']} / {metrics['n_unplanned']}"
-          f"{f'  ({pct:.0f}% unplanned)' if pct is not None else '  (no delivered work)'}")
+    if not metrics.get("marker_in_use", True):
+        # The marker has never been applied repo-wide, so NOTHING delivered can be
+        # classified by arrival. Printing "N / 0  (0% unplanned)" here would be a
+        # fabrication wearing a measurement's clothes (Issue #1180).
+        print(f"  arrival: UNCLASSIFIABLE          : "
+              f"{metrics['n_unclassifiable']} delivered, none classifiable "
+              f"(the `{UNPLANNED_LABEL}` marker is not in use repo-wide)")
+    else:
+        print(f"  arrival: committed / unplanned   : "
+              f"{metrics['n_committed']} / {metrics['n_unplanned']}"
+              f"{f'  ({pct:.0f}% unplanned)' if pct is not None else '  (no delivered work)'}")
     print(f"  duration (days)                  : {_fmt(metrics['duration_days'])}")
     print(f"  throughput (delivered/week)      : {_fmt(metrics['throughput_per_week'])}")
     print(f"  cycle time avg / median (days)   : "
@@ -706,7 +792,7 @@ def _generate(milestone: dict, issues: list[dict], metrics: dict,
 def _run_milestone_mode(name: str, out_dir: Optional[Path], dry_run: bool) -> int:
     milestone = fetch_milestone(name)
     issues = fetch_milestone_issues(name)
-    metrics = compute_metrics(issues, milestone)
+    metrics = compute_metrics(issues, milestone, marker_in_use=fetch_marker_in_use())
     return _generate(milestone, issues, metrics, out_dir or DEFAULT_OUT_DIR, dry_run, "milestone")
 
 
@@ -745,7 +831,8 @@ def _run_window_mode(ap: argparse.ArgumentParser, since: Optional[str], until: O
 
     all_issues = fetch_window_issues(*fetch_span(until_dt, n_weeks))
     week_issues = closed_in_window(all_issues, report_start, report_end)
-    metrics = compute_window_metrics(week_issues, all_issues, until_dt, n_weeks)
+    metrics = compute_window_metrics(week_issues, all_issues, until_dt, n_weeks,
+                                     marker_in_use=fetch_marker_in_use())
 
     if metrics["n_total"] == 0:  # nothing closed in the reporting week -> no artifact
         print(f"Meta-work SDR - week ending {report_end.date().isoformat()}: "

--- a/scripts/pm/milestone_report.py
+++ b/scripts/pm/milestone_report.py
@@ -762,8 +762,26 @@ def print_metrics(milestone: dict, metrics: dict) -> None:
         print("  weekly trend (delivered [committed+unplanned] / median cycle days):")
         for w in series:
             print(f"    {w['week_start']}..{w['week_end']} : "
-                  f"{w['n_delivered']} [{w['n_committed']}+{w['n_unplanned']}] / "
+                  f"{w['n_delivered']} [{_fmt_arrival(w)}] / "
                   f"{_fmt(w['median_cycle_time_days'])}")
+
+
+def _fmt_arrival(w: dict) -> str:
+    """Render one weekly row's arrival split, or say it cannot be rendered.
+
+    Mirrors the headline `arrival:` line. Without this the row printed the literal
+    ``[None+None]`` whenever the marker was not in use - not a fabrication (None is at
+    least honest), but a leak of an internal sentinel into a human-facing report, and
+    inconsistent with every other surface this fix touched.
+
+    Caught in review, and worth recording HOW it survived: the live check that was
+    supposed to verify this fix grepped the output for `arrival` - i.e. for the line
+    already known to be fixed. A check aimed only at what you changed cannot show you
+    what you missed.
+    """
+    if w["n_committed"] is None:
+        return "unclassifiable"
+    return f"{w['n_committed']}+{w['n_unplanned']}"
 
 
 # --- orchestration ----------------------------------------------------------

--- a/scripts/pm/templates/milestone_report.html.j2
+++ b/scripts/pm/templates/milestone_report.html.j2
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Milestone closure report — {{ milestone.title }}</title>
+<title>Milestone closure report - {{ milestone.title }}</title>
 <style>
   :root { --fg:#1b1f24; --muted:#656d76; --line:#d0d7de; --accent:#0969da;
           --ok:#1a7f37; --warn:#9a6700; --bg:#fff; --soft:#f6f8fa; }
@@ -64,18 +64,29 @@
     <div class="card"><div class="n">{{ metrics.n_delivered }}</div><div class="l">Delivered</div></div>
     {% if metrics.n_descoped %}<div class="card"><div class="n">{{ metrics.n_descoped }}</div><div class="l">Descoped</div></div>{% endif %}
     <div class="card"><div class="n">{{ metrics.n_carried_forward }}</div><div class="l">Carried forward</div></div>
-    <div class="card"><div class="n">{{ "%.1f"|format(metrics.throughput_per_week) if metrics.throughput_per_week is not none else "—" }}</div><div class="l">Delivered / week</div></div>
-    <div class="card"><div class="n">{{ "%.1f"|format(metrics.avg_cycle_time_days) if metrics.avg_cycle_time_days is not none else "—" }}</div><div class="l">Avg cycle (days)</div></div>
-    <div class="card"><div class="n">{{ "%.1f"|format(metrics.median_cycle_time_days) if metrics.median_cycle_time_days is not none else "—" }}</div><div class="l">Median cycle (days)</div></div>
-    <div class="card"><div class="n">{{ "%.0f%%"|format(metrics.pct_unplanned) if metrics.pct_unplanned is not none else "-" }}</div><div class="l">Unplanned share</div></div>
+    <div class="card"><div class="n">{{ "%.1f"|format(metrics.throughput_per_week) if metrics.throughput_per_week is not none else "n/a" }}</div><div class="l">Delivered / week</div></div>
+    <div class="card"><div class="n">{{ "%.1f"|format(metrics.avg_cycle_time_days) if metrics.avg_cycle_time_days is not none else "n/a" }}</div><div class="l">Avg cycle (days)</div></div>
+    <div class="card"><div class="n">{{ "%.1f"|format(metrics.median_cycle_time_days) if metrics.median_cycle_time_days is not none else "n/a" }}</div><div class="l">Median cycle (days)</div></div>
+    <div class="card"><div class="n">{{ "%.0f%%"|format(metrics.pct_unplanned) if metrics.pct_unplanned is not none else "n/a" }}</div><div class="l">Unplanned share</div></div>
   </div>
 
   <!-- Throughput breakdown by arrival (Issue #811): committed = crossed Backlog -> Ready;
-       unplanned = barged in mid-session. Arrival, not urgency - priority cannot express it. -->
+       unplanned = barged in mid-session. Arrival, not urgency - priority cannot express it.
+
+       The marker-not-in-use branch (Issue #1180) is load-bearing, not cosmetic: if the
+       `unplanned` label has never been applied repo-wide, NOTHING delivered can be
+       classified by arrival, and rendering "N committed / 0 unplanned / 0%" would be a
+       fabrication that looks exactly like a measurement. This card sits ABOVE the
+       narrative, so no prose caveat can outrank it - only the generator can. -->
   <div class="rolebar">
+    {% if metrics.marker_in_use is defined and not metrics.marker_in_use %}
+    <span class="pill">arrival · <strong>unclassifiable</strong></span>
+    <span class="sub">{{ metrics.n_unclassifiable }} delivered, none classifiable - the <code>unplanned</code> marker is not in use repo-wide, so a 0% here would be fabricated, not measured</span>
+    {% else %}
     <span class="pill">committed · <strong>{{ metrics.n_committed }}</strong></span>
     <span class="pill">unplanned · <strong>{{ metrics.n_unplanned }}</strong></span>
     {% if metrics.pct_unplanned is none %}<span class="sub">no delivered work in window</span>{% endif %}
+    {% endif %}
   </div>
   <div class="rolebar">
     {% for role, count in metrics.per_role_counts.items() %}
@@ -92,7 +103,7 @@
     <thead><tr><th>Week ending</th><th>Delivered</th><th>Committed</th><th>Unplanned</th><th>Unplanned %</th><th>Median cycle (days)</th></tr></thead>
     <tbody>
       {% for w in metrics.weekly_series %}
-      <tr><td>{{ w.week_end }}</td><td>{{ w.n_delivered }}</td><td>{{ w.n_committed }}</td><td>{{ w.n_unplanned }}</td><td>{{ "%.0f%%"|format(w.pct_unplanned) if w.pct_unplanned is not none else "-" }}</td><td>{{ "%.1f"|format(w.median_cycle_time_days) if w.median_cycle_time_days is not none else "-" }}</td></tr>
+      <tr><td>{{ w.week_end }}</td><td>{{ w.n_delivered }}</td><td>{{ w.n_committed if w.n_committed is not none else "n/a" }}</td><td>{{ w.n_unplanned if w.n_unplanned is not none else "n/a" }}</td><td>{{ "%.0f%%"|format(w.pct_unplanned) if w.pct_unplanned is not none else "n/a" }}</td><td>{{ "%.1f"|format(w.median_cycle_time_days) if w.median_cycle_time_days is not none else "n/a" }}</td></tr>
       {% endfor %}
     </tbody>
   </table>
@@ -113,10 +124,10 @@
         <td><a href="{{ i.url }}">#{{ i.number }}</a></td>
         <td>{{ i.title }}</td>
         <td>{{ i.status }}{% if i.is_descoped %}<span class="badge descoped">descoped</span>{% endif %}</td>
-        <td>{{ i.roles|join(", ")|replace("role:", "") or "—" }}</td>
+        <td>{{ i.roles|join(", ")|replace("role:", "") or "n/a" }}</td>
         <td>{{ i.size }}</td>
         <td>{{ i.priority }}</td>
-        <td>{{ i.closed_at[:10] if i.closed_at else "—" }}</td>
+        <td>{{ i.closed_at[:10] if i.closed_at else "n/a" }}</td>
       </tr>
       {% endfor %}
     </tbody>

--- a/tools/ci/test_milestone_report.py
+++ b/tools/ci/test_milestone_report.py
@@ -10,6 +10,7 @@ inside the render/aggregation functions so this test runs in the bare
 ``ci-tools-pytest`` env (pytest + pyyaml only).
 """
 
+import ast
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
@@ -179,6 +180,7 @@ class TestComputeMetrics:
         m = mr.compute_metrics(
             SAMPLE,
             {"created_at": "2026-06-01T00:00:00Z", "closed_at": "2026-06-08T00:00:00Z"},
+            marker_in_use=True,
         )
         assert m["n_total"] == 4
         assert m["n_closed"] == 3
@@ -196,6 +198,7 @@ class TestComputeMetrics:
         m = mr.compute_metrics(
             MIXED,
             {"created_at": "2026-06-01T00:00:00Z", "closed_at": "2026-06-08T00:00:00Z"},
+            marker_in_use=True,
         )
         assert m["n_closed"] == 4
         assert m["n_delivered"] == 2
@@ -211,12 +214,13 @@ class TestComputeMetrics:
     def test_partition_invariant(self):
         # delivered + descoped always exactly partitions closed.
         m = mr.compute_metrics(
-            MIXED, {"created_at": None, "closed_at": "2026-06-08T00:00:00Z"}
+            MIXED, {"created_at": None, "closed_at": "2026-06-08T00:00:00Z"},
+            marker_in_use=True,
         )
         assert m["n_delivered"] + m["n_descoped"] == m["n_closed"]
 
     def test_empty_milestone_degrades(self):
-        m = mr.compute_metrics([], {"created_at": None, "closed_at": None})
+        m = mr.compute_metrics([], {"created_at": None, "closed_at": None}, marker_in_use=True)
         assert m["n_total"] == m["n_closed"] == m["n_carried_forward"] == 0
         assert m["n_delivered"] == m["n_descoped"] == 0
         assert m["duration_days"] is None
@@ -274,7 +278,7 @@ class TestClosedInWindow:
 
 class TestWeeklySeries:
     def test_trend_buckets_and_medians(self):
-        s = mr.weekly_series(WINDOW_ISSUES, UNTIL, 4)
+        s = mr.weekly_series(WINDOW_ISSUES, UNTIL, 4, marker_in_use=True)
         assert [w["n_delivered"] for w in s] == [1, 0, 1, 2]   # w1, w2(empty), w3, w4
         assert s[1]["median_cycle_time_days"] is None          # empty week -> None
         assert s[0]["median_cycle_time_days"] == pytest.approx(2.0)   # #5
@@ -287,7 +291,7 @@ class TestComputeWindowMetrics:
     def test_headline_over_reporting_week_plus_trend(self):
         week_issues = mr.closed_in_window(
             WINDOW_ISSUES, datetime(2026, 6, 26, tzinfo=timezone.utc), UNTIL)
-        m = mr.compute_window_metrics(week_issues, WINDOW_ISSUES, UNTIL, 4)
+        m = mr.compute_window_metrics(week_issues, WINDOW_ISSUES, UNTIL, 4, marker_in_use=True)
         assert m["n_total"] == 3            # #1, #2, #4 closed in the reporting week
         assert m["n_delivered"] == 2        # #1, #2 (descoped #4 excluded)
         assert m["n_descoped"] == 1         # #4 NOT_PLANNED
@@ -302,7 +306,7 @@ class TestComputeWindowMetrics:
         old = [_issue(20, "CLOSED", "2026-06-08T00:00:00Z", "2026-06-10T00:00:00Z", ["role:pm"], "COMPLETED")]
         week_issues = mr.closed_in_window(
             old, datetime(2026, 6, 26, tzinfo=timezone.utc), UNTIL)
-        m = mr.compute_window_metrics(week_issues, old, UNTIL, 4)
+        m = mr.compute_window_metrics(week_issues, old, UNTIL, 4, marker_in_use=True)
         # main() gates the zero-ship skip on n_total == 0 (nothing closed in the
         # reporting week); delivered is 0 and cycle time is undefined.
         assert m["n_total"] == 0
@@ -376,7 +380,7 @@ class TestArrivalAxis:
     def test_matched_pair_lands_on_opposite_sides(self):
         # Identical but for the marker -> opposite sides. This is the control:
         # if the marker were ignored, both would land as committed and this fails.
-        b = mr.throughput_breakdown(ARRIVAL)
+        b = mr.throughput_breakdown(ARRIVAL, marker_in_use=True)
         assert b["n_committed"] == 1
         assert b["n_unplanned"] == 1
 
@@ -384,16 +388,16 @@ class TestArrivalAxis:
         # #3 carries the marker but closed NOT_PLANNED. It is not shipped work,
         # so it must not inflate the unplanned count - otherwise the "unplanned
         # share" would be measuring abandoned work, not absorbed capacity.
-        b = mr.throughput_breakdown(ARRIVAL)
+        b = mr.throughput_breakdown(ARRIVAL, marker_in_use=True)
         assert b["n_committed"] + b["n_unplanned"] == len(mr.delivered_issues(ARRIVAL)) == 2
 
     def test_pct_unplanned(self):
-        assert mr.throughput_breakdown(ARRIVAL)["pct_unplanned"] == pytest.approx(50.0)
+        assert mr.throughput_breakdown(ARRIVAL, marker_in_use=True)["pct_unplanned"] == pytest.approx(50.0)
 
     def test_pct_is_none_not_zero_on_empty_window(self):
         # A zero-ship week must read as "no data", not as a truthful-looking 0%
         # unplanned - the latter would be a number the WIP retune could act on.
-        assert mr.throughput_breakdown([])["pct_unplanned"] is None
+        assert mr.throughput_breakdown([], marker_in_use=True)["pct_unplanned"] is None
 
     def test_unlabelled_issue_is_committed(self):
         # Guards the back-compat assumption every pre-#811 fixture leans on.
@@ -407,18 +411,174 @@ class TestArrivalAxis:
                               ["role:pm"], "COMPLETED", ["P1"])
         p2_unplanned = _issue(11, "CLOSED", "2026-06-01T00:00:00Z", "2026-06-02T00:00:00Z",
                               ["role:pm"], "COMPLETED", ["P2", "unplanned"])
-        b = mr.throughput_breakdown([p1_committed, p2_unplanned])
+        b = mr.throughput_breakdown([p1_committed, p2_unplanned], marker_in_use=True)
         assert (b["n_committed"], b["n_unplanned"]) == (1, 1)
 
     def test_metrics_carry_the_split(self):
-        m = mr.compute_metrics(ARRIVAL, {"closed_at": None, "created_at": None})
+        m = mr.compute_metrics(ARRIVAL, {"closed_at": None, "created_at": None}, marker_in_use=True)
         assert m["n_committed"] == 1 and m["n_unplanned"] == 1
         assert m["pct_unplanned"] == pytest.approx(50.0)
 
     def test_weekly_series_carries_the_split(self):
         until = datetime(2026, 6, 8, tzinfo=timezone.utc)
-        series = mr.weekly_series(ARRIVAL, until, 1)
+        series = mr.weekly_series(ARRIVAL, until, 1, marker_in_use=True)
         assert series[0]["n_committed"] == 1
         assert series[0]["n_unplanned"] == 1
         # Conservation: the split must exactly partition the delivered count.
         assert series[0]["n_committed"] + series[0]["n_unplanned"] == series[0]["n_delivered"]
+
+
+# --- the marker's OWN falsifier (Issue #1180) --------------------------------
+
+# A window of delivered work in which NOT ONE issue carries the marker. From this
+# list alone, two completely different worlds are information-theoretically
+# identical:
+#   (a) the marker IS in use, and we genuinely absorbed no unplanned work -> a real 0%
+#   (b) the marker was NEVER applied to anything                          -> 0% is a fiction
+# The list cannot tell them apart. Only the injected `marker_in_use` fact can.
+NO_MARKER_ANYWHERE = [
+    _issue(1, "CLOSED", "2026-06-01T00:00:00Z", "2026-06-03T00:00:00Z",
+           ["role:pm"], "COMPLETED"),
+    _issue(2, "CLOSED", "2026-06-01T00:00:00Z", "2026-06-03T00:00:00Z",
+           ["role:dev"], "COMPLETED"),
+]
+
+# Built from codepoints, not typed: this file must CONTAIN no em/en dash (the repo
+# guard rejects one on sight) while still asserting their absence elsewhere.
+EM_DASH = chr(0x2014)
+EN_DASH = chr(0x2013)
+
+
+class TestMarkerNotInUse:
+    """The metric's own falsifier: a 0% that could only ever come back one way.
+
+    Before Issue #1180 the SDR printed a clean, confident `25 / 0 (0% unplanned)` on
+    every weekly row - while `gh issue list --label unplanned --state all` returned
+    ZERO issues repo-wide. The label had never been applied to anything. The
+    measurement shipped; the thing being measured did not.
+    """
+
+    def test_matched_pair_real_zero_vs_fabricated_zero(self):
+        """THE test. Identical input, one fact flipped, opposite outputs.
+
+        Without this pair the fix is unfalsifiable - which is precisely the disease
+        being cured, so shipping the cure without it would be self-refuting.
+        """
+        real_zero = mr.throughput_breakdown(NO_MARKER_ANYWHERE, marker_in_use=True)
+        fabricated = mr.throughput_breakdown(NO_MARKER_ANYWHERE, marker_in_use=False)
+
+        # In use + nobody was unplanned -> a genuine, hard-won zero. Report it.
+        assert real_zero["pct_unplanned"] == pytest.approx(0.0)
+        assert real_zero["n_committed"] == 2
+        assert real_zero["n_unclassifiable"] == 0
+
+        # Not in use -> the SAME list means nothing. Refuse to print a number.
+        assert fabricated["pct_unplanned"] is None
+        assert fabricated["n_committed"] is None, (
+            "'2 committed' is the same false assertion as '0% unplanned', one column over"
+        )
+        assert fabricated["n_unplanned"] is None
+        assert fabricated["n_unclassifiable"] == 2, "the degraded input must be VISIBLE"
+
+    def test_marker_in_use_is_zero_vs_nonzero_on_the_repo_count(self):
+        assert mr.is_marker_in_use(0) is False
+        assert mr.is_marker_in_use(1) is True
+
+    def test_the_two_none_worlds_stay_distinguishable(self):
+        """`pct_unplanned is None` now has two causes; they must not collapse.
+
+        Empty window (no delivered work) and marker-not-in-use both yield None, but
+        they are different failures and the report says different things about them -
+        so the `marker_in_use` flag has to survive into the metrics dict.
+        """
+        empty_window = mr.throughput_breakdown([], marker_in_use=True)
+        assert empty_window["pct_unplanned"] is None
+        assert empty_window["marker_in_use"] is True
+        assert empty_window["n_committed"] == 0     # honestly zero: there IS no work
+
+        not_in_use = mr.throughput_breakdown(NO_MARKER_ANYWHERE, marker_in_use=False)
+        assert not_in_use["pct_unplanned"] is None
+        assert not_in_use["marker_in_use"] is False
+        assert not_in_use["n_committed"] is None    # unknowable: there IS work, unclassified
+
+    def test_marker_in_use_is_a_required_keyword(self):
+        """A default would let a new call site silently fabricate. It must decide."""
+        with pytest.raises(TypeError):
+            mr.throughput_breakdown(NO_MARKER_ANYWHERE)
+
+    def test_weekly_series_propagates_unclassifiable(self):
+        """The fabricated 0% appeared in EVERY trend row, not just the headline card."""
+        until = datetime(2026, 6, 8, tzinfo=timezone.utc)
+        series = mr.weekly_series(NO_MARKER_ANYWHERE, until, 1, marker_in_use=False)
+        assert series[0]["pct_unplanned"] is None
+        assert series[0]["n_committed"] is None
+        assert series[0]["n_unclassifiable"] == 2
+
+    def test_compute_metrics_propagates_unclassifiable(self):
+        m = mr.compute_metrics(NO_MARKER_ANYWHERE, {"closed_at": None, "created_at": None},
+                               marker_in_use=False)
+        assert m["marker_in_use"] is False
+        assert m["pct_unplanned"] is None
+        assert m["n_unclassifiable"] == 2
+        # The delivered headline is unaffected - we know WHAT shipped, not how it arrived.
+        assert m["n_delivered"] == 2
+
+
+class TestGeneratedHtmlHasNoEmDash:
+    """The report is machine-generated, so the PreToolUse no-em-dash guard cannot see
+    it - that guard scans Claude's edits, not a script's output. Left unchecked, every
+    report the script ever produces violates the house rule. Issue #1180.
+
+    **The rule is about AUTHORED strings, not the rendered artifact.** The report also
+    embeds *data* - Issue titles straight from GitHub, some of which genuinely contain
+    an em-dash (e.g. "fix(guards): cross-repo coverage - project-repo guards..."). Those
+    must pass through **verbatim**: a report that rewrites a real title is falsifying its
+    own source data, which is a far worse sin than a stray dash. So these tests assert
+    over what the *script writes*, never over the generated HTML as a whole.
+    """
+
+    def test_template_emits_no_em_dash(self):
+        template = mr.TEMPLATE_PATH.read_text(encoding="utf-8")
+        assert EM_DASH not in template, "em-dash in the report template"
+        assert EN_DASH not in template, "en-dash in the report template"
+
+    def test_authored_output_strings_are_not_em_dashes(self):
+        """Every em-dash the SCRIPT emits, across all three emitters.
+
+        A template-only check passes while the HTML still carries them, because the
+        script emits authored strings from three separate places:
+          - the normalizer's Size/Pri/status placeholders (`or "..."` / `else "..."`)
+          - the `_fmt` None-placeholder
+          - the seeded-narrative boilerplate (comments, TBD suffixes)
+        The first live HTML render caught a fourth I had missed by grepping - a Jinja
+        `pct` filter - which is precisely why this asserts over the source, not a diff.
+        """
+        tree = ast.parse(Path(mr.__file__).read_text(encoding="utf-8"))
+
+        # Docstrings are prose ABOUT the code, never emitted into the artifact, so they
+        # are exempt (this file's own history: a line-based heuristic kept snagging them
+        # and had to be replaced by this AST walk - approximate matching on source text
+        # is exactly the class of bug the rest of this PR is about).
+        docstrings = set()
+        for node in ast.walk(tree):
+            if isinstance(node, (ast.Module, ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)):
+                doc = ast.get_docstring(node, clean=False)
+                if doc:
+                    docstrings.add(doc)
+
+        offenders = []
+        for node in ast.walk(tree):
+            if not (isinstance(node, ast.Constant) and isinstance(node.value, str)):
+                continue
+            text = node.value
+            if text in docstrings:
+                continue
+            if EM_DASH in text or EN_DASH in text:
+                # `.lstrip("#*->-- ")` strips dashes OFF INPUT; it emits nothing.
+                if text.startswith("#*->"):
+                    continue
+                offenders.append(f"line {node.lineno}: {text[:60]!r}")
+
+        assert not offenders, (
+            "the script emits an em/en dash into the generated report: " + str(offenders)
+        )

--- a/tools/ci/test_milestone_report.py
+++ b/tools/ci/test_milestone_report.py
@@ -514,6 +514,31 @@ class TestMarkerNotInUse:
         assert series[0]["n_committed"] is None
         assert series[0]["n_unclassifiable"] == 2
 
+    def test_console_trend_row_never_leaks_a_none_sentinel(self):
+        """The RENDERED row, not just the metrics dict.
+
+        `n_committed=None` is honest in the data, but the console loop f-stringed it
+        straight out as the literal `[None+None]` on every row. Asserting on the dict
+        (the test above) passes happily while the human-facing output is garbage - so
+        this one asserts on what a person actually reads.
+
+        It survived my own live check because that check grepped the output for
+        `arrival` - the line I had just fixed. A verification aimed only at what you
+        changed cannot show you what you missed.
+        """
+        until = datetime(2026, 6, 8, tzinfo=timezone.utc)
+        series = mr.weekly_series(NO_MARKER_ANYWHERE, until, 1, marker_in_use=False)
+
+        rendered = mr._fmt_arrival(series[0])
+        assert "None" not in rendered, "internal sentinel leaked into a human-facing row"
+        assert rendered == "unclassifiable"
+
+    def test_console_trend_row_still_shows_the_split_when_in_use(self):
+        """Matched pair: same row, marker in use -> the real split, not 'unclassifiable'."""
+        until = datetime(2026, 6, 8, tzinfo=timezone.utc)
+        series = mr.weekly_series(ARRIVAL, until, 1, marker_in_use=True)
+        assert mr._fmt_arrival(series[0]) == "1+1"
+
     def test_compute_metrics_propagates_unclassifiable(self):
         m = mr.compute_metrics(NO_MARKER_ANYWHERE, {"closed_at": None, "created_at": None},
                                marker_in_use=False)
@@ -566,17 +591,34 @@ class TestGeneratedHtmlHasNoEmDash:
                 if doc:
                     docstrings.add(doc)
 
+        # A dash inside a `.lstrip(...)`/`.strip(...)` argument is a char-class being
+        # stripped OFF INPUT - it emits nothing. Identify those by their AST CONTEXT
+        # (an argument to a strip call), not by their value.
+        #
+        # The first cut skipped them with `text.startswith("#*->")`, which the review
+        # correctly called out: that is a value-heuristic, so a future *emitted* string
+        # that happened to start with those characters would be silently exempted. Using
+        # an approximate match inside a test written to reject approximate matching would
+        # have been a poor joke to ship.
+        stripped_args = set()
+        for node in ast.walk(tree):
+            if (isinstance(node, ast.Call)
+                    and isinstance(node.func, ast.Attribute)
+                    and node.func.attr in {"strip", "lstrip", "rstrip"}):
+                for arg in node.args:
+                    if isinstance(arg, ast.Constant) and isinstance(arg.value, str):
+                        stripped_args.add(id(arg))
+
         offenders = []
         for node in ast.walk(tree):
             if not (isinstance(node, ast.Constant) and isinstance(node.value, str)):
+                continue
+            if id(node) in stripped_args:
                 continue
             text = node.value
             if text in docstrings:
                 continue
             if EM_DASH in text or EN_DASH in text:
-                # `.lstrip("#*->-- ")` strips dashes OFF INPUT; it emits nothing.
-                if text.startswith("#*->"):
-                    continue
                 offenders.append(f"line {node.lineno}: {text[:60]!r}")
 
         assert not offenders, (

--- a/workflow/tests/test_milestone_report_windows.py
+++ b/workflow/tests/test_milestone_report_windows.py
@@ -135,7 +135,7 @@ def test_week_label_names_the_days_the_bucket_actually_covers():
     Mislabelling this way is what produced the bogus reference counts in Issue #1099.
     """
     until = mr.normalize_until(datetime(2026, 7, 10, 14, 30, 0, tzinfo=UTC))
-    series = mr.weekly_series([], until, 4)
+    series = mr.weekly_series([], until, 4, marker_in_use=True)
 
     # Each row covers exactly 7 whole days, inclusive of both labelled endpoints.
     for w in series:
@@ -166,5 +166,5 @@ def test_weekly_series_totals_match_the_fetched_population():
         t += timedelta(hours=6)
         n += 1
 
-    series = mr.weekly_series(issues, until, 4)
+    series = mr.weekly_series(issues, until, 4, marker_in_use=True)
     assert sum(w["n_delivered"] for w in series) == len(mr.delivered_issues(issues))


### PR DESCRIPTION
**Created by:** PM

Closes [Issue #1180](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1180). First slice of [Issue #1144](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1144).

## The measurement shipped; the thing being measured did not

`throughput_breakdown` guarded the **empty-window** case (0 delivered -> `pct = None` -> "no data"). It did **not** guard the second degenerate case: a **non-empty window in which the marker is simply not in use.** That returned `0.0` - and `0.0` is indistinguishable from a real, hard-won, measured zero.

| Reality | What the SDR printed |
|---|---|
| We genuinely absorbed no unplanned work | `0% unplanned` |
| **Nobody ever applied the label** | `0% unplanned` |
| The label-reading code is broken | `0% unplanned` |

Three different worlds, one confident output. **The number could only ever come back one way** - the exact property [PR #1143](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/1143) built a live matched-pair control to escape, reproduced one layer up, **in its own input**.

**Live, not hypothetical.** `gh issue list --label unplanned --state all` returns **0 issues repo-wide** (verified 2026-07-14). The label has never been applied to anything. Yet the week-ending-2026-07-13 SDR printed a clean `25 / 0 (0% unplanned)` and `[n+0]` on **every** weekly trend row.

## The fix

**`marker_in_use` is a REQUIRED keyword.** It cannot be derived from the issue list - from that list alone, *"no delivered issue carries the label"* is information-theoretically identical in both worlds. A default would let a new call site silently fabricate; required means a caller must **decide**.

**When the marker is not in use, `n_committed` is `None` too.** This is the part worth reviewing: printing "25 committed" is the **same false assertion** as "0% unplanned", one column over. Nothing delivered is classifiable, so the delivered count surfaces as `n_unclassifiable` and the degraded input becomes **visible** instead of silently reading as clean.

**Card, pills, trend column, and text summary** all render `unclassifiable`. This had to be the generator: the fabricated `0%` sits in the at-a-glance card **above** the narrative, so a prose caveat can never outrank it - only the code can.

## Riding along: the generated HTML emitted em-dashes

Same file, same placeholder-rendering logic, and machine-generated - so the PreToolUse guard structurally cannot see it (it scans Claude's edits, not a script's output) and it recurs in **every** report the script produces. Fixed at **four** authored sites: the template, the normalizer's `Size`/`Pri`/`status` placeholders, `_fmt`, the seeded-narrative boilerplate, **and a Jinja `pct` filter I had missed by grepping** - found only when the new test ran against a live render.

**Issue titles containing em-dashes pass through verbatim.** A report that rewrites its own source data is a worse defect than a stray dash, so the rule is *the script's authored strings must be clean*, not *the artifact must be dash-free*.

## Test plan

- [x] **65 tests pass** (was 57). The load-bearing one is the **matched pair**: the *same* issue list with `marker_in_use` flipped -> a real `0%` vs `unclassifiable`. Without that pair the fix would be **unfalsifiable**, which is precisely the disease being cured - shipping it unpaired would be self-refuting.
- [x] **Falsifier probe:** disabling the not-in-use branch reds exactly 4 tests; reverted to green.
- [x] `test_marker_in_use_is_a_required_keyword` - a default would reintroduce silent fabrication.
- [x] `test_the_two_none_worlds_stay_distinguishable` - `pct is None` now has two causes (empty window vs marker unused); they must not collapse.
- [x] The em-dash test is an **AST walk over string literals**, not a line-heuristic. The heuristic version kept snagging docstrings - the same approximate-matching bug class this PR is about, so it got the same treatment.
- [x] **Existing 57 tests updated in the same change** (the required keyword breaks every caller by design - that is the point of making it required).
- [x] **LIVE end-to-end:** regenerated the very SDR that fabricated the number. It now prints `arrival: UNCLASSIFIABLE : 26 delivered, none classifiable (the unplanned marker is not in use repo-wide)`. Artifact em-dashes **7 -> 2**, and both survivors are inside real Issue titles (data, not authored).

## Out of scope (stays on [Issue #1144](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1144))

Measuring the marker's **slip rate** once it *is* in use (a forgotten label on one item, cross-checked against the `Backlog -> Ready` commitment transition), and the decision on whether that rate warrants a closure-time mechanism. Both need the transition history that [Issue #1138](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1138) is about - which is exactly why this slice was carved rather than blocked behind it.