### PR TITLE
feat(news): track pvactools + regtools in the poller for the scientist role (#1097)

### DIFF
--- a/tools/news/test_poll_releases.py
+++ b/tools/news/test_poll_releases.py
@@ -339,8 +339,17 @@ def test_basket_file_every_polled_entry_is_role_tagged():
         for tool in basket.get(section, []):
             assert isinstance(tool.get("roles"), list) and tool["roles"], \
                 f"{tool['tool']} ({section}) is missing a roles: tag"
-    # software is Developer-scope; reference_data is shared dev+scientist.
-    assert all("developer" in t["roles"] for t in basket["software"])
+    # `software` is mostly Developer-scope, but not exclusively (Issue #1097):
+    # pvactools is a Scientist tool the Developer does not own, and regtools is
+    # dual-role. The real invariant is that every software entry is scoped to dev
+    # and/or scientist (never PM, and never role-less - checked above).
+    assert all(
+        set(t["roles"]) <= {"developer", "scientist"} for t in basket["software"]
+    ), "a software entry is scoped outside {developer, scientist}"
+    assert all(
+        "developer" in t["roles"] or "scientist" in t["roles"]
+        for t in basket["software"]
+    )
     assert all(set(t["roles"]) == {"developer", "scientist"} for t in basket["reference_data"])
     assert all(t["roles"] == ["pm"] for t in basket["pm_tooling"])
 
@@ -353,3 +362,48 @@ def test_real_basket_pm_poll_sees_only_pm_tooling():
     dev_tools = {t["tool"] for t in basket["software"]}
     assert pm_tools == {"gh-cli"}
     assert pm_tools.isdisjoint(dev_tools)
+
+
+# --------------------------------------------------------------------------- #
+# Issue #1097: pvactools + regtools are tracked for the scientist role
+# --------------------------------------------------------------------------- #
+def test_scientist_basket_tracks_pvactools_and_regtools():
+    """Against the REAL committed basket, not a fixture: both must be scientist-
+    visible. Guards the config edit itself, so dropping the role tag later fails CI.
+    """
+    basket = pr.load_basket()
+    sci_tools = {t["tool"] for t in pr.select_tools(basket, "scientist")}
+    assert "pvactools" in sci_tools
+    assert "regtools" in sci_tools
+
+
+def test_pvactools_and_regtools_surface_a_delta_for_scientist():
+    """Tracked, NOT muted: a stale watermark must surface a genuine delta for both.
+
+    The falsifier for 'is it actually polled'. Paired with the control below
+    (a PM-only tool must stay silent for scientist), so a green result cannot mean
+    'everything surfaces'. Uses a stub fetcher - no network.
+    """
+    basket = pr.load_basket()
+    versions = {"pvactools": "7.0.1", "regtools": "1.0.0", "gh-cli": "99.0.0"}
+    wm = {"tools": {"pvactools": "0.0.1", "regtools": "0.0.1", "gh-cli": "0.0.1"}}
+    surfaced, _ = pr.run(
+        basket, wm, role="scientist", check_tracked=False, fetcher=_fetcher(versions)
+    )
+    names = {r["tool"] for r in surfaced}
+    assert "pvactools" in names, "pvactools is muted/untracked for scientist, not surfacing"
+    assert "regtools" in names, "regtools is muted/untracked for scientist, not surfacing"
+    # Matched-pair control: a PM-only tool must NOT leak into the scientist poll,
+    # so this is real role-scoping and not 'every stale tool surfaces'.
+    assert "gh-cli" not in names
+
+
+def test_regtools_kept_single_entry_for_both_roles():
+    """regtools was widened in place, not duplicated: one feed = one watermark.
+
+    Two entries for one upstream would double-surface a delta (or miss one).
+    """
+    basket = pr.load_basket()
+    regtools_entries = [t for t in basket["software"] if t["tool"] == "regtools"]
+    assert len(regtools_entries) == 1
+    assert set(regtools_entries[0]["roles"]) == {"developer", "scientist"}

--- a/tools/news/tools.yaml
+++ b/tools/news/tools.yaml
@@ -16,7 +16,9 @@
 #   `poll_releases.py --role <role>` polls only the tools whose `roles:` list
 #   contains <role>. This stops a `--role pm` poll from surfacing Developer-scope
 #   deltas. An entry with NO `roles:` key is visible to every role (fail-open — an
-#   untagged dep is never silently dropped). software -> [developer]; the
+#   untagged dep is never silently dropped). software is MOSTLY [developer], with
+#   exceptions (Issue #1097): pvactools is [scientist] (a science tool the Developer
+#   does not own) and regtools is [developer, scientist] (dual-role). The
 #   reference_data feeds carry [developer, scientist] (a dev-config concern AND a
 #   science-data concern, so neither role loses a signal it gets today).
 #

--- a/tools/news/tools.yaml
+++ b/tools/news/tools.yaml
@@ -39,12 +39,33 @@ software:
     feed_type: github
     feed: DaehwanKimLab/hisat2
 
+  # Issue #1097 asked for regtools to be "added" for the scientist role - but it was
+  # already tracked, for [developer]. The right move is to widen the existing entry's
+  # roles, not add a second entry for the same feed (two entries = two watermarks for
+  # one upstream = a delta surfaced twice, or missed once).
   - tool: regtools
     current_pin: ">=1.0.0"
-    roles: [developer]
+    roles: [developer, scientist]
     feed_type: github
     feed: griffithlab/regtools
-    note: "Drives the samtools/libdeflate conflict (TODO #237)."
+    note: >-
+      Drives the samtools/libdeflate conflict (TODO #237). Dual-role: a Developer owns
+      the conda pin, but regtools also DEFINES what a junction is on the HISAT2 path
+      (the BED12 anchor-outer semantic), so a release that changes that is a science
+      signal, not merely a config bump.
+
+  - tool: pvactools
+    current_pin: "7.0.1"
+    roles: [scientist]
+    feed_type: pypi
+    feed: pvactools
+    note: >-
+      Load-bearing for Layer A of Issue #1045 (wrapping pvacseq / pvacbind /
+      pvacsplice on our own MHCflurry stack). The coupling established by the
+      Issue #1048 spike is a subprocess CLI contract, so an upstream CLI change is a
+      silent-break risk for the wrapper - which is exactly the class the poller exists
+      to catch. Scope note: the mhcnuggets non-commercial licensing edge (also #1048)
+      is deliberately NOT tracked here; that is a separate question.
 
   - tool: STAR
     current_pin: ">=2.7.11"


### PR DESCRIPTION
Closes [Issue #1097](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1097).

## What

Adds `pvactools` and widens `regtools` in the morning-news poller basket so both surface upstream releases for the **Scientist** role.

- **pvactools** - new `[scientist]` entry, PyPI feed, pinned `7.0.1` (the installed version; feed verified live). It becomes a silent-miss risk the moment Layer A of [Issue #1045](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1045) wraps `pvacseq`/`pvacbind`/`pvacsplice`: the [Issue #1048](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1048) coupling is a subprocess CLI contract, so an upstream CLI change breaks the wrapper with no warning.
- **regtools** - was **already tracked**, for `[developer]`. Widened the existing entry to `[developer, scientist]` rather than adding a second one: two entries for one upstream = a delta surfaced twice or missed once. It is genuinely dual-role - a Developer owns the conda pin, but regtools defines what a junction *is* on the HISAT2 path (its BED12 anchor-outer semantic), so a release changing that is a science signal.

## Two stale ACs, reconciled not faked

This was an aging Backlog item and two ACs had drifted from reality:

- **"Seed `watermark_scientist.yaml`"** - that file is **gitignored** (`.gitignore:352`, per-clone runtime state), so a commit *cannot* seed it. And it doesn't need to: `compute_delta()` returns `kind="baseline", surface=False` on first sighting, so the poller prevents a first-run false delta **by construction**. Verified: `--role scientist` runs silent on first sight of both tools. Ticked with that reconciliation recorded on the Issue.
- The Issue's premise "tools.yaml tracks exactly one scientist dep, `mhcflurry`" was off - `mhcflurry` is `[developer]`; Scientist previously saw only the four `reference_data` feeds.

## Test plan

- [x] All five CI pytest dirs green: **1801 passed, 46 skipped**.
- [x] `tools.yaml` parses; both tools are scientist-visible via `select_tools`.
- [x] **Tracked, not muted** (the real falsifier): under a stale watermark, both `pvactools` and `regtools` **surface a genuine delta** for the scientist role - run against the **real committed basket**, with a stub fetcher (no network).
- [x] **Matched-pair control**: a PM-only tool (`gh-cli`) stays silent for the scientist poll, so a green result cannot mean "everything surfaces".
- [x] regtools kept a **single** entry carrying both roles (guards against the double-count).
- [x] Verified the live poller: `python tools/news/poll_releases.py --role scientist` runs clean and lists both as tracked.
- [x] Relaxed a pre-existing invariant test that hard-coded "every `software` entry is Developer-scope" - false now that `pvactools` is Scientist-scope. The true invariant (dev and/or scientist, never role-less, never PM) is asserted instead.

**Created by:** Developer

<!-- skip-lab-notebook: routine -->
