### PR TITLE
fix(pm): bucket a multi-role item under every role, not just the first (#1139)

### DIFF
--- a/scripts/pm/dispatch_digest.py
+++ b/scripts/pm/dispatch_digest.py
@@ -62,9 +62,27 @@ ROLE_DISPLAY = {
 DEFAULT_STALE_DAYS = 14
 
 
-def _role_slug(item: dict[str, Any]) -> str:
-    role = item.get("role")
-    return role.removeprefix("role:") if role else UNASSIGNED
+def _role_slugs(item: dict[str, Any]) -> list[str]:
+    """Every role slug an item carries (Issue #1139).
+
+    Reading the singular `item["role"]` scalar buckets a multi-role item under
+    exactly ONE role, leaving it invisible to the other and under-reporting that
+    role's depth - which manufactures a phantom shortfall against
+    `check_ready_queue.sh`, the gate that counts an item under EVERY role label
+    it carries. Same first-label-only class as Issue #1153 (board_open_items) and
+    Issue #1154 (check_roadmap_health); this is its last site.
+
+    `roles` is board_open_items' authoritative list; the `role` scalar is only a
+    fallback for a hand-built item that predates it.
+    """
+    roles = item.get("roles") or ([item["role"]] if item.get("role") else [])
+    slugs = [r.removeprefix("role:") for r in roles]
+    return slugs or [UNASSIGNED]
+
+
+def _role_label(item: dict[str, Any]) -> str:
+    """Display form: name every owner, not just the first."""
+    return ", ".join(ROLE_DISPLAY.get(s, s) for s in _role_slugs(item))
 
 
 def group_by_role_status(
@@ -76,14 +94,17 @@ def group_by_role_status(
     dropped (not active work). A role-less committed item lands under UNASSIGNED
     rather than being silently discarded - it is a hygiene signal worth surfacing.
     Insertion order within each bucket follows the input order.
+
+    A multi-role item is filed under EVERY role it carries (Issue #1139), so both
+    owners see it and the digest's per-role depth agrees with the gate's count.
     """
     grouped: dict[str, dict[str, list[dict[str, Any]]]] = {}
     for it in items:
         status = it.get("status")
         if status not in COMMITTED_STATUSES:
             continue
-        role = _role_slug(it)
-        grouped.setdefault(role, {}).setdefault(status, []).append(it)
+        for role in _role_slugs(it):
+            grouped.setdefault(role, {}).setdefault(status, []).append(it)
     return grouped
 
 
@@ -229,7 +250,7 @@ def render_digest(
         for it in aged:
             age = boi.age_label(it.get("updated_at"), now)
             lines.append(
-                f"- {_item_link(it)} - {ROLE_DISPLAY.get(_role_slug(it), _role_slug(it))}"
+                f"- {_item_link(it)} - {_role_label(it)}"
                 f" - {it.get('status')} - {age}"
             )
     else:

--- a/scripts/tests/test_dispatch_digest_role.py
+++ b/scripts/tests/test_dispatch_digest_role.py
@@ -1,0 +1,88 @@
+# scripts/tests/test_dispatch_digest_role.py
+#
+# Issue #1139 - the LAST site of the #1153 first-role-only class.
+#
+# `board_open_items` (#1153) and `check_roadmap_health` (#1154) were both fixed to
+# key off EVERY role label. `dispatch_digest._role_slug` still read the singular
+# scalar `item["role"]`, so a multi-role item was bucketed under exactly one role
+# and was INVISIBLE to the other. The digest therefore under-reported that role's
+# Ready depth, which is what manufactures a phantom `[REPLENISH role]` shortfall
+# against `check_ready_queue.sh` - the gate that counts by every role label and so
+# disagrees with the digest.
+#
+# The failure is silent in the worst way: the digest returns a clean, short,
+# entirely plausible list. Nothing crashes. An under-count reads exactly like a
+# small backlog.
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "pm"))
+import dispatch_digest as dd  # noqa: E402
+
+
+def _item(number, roles, status="Ready"):
+    """A board item shaped as board_open_items.normalize() emits it."""
+    return {
+        "number": number,
+        "title": f"item {number}",
+        "url": f"https://example.invalid/{number}",
+        "status": status,
+        # `role` is the first label (what the buggy code read); `roles` is the
+        # authoritative full list, exactly as board_open_items sets it.
+        "role": roles[0] if roles else None,
+        "roles": list(roles),
+    }
+
+
+def test_multirole_item_appears_under_every_role():
+    """The blocking one: a dual-role item must be visible to BOTH owners."""
+    grouped = dd.group_by_role_status(
+        [_item(1, ["role:scientist", "role:developer"])]
+    )
+    assert "scientist" in grouped, "item vanished from its first role"
+    assert "developer" in grouped, (
+        "item is invisible to its SECOND role - this is the #1153 under-count: "
+        "the digest silently under-reports that role's Ready depth"
+    )
+    assert grouped["scientist"]["Ready"][0]["number"] == 1
+    assert grouped["developer"]["Ready"][0]["number"] == 1
+
+
+def test_single_role_item_is_unchanged():
+    """Matched-pair control: the single-role path must not regress."""
+    grouped = dd.group_by_role_status([_item(2, ["role:developer"])])
+    assert list(grouped) == ["developer"]
+    assert grouped["developer"]["Ready"][0]["number"] == 2
+
+
+def test_roleless_committed_item_still_surfaces_as_unassigned():
+    """A role-less committed item is a hygiene signal, not something to drop."""
+    grouped = dd.group_by_role_status([_item(3, [])])
+    assert dd.UNASSIGNED in grouped
+
+
+def test_digest_role_depth_matches_a_by_every_label_count():
+    """The regression that motivated the Issue, stated as the gate states it.
+
+    `check_ready_queue.sh` counts an item under EVERY role label it carries. The
+    digest must agree, or a role reads as short when it is not.
+    """
+    items = [
+        _item(10, ["role:developer"]),
+        _item(11, ["role:scientist", "role:developer"]),
+        _item(12, ["role:pm", "role:developer"]),
+    ]
+    grouped = dd.group_by_role_status(items)
+    dev_ready = grouped["developer"]["Ready"]
+    assert [it["number"] for it in dev_ready] == [10, 11, 12], (
+        "developer owns all three items; a first-label-only bucket sees only one, "
+        "under-reporting the lane by 2 and manufacturing a phantom shortfall"
+    )
+
+
+def test_uncommitted_statuses_are_still_dropped():
+    """Backlog / Done are not active work; multi-role must not smuggle them in."""
+    grouped = dd.group_by_role_status(
+        [_item(4, ["role:pm", "role:developer"], status="Backlog")]
+    )
+    assert grouped == {}


### PR DESCRIPTION
Closes [Issue #1139](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1139).

## What

`dispatch_digest._role_slug` read the singular `item["role"]` scalar, so a multi-role board item was bucketed under exactly **one** role and was invisible to the other. The digest under-reported that role's Ready depth and therefore disagreed with `check_ready_queue.sh`, which counts an item under **every** `role:` label it carries. That disagreement is what manufactures a phantom `[REPLENISH role]` shortfall.

This is the **last site** of the first-label-only class already fixed in `board_open_items` ([Issue #1153](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1153)) and `check_roadmap_health` ([Issue #1154](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1154)). PM folded [Issue #1158](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1158) into this one.

The failure mode is the quiet kind: nothing crashes, and the digest returns a clean, short, entirely plausible list. **An under-count reads exactly like a small backlog.**

## Changes

- `_role_slugs()` returns every label, keeping the legacy `role` scalar as a fallback (reading `roles` alone would bucket every legacy-shaped item into `(unassigned)` - the same silent-wrong-answer class, one level down). Mirrors `check_roadmap_health._roles_of`.
- `_role_label()` names every owner in the aging-WIP display, not just the first.
- `group_by_role_status()` files an item under **each** of its roles.
- `scripts/tests/test_dispatch_digest_role.py` - `dispatch_digest` had **no tests at all**.

## Grepped the whole shape, not just the reported line

The recurring defect in this repo is fixing the reported instance and missing its siblings, so I grepped every singular-scalar read before opening this. The only two left are both correct:

- `board_open_items.py:412` - table display, and it already renders a `+N` suffix for extra roles.
- `check_roadmap_health.py:73` - its documented `roles`-absent fallback, inside `_roles_of`.

There is no third site.

## Test plan

- [x] New tests fail RED against the old code for the right reason (2 failed / 3 passed: both multi-role cases fail, the single-role and role-less controls pass), then GREEN after the fix (5 passed).
- [x] Matched-pair control included: a single-role item must still bucket exactly as before, so the fix cannot pass by simply filing everything everywhere.
- [x] Uncommitted-status drop still holds - a multi-role `Backlog` item must not smuggle itself into the digest.
- [x] All five CI pytest dirs green: `workflow/tests`, `tools/ci`, `tools/news`, `tools/project_map`, `scripts/tests` - **1786 passed, 46 skipped**.
- [x] `dispatch_digest.py --help` runs (the fix removes `_role_slug`, so a missed caller would be an import-time break, not a test failure).

**Created by:** Developer

<!-- skip-lab-notebook: routine -->
