### PR TITLE
refactor(tooling): converge the last hand-rolled gh helper onto gh_client (#1062)

### DIFF
--- a/scripts/pm/check_closed_recent.py
+++ b/scripts/pm/check_closed_recent.py
@@ -24,10 +24,12 @@ Exit 0 on a completed scan - finding nothing closed is not a failure. A hard `gh
 as a false "nothing closed". Issue #784.
 """
 import argparse
-import json
-import subprocess
 import sys
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from gh_client import gh  # noqa: E402
 
 REPO = "Jin-HoMLee/splice-neoepitope-pipeline"
 UTC = timezone.utc
@@ -99,14 +101,19 @@ def is_within(when_ts, floor):
 # --- gh I/O ---
 
 
-def gh_json(*args):
-    result = subprocess.run(["gh", *args], capture_output=True, text=True, check=True)
-    return json.loads(result.stdout)
-
-
 def list_closed_issues(search):
-    """Closed Issues matching `search` (number, title, closedAt)."""
-    return gh_json(
+    """Closed Issues matching `search` (number, title, closedAt).
+
+    Goes through the shared `gh_client.gh` wrapper (Issue #1062), the last of the
+    hand-rolled `gh` helpers to converge. The local `gh_json()` was bare
+    `check=True` with no retry, so a transient 5xx / secondary-rate-limit /
+    replication blip raised - and in a *recap* that reads as "nothing closed",
+    which is the silent-wrong-answer this script already exists to prevent
+    (Issue #784). The wrapper retries transient failures with exponential backoff
+    and honors Retry-After, while still raising GhError on a terminal failure, so
+    the check=True contract callers rely on is preserved.
+    """
+    return gh(
         "issue", "list", "--repo", REPO, "--state", "closed",
         "--search", search, "--limit", "1000",
         "--json", "number,title,closedAt",
@@ -120,7 +127,7 @@ def list_merged_prs(search):
     PRs; only merged PRs belong in a shipped-work recap, so the unmerged ones
     (mergedAt is null) are dropped.
     """
-    rows = gh_json(
+    rows = gh(
         "pr", "list", "--repo", REPO, "--state", "all",
         "--search", search, "--limit", "1000",
         "--json", "number,title,mergedAt",

--- a/scripts/tests/test_check_closed_recent_gh_client.py
+++ b/scripts/tests/test_check_closed_recent_gh_client.py
@@ -1,0 +1,110 @@
+"""Issue #1062 - check_closed_recent's gh I/O now goes through the shared gh_client.
+
+The local `gh_json()` was a bare `subprocess.run(..., check=True)` with **no retry**:
+a transient 5xx / secondary-rate-limit / replication blip raised. In a *recap*, that
+surfaces as "nothing closed recently" - which is precisely the silent-wrong-answer
+this script exists to prevent (Issue #784). It was the last hand-rolled `gh` helper;
+#1017 and #1055 converged the other four.
+
+These tests prove the convergence is BEHAVIORAL, not cosmetic: a transient failure
+must now be retried and survive. The matched-pair control is the deterministic 4xx,
+which must still raise - otherwise "it retries" would be indistinguishable from
+"it swallows every error".
+"""
+import functools
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPTS_PM = Path(__file__).parent.parent / "pm"
+sys.path.insert(0, str(SCRIPTS_PM))
+
+import check_closed_recent as c  # noqa: E402
+import gh_client  # noqa: E402
+
+ROWS = [{"number": 1, "title": "t", "closedAt": "2026-07-14T00:00:00Z"}]
+
+
+class _Result:
+    def __init__(self, returncode, stdout="", stderr=""):
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+def _fake_runner(script):
+    """A subprocess.run stand-in replaying `script` (a list of _Result), recording calls."""
+    calls = []
+
+    def run(cmd, **kwargs):
+        calls.append(cmd)
+        return script[min(len(calls) - 1, len(script) - 1)]
+
+    run.calls = calls
+    return run
+
+
+def _inject(monkeypatch, runner):
+    """Point the module's `gh` at the REAL gh_client.gh with the runner injected.
+
+    Note gh()'s `_runner=subprocess.run` default is bound at import time, so
+    monkeypatching `gh_client.subprocess.run` would patch nothing - the default has
+    already captured the original callable. Injecting through the seam the wrapper
+    exposes keeps the real retry/backoff logic under test rather than a stub of it.
+    """
+    monkeypatch.setattr(
+        c, "gh", functools.partial(gh_client.gh, _runner=runner, _sleep=lambda _s: None)
+    )
+
+
+def test_transient_failure_is_retried_and_survives(monkeypatch):
+    """The whole point of #1062: a blip no longer becomes a false 'nothing closed'."""
+    runner = _fake_runner([
+        _Result(1, "", "HTTP 502 Bad Gateway"),      # transient: must be retried
+        _Result(0, json.dumps(ROWS), ""),            # ...and then succeed
+    ])
+    _inject(monkeypatch, runner)
+
+    rows = c.list_closed_issues("closed:>=2026-07-13")
+
+    assert rows == ROWS
+    assert len(runner.calls) == 2, "a transient failure must be RETRIED, not raised"
+
+
+def test_deterministic_4xx_still_raises(monkeypatch):
+    """MATCHED-PAIR CONTROL. Without this, 'it retries' could mean 'it swallows
+    everything' - and a recap that silently eats a real error is the original bug."""
+    runner = _fake_runner([_Result(1, "", "HTTP 404 Not Found")])
+    _inject(monkeypatch, runner)
+
+    with pytest.raises(subprocess.CalledProcessError):
+        c.list_closed_issues("closed:>=2026-07-13")
+
+    assert len(runner.calls) == 1, "a deterministic 4xx must NOT be retried"
+
+
+def test_merged_pr_listing_also_goes_through_the_wrapper(monkeypatch):
+    """Both call sites converged, not just the first one."""
+    prs = [
+        {"number": 9, "title": "merged", "mergedAt": "2026-07-14T00:00:00Z"},
+        {"number": 10, "title": "closed unmerged", "mergedAt": None},
+    ]
+    runner = _fake_runner([
+        _Result(1, "", "HTTP 503 Service Unavailable"),
+        _Result(0, json.dumps(prs), ""),
+    ])
+    _inject(monkeypatch, runner)
+
+    rows = c.list_merged_prs("closed:>=2026-07-13")
+
+    assert [r["number"] for r in rows] == [9], "unmerged PRs are still dropped"
+    assert len(runner.calls) == 2, "list_merged_prs must retry too"
+
+
+def test_no_hand_rolled_helper_survives():
+    """`gh_json` is gone; the module now imports the shared wrapper."""
+    assert not hasattr(c, "gh_json")
+    assert c.gh is gh_client.gh


### PR DESCRIPTION
Closes [Issue #1062](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1062).

## What

`check_closed_recent.gh_json()` was a bare `subprocess.run(..., check=True)` with **no retry**, so a transient 5xx / secondary-rate-limit / replication blip raised. In a **recap**, that surfaces as *"nothing closed recently"* - which is precisely the silent-wrong-answer the script exists to prevent ([Issue #784](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/784)).

[Issue #1017](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1017) and [Issue #1055](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1055) converged the four literal `gh()` copies onto `gh_client`; this one carried a **differently-named** helper and so was missed by both.

## Changes

- Both call sites (`list_closed_issues`, `list_merged_prs`) now go through `gh_client.gh`: retries transient failures with exponential backoff, honors `Retry-After`, and still raises `GhError` on a terminal failure, preserving the `check=True` contract callers depend on.
- Dropped the now-unused `json` / `subprocess` imports.

## Grepped the shape, not just the reported line

- No `gh_json` survives anywhere.
- No other hand-rolled `subprocess.run(["gh", ...])` exists outside `gh_client`.

It really was the last straggler; `gh_client` is now the sole chokepoint.

## Test plan

- [x] All five CI pytest dirs green: **1802 passed, 46 skipped**.
- [x] **Behavioral, not cosmetic**: a transient `502` / `503` is retried and the call survives (2 attempts). Under the old `gh_json` this raised.
- [x] **Matched-pair control**: a deterministic `404` must still raise **and must not be retried** (1 attempt). Without it, "it retries" would be indistinguishable from "it swallows every error" - which is the original bug wearing a different hat.
- [x] Both call sites covered, so only one of the two didn't quietly converge.
- [x] Ran the real script (`--days 1`) against live GitHub: recap renders correctly.

## Note for the next person

`gh()`'s `_runner=subprocess.run` default **binds at import time**, so monkeypatching `gh_client.subprocess.run` patches nothing - the default already captured the original callable. My first draft of these tests did exactly that and failed. They now inject through the wrapper's own seam, which keeps the real retry/backoff logic under test rather than a stub of it.

**Created by:** Developer

<!-- skip-lab-notebook: routine -->
