### PR TITLE
fix(pm): an Epic-parked parent is mis-dated, not overdue (#1149)

### DIFF
--- a/scripts/check_roadmap_health.py
+++ b/scripts/check_roadmap_health.py
@@ -44,19 +44,50 @@ def _parse_target(s: str | None) -> date | None:
     return datetime.strptime(s[:10], "%Y-%m-%d").date()
 
 
+# Parents/epics are PARKED in this off-ladder Status and carry neither a milestone
+# nor a Target date by convention (Issue #690 sub-question A). A Target on one is
+# leftover data, not a commitment.
+EPIC_STATUS = "Epic"
+
+
+def _is_epic_parked(it: dict[str, Any]) -> bool:
+    return (it.get("status") or "") == EPIC_STATUS
+
+
 def find_overdue(items: list[dict[str, Any]], today: date) -> list[dict[str, Any]]:
     """Items whose Target date is strictly before `today`, most-overdue first.
 
     Items without a Target date are excluded; `today` itself is the deadline, not
     overdue (matches the AC's "Target date < today").
+
+    Epic-parked parents are excluded (Issue #1149). A parked epic carries no Target
+    by convention, so a leftover date on one is a DATA-HYGIENE problem ("clear the
+    date"), not a missed DEADLINE ("ship it") - reporting it as overdue frames the
+    finding wrongly and puts a permanently-noisy line in a daily sweep. They are not
+    dropped: find_parent_targets() surfaces them under their correct frame.
     """
     overdue = []
     for it in items:
+        if _is_epic_parked(it):
+            continue
         td = _parse_target(it.get("target_date"))
         if td is not None and td < today:
             overdue.append((td, it))
     overdue.sort(key=lambda pair: pair[0])  # oldest Target (most overdue) first
     return [it for _, it in overdue]
+
+
+def find_parent_targets(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Epic-parked parents that carry a Target date at all (Issue #1149).
+
+    Not date-compared: ANY Target on a parked epic is the finding, past or future,
+    because the convention is that a parent carries none. The remedy is to clear it.
+    """
+    return [
+        it
+        for it in items
+        if _is_epic_parked(it) and _parse_target(it.get("target_date")) is not None
+    ]
 
 
 def _roles_of(it: dict[str, Any]) -> list[str]:
@@ -102,20 +133,53 @@ def group_by_role(items: list[dict[str, Any]]) -> dict[str, list[dict[str, Any]]
     return groups
 
 
-def format_report(overdue: list[dict[str, Any]], today: date) -> str:
-    if not overdue:
+def _format_parent_targets(parent_targets: list[dict[str, Any]]) -> list[str]:
+    """The [PARENT-TARGET] hygiene block (Issue #1149).
+
+    A separate frame on purpose: the remedy is to CLEAR the date, not to ship the
+    work, so folding these into the overdue list would prescribe the wrong action.
+    """
+    lines = [
+        f"[PARENT-TARGET] {len(parent_targets)} Epic-parked parent(s) carry a Target date,",
+        "which the parent convention forbids (Issue #690-A). Remedy: clear the date.",
+        "",
+    ]
+    for it in parent_targets:
+        td = _parse_target(it.get("target_date"))
+        lines.append(
+            f"  #{it['number']:<5} Target={td.isoformat() if td else '?'}"
+            f"  {(it.get('title') or '')[:60]}"
+        )
+    lines.append("")
+    return lines
+
+
+def format_report(
+    overdue: list[dict[str, Any]],
+    today: date,
+    parent_targets: list[dict[str, Any]] | None = None,
+) -> str:
+    parent_targets = parent_targets or []
+    if not overdue and not parent_targets:
         return "Roadmap health: all clear — no open item past its Target date.\n"
-    lines = [f"Roadmap-overdue (Target date < {today.isoformat()}): {len(overdue)} item(s)\n"]
-    for role, items in sorted(group_by_role(overdue).items()):
-        lines.append(f"{role} ({len(items)}):")
-        for it in items:
-            td = _parse_target(it.get("target_date"))
-            days = (today - td).days if td else "?"
-            lines.append(
-                f"  #{it['number']:<5} {td.isoformat() if td else '—'} "
-                f"({days}d overdue)  {(it.get('title') or '')[:60]}"
-            )
-        lines.append("")
+
+    lines: list[str] = []
+    if overdue:
+        lines.append(
+            f"Roadmap-overdue (Target date < {today.isoformat()}): {len(overdue)} item(s)\n"
+        )
+        for role, items in sorted(group_by_role(overdue).items()):
+            lines.append(f"{role} ({len(items)}):")
+            for it in items:
+                td = _parse_target(it.get("target_date"))
+                days = (today - td).days if td else "?"
+                lines.append(
+                    f"  #{it['number']:<5} {td.isoformat() if td else '—'} "
+                    f"({days}d overdue)  {(it.get('title') or '')[:60]}"
+                )
+            lines.append("")
+    if parent_targets:
+        lines.extend(_format_parent_targets(parent_targets))
     return "\n".join(lines)
 
 
@@ -142,12 +206,13 @@ def main() -> int:
         normalized = [it for it in normalized if matches_role(it, args.role)]
 
     overdue = find_overdue(normalized, today)
+    parent_targets = find_parent_targets(normalized)
 
     if args.as_json:
         json.dump(overdue, sys.stdout, indent=2)
         sys.stdout.write("\n")
     else:
-        sys.stdout.write(format_report(overdue, today))
+        sys.stdout.write(format_report(overdue, today, parent_targets))
 
     return 2 if overdue else 0
 

--- a/scripts/tests/test_check_roadmap_health_epic.py
+++ b/scripts/tests/test_check_roadmap_health_epic.py
@@ -1,0 +1,90 @@
+# scripts/tests/test_check_roadmap_health_epic.py
+#
+# Issue #1149 - the roadmap-overdue sweep listed any open item with a past Target
+# date, with no regard for Status. But a parent/epic is PARKED in the off-ladder
+# `Epic` Status and carries neither a milestone nor a Target by convention
+# (Issue #690 sub-question A). So a leftover Target on a parked epic surfaced as a
+# missed DEADLINE (parent epic #679 read as "3 days overdue" on 2026-07-14) when it
+# is really a DATA-HYGIENE finding whose remedy is "clear the date", not "ship it".
+#
+# Treatment 2 of the two PM offered: route it to its own section rather than drop
+# it, so the finding survives under its correct frame instead of being suppressed.
+#
+# The last test is the falsifier the Issue explicitly asks for: a non-Epic leaf with
+# a past Target MUST still be reported. Without it, "no overdue items" would be
+# indistinguishable from a filter that suppresses everything.
+import os
+import sys
+from datetime import date
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+import check_roadmap_health as crh  # noqa: E402
+
+TODAY = date(2026, 7, 14)
+
+
+def _item(number, status, target, roles=("role:developer",)):
+    return {
+        "number": number,
+        "title": f"item {number}",
+        "url": f"https://example.invalid/{number}",
+        "status": status,
+        "target_date": target,
+        "role": roles[0] if roles else None,
+        "roles": list(roles),
+    }
+
+
+class TestEpicParkedParents:
+    def test_epic_with_past_target_is_not_a_deadline_finding(self):
+        """The #679 shape: a parked epic is not 'overdue', it is mis-dated."""
+        items = [_item(679, "Epic", "2026-07-11")]
+        assert crh.find_overdue(items, TODAY) == [], (
+            "an Epic-parked parent carries no Target by convention, so a leftover "
+            "date is a hygiene finding, not a missed deadline"
+        )
+
+    def test_epic_with_past_target_is_surfaced_as_a_hygiene_finding(self):
+        """Routed, not dropped - the finding survives under the correct frame."""
+        items = [_item(679, "Epic", "2026-07-11")]
+        flagged = crh.find_parent_targets(items)
+        assert [it["number"] for it in flagged] == [679]
+
+    def test_epic_without_a_target_is_flagged_by_neither(self):
+        """The correct steady state for a parked epic: no Target at all."""
+        items = [_item(680, "Epic", None)]
+        assert crh.find_overdue(items, TODAY) == []
+        assert crh.find_parent_targets(items) == []
+
+    def test_leaf_with_past_target_is_still_overdue(self):
+        """THE FALSIFIER. Flip only the Status: this must still be reported.
+
+        If this passed while the Epic cases also passed, the filter would just be
+        suppressing everything, and a green sweep would mean nothing.
+        """
+        items = [_item(700, "In progress", "2026-07-11")]
+        overdue = crh.find_overdue(items, TODAY)
+        assert [it["number"] for it in overdue] == [700]
+        assert crh.find_parent_targets(items) == [], "a leaf is not a parent-target finding"
+
+    def test_mixed_board_splits_into_the_two_frames(self):
+        items = [
+            _item(679, "Epic", "2026-07-11"),
+            _item(700, "In progress", "2026-07-11"),
+            _item(701, "Ready", "2026-07-20"),  # future Target: neither
+        ]
+        assert [it["number"] for it in crh.find_overdue(items, TODAY)] == [700]
+        assert [it["number"] for it in crh.find_parent_targets(items)] == [679]
+
+
+class TestReport:
+    def test_report_names_the_remedy_for_a_parent_target(self):
+        report = crh.format_report(
+            [], TODAY, parent_targets=[_item(679, "Epic", "2026-07-11")]
+        )
+        assert "679" in report
+        assert "clear" in report.lower(), "the report must name the remedy: clear the date"
+
+    def test_all_clear_report_is_unchanged_when_nothing_is_flagged(self):
+        report = crh.format_report([], TODAY, parent_targets=[])
+        assert "all clear" in report.lower()


### PR DESCRIPTION
Closes [Issue #1149](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1149).

## What

The roadmap-overdue sweep listed **any** open item with a past Target date, with no regard for Status. But a parent/epic is parked in the off-ladder `Epic` Status and carries neither a milestone nor a Target **by convention** ([Issue #690](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/690) sub-question A). So a leftover Target on a parked epic surfaced as a missed **deadline** - parent epic [#679](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/679) read as "3 days overdue" - when it is really a **data-hygiene** finding.

The two frames prescribe different actions, and that is the whole point. "Overdue" says *ship it*. The truth is *clear the date*.

## Approach: treatment 2 (route, don't drop)

PM offered two treatments and flagged the second as likely better because it preserves the signal. Agreed - a silent skip would trade a wrongly-framed finding for no finding at all.

- `find_overdue()` excludes Epic-parked items.
- `find_parent_targets()` surfaces them under a distinct `[PARENT-TARGET]` block naming the correct remedy. It is deliberately **not** date-compared: **any** Target on a parked epic is the finding, past or future, because the convention is that it carries none.
- `main()` calls it and `format_report()` renders it. Without that wiring the fix would ship **inert** - suppressing the finding rather than reframing it, which is the failure this PR exists to avoid.
- Exit `2` stays reserved for genuine missed deadlines. A mis-dated parent is hygiene, not a deadline, so it does not fail the sweep.

## Test plan

- [x] All five CI pytest dirs green: **1805 passed, 46 skipped**.
- [x] An `Epic` item with a past Target is **not** an overdue finding, and **is** a `[PARENT-TARGET]` finding.
- [x] An `Epic` item with **no** Target is flagged by neither (the correct steady state).
- [x] **The falsifier the Issue asks for**: a non-Epic leaf with a past Target is **still reported as overdue**. Flip only the Status and the behavior flips. Without this, "no overdue items" would be indistinguishable from a filter that suppresses everything.
- [x] The report names the remedy (`clear`), so the finding arrives actionable.
- [x] Ran the real script against the **live board** (10 pages, 1018 items): reports `all clear`.

## One honest caveat on that live run

The live sweep shows `all clear` for **both** frames, so it does **not** demonstrate the new `[PARENT-TARGET]` block firing. That is expected, not luck: [#679](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/679)'s stray Target was **already cleared by hand** (the Issue's own Meta section says so), so there is no live parent-target left to catch. The new frame is covered by unit tests, not by a live reproduction - stating that rather than implying a confirmation I do not have.

**Created by:** Developer

<!-- skip-lab-notebook: routine -->
