### PR TITLE
fix(pm): the SDR's "cycle time" was lead time - report both, from the real commitment point (#1138)

### DIFF
--- a/docs/pm/milestone_reports/README.md
+++ b/docs/pm/milestone_reports/README.md
@@ -68,9 +68,37 @@ python scripts/pm/milestone_report.py "<milestone full name>" --dry-run
 
 Headline only, computed as pure (unit-tested) functions —
 [`tools/ci/test_milestone_report.py`](../../../tools/ci/test_milestone_report.py):
-duration (days), throughput (closed/week), avg & median cycle time (days),
-per-role closed counts. Cumulative-flow / burn-down charts and status-transition
-timing are out of scope (YAGNI; the board has no native transition timestamps).
+duration (days), throughput (closed/week), avg & median **cycle time** and **lead
+time** (days), per-role closed counts. Cumulative-flow / burn-down charts remain
+out of scope (YAGNI).
+
+**Cycle time vs lead time (Issue #1138) - they are different metrics and the report
+prints both:**
+
+| Metric | Span | Answers |
+|---|---|---|
+| **Cycle time** | commitment act (`Backlog -> Ready`) -> close | how fast we deliver **once we commit** |
+| **Lead time** | created -> close | the whole wait, **including** uncommitted Backlog dwell |
+
+Before #1138 the report computed `created -> closed` and **labelled it cycle time**.
+That charges uncommitted option-holding to delivery performance: an option may
+legitimately rest in Backlog for six weeks - which late-commitment Kanban
+*prescribes* - be committed, and ship in two days, and the old metric called that a
+44-day "cycle time". **Any report generated before 2026-07-14 whose narrative
+discusses "cycle time" is discussing lead time.**
+
+An item that **never crossed into `Ready`** has **no cycle time** - undefined, not
+zero. It is excluded from the cycle-time figures and reported separately as a
+`never crossed Backlog->Ready` count, because silently dropping it would bias the
+mean toward exactly the committed work.
+
+> **Correction:** this file previously stated *"the board has no native transition
+> timestamps"*. **That was false**, and it is the assumption that let the mislabelling
+> stand. GitHub exposes `ProjectV2ItemStatusChangedEvent` on the issue timeline
+> (`createdAt` / `previousStatus` / `status` / `project`), with coverage back to at
+> least 2026-05. The commitment act is the item's **first transition INTO `Ready`** -
+> *not* `previousStatus == "Backlog"`, since an item can be committed straight from
+> intake (`No Status -> Ready`), which is a real commitment and happens in practice.
 
 ## Weekly meta-work Service Delivery Review (SDR)
 

--- a/research/lab_notebook/pm.md
+++ b/research/lab_notebook/pm.md
@@ -8,6 +8,26 @@ Format and rules unchanged from the unified notebook — see `shared/feedback_la
 
 ## 2026-07-14
 
+### 22:30 UTC - Editor: PM
+
+**Half our delivered work never crossed the commitment point, and we had no idea.** [Issue #1138](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1138) -> [PR #1185](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/1185).
+
+The SDR's "cycle time" was computing `created -> closed`. That is **lead time**. Cycle time runs from the **commitment point**, and this board has an explicit one - the `Backlog -> Ready` boundary that the whole late-commitment model rests on. So the metric ignored the single transition that *defines* it, and charged uncommitted Backlog dwell to delivery performance: an option may rest six weeks in Backlog (which the model **prescribes**), be committed, ship in two days, and the old number called that a **44-day cycle time.** It penalized the exact behavior we designed for, and it was queued to feed the WIP retune.
+
+**AC1 demanded I verify the premise before building, and that instruction earned its keep three times over.** `ProjectV2ItemStatusChangedEvent` exists, with history back to May. And the verification *changed the design*: the commitment point is the **first transition INTO `Ready`**, not `previousStatus == "Backlog"` - because an item can be committed straight from intake, which I had done to [#1162](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1162) that very afternoon. The naive rule I would have written from the Issue body alone would have silently under-counted commitments. A probe pins it.
+
+**The number: 13 of 26 delivered items never crossed `Backlog -> Ready`.** Half. While the `unplanned` label reports zero. So the WIP retune would have run on 0% when the observable figure is ~50%. That is [#1144](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1144)'s slip rate, measured against a source that owes nothing to anyone's memory - and it fell out of this Issue for free, exactly as #1144's body predicted it would.
+
+**And then the review caught me doing it again. Not a similar thing. The same thing.**
+
+`fetch_commitment_times` returned `{}` on any GraphQL error. Every item then had no `committed_at`, so the report **asserted** that the entire delivered population never crossed `Backlog -> Ready` - in stdout *and* in the HTML - with the truth confined to a stderr line no reader ever sees. **One output, three worlds.** That is the precise fabrication [#1180](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1180) exists to kill, reintroduced **one layer down, inside the PR that kills it**, by someone who had spent the preceding hour writing docstrings about exactly this failure mode.
+
+**Two reviews in a row now, both catching me re-committing the error the PR was written to eliminate.** I don't think that is chance. The hypothesis I want to record: **the moment I fix a class of bug I am at my most blind to it**, because I have just spent an hour convincing myself I understand it - and understanding a failure mode feels, from the inside, exactly like being immune to it. The fix is not more care. Care is what produced both.
+
+**One design call I want to defend, because it cost something.** The reviewer suggested keeping successfully-fetched chunks on a later chunk's failure. I went the other way: **partial commitment data is not used at all.** A half-populated map makes items from the failed chunk indistinguishable from genuinely-uncommitted ones - the identical conflation, one chunk smaller. Keeping the good chunk buys a partly-correct number at the price of a silently-wrong caveat, and that trade is what got us here. One bad chunk now marks the whole report **unknown**, loudly.
+
+**Also corrected a false claim in `docs/pm/milestone_reports/README.md`** - *"the board has no native transition timestamps"* - which is the assumption that let the mislabelling stand for months. And the legacy tests asserted `created -> closed` **under the name `cycle_time_days`**: the mislabelling lived in the tests as faithfully as in the code, which is exactly why they never caught it. **A test written from the same misunderstanding as the code is not a check; it is a second copy of the assumption.**
+
 ### 21:45 UTC - Editor: PM
 
 **The SDR has been printing a number that was never a measurement.** [Issue #1180](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1180) -> [PR #1181](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/1181), carved as the first slice of [#1144](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1144).

--- a/scripts/pm/milestone_report.py
+++ b/scripts/pm/milestone_report.py
@@ -202,8 +202,22 @@ def throughput_breakdown(issues: list[dict], *, marker_in_use: bool) -> dict[str
     }
 
 
-def cycle_time_days(issue: dict) -> Optional[float]:
-    """(closed_at - created_at) in days for a closed issue; None otherwise."""
+def lead_time_days(issue: dict) -> Optional[float]:
+    """(closed_at - created_at) in days for a closed issue; None otherwise.
+
+    **This is LEAD time, and it used to be mislabelled `cycle_time_days`** (Issue #1138).
+    Canonically, lead time spans the whole customer-visible wait - request to delivery -
+    and therefore INCLUDES the uncommitted dwell in Backlog. Cycle time starts at the
+    **commitment point** (see ``cycle_time_days`` below).
+
+    The distinction is load-bearing here rather than pedantic. This board has an explicit,
+    deliberately-designed commitment point (the `Backlog -> Ready` boundary, the whole
+    basis of the late-commitment Kanban model in epic #580). Reporting lead time under a
+    "cycle time" label **charges uncommitted option-holding to delivery performance**: an
+    option can legitimately rest in Backlog for six weeks, be committed, and ship in two
+    days - and the old metric called that a 44-day "cycle time". It penalized precisely
+    the behavior the model is built on, and it fed that number to the WIP retune.
+    """
     if issue.get("state") != "CLOSED":
         return None
     created = parse_iso(issue.get("created_at"))
@@ -213,8 +227,61 @@ def cycle_time_days(issue: dict) -> Optional[float]:
     return (closed - created).total_seconds() / 86400.0
 
 
+def cycle_time_days(issue: dict) -> Optional[float]:
+    """(closed_at - committed_at) in days: the TRUE cycle time, from the commitment point.
+
+    ``committed_at`` is the timestamp of the item's **first transition into `Ready`** on
+    board 9 - the commitment act itself (`ProjectV2ItemStatusChangedEvent`).
+
+    Returns **None** for an item that never crossed into `Ready`. That is an *undefined*
+    cycle time, NOT a zero and NOT something to quietly drop:
+
+    - Dropping it silently would bias the mean toward exactly the committed work, which is
+      the same "a number that can only come back one way" disease as the #1180 fabricated
+      0% - so the never-committed population is counted and reported (``n_never_committed``).
+    - Zeroing it would be worse still: it would assert an instantaneous delivery.
+
+    Why "first transition INTO Ready" and not "previousStatus == Backlog": an item can be
+    committed straight from intake (`No Status -> Ready`), which is a real commitment and
+    happens in practice (verified on Issue #1162). Keying on the previous status would
+    silently under-count commitments.
+    """
+    if issue.get("state") != "CLOSED":
+        return None
+    committed = parse_iso(issue.get("committed_at"))
+    closed = parse_iso(issue.get("closed_at"))
+    if not committed or not closed:
+        return None
+    return (closed - committed).total_seconds() / 86400.0
+
+
+def never_committed_issues(issues: list[dict]) -> list[dict]:
+    """Closed issues that never crossed into `Ready` - no observable commitment act.
+
+    Their cycle time is undefined. They are also, by *observation* rather than by anyone
+    remembering a label, the **unplanned** arrivals - which is the independent source the
+    `unplanned` marker's fidelity check (Issue #1144) needs. Surfaced here; the slip-rate
+    cross-check itself belongs to that Issue.
+    """
+    return [i for i in delivered_issues(issues) if not i.get("committed_at")]
+
+
+def lead_times(issues: list[dict]) -> list[float]:
+    return [t for t in (lead_time_days(i) for i in issues) if t is not None]
+
+
 def cycle_times(issues: list[dict]) -> list[float]:
     return [t for t in (cycle_time_days(i) for i in issues) if t is not None]
+
+
+def avg_lead_time(issues: list[dict]) -> Optional[float]:
+    ts = lead_times(issues)
+    return statistics.fmean(ts) if ts else None
+
+
+def median_lead_time(issues: list[dict]) -> Optional[float]:
+    ts = lead_times(issues)
+    return statistics.median(ts) if ts else None
 
 
 def avg_cycle_time(issues: list[dict]) -> Optional[float]:
@@ -374,6 +441,8 @@ def weekly_series(issues: list[dict], until: datetime, n_weeks: int,
             **throughput_breakdown(in_window, marker_in_use=marker_in_use),
             "n_delivered": len(delivered),
             "median_cycle_time_days": median_cycle_time(delivered),
+            "median_lead_time_days": median_lead_time(delivered),
+            "n_never_committed": len(never_committed_issues(in_window)),
         })
     return series
 
@@ -401,6 +470,9 @@ def compute_window_metrics(
         "throughput_per_week": throughput_per_week(len(delivered), 7.0),
         "avg_cycle_time_days": avg_cycle_time(delivered),
         "median_cycle_time_days": median_cycle_time(delivered),
+        "avg_lead_time_days": avg_lead_time(delivered),
+        "median_lead_time_days": median_lead_time(delivered),
+        "n_never_committed": len(never_committed_issues(week_issues)),
         "per_role_counts": per_role_counts(week_issues),
         **throughput_breakdown(week_issues, marker_in_use=marker_in_use),
         "weekly_series": weekly_series(all_issues, until, n_weeks,
@@ -430,6 +502,9 @@ def compute_metrics(issues: list[dict], milestone: dict,
         "throughput_per_week": throughput_per_week(len(delivered), duration),
         "avg_cycle_time_days": avg_cycle_time(delivered),
         "median_cycle_time_days": median_cycle_time(delivered),
+        "avg_lead_time_days": avg_lead_time(delivered),
+        "median_lead_time_days": median_lead_time(delivered),
+        "n_never_committed": len(never_committed_issues(issues)),
         "per_role_counts": per_role_counts(issues),
         **throughput_breakdown(issues, marker_in_use=marker_in_use),
     }
@@ -504,14 +579,20 @@ def _board_fields_by_number() -> dict[int, dict]:
         return {}
 
 
-def _normalize_issue(it: dict, board: dict[int, dict]) -> dict:
+def _normalize_issue(it: dict, board: dict[int, dict],
+                     commitments: Optional[dict[int, Optional[str]]] = None) -> dict:
     """Normalize one ``gh issue list --json`` record into the report's issue dict.
 
     Shared by the milestone and window fetchers so both carry an identical shape.
+
+    ``commitments`` maps issue number -> the ISO timestamp of its first transition into
+    `Ready` (the commitment act), or None if it never crossed. Injected rather than
+    fetched here so the metrics layer stays pure and testable (Issue #1138).
     """
     labels = [lbl["name"] for lbl in it.get("labels", [])]
     num = it["number"]
     b = board.get(num, {})
+    commitments = commitments or {}
     # stateReason: COMPLETED | NOT_PLANNED | None (open). Upper-cased so the
     # metrics layer can compare against the canonical NOT_PLANNED token.
     reason = it.get("stateReason")
@@ -523,6 +604,9 @@ def _normalize_issue(it: dict, board: dict[int, dict]) -> dict:
         "state_reason": reason.upper() if reason else None,
         "created_at": it.get("createdAt"),
         "closed_at": it.get("closedAt"),
+        # First entry into `Ready` = the commitment act. None = never committed, which is
+        # an UNDEFINED cycle time, not a zero (Issue #1138).
+        "committed_at": commitments.get(num),
         "labels": labels,
         "roles": [l for l in labels if l.startswith("role:")],
         "arcs": [l for l in labels if l.startswith("arc:")],
@@ -537,6 +621,78 @@ def _normalize_issue(it: dict, board: dict[int, dict]) -> dict:
     # NOT_PLANNED + DUPLICATE without the template hardcoding the set).
     issue["is_descoped"] = is_descoped(issue)
     return issue
+
+
+def first_ready_at(events: list[dict], project_number: int = PROJECT_NUMBER) -> Optional[str]:
+    """Earliest timestamp at which an item entered `Ready` on our board. Pure.
+
+    **The commitment point is "first transition INTO `Ready`", not "previousStatus ==
+    Backlog".** An item can be committed straight from intake (`No Status -> Ready`) -
+    verified live on Issue #1162 - and that is a real commitment. Keying on the previous
+    status would silently under-count commitments, which would then inflate the
+    never-committed population and understate cycle time coverage.
+
+    *Earliest*, not latest: an item can bounce (Ready -> In progress -> Ready). The
+    commitment act is the first crossing; later re-entries are not new commitments.
+
+    Returns None if the item never entered `Ready` - an UNDEFINED cycle time.
+    """
+    ready = [
+        e["createdAt"] for e in events
+        if e.get("status") == "Ready"
+        and (e.get("project") or {}).get("number") == project_number
+        and e.get("createdAt")
+    ]
+    return min(ready) if ready else None
+
+
+def fetch_commitment_times(numbers: list[int]) -> dict[int, Optional[str]]:
+    """Map issue number -> ISO timestamp of its commitment act (first entry into `Ready`).
+
+    Reads `ProjectV2ItemStatusChangedEvent` off each issue's timeline. Verified live
+    (Issue #1138 AC 1): the event carries `createdAt` / `previousStatus` / `status` /
+    `project`, and coverage extends back at least to 2026-05, well beyond any window the
+    SDR reports on.
+
+    **Batched with GraphQL aliases** (50 issues per request) rather than one request per
+    issue: a 4-week SDR window spans 100+ issues, and a per-issue query would turn one
+    report into 100+ round-trips against a shared, per-user rate budget.
+
+    A missing entry means "never entered Ready", which the metrics layer treats as an
+    undefined cycle time - never a zero, and never silently dropped.
+    """
+    out: dict[int, Optional[str]] = {}
+    CHUNK = 50
+    for start in range(0, len(numbers), CHUNK):
+        chunk = numbers[start:start + CHUNK]
+        aliases = "\n".join(
+            f'  i{n}: issue(number: {n}) {{ number timelineItems(first: 100, '
+            f'itemTypes: [PROJECT_V2_ITEM_STATUS_CHANGED_EVENT]) {{ nodes {{ '
+            f'... on ProjectV2ItemStatusChangedEvent {{ createdAt status '
+            f'project {{ number }} }} }} }} }}'
+            for n in chunk
+        )
+        query = (f'query {{ repository(owner: "{OWNER}", name: "{REPO}") {{\n'
+                 f'{aliases}\n}} }}')
+        try:
+            raw = _gh(["api", "graphql", "-f", f"query={query}"])
+        except SystemExit:
+            raise
+        except Exception as exc:  # noqa: BLE001
+            # Degrade loudly, not silently: without commitment times, cycle time is
+            # unknown for every item, and the report must SAY so rather than fall back
+            # to the lead-time number under a cycle-time label (which is the exact
+            # defect this Issue exists to fix).
+            print(f"  (commitment-time enrichment unavailable: {exc})", file=sys.stderr)
+            return {}
+        repo = (json.loads(raw).get("data") or {}).get("repository") or {}
+        for n in chunk:
+            node = repo.get(f"i{n}")
+            if not node:
+                continue
+            events = ((node.get("timelineItems") or {}).get("nodes")) or []
+            out[n] = first_ready_at(events)
+    return out
 
 
 def fetch_marker_in_use() -> bool:
@@ -565,7 +721,9 @@ def fetch_milestone_issues(name: str) -> list[dict]:
         "--json", "number,title,state,stateReason,labels,createdAt,closedAt,url",
     ])
     board = _board_fields_by_number()
-    return [_normalize_issue(it, board) for it in json.loads(raw)]
+    items = json.loads(raw)
+    commitments = fetch_commitment_times([it["number"] for it in items])
+    return [_normalize_issue(it, board, commitments) for it in items]
 
 
 def fetch_window_issues(since: str, until: str) -> list[dict]:
@@ -582,11 +740,9 @@ def fetch_window_issues(since: str, until: str) -> list[dict]:
         "--json", "number,title,state,stateReason,labels,createdAt,closedAt,url,milestone",
     ])
     board = _board_fields_by_number()
-    return [
-        _normalize_issue(it, board)
-        for it in json.loads(raw)
-        if not it.get("milestone")  # skip lifecycle (milestoned) work
-    ]
+    items = [it for it in json.loads(raw) if not it.get("milestone")]  # skip lifecycle work
+    commitments = fetch_commitment_times([it["number"] for it in items])
+    return [_normalize_issue(it, board, commitments) for it in items]
 
 
 # --- aggregation layer (narrative auto-seed) --------------------------------
@@ -754,16 +910,28 @@ def print_metrics(milestone: dict, metrics: dict) -> None:
               f"{f'  ({pct:.0f}% unplanned)' if pct is not None else '  (no delivered work)'}")
     print(f"  duration (days)                  : {_fmt(metrics['duration_days'])}")
     print(f"  throughput (delivered/week)      : {_fmt(metrics['throughput_per_week'])}")
+    # Cycle time (commitment -> close) and lead time (created -> close) are reported
+    # SIDE BY SIDE, never one relabelled as the other. The gap between them IS the
+    # uncommitted Backlog dwell, which late-commitment Kanban prescribes and which the
+    # old single "cycle time" number silently charged to delivery performance (#1138).
     print(f"  cycle time avg / median (days)   : "
-          f"{_fmt(metrics['avg_cycle_time_days'])} / {_fmt(metrics['median_cycle_time_days'])}")
+          f"{_fmt(metrics['avg_cycle_time_days'])} / {_fmt(metrics['median_cycle_time_days'])}"
+          f"   [commitment -> close]")
+    print(f"  lead  time avg / median (days)   : "
+          f"{_fmt(metrics['avg_lead_time_days'])} / {_fmt(metrics['median_lead_time_days'])}"
+          f"   [created -> close]")
+    n_nc = metrics.get("n_never_committed")
+    if n_nc:
+        print(f"  never crossed Backlog->Ready     : {n_nc} delivered "
+              f"(no commitment act -> cycle time UNDEFINED for these, not zero)")
     print(f"  per-role (delivered)             : {metrics['per_role_counts']}")
     series = metrics.get("weekly_series")
     if series:
-        print("  weekly trend (delivered [committed+unplanned] / median cycle days):")
+        print("  weekly trend (delivered [committed+unplanned] / median cycle / median lead days):")
         for w in series:
             print(f"    {w['week_start']}..{w['week_end']} : "
                   f"{w['n_delivered']} [{_fmt_arrival(w)}] / "
-                  f"{_fmt(w['median_cycle_time_days'])}")
+                  f"{_fmt(w['median_cycle_time_days'])} / {_fmt(w['median_lead_time_days'])}")
 
 
 def _fmt_arrival(w: dict) -> str:

--- a/scripts/pm/milestone_report.py
+++ b/scripts/pm/milestone_report.py
@@ -252,7 +252,23 @@ def cycle_time_days(issue: dict) -> Optional[float]:
     closed = parse_iso(issue.get("closed_at"))
     if not committed or not closed:
         return None
-    return (closed - committed).total_seconds() / 86400.0
+    days = (closed - committed).total_seconds() / 86400.0
+    if days < 0:
+        # committed_at AFTER closed_at: possible on a close -> reopen -> re-commit, or a
+        # card dragged to Ready post-close. A negative cycle time is not a fast delivery,
+        # it is a nonsense one - drop it rather than let it drag the mean below zero.
+        return None
+    return days
+
+
+def commitments_available(issues: list[dict]) -> bool:
+    """Did the commitment-time fetch succeed? Pure over the (injected) per-issue flag.
+
+    Defaults to True when the flag is absent, so pure unit fixtures behave as before.
+    Set to False by the fetchers on a GraphQL failure - see ``fetch_commitment_times``
+    for why a failure must read as UNKNOWN and not as "never committed".
+    """
+    return all(i.get("commitments_available", True) for i in issues)
 
 
 def never_committed_issues(issues: list[dict]) -> list[dict]:
@@ -263,6 +279,13 @@ def never_committed_issues(issues: list[dict]) -> list[dict]:
     `unplanned` marker's fidelity check (Issue #1144) needs. Surfaced here; the slip-rate
     cross-check itself belongs to that Issue.
     """
+    if not commitments_available(issues):
+        # We could not read the commitment history, so we do NOT know which items crossed
+        # Backlog -> Ready. Returning the whole delivered population here would assert
+        # "none of them committed" - a confident, wrong caveat, and exactly the
+        # one-output-for-three-worlds fabrication this module exists to kill (#1180).
+        # The caller renders this as unknown; see ``n_never_committed`` below.
+        return []
     return [i for i in delivered_issues(issues) if not i.get("committed_at")]
 
 
@@ -442,7 +465,8 @@ def weekly_series(issues: list[dict], until: datetime, n_weeks: int,
             "n_delivered": len(delivered),
             "median_cycle_time_days": median_cycle_time(delivered),
             "median_lead_time_days": median_lead_time(delivered),
-            "n_never_committed": len(never_committed_issues(in_window)),
+            "n_never_committed": (len(never_committed_issues(in_window))
+                                  if commitments_available(in_window) else None),
         })
     return series
 
@@ -472,7 +496,9 @@ def compute_window_metrics(
         "median_cycle_time_days": median_cycle_time(delivered),
         "avg_lead_time_days": avg_lead_time(delivered),
         "median_lead_time_days": median_lead_time(delivered),
-        "n_never_committed": len(never_committed_issues(week_issues)),
+        "n_never_committed": (len(never_committed_issues(week_issues))
+                              if commitments_available(week_issues) else None),
+        "commitments_available": commitments_available(week_issues),
         "per_role_counts": per_role_counts(week_issues),
         **throughput_breakdown(week_issues, marker_in_use=marker_in_use),
         "weekly_series": weekly_series(all_issues, until, n_weeks,
@@ -504,7 +530,9 @@ def compute_metrics(issues: list[dict], milestone: dict,
         "median_cycle_time_days": median_cycle_time(delivered),
         "avg_lead_time_days": avg_lead_time(delivered),
         "median_lead_time_days": median_lead_time(delivered),
-        "n_never_committed": len(never_committed_issues(issues)),
+        "n_never_committed": (len(never_committed_issues(issues))
+                              if commitments_available(issues) else None),
+        "commitments_available": commitments_available(issues),
         "per_role_counts": per_role_counts(issues),
         **throughput_breakdown(issues, marker_in_use=marker_in_use),
     }
@@ -646,7 +674,7 @@ def first_ready_at(events: list[dict], project_number: int = PROJECT_NUMBER) -> 
     return min(ready) if ready else None
 
 
-def fetch_commitment_times(numbers: list[int]) -> dict[int, Optional[str]]:
+def fetch_commitment_times(numbers: list[int]) -> tuple[dict[int, Optional[str]], bool]:
     """Map issue number -> ISO timestamp of its commitment act (first entry into `Ready`).
 
     Reads `ProjectV2ItemStatusChangedEvent` off each issue's timeline. Verified live
@@ -658,8 +686,21 @@ def fetch_commitment_times(numbers: list[int]) -> dict[int, Optional[str]]:
     issue: a 4-week SDR window spans 100+ issues, and a per-issue query would turn one
     report into 100+ round-trips against a shared, per-user rate budget.
 
-    A missing entry means "never entered Ready", which the metrics layer treats as an
-    undefined cycle time - never a zero, and never silently dropped.
+    **Returns (map, available).** The bool is load-bearing and was added in review: on a
+    fetch failure the map is empty, every item then looks like it has no `committed_at`,
+    and `never_committed_issues` would report the ENTIRE delivered population as "never
+    crossed Backlog -> Ready" - a confident, wrong caveat, contradicted only on stderr,
+    which never reaches the report's reader. That is *precisely* the "one output for three
+    different worlds" fabrication this file exists to eliminate (#1180), reintroduced one
+    layer down in the PR that eliminates it.
+
+    So a failure is **unknown**, not "never committed", and the caller must render it as
+    unknown. Partial data is deliberately NOT used: a half-populated map makes the items in
+    the failed chunk indistinguishable from genuinely-uncommitted ones, which is the same
+    conflation one chunk smaller.
+
+    A missing entry when ``available`` is True means "never entered Ready", which the
+    metrics layer treats as an undefined cycle time - never a zero, never silently dropped.
     """
     out: dict[int, Optional[str]] = {}
     CHUNK = 50
@@ -684,7 +725,7 @@ def fetch_commitment_times(numbers: list[int]) -> dict[int, Optional[str]]:
             # to the lead-time number under a cycle-time label (which is the exact
             # defect this Issue exists to fix).
             print(f"  (commitment-time enrichment unavailable: {exc})", file=sys.stderr)
-            return {}
+            return {}, False
         repo = (json.loads(raw).get("data") or {}).get("repository") or {}
         for n in chunk:
             node = repo.get(f"i{n}")
@@ -692,7 +733,7 @@ def fetch_commitment_times(numbers: list[int]) -> dict[int, Optional[str]]:
                 continue
             events = ((node.get("timelineItems") or {}).get("nodes")) or []
             out[n] = first_ready_at(events)
-    return out
+    return out, True
 
 
 def fetch_marker_in_use() -> bool:
@@ -722,8 +763,15 @@ def fetch_milestone_issues(name: str) -> list[dict]:
     ])
     board = _board_fields_by_number()
     items = json.loads(raw)
-    commitments = fetch_commitment_times([it["number"] for it in items])
-    return [_normalize_issue(it, board, commitments) for it in items]
+    # Only CLOSED issues can have a cycle/lead time or be "never committed", so only they
+    # need a timeline fetch. Fetching open ones burned rate budget for data nothing reads,
+    # on a per-user budget we already exhaust (#1165). Review finding 2.
+    closed_nums = [it["number"] for it in items if it["state"].upper() == "CLOSED"]
+    commitments, available = fetch_commitment_times(closed_nums)
+    out = [_normalize_issue(it, board, commitments) for it in items]
+    for i in out:
+        i["commitments_available"] = available
+    return out
 
 
 def fetch_window_issues(since: str, until: str) -> list[dict]:
@@ -741,8 +789,12 @@ def fetch_window_issues(since: str, until: str) -> list[dict]:
     ])
     board = _board_fields_by_number()
     items = [it for it in json.loads(raw) if not it.get("milestone")]  # skip lifecycle work
-    commitments = fetch_commitment_times([it["number"] for it in items])
-    return [_normalize_issue(it, board, commitments) for it in items]
+    closed_nums = [it["number"] for it in items if it["state"].upper() == "CLOSED"]
+    commitments, available = fetch_commitment_times(closed_nums)
+    out = [_normalize_issue(it, board, commitments) for it in items]
+    for i in out:
+        i["commitments_available"] = available
+    return out
 
 
 # --- aggregation layer (narrative auto-seed) --------------------------------
@@ -920,9 +972,15 @@ def print_metrics(milestone: dict, metrics: dict) -> None:
     print(f"  lead  time avg / median (days)   : "
           f"{_fmt(metrics['avg_lead_time_days'])} / {_fmt(metrics['median_lead_time_days'])}"
           f"   [created -> close]")
-    n_nc = metrics.get("n_never_committed")
-    if n_nc:
-        print(f"  never crossed Backlog->Ready     : {n_nc} delivered "
+    if not metrics.get("commitments_available", True):
+        # The failure must reach the READER, not just stderr. Previously a fetch failure
+        # printed a confident "N delivered never crossed Backlog->Ready" - i.e. it
+        # asserted the exact opposite of what it knew. Review finding on PR #1185.
+        print("  never crossed Backlog->Ready     : UNKNOWN - commitment history could "
+              "not be read, so cycle time and this count are both unavailable "
+              "(NOT the same as 'none committed')")
+    elif metrics.get("n_never_committed"):
+        print(f"  never crossed Backlog->Ready     : {metrics['n_never_committed']} delivered "
               f"(no commitment act -> cycle time UNDEFINED for these, not zero)")
     print(f"  per-role (delivered)             : {metrics['per_role_counts']}")
     series = metrics.get("weekly_series")

--- a/scripts/pm/templates/milestone_report.html.j2
+++ b/scripts/pm/templates/milestone_report.html.j2
@@ -65,8 +65,15 @@
     {% if metrics.n_descoped %}<div class="card"><div class="n">{{ metrics.n_descoped }}</div><div class="l">Descoped</div></div>{% endif %}
     <div class="card"><div class="n">{{ metrics.n_carried_forward }}</div><div class="l">Carried forward</div></div>
     <div class="card"><div class="n">{{ "%.1f"|format(metrics.throughput_per_week) if metrics.throughput_per_week is not none else "n/a" }}</div><div class="l">Delivered / week</div></div>
+    <!-- Cycle time (commitment -> close) and lead time (created -> close) are shown SIDE
+         BY SIDE, never one relabelled as the other (Issue #1138). The gap between them is
+         the uncommitted Backlog dwell - which late-commitment Kanban actively prescribes,
+         and which the old single "cycle time" number silently charged to delivery
+         performance. It penalized the very behavior the model is built on. -->
+    <div class="card"><div class="n">{{ "%.1f"|format(metrics.median_cycle_time_days) if metrics.median_cycle_time_days is not none else "n/a" }}</div><div class="l">Median cycle (days)<br><span class="sub">commit to close</span></div></div>
+    <div class="card"><div class="n">{{ "%.1f"|format(metrics.median_lead_time_days) if metrics.median_lead_time_days is not none else "n/a" }}</div><div class="l">Median lead (days)<br><span class="sub">created to close</span></div></div>
     <div class="card"><div class="n">{{ "%.1f"|format(metrics.avg_cycle_time_days) if metrics.avg_cycle_time_days is not none else "n/a" }}</div><div class="l">Avg cycle (days)</div></div>
-    <div class="card"><div class="n">{{ "%.1f"|format(metrics.median_cycle_time_days) if metrics.median_cycle_time_days is not none else "n/a" }}</div><div class="l">Median cycle (days)</div></div>
+    <div class="card"><div class="n">{{ "%.1f"|format(metrics.avg_lead_time_days) if metrics.avg_lead_time_days is not none else "n/a" }}</div><div class="l">Avg lead (days)</div></div>
     <div class="card"><div class="n">{{ "%.0f%%"|format(metrics.pct_unplanned) if metrics.pct_unplanned is not none else "n/a" }}</div><div class="l">Unplanned share</div></div>
   </div>
 
@@ -87,6 +94,9 @@
     <span class="pill">unplanned · <strong>{{ metrics.n_unplanned }}</strong></span>
     {% if metrics.pct_unplanned is none %}<span class="sub">no delivered work in window</span>{% endif %}
     {% endif %}
+    {% if metrics.n_never_committed %}
+    <span class="sub">{{ metrics.n_never_committed }} delivered never crossed <code>Backlog -&gt; Ready</code> - cycle time is <strong>undefined</strong> for those (not zero), so they are excluded from the cycle-time figures and counted here instead</span>
+    {% endif %}
   </div>
   <div class="rolebar">
     {% for role, count in metrics.per_role_counts.items() %}
@@ -100,10 +110,10 @@
   <!-- Weekly trend (SDR window mode; script-generated) -->
   <h2>Weekly trend</h2>
   <table>
-    <thead><tr><th>Week ending</th><th>Delivered</th><th>Committed</th><th>Unplanned</th><th>Unplanned %</th><th>Median cycle (days)</th></tr></thead>
+    <thead><tr><th>Week ending</th><th>Delivered</th><th>Committed</th><th>Unplanned</th><th>Unplanned %</th><th>Median cycle (d)</th><th>Median lead (d)</th></tr></thead>
     <tbody>
       {% for w in metrics.weekly_series %}
-      <tr><td>{{ w.week_end }}</td><td>{{ w.n_delivered }}</td><td>{{ w.n_committed if w.n_committed is not none else "n/a" }}</td><td>{{ w.n_unplanned if w.n_unplanned is not none else "n/a" }}</td><td>{{ "%.0f%%"|format(w.pct_unplanned) if w.pct_unplanned is not none else "n/a" }}</td><td>{{ "%.1f"|format(w.median_cycle_time_days) if w.median_cycle_time_days is not none else "n/a" }}</td></tr>
+      <tr><td>{{ w.week_end }}</td><td>{{ w.n_delivered }}</td><td>{{ w.n_committed if w.n_committed is not none else "n/a" }}</td><td>{{ w.n_unplanned if w.n_unplanned is not none else "n/a" }}</td><td>{{ "%.0f%%"|format(w.pct_unplanned) if w.pct_unplanned is not none else "n/a" }}</td><td>{{ "%.1f"|format(w.median_cycle_time_days) if w.median_cycle_time_days is not none else "n/a" }}</td><td>{{ "%.1f"|format(w.median_lead_time_days) if w.median_lead_time_days is not none else "n/a" }}</td></tr>
       {% endfor %}
     </tbody>
   </table>

--- a/scripts/pm/templates/milestone_report.html.j2
+++ b/scripts/pm/templates/milestone_report.html.j2
@@ -94,7 +94,9 @@
     <span class="pill">unplanned · <strong>{{ metrics.n_unplanned }}</strong></span>
     {% if metrics.pct_unplanned is none %}<span class="sub">no delivered work in window</span>{% endif %}
     {% endif %}
-    {% if metrics.n_never_committed %}
+    {% if metrics.commitments_available is defined and not metrics.commitments_available %}
+    <span class="sub"><strong>Commitment history unavailable</strong> - cycle time and the never-committed count are <strong>unknown</strong> for this report. This is NOT the same as "nothing was committed": we could not read the data. (Reporting a count here on a failed fetch would assert the opposite of what we know - Issue #1138 review.)</span>
+    {% elif metrics.n_never_committed %}
     <span class="sub">{{ metrics.n_never_committed }} delivered never crossed <code>Backlog -&gt; Ready</code> - cycle time is <strong>undefined</strong> for those (not zero), so they are excluded from the cycle-time figures and counted here instead</span>
     {% endif %}
   </div>

--- a/tools/ci/test_milestone_report.py
+++ b/tools/ci/test_milestone_report.py
@@ -624,6 +624,87 @@ class TestCycleVsLeadTime:
         assert mr.lead_time_days(opened) is None
 
 
+class TestCommitmentFetchFailureIsUnknownNotZero:
+    """A failed commitment fetch must read as UNKNOWN, never as "nobody committed".
+
+    Caught in review of PR #1185, and it is the sharpest possible instance: on a GraphQL
+    error `fetch_commitment_times` returned {}, so every item had no `committed_at`, and
+    the report then CONFIDENTLY asserted that the entire delivered population "never
+    crossed Backlog -> Ready" - contradicted only by a stderr line the reader never sees.
+
+    One output, three different worlds (nobody committed / we could not read the history /
+    the reader is being lied to). That is the exact fabrication #1180 exists to kill,
+    reintroduced one layer down, inside the PR that kills it.
+    """
+
+    def _delivered(self, n, committed=None, available=True):
+        i = _issue(n, "CLOSED", "2026-06-01T00:00:00Z", "2026-06-05T00:00:00Z",
+                   ["role:pm"], "COMPLETED")
+        if committed:
+            i["committed_at"] = committed
+        i["commitments_available"] = available
+        return i
+
+    def test_matched_pair_genuinely_uncommitted_vs_fetch_failed(self):
+        """THE control: identical issue lists, one flag flipped, opposite meanings."""
+        genuinely = [self._delivered(1, available=True),
+                     self._delivered(2, available=True)]
+        fetch_died = [self._delivered(1, available=False),
+                      self._delivered(2, available=False)]
+
+        # We CAN see the history, and neither crossed Ready -> a real finding.
+        assert len(mr.never_committed_issues(genuinely)) == 2
+
+        # We CANNOT see the history -> we know nothing. Asserting "2 never committed"
+        # here would state the opposite of the truth.
+        assert mr.never_committed_issues(fetch_died) == []
+        assert mr.commitments_available(fetch_died) is False
+
+    def test_metrics_render_never_committed_as_none_when_unavailable(self):
+        m = mr.compute_metrics(
+            [self._delivered(1, available=False)],
+            {"closed_at": None, "created_at": None}, marker_in_use=True)
+        assert m["commitments_available"] is False
+        assert m["n_never_committed"] is None, "a count here would be a fabricated caveat"
+        assert m["avg_cycle_time_days"] is None, "cycle time is unknown too, not zero"
+
+    def test_metrics_report_the_count_when_the_fetch_worked(self):
+        """Matched pair to the above: same shape, fetch succeeded -> report the number."""
+        m = mr.compute_metrics(
+            [self._delivered(1, available=True)],
+            {"closed_at": None, "created_at": None}, marker_in_use=True)
+        assert m["commitments_available"] is True
+        assert m["n_never_committed"] == 1
+
+    def test_availability_defaults_true_for_plain_fixtures(self):
+        """Absent flag = available, so pure fixtures behave as before."""
+        assert mr.commitments_available([_issue(1, "CLOSED", "a", "b", [])]) is True
+
+    def test_one_unavailable_item_taints_the_whole_report(self):
+        """Partial commitment data is deliberately NOT used.
+
+        A half-populated map makes the items from the failed chunk indistinguishable from
+        genuinely-uncommitted ones - the same conflation, one chunk smaller.
+        """
+        mixed = [self._delivered(1, available=True), self._delivered(2, available=False)]
+        assert mr.commitments_available(mixed) is False
+
+
+class TestNegativeCycleTimeIsDropped:
+    def test_committed_after_closed_is_not_a_fast_delivery(self):
+        """A close -> reopen -> re-commit can put committed_at AFTER closed_at.
+
+        A negative cycle time is not a fast delivery, it is a nonsense one, and left in it
+        would drag the mean below zero. Dropped, not clamped to 0 (a 0 would assert an
+        instantaneous delivery - the same lie in the other direction).
+        """
+        i = _issue(1, "CLOSED", "2026-06-01T00:00:00Z", "2026-06-05T00:00:00Z",
+                   ["role:pm"], "COMPLETED")
+        i["committed_at"] = "2026-06-09T00:00:00Z"   # after the close
+        assert mr.cycle_time_days(i) is None
+        assert mr.avg_cycle_time([i]) is None
+
+
 class TestFirstReadyAt:
     """Extracting the commitment act from the status-change timeline."""
 

--- a/tools/ci/test_milestone_report.py
+++ b/tools/ci/test_milestone_report.py
@@ -75,29 +75,43 @@ class TestSlugify:
 
 # --- cycle time -------------------------------------------------------------
 
-class TestCycleTime:
+class TestLeadTime:
+    """These were `TestCycleTime` and asserted `created -> closed` under that name.
+
+    They measure LEAD time, and always did (Issue #1138) - the mislabelling lived in the
+    tests as faithfully as in the code, which is why the tests never caught it. Renamed to
+    what they actually measure. The SAMPLE fixture carries no `committed_at`, so under the
+    corrected definitions its cycle times are all None - see TestCycleVsLeadTime.
+    """
+
     def test_closed_issue_days(self):
-        assert mr.cycle_time_days(SAMPLE[0]) == 2.0
-        assert mr.cycle_time_days(SAMPLE[1]) == 4.0
+        assert mr.lead_time_days(SAMPLE[0]) == 2.0
+        assert mr.lead_time_days(SAMPLE[1]) == 4.0
 
     def test_open_issue_is_none(self):
-        assert mr.cycle_time_days(SAMPLE[3]) is None
+        assert mr.lead_time_days(SAMPLE[3]) is None
 
     def test_missing_timestamp_is_none(self):
-        assert mr.cycle_time_days(_issue(9, "CLOSED", None, "2026-06-03T00:00:00Z", [])) is None
+        assert mr.lead_time_days(_issue(9, "CLOSED", None, "2026-06-03T00:00:00Z", [])) is None
 
-    def test_cycle_times_only_closed(self):
-        assert sorted(mr.cycle_times(SAMPLE)) == [2.0, 4.0, 6.0]
+    def test_lead_times_only_closed(self):
+        assert sorted(mr.lead_times(SAMPLE)) == [2.0, 4.0, 6.0]
 
-    def test_avg_cycle_time(self):
-        assert mr.avg_cycle_time(SAMPLE) == pytest.approx(4.0)  # (2+4+6)/3
+    def test_avg_lead_time(self):
+        assert mr.avg_lead_time(SAMPLE) == pytest.approx(4.0)  # (2+4+6)/3
 
-    def test_median_cycle_time(self):
-        assert mr.median_cycle_time(SAMPLE) == pytest.approx(4.0)
+    def test_median_lead_time(self):
+        assert mr.median_lead_time(SAMPLE) == pytest.approx(4.0)
 
     def test_avg_empty_is_none(self):
-        assert mr.avg_cycle_time([]) is None
-        assert mr.median_cycle_time([]) is None
+        assert mr.avg_lead_time([]) is None
+        assert mr.median_lead_time([]) is None
+
+    def test_uncommitted_sample_has_no_cycle_time_at_all(self):
+        """The corrected contract, stated on the legacy fixture: no commitment act
+        recorded -> cycle time is undefined for every one of them."""
+        assert mr.cycle_times(SAMPLE) == []
+        assert mr.avg_cycle_time(SAMPLE) is None
 
 
 # --- per-role counts --------------------------------------------------------
@@ -189,8 +203,9 @@ class TestComputeMetrics:
         assert m["n_carried_forward"] == 1
         assert m["duration_days"] == 7.0
         assert m["throughput_per_week"] == pytest.approx(3.0)
-        assert m["avg_cycle_time_days"] == pytest.approx(4.0)
-        assert m["median_cycle_time_days"] == pytest.approx(4.0)
+        assert m["avg_lead_time_days"] == pytest.approx(4.0)
+        assert m["avg_cycle_time_days"] is None   # fixture has no commitment act
+        assert m["median_lead_time_days"] == pytest.approx(4.0)
         assert m["per_role_counts"] == {"role:scientist": 2, "role:developer": 2}
 
     def test_split_counts_and_delivered_throughput(self):
@@ -208,8 +223,9 @@ class TestComputeMetrics:
         assert m["per_role_counts"] == {"role:scientist": 2, "role:developer": 1}
         # cycle time is over delivered only: #1=2d, #3=6d -> avg/median 4.0.
         # The descoped #2 (4d) and #5 (8d) must not skew it.
-        assert m["avg_cycle_time_days"] == pytest.approx(4.0)
-        assert m["median_cycle_time_days"] == pytest.approx(4.0)
+        assert m["avg_lead_time_days"] == pytest.approx(4.0)
+        assert m["avg_cycle_time_days"] is None   # fixture has no commitment act
+        assert m["median_lead_time_days"] == pytest.approx(4.0)
 
     def test_partition_invariant(self):
         # delivered + descoped always exactly partitions closed.
@@ -280,9 +296,11 @@ class TestWeeklySeries:
     def test_trend_buckets_and_medians(self):
         s = mr.weekly_series(WINDOW_ISSUES, UNTIL, 4, marker_in_use=True)
         assert [w["n_delivered"] for w in s] == [1, 0, 1, 2]   # w1, w2(empty), w3, w4
-        assert s[1]["median_cycle_time_days"] is None          # empty week -> None
-        assert s[0]["median_cycle_time_days"] == pytest.approx(2.0)   # #5
-        assert s[3]["median_cycle_time_days"] == pytest.approx(4.5)   # #1=2d, #2=7d
+        assert s[1]["median_lead_time_days"] is None          # empty week -> None
+        assert s[0]["median_lead_time_days"] == pytest.approx(2.0)   # #5
+        assert s[0]["median_cycle_time_days"] is None   # no commitment act
+        assert s[3]["median_lead_time_days"] == pytest.approx(4.5)   # #1=2d, #2=7d
+        assert s[3]["median_cycle_time_days"] is None   # no commitment act on the fixture
         # descoped #4 must not inflate the reporting-week bucket count.
         assert s[3]["week_end"] == "2026-07-03"
 
@@ -297,7 +315,8 @@ class TestComputeWindowMetrics:
         assert m["n_descoped"] == 1         # #4 NOT_PLANNED
         assert m["n_carried_forward"] == 0  # window mode has no carried concept
         assert m["throughput_per_week"] == pytest.approx(2.0)  # 2 delivered / 1 week
-        assert m["avg_cycle_time_days"] == pytest.approx(4.5)  # (2 + 7) / 2
+        assert m["avg_lead_time_days"] == pytest.approx(4.5)  # (2 + 7) / 2
+        assert m["avg_cycle_time_days"] is None   # fixture has no commitment act
         assert m["per_role_counts"] == {"role:pm": 1, "role:developer": 1}  # delivered only
         assert [w["n_delivered"] for w in m["weekly_series"]] == [1, 0, 1, 2]
 
@@ -547,6 +566,103 @@ class TestMarkerNotInUse:
         assert m["n_unclassifiable"] == 2
         # The delivered headline is unaffected - we know WHAT shipped, not how it arrived.
         assert m["n_delivered"] == 2
+
+
+class TestCycleVsLeadTime:
+    """Cycle time starts at the COMMITMENT POINT; lead time starts at creation.
+
+    The old metric computed created -> closed and called it "cycle time" (Issue #1138).
+    That charges uncommitted Backlog dwell to delivery performance: an option can rest in
+    Backlog for six weeks (which late-commitment Kanban actively PRESCRIBES), be
+    committed, and ship in two days - and the old number called that a 44-day cycle time.
+    It penalized the exact behavior the model is built on, and fed that to the WIP retune.
+    """
+
+    def test_the_44_day_scenario_the_issue_describes(self):
+        """The establishing case, as a number: 6 weeks resting + 2 days working."""
+        issue = _issue(1, "CLOSED", "2026-05-01T00:00:00Z", "2026-06-14T00:00:00Z",
+                       ["role:pm"], "COMPLETED")
+        issue["committed_at"] = "2026-06-12T00:00:00Z"
+
+        assert mr.lead_time_days(issue) == pytest.approx(44.0)   # what it used to report
+        assert mr.cycle_time_days(issue) == pytest.approx(2.0)   # what it actually took
+
+    def test_never_committed_cycle_time_is_undefined_not_zero(self):
+        """An item that never crossed into Ready has NO cycle time.
+
+        None, never 0.0. A zero would assert an instantaneous delivery; and silently
+        dropping it from the mean would bias the average toward exactly the committed
+        work - the same "can only come back one way" disease as the #1180 fabricated 0%.
+        """
+        issue = _issue(1, "CLOSED", "2026-06-01T00:00:00Z", "2026-06-03T00:00:00Z",
+                       ["role:pm"], "COMPLETED")   # no committed_at at all
+        assert mr.cycle_time_days(issue) is None
+        assert mr.lead_time_days(issue) == pytest.approx(2.0), "lead time is still defined"
+
+    def test_never_committed_are_counted_not_dropped(self):
+        committed = _issue(1, "CLOSED", "2026-06-01T00:00:00Z", "2026-06-05T00:00:00Z",
+                           ["role:pm"], "COMPLETED")
+        committed["committed_at"] = "2026-06-03T00:00:00Z"
+        barged = _issue(2, "CLOSED", "2026-06-01T00:00:00Z", "2026-06-05T00:00:00Z",
+                        ["role:pm"], "COMPLETED")   # never committed
+
+        assert [i["number"] for i in mr.never_committed_issues([committed, barged])] == [2]
+        # The cycle-time mean uses only the item that HAS a cycle time...
+        assert mr.avg_cycle_time([committed, barged]) == pytest.approx(2.0)
+        # ...which is exactly why the excluded one must be counted and surfaced.
+
+    def test_descoped_never_counted_as_never_committed(self):
+        """never_committed keys off DELIVERED, so a descoped close is not shipped work."""
+        descoped = _issue(3, "CLOSED", "2026-06-01T00:00:00Z", "2026-06-05T00:00:00Z",
+                          ["role:pm"], "NOT_PLANNED")
+        assert mr.never_committed_issues([descoped]) == []
+
+    def test_open_issue_has_neither(self):
+        opened = _issue(4, "OPEN", "2026-06-01T00:00:00Z", None, ["role:pm"])
+        opened["committed_at"] = "2026-06-02T00:00:00Z"
+        assert mr.cycle_time_days(opened) is None
+        assert mr.lead_time_days(opened) is None
+
+
+class TestFirstReadyAt:
+    """Extracting the commitment act from the status-change timeline."""
+
+    def _ev(self, when, status, previous=None, project=mr.PROJECT_NUMBER):
+        return {"createdAt": when, "status": status, "previousStatus": previous,
+                "project": {"number": project}}
+
+    def test_commitment_is_first_entry_INTO_ready_whatever_preceded_it(self):
+        """NOT `previousStatus == "Backlog"`.
+
+        An item can be committed straight from intake (No Status -> Ready) - verified live
+        on Issue #1162. Keying on the previous status would silently MISS that commitment,
+        under-counting commitments and inflating the never-committed population.
+        """
+        events = [self._ev("2026-07-14T16:05:00Z", "Ready", previous=None)]
+        assert mr.first_ready_at(events) == "2026-07-14T16:05:00Z"
+
+    def test_earliest_ready_wins_when_the_item_bounces(self):
+        """Ready -> In progress -> Ready: the commitment act is the FIRST crossing."""
+        events = [
+            self._ev("2026-07-01T00:00:00Z", "Ready", "Backlog"),
+            self._ev("2026-07-02T00:00:00Z", "In progress", "Ready"),
+            self._ev("2026-07-03T00:00:00Z", "Ready", "In progress"),   # re-entry, not new
+        ]
+        assert mr.first_ready_at(events) == "2026-07-01T00:00:00Z"
+
+    def test_never_ready_is_none(self):
+        events = [
+            self._ev("2026-07-01T00:00:00Z", "Backlog", None),
+            self._ev("2026-07-02T00:00:00Z", "Done", "Backlog"),        # closed from Backlog
+        ]
+        assert mr.first_ready_at(events) is None
+
+    def test_another_projects_ready_does_not_count(self):
+        events = [self._ev("2026-07-01T00:00:00Z", "Ready", "Backlog", project=999)]
+        assert mr.first_ready_at(events) is None, "a Ready on another board is not our commitment"
+
+    def test_empty_timeline_is_none(self):
+        assert mr.first_ready_at([]) is None
 
 
 class TestGeneratedHtmlHasNoEmDash:


### PR DESCRIPTION
**Created by:** PM

Closes [Issue #1138](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1138).

## The defect

The metric labelled **cycle time** computed `created -> closed`. That is **lead time**. Canonically cycle time runs from the **commitment point** - and this board has an explicit, deliberately-designed one: the `Backlog -> Ready` boundary, the entire basis of the late-commitment Kanban model ([epic #580](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/580)). The metric ignored the one transition that *defines* it.

**This is not pedantic.** It charges uncommitted Backlog dwell to delivery performance. An option can legitimately rest in Backlog for six weeks - which the model actively **prescribes** - be committed, and ship in two days. The old number called that a **44-day "cycle time"**. It penalized the exact behavior we designed the board around, and it was scheduled to feed the WIP retune ([Issue #902](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/902)).

## AC 1 first: the premise, verified before any code

The Issue said *"confirm that before committing to the approach."* Done, empirically. GitHub exposes **`ProjectV2ItemStatusChangedEvent`** on the issue timeline (`createdAt` / `previousStatus` / `status` / `project`), with coverage back to at least 2026-05 - well beyond any window the SDR reports on. Full write-up in [the AC-1 comment](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1138#issuecomment-4974293467).

**Three findings from that verification, each of which shaped the code:**

1. **The commitment point is the FIRST transition INTO `Ready`, not `previousStatus == "Backlog"`.** An item can be committed straight from intake (`No Status -> Ready`) - verified live on [Issue #1162](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1162), which I committed that way today. Keying on the previous status would **silently under-count commitments** and inflate the never-committed population. A falsifier probe pins it: switching to the `previousStatus` rule reds the test.
2. **An item that never entered `Ready` has NO cycle time.** Undefined, not zero - and **not silently dropped**, because dropping it biases the mean toward exactly the committed work, which is the same "a number that can only come back one way" disease as [Issue #1180](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1180). It is counted and surfaced.
3. **Batched with GraphQL aliases** (50/request). A 4-week window spans 100+ issues; per-issue queries would turn one report into 100+ round-trips against a **per-user** budget we already know we exhaust ([Issue #1165](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1165)).

## The live number, and it is the headline

> **13 of 26 delivered items in the last SDR week NEVER crossed `Backlog -> Ready`.**

**Half our delivered work has no commitment act at all** - while the `unplanned` label reports **zero**. That is the marker's slip rate, measured against a source **independent of the label**, which is exactly the falsifier [Issue #1144](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1144) AC 1 asks for. #1144's body predicted this would fall out of #1138 for free, and it did.

**Consequence for the WIP retune:** it would have been run on `0% unplanned` when the observable figure is ~50%.

## Test plan

- [x] **78 tests pass** (was 65).
- [x] **The 44-day scenario as a number**: 6 weeks resting + 2 days working -> lead 44.0d, cycle 2.0d.
- [x] **Falsifier probe**: swapping in the `previousStatus == "Backlog"` rule reds `test_commitment_is_first_entry_INTO_ready_whatever_preceded_it`; reverted to green.
- [x] Bounce case (`Ready -> In progress -> Ready`) takes the **first** crossing, not the last.
- [x] A `Ready` on **another project** does not count as our commitment.
- [x] Never-committed: cycle `None` (not `0.0`), lead still defined, counted in `n_never_committed`, excluded from the cycle mean.
- [x] Descoped closes never counted as never-committed (keys off *delivered*).
- [x] **Legacy `TestCycleTime` renamed to `TestLeadTime`** - it asserted `created -> closed` under the cycle-time name, so **the mislabelling lived in the tests as faithfully as in the code**, which is precisely why they never caught it.
- [x] **LIVE end-to-end**, read whole rather than grepped: cycle 4.9/2.0 vs lead 6.8/2.5, 13 never-committed, HTML cards + trend columns render side by side, authored-em-dash test green.

## Docs (AC 5)

`docs/pm/milestone_reports/README.md` claimed **"the board has no native transition timestamps."** That is **false**, and it is the assumption that let the mislabelling stand - corrected, with the mechanism named. The SDR memory rules now carry the cycle-vs-lead distinction and the warning that **every pre-2026-07-14 narrative discussing "cycle time" is discussing lead time** (including the week-ending-07-13 report's headline "median cycle time drifting 0.0 -> 2.9d", which is a *lead-time* drift and must not be carried forward as a cycle-time trend).