### PR TITLE
fix(ci): let the close reason select the checklist, not one checklist for all (#1137)

### DIFF
--- a/tools/ci/closure_audit.py
+++ b/tools/ci/closure_audit.py
@@ -14,11 +14,20 @@ routine single-PR-closes-single-Issue skip that #483 declared optional, so the
 bot stops coercing entries the lab-notebook rule says are unnecessary. The AC
 and Priority-rationale checks are unaffected by the marker.
 
-On the issue path, the lab-notebook check is also skipped when the Issue closed
-as `not_planned` (descoped / superseded): such a close ships no work and routes
-through a closing comment, not a notebook entry (closure ritual, #743). The AC
-and Priority-rationale checks still run — superseded ACs are annotated to their
-disposition (e.g. `- [superseded]`) rather than left as `- [ ]`.
+On the issue path the close REASON selects the checklist (#1137):
+
+- `not_planned` (descoped / superseded) ships no work, so the whole completed-close
+  checklist is skipped - AC ticks, notebook entry, disposition alike. Its AC boxes
+  are SUPPOSED to stay unticked. What such a close does owe is a closing comment
+  (reason + outcome routing), and only its total absence is flagged (closure
+  ritual, #743).
+- a parent/epic (subIssuesSummary.total > 0) closes as a rollup of children that
+  each shipped behind their own PR, so it owes no lab-notebook entry of its own.
+
+Applying the completed-close checklist to every close is what produced the n=3
+false positives (#451, #1071, #665). This is a LINTER: its failure mode is the
+false ALARM, and a gate that cries wolf on correct behavior trains the team to
+skim its output, which costs the mechanism its entire value.
 
 Usage (called by .github/workflows/closure-audit.yml):
     python closure_audit.py --event-type {pr|issue} --number <N>

--- a/tools/ci/closure_audit.py
+++ b/tools/ci/closure_audit.py
@@ -454,8 +454,12 @@ def format_comment(
     ac_gaps: list[tuple[int, str]],
     pr_gaps: list[tuple[int, str]],
     nb_gaps: list[tuple[str, str]],
+    cc_gaps: list[tuple[int, str]] | None = None,
 ) -> str:
-    if not (ac_gaps or pr_gaps or nb_gaps):
+    # Defaulted so audit_pr's 4-arg calls stay valid: a PR close has no
+    # closing-comment branch (that is the not-planned Issue path, Issue #1137).
+    cc_gaps = cc_gaps or []
+    if not (ac_gaps or pr_gaps or nb_gaps or cc_gaps):
         return (
             f"{COMMENT_MARKER}\n"
             f"✅ Closure audit — all clear\n\n"
@@ -474,6 +478,8 @@ def format_comment(
         lines.append(f"- ⚠️ **Priority rationale** on Issue #{n} — {d}")
     for r, d in nb_gaps:
         lines.append(f"- ⚠️ **Lab notebook entry** for `{r}` — {d}")
+    for n, d in cc_gaps:
+        lines.append(f"- ⚠️ **Closing comment** on Issue #{n} - {d}")
     lines += [
         "",
         "Per [closure ritual](shared/feedback_closure_ritual.md): tick the boxes, add a comment-deferral, or add the missing entry/rationale. This comment is a snapshot of close-time state — it won't auto-update after fixes.",
@@ -511,7 +517,10 @@ def fetch_pr(n: int, repo: str | None = None) -> dict:
 def fetch_issue(n: int, repo: str | None = None) -> dict:
     return json.loads(_gh(
         "issue", "view", str(n),
-        "--json", "number,body,labels,comments,closedAt,stateReason",
+        # subIssuesSummary drives the parent/epic notebook exemption (Issue #1137).
+        # Without it the field reads as None, is_parent_rollup() is always False,
+        # and the exemption silently never fires - a fix that ships inert.
+        "--json", "number,body,labels,comments,closedAt,stateReason,subIssuesSummary",
         repo=repo,
     ))
 
@@ -658,34 +667,95 @@ def collect_cross_repo_ac_gaps(
     return gaps
 
 
-def audit_issue(n: int) -> None:
-    issue = fetch_issue(n)
+def is_not_planned(issue: dict) -> bool:
+    """True iff the Issue closed as NOT_PLANNED (descoped / superseded / declined)."""
+    return (issue.get("stateReason") or "").upper() == "NOT_PLANNED"
+
+
+def is_parent_rollup(issue: dict) -> bool:
+    """True iff the Issue is a parent/epic (it has sub-issues).
+
+    A parent closes as a *rollup* of children that each shipped their own work
+    behind their own PRs. It has no deliverable of its own, so it owes no
+    lab-notebook entry (Issue #1137; the #665 false positive).
+    """
+    return ((issue.get("subIssuesSummary") or {}).get("total") or 0) > 0
+
+
+def check_closing_comment(comments: list[str]) -> str | None:
+    """Gap when a not-planned close carries no closing comment at all.
+
+    What a not-planned close *does* owe is a closing comment (reason + outcome
+    routing) - that is the closure ritual's branch for work that ships nothing.
+
+    Deliberately conservative: it flags ONLY the total absence of any comment. It
+    does not try to parse a comment for "a reason" or "outcome routing", because
+    this is a LINTER and its failure mode is the false ALARM (shared rule: fail
+    safe, not fail open). A keyword heuristic over free prose would re-create
+    exactly the cry-wolf problem Issue #1137 exists to fix, one layer up. A
+    not-planned close with zero comments is unambiguous; anything subtler than
+    that is a human judgment, not a lint.
+    """
+    if comments:
+        return None
+    return "closed as not-planned with no closing comment (reason + outcome routing)"
+
+
+def collect_issue_gaps(
+    issue: dict,
+    notebooks: dict[str, str | None],
+) -> tuple[list[tuple[int, str]], list[tuple[int, str]], list[tuple[str, str]], list[tuple[int, str]]]:
+    """All closure gaps for a closed Issue. Pure given (issue, notebooks).
+
+    The close *reason* selects which checklist applies (Issue #1137). Applying the
+    completed-close checklist to every close is what produced the n=3 false
+    positives: it flagged a not-planned close for the unticked AC boxes it is
+    supposed to have, and a parent epic for a lab-notebook entry it does not owe.
+    """
+    n = issue["number"]
     body = issue.get("body") or ""
     cmts = [c.get("body", "") for c in issue.get("comments", [])]
-    date = issue["closedAt"][:10]
 
     ac_gaps: list[tuple[int, str]] = []
     pr_gaps: list[tuple[int, str]] = []
     nb_gaps: list[tuple[str, str]] = []
+    cc_gaps: list[tuple[int, str]] = []
+
+    if is_not_planned(issue):
+        # Ships no work: no ACs to tick, no notebook entry, no disposition. The one
+        # thing it owes is the closing comment.
+        if d := check_closing_comment(cmts):
+            cc_gaps.append((n, d))
+        return ac_gaps, pr_gaps, nb_gaps, cc_gaps
 
     if d := check_ac(body, cmts):
         ac_gaps.append((n, d))
     if d := check_priority_rationale(body):
         pr_gaps.append((n, d))
 
-    # A not_planned (descoped / superseded) close ships no work, so it routes
-    # through a closing comment, not a lab-notebook entry (closure ritual, #743).
-    # Skip ONLY the notebook check — AC + priority-rationale still run (the AC
-    # boxes are annotated to their disposition, e.g. `- [superseded]`).
-    if (issue.get("stateReason") or "").upper() != "NOT_PLANNED":
+    # A parent/epic close is a rollup of children that each shipped behind their
+    # own PR; it has no deliverable of its own, so it owes no notebook entry.
+    if not is_parent_rollup(issue):
+        date = issue["closedAt"][:10]
         labels = [lbl["name"] for lbl in issue.get("labels", [])]
         role_sets = resolve_roles([labels])
-        all_roles = {r for rs in role_sets for r in rs}
-        notebooks = {r: _load_notebook(r) for r in all_roles}
         nb_gaps.extend(collect_notebook_gaps(role_sets, date, n, notebooks))
 
-    if ac_gaps or pr_gaps or nb_gaps:
-        post_comment("issue", n, format_comment(f"Issue #{n}", ac_gaps, pr_gaps, nb_gaps))
+    return ac_gaps, pr_gaps, nb_gaps, cc_gaps
+
+
+def audit_issue(n: int) -> None:
+    issue = fetch_issue(n)
+    labels = [lbl["name"] for lbl in issue.get("labels", [])]
+    all_roles = {r for rs in resolve_roles([labels]) for r in rs}
+    notebooks = {r: _load_notebook(r) for r in all_roles}
+
+    ac_gaps, pr_gaps, nb_gaps, cc_gaps = collect_issue_gaps(issue, notebooks)
+
+    if ac_gaps or pr_gaps or nb_gaps or cc_gaps:
+        post_comment(
+            "issue", n, format_comment(f"Issue #{n}", ac_gaps, pr_gaps, nb_gaps, cc_gaps)
+        )
 
 
 def main() -> int:

--- a/tools/ci/closure_audit.py
+++ b/tools/ci/closure_audit.py
@@ -523,15 +523,43 @@ def fetch_pr(n: int, repo: str | None = None) -> dict:
     ))
 
 
+def _fetch_sub_total(n: int, repo: str | None = None) -> int:
+    """subIssuesSummary.total for issue `n`, or 0 on ANY failure (fail-safe).
+
+    Fetched SEPARATELY from the main issue view, and fail-open, on purpose
+    (Issue #1137 review). `gh issue view --json` validates field names client-side,
+    so if a `gh` build ever does not know `subIssuesSummary` the call exits non-zero
+    - and folding it into the main fetch (which runs `check=True`) would crash
+    audit_issue on EVERY closed issue, posting nothing at all. That is worse than
+    the bug this fixes. Isolating it means a rejected field degrades the parent
+    exemption to "treat as leaf" (the pre-#1137 behavior: run the notebook check),
+    never a crash. Treating-as-leaf is the safe direction for a linter - it risks a
+    single false ALARM on a real parent, never a silent false pass.
+
+    (`subIssuesSummary` IS supported on current gh - verified on 2.95.0 - so this
+    is belt-and-suspenders against version drift, not a live breakage.)
+    """
+    try:
+        data = json.loads(_gh(
+            "issue", "view", str(n), "--json", "subIssuesSummary", repo=repo,
+        ))
+        return (data.get("subIssuesSummary") or {}).get("total") or 0
+    except (subprocess.CalledProcessError, json.JSONDecodeError, ValueError, KeyError):
+        return 0
+
+
 def fetch_issue(n: int, repo: str | None = None) -> dict:
-    return json.loads(_gh(
+    # Only long-standing fields here, so this core fetch cannot be broken by a
+    # newer field on an older gh. subIssuesSummary is fetched separately and
+    # fail-open (see _fetch_sub_total), then merged into the shape the rest of the
+    # module reads (is_parent_rollup expects issue["subIssuesSummary"]["total"]).
+    issue = json.loads(_gh(
         "issue", "view", str(n),
-        # subIssuesSummary drives the parent/epic notebook exemption (Issue #1137).
-        # Without it the field reads as None, is_parent_rollup() is always False,
-        # and the exemption silently never fires - a fix that ships inert.
-        "--json", "number,body,labels,comments,closedAt,stateReason,subIssuesSummary",
+        "--json", "number,body,labels,comments,closedAt,stateReason",
         repo=repo,
     ))
+    issue["subIssuesSummary"] = {"total": _fetch_sub_total(n, repo)}
+    return issue
 
 
 def post_comment(target: str, n: int, body: str) -> None:

--- a/tools/ci/test_closure_audit.py
+++ b/tools/ci/test_closure_audit.py
@@ -646,7 +646,13 @@ _ANNOTATED_BODY = (
 )
 
 
-def _run_audit_issue(monkeypatch, *, state_reason, labels, notebook_text, body=None):
+_CLOSING_COMMENT = "Closing as superseded by Issue #999. Outcome: no follow-up needed."
+
+
+def _run_audit_issue(
+    monkeypatch, *, state_reason, labels, notebook_text, body=None,
+    comments=None, sub_total=0,
+):
     """Drive audit_issue with a controlled issue + notebook; capture any post.
 
     Default body has its AC boxes annotated to a disposition (`- [superseded]`)
@@ -655,14 +661,23 @@ def _run_audit_issue(monkeypatch, *, state_reason, labels, notebook_text, body=N
     text deliberately omits the Issue ref, so the notebook check WOULD fail if
     it ran. Pass `body` to exercise the AC check (e.g. with a real `- [ ]`).
     Returns the posted comment body, or None if nothing was posted.
+
+    `comments` defaults to a proper closing comment, because that is what a
+    correctly-closed not-planned Issue actually carries (Issue #1137). Pass
+    `comments=[]` to exercise the missing-closing-comment gap. `sub_total` > 0
+    makes the Issue a parent/epic, which owes no lab-notebook entry of its own.
     """
     issue = {
         "number": 743,
         "body": _ANNOTATED_BODY if body is None else body,
         "labels": [{"name": lbl} for lbl in labels],
-        "comments": [],
+        "comments": [
+            {"body": c}
+            for c in ([_CLOSING_COMMENT] if comments is None else comments)
+        ],
         "closedAt": "2026-06-15T14:00:00Z",
         "stateReason": state_reason,
+        "subIssuesSummary": {"total": sub_total, "completed": sub_total},
     }
     monkeypatch.setattr(ca, "fetch_issue", lambda n: issue)
     monkeypatch.setattr(ca, "_load_notebook", lambda role: notebook_text)
@@ -719,18 +734,71 @@ def test_unticked_regex_ignores_annotated_boxes():
     assert ca._UNTICKED.findall("- [ ] x\n"), "regex must still match a real `- [ ]`"
 
 
-def test_audit_issue_not_planned_still_flags_unticked_ac(monkeypatch):
-    """not_planned skips ONLY the notebook check — a genuinely unticked AC
-    (left as `- [ ]`, not annotated) is still flagged. Guards the skip's scope."""
+_NB_NO_REF = "## 2026-06-15\n\n### 14:00 UTC - Editor: Developer\nUnrelated.\n"
+
+
+def test_audit_issue_not_planned_does_not_flag_unticked_ac(monkeypatch):
+    """BEHAVIOR INVERTED by Issue #1137 (was: not_planned still flags unticked ACs).
+
+    The old contract skipped ONLY the notebook check, so a not-planned close was
+    still flagged for `- [ ]` boxes. That is a false positive **by construction**:
+    a not-planned close ships no work, so its AC boxes are SUPPOSED to stay
+    unticked. It fired on real, correctly-closed Issues (n=3; Issue #451 was
+    flagged for 8 unticked boxes while carrying a proper closing comment).
+
+    A linter's failure mode is the false ALARM, and a gate that cries wolf on
+    correct behavior trains the team to skim it, which costs the mechanism its
+    entire value.
+    """
     body = _run_audit_issue(
         monkeypatch,
         state_reason="NOT_PLANNED",
         labels=["role:developer"],
-        notebook_text="## 2026-06-15\n\n### 14:00 UTC — Editor: Developer\nUnrelated.\n",
-        body="## Acceptance criteria\n- [ ] one\n- [superseded] two\n\n**Priority rationale:** P2 — x.\n",
+        notebook_text=_NB_NO_REF,
+        body="## Acceptance criteria\n- [ ] one\n- [ ] two\n\n**Priority rationale:** P2 - x.\n",
     )
-    assert body is not None and "AC checkboxes" in body
-    assert "Lab notebook" not in body  # notebook check still skipped
+    assert body is None, "a not-planned close owes no ticked ACs and no notebook entry"
+
+
+def test_audit_issue_not_planned_without_closing_comment_is_flagged(monkeypatch):
+    """CONTROL for the inversion above: not-planned is exempt from the completed
+    checklist, but it still owes the one thing it DOES owe - a closing comment.
+
+    Without this, the exemption would be indistinguishable from a bot that simply
+    stopped checking not-planned closes altogether."""
+    body = _run_audit_issue(
+        monkeypatch,
+        state_reason="NOT_PLANNED",
+        labels=["role:developer"],
+        notebook_text=_NB_NO_REF,
+        comments=[],
+    )
+    assert body is not None and "Closing comment" in body
+
+
+def test_audit_issue_parent_rollup_owes_no_notebook_entry(monkeypatch):
+    """Issue #1137 / the #665 shape: a parent epic closes as a rollup of children
+    that each shipped behind their own PR, so it has no deliverable of its own."""
+    body = _run_audit_issue(
+        monkeypatch,
+        state_reason="COMPLETED",
+        labels=["role:developer"],
+        notebook_text=_NB_NO_REF,
+        sub_total=3,
+    )
+    assert body is None, "a parent epic owes no lab-notebook entry of its own"
+
+
+def test_audit_issue_leaf_completed_still_flags_missing_notebook(monkeypatch):
+    """CONTROL for the parent exemption: flip ONLY sub_total and it must fire."""
+    body = _run_audit_issue(
+        monkeypatch,
+        state_reason="COMPLETED",
+        labels=["role:developer"],
+        notebook_text=_NB_NO_REF,
+        sub_total=0,
+    )
+    assert body is not None and "Lab notebook" in body
 
 
 # --- #730: stray-AC-box lint (gating boxes outside an "Acceptance criteria" section) ---

--- a/tools/ci/test_closure_audit_not_planned.py
+++ b/tools/ci/test_closure_audit_not_planned.py
@@ -1,0 +1,88 @@
+# tools/ci/test_closure_audit_not_planned.py
+#
+# Issue #1137 - the closure-audit bot applied the COMPLETED-close checklist to
+# every close, so it flagged correctly-closed Issues:
+#
+#   #451  NOT_PLANNED, proper closing comment  -> flagged "8 unticked AC boxes"
+#   #665  parent-epic rollup, no own deliverable -> flagged "missing lab-notebook entry"
+#
+# Both are false by construction. A not-planned close ships no work, so its AC
+# boxes are SUPPOSED to stay unticked; a parent epic has no deliverable of its own,
+# so it owes no lab-notebook entry. n=3 on this shape.
+#
+# The polarity here matters and is the whole point (shared rule: "fail safe, not
+# fail open"). This is a LINTER, not a gate: its failure mode is the false ALARM.
+# A gate that cries wolf on correct behavior trains the team to skim it, and the
+# bot's signal-to-noise ratio IS its value. So every exemption below is paired with
+# a control proving the check still FIRES on the shape it exists to catch -
+# otherwise "no findings" would be indistinguishable from a bot that checks nothing.
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(__file__))
+import closure_audit as ca  # noqa: E402
+
+UNTICKED = "## Acceptance criteria\n- [ ] one\n- [ ] two\n\n**Priority rationale:** P2 because.\n"
+
+
+def _issue(*, state_reason=None, body=UNTICKED, comments=(), sub_total=0, labels=("role:developer",)):
+    return {
+        "number": 1,
+        "body": body,
+        "labels": [{"name": n} for n in labels],
+        "comments": [{"body": c} for c in comments],
+        "closedAt": "2026-07-10T00:00:00Z",
+        "stateReason": state_reason,
+        "subIssuesSummary": {"total": sub_total, "completed": sub_total},
+    }
+
+
+class TestNotPlanned:
+    def test_not_planned_close_is_not_flagged_for_unticked_acs(self):
+        """The #451 shape. Unticked ACs on a not-planned close are CORRECT."""
+        issue = _issue(state_reason="NOT_PLANNED", comments=["Closing: superseded by X. Outcome: no follow-up."])
+        ac, pr, nb, cc = ca.collect_issue_gaps(issue, notebooks={})
+        assert ac == [], "a not-planned close ships no work; its AC boxes are supposed to stay unticked"
+        assert nb == [], "a not-planned close routes through a closing comment, not a notebook entry"
+        assert cc == [], "it HAS a closing comment"
+
+    def test_completed_close_with_unticked_acs_is_still_flagged(self):
+        """CONTROL. Flip only stateReason: the AC check must still fire."""
+        issue = _issue(state_reason="COMPLETED")
+        ac, pr, nb, cc = ca.collect_issue_gaps(issue, notebooks={})
+        assert ac, "the AC check must still catch a COMPLETED close with unticked boxes"
+
+    def test_not_planned_without_any_closing_comment_is_flagged(self):
+        """What a not-planned close DOES owe: a reason + outcome routing."""
+        issue = _issue(state_reason="NOT_PLANNED", comments=[])
+        ac, pr, nb, cc = ca.collect_issue_gaps(issue, notebooks={})
+        assert cc, "a not-planned close with no closing comment at all has no recorded reason"
+
+
+class TestParentRollup:
+    def test_parent_rollup_owes_no_lab_notebook_entry(self):
+        """The #665 shape: an epic closes as a rollup of children that each shipped."""
+        issue = _issue(state_reason="COMPLETED", body="## Acceptance criteria\n- [x] done\n\n**Priority rationale:** P2 x.\n", sub_total=3)
+        ac, pr, nb, cc = ca.collect_issue_gaps(issue, notebooks={"developer": ""})
+        assert nb == [], "a parent epic has no deliverable of its own, so it owes no notebook entry"
+
+    def test_leaf_completed_close_still_needs_a_notebook_entry(self):
+        """CONTROL. Flip only sub_total: the notebook check must still fire."""
+        issue = _issue(state_reason="COMPLETED", body="## Acceptance criteria\n- [x] done\n\n**Priority rationale:** P2 x.\n", sub_total=0)
+        ac, pr, nb, cc = ca.collect_issue_gaps(issue, notebooks={"developer": ""})
+        assert nb, "a leaf Issue that shipped work still owes its role's lab-notebook entry"
+
+
+class TestPredicates:
+    def test_is_not_planned_is_case_insensitive_and_none_safe(self):
+        assert ca.is_not_planned({"stateReason": "not_planned"})
+        assert ca.is_not_planned({"stateReason": "NOT_PLANNED"})
+        assert not ca.is_not_planned({"stateReason": "COMPLETED"})
+        assert not ca.is_not_planned({"stateReason": None})
+        assert not ca.is_not_planned({})
+
+    def test_is_parent_rollup_is_none_safe(self):
+        assert ca.is_parent_rollup({"subIssuesSummary": {"total": 2}})
+        assert not ca.is_parent_rollup({"subIssuesSummary": {"total": 0}})
+        assert not ca.is_parent_rollup({"subIssuesSummary": None})
+        assert not ca.is_parent_rollup({})

--- a/tools/ci/test_closure_audit_not_planned.py
+++ b/tools/ci/test_closure_audit_not_planned.py
@@ -86,3 +86,38 @@ class TestPredicates:
         assert not ca.is_parent_rollup({"subIssuesSummary": {"total": 0}})
         assert not ca.is_parent_rollup({"subIssuesSummary": None})
         assert not ca.is_parent_rollup({})
+
+
+# --- Issue #1137 PR review: the subIssuesSummary fetch must never crash the audit ---
+
+
+def test_fetch_sub_total_fails_open_on_gh_error(monkeypatch):
+    """The bot's blocking scenario: if `gh issue view --json subIssuesSummary` is
+    rejected (unknown field on some gh build), audit_issue must NOT crash on every
+    closed issue. It degrades to total=0 (treat as leaf), never raises."""
+    import subprocess as sp
+
+    def boom(*a, **k):
+        raise sp.CalledProcessError(1, "gh", stderr='Unknown JSON field: "subIssuesSummary"')
+
+    monkeypatch.setattr(ca, "_gh", boom)
+    assert ca._fetch_sub_total(1) == 0  # fail-open, not a raised exception
+
+
+def test_fetch_issue_survives_a_subissues_field_rejection(monkeypatch):
+    """End-to-end: the CORE fields still fetch even when the subIssues field errors.
+
+    Matched-pair control against the fail-open above: the main fetch must succeed
+    (returning a usable issue dict) rather than the whole call blowing up."""
+    import subprocess as sp
+
+    def fake_gh(*args, repo=None):
+        if "subIssuesSummary" in args:  # the isolated second fetch
+            raise sp.CalledProcessError(1, "gh", stderr='Unknown JSON field')
+        return '{"number": 1, "body": "b", "labels": [], "comments": [], "closedAt": "2026-07-10T00:00:00Z", "stateReason": "COMPLETED"}'
+
+    monkeypatch.setattr(ca, "_gh", fake_gh)
+    issue = ca.fetch_issue(1)
+    assert issue["number"] == 1
+    assert issue["subIssuesSummary"]["total"] == 0  # degraded to leaf, no crash
+    assert ca.is_parent_rollup(issue) is False


### PR DESCRIPTION
Closes [Issue #1137](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1137).

## What

The closure-audit bot applied the **completed-close checklist to every close**, so it flagged correctly-closed Issues. The close *reason* now selects which checklist applies.

| Issue | Close | Was flagged for | Correct? |
|---|---|---|---|
| [#451](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/451) | NOT_PLANNED, proper closing comment | 8/8 unticked AC boxes | no |
| [#1071](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1071) | NOT_PLANNED, superseded | 2/2 unticked AC boxes | no |
| [#665](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/665) | parent-epic rollup | missing lab-notebook entry | no |

Both shapes are false **by construction**. A not-planned close ships no work, so its AC boxes are *supposed* to stay unticked. A parent epic closes as a rollup of children that each shipped behind their own PR, so it owes no notebook entry of its own.

This is a **linter, not a gate**, and a linter's failure mode is the false ALARM (the `fail safe, not fail open` shared rule). A gate that cries wolf on correct behavior trains the team to skim its output, which costs the mechanism its entire value.

## Changes

- `is_not_planned()` / `is_parent_rollup()` - pure, `None`-safe predicates.
- `check_closing_comment()` - what a not-planned close **does** owe. Deliberately conservative: it flags only the total **absence** of any comment, and does not parse prose for "a reason" or "outcome routing". A keyword heuristic over free text would re-create the exact cry-wolf problem this Issue exists to fix, one layer up. A zero-comment not-planned close is unambiguous; anything subtler is human judgment, not a lint.
- `collect_issue_gaps()` - pure, so the reason-routing is testable without `gh`; `audit_issue()` reduces to I/O around it.
- `fetch_issue()` now requests `subIssuesSummary`. **Without this the fix would ship inert**: the field reads `None`, `is_parent_rollup()` is always `False`, and the exemption never fires.

## Behavior change, stated loudly

`test_audit_issue_not_planned_still_flags_unticked_ac` **pinned the old contract** ("not_planned skips ONLY the notebook check"). I inverted it, because that pinned behavior *is* the bug. I did not weaken it silently: its replacement asserts no findings **and** is paired with a control proving the bot still flags a not-planned close that lacks a closing comment - so the exemption cannot be mistaken for a bot that quietly stopped checking not-planned closes at all.

## Test plan

- [x] All five CI pytest dirs green: **1791 passed, 46 skipped**.
- [x] New unit tests for each of the three shapes, each with a **matched-pair control** (flip only `stateReason` -> the AC check must still fire; flip only `sub_total` -> the notebook check must still fire).
- [x] **Live verification against the three real Issues**: `#451`, `#665`, `#1071` all now produce **0 findings**.
- [x] **Matched-pair control on that live run** (exemptions switched off, same live data), because "0 findings" is otherwise a check that can only confirm:
  - `#451` -> reproduces its false positive exactly (`8/8 unticked` + notebook gap), drops to 0 with the fix.
  - `#1071` -> reproduces (`2/2 unticked`), drops to 0.
  - `#665` -> **0 findings either way**, so it does *not* discriminate. Its lab-notebook entry has since been added, so the original false positive is no longer reproducible from current repo state. The parent-rollup exemption is therefore covered by **unit tests only, not a live reproduction** - saying so rather than claiming a confirmation I do not have.

**Created by:** Developer

<!-- skip-lab-notebook: routine -->
