### PR TITLE
fix(hooks): allow a branch delete - it is a pointer removal, not a history rewrite (#1134)

### DIFF
--- a/.agents/hooks/check_no_force_push.py
+++ b/.agents/hooks/check_no_force_push.py
@@ -1,12 +1,23 @@
 #!/usr/bin/env python3
-"""Pre-flight hook: refuse a history-destructive `git push`.
+"""Pre-flight hook: refuse a history-REWRITING `git push`.
 
-Force-pushing - and its cousins, a `+ref` force refspec, a `:ref` delete
-refspec, `--delete`, `--mirror` - rewrites or removes published history: it can
-clobber a teammate's commits on a shared branch and is irreversible on the
-remote. The house rule is "never force-push without explicit user confirmation",
-but an agent cannot ask mid-tool-call, so this guard denies the push and points
-at the escape hatch for the case where the user HAS authorized it.
+Force-pushing - and its cousins, a `+ref` force refspec and `--mirror` - rewrites
+published history: it can clobber a teammate's commits on a shared branch and is
+irreversible on the remote. The house rule is "never force-push without explicit
+user confirmation", but an agent cannot ask mid-tool-call, so this guard denies
+the push and points at the escape hatch for the case where the user HAS authorized
+it.
+
+SCOPE - rewrite, NOT delete (Issue #1134): a remote *branch deletion* is
+explicitly ALLOWED. `git push --delete`, `git push -d`, and the colon delete
+refspec `git push origin :branch` remove a *pointer*; they rewrite no history, the
+commits stay reachable via the reflog and any open PR, and GitHub offers a
+one-click restore. Deleting a stale remote branch is the whole point of the weekly
+branch-cleanup ritual, so denying it (as this guard used to) fired on every sweep
+and pushed people toward the obscure `gh api -X DELETE .../git/refs/heads/<b>`
+workaround - i.e. the branch just never got deleted. `--mirror` stays denied: it
+force-updates existing refs AND deletes any the local side lacks, which is a
+wholesale rewrite, not a single-ref delete.
 
 WHY A HOOK, NOT `permissions.deny`: the official permissions docs call
 argument-constrained static denies "fragile" - a pattern like
@@ -63,8 +74,11 @@ _SHORT_FORCE_RE = re.compile(r"^-[a-zA-Z]*f[a-zA-Z]*$")
 # them + their arg lets us find the real subcommand in `git -c k=v push` etc.
 _VALUE_OPTS = {"-c", "-C", "--git-dir", "--work-tree", "--namespace",
                "--super-prefix", "--config-env", "--exec-path"}
-# push flags that delete/rewrite remote refs (force-* flags handled separately).
-_DELETE_FLAGS = {"--mirror", "--delete", "-d"}
+# `--mirror` force-updates existing refs and deletes any absent locally: a
+# wholesale history rewrite, so it stays denied alongside the force flags.
+# `--delete` / `-d` are deliberately NOT here (Issue #1134): a branch delete is a
+# pointer removal, not a history rewrite, so it is allowed.
+_REWRITE_FLAGS = {"--mirror"}
 
 
 # --- pure helpers (unit-tested, no I/O) ---
@@ -118,9 +132,16 @@ def _is_force_flag(tok: str) -> bool:
     return bool(_SHORT_FORCE_RE.match(tok))
 
 
-def _is_destructive_refspec(tok: str) -> bool:
-    """True iff a token is a force refspec (`+ref`) or a delete refspec (`:ref`)."""
-    return tok.startswith("+") or tok.startswith(":")
+def _is_force_refspec(tok: str) -> bool:
+    """True iff a token is a FORCE refspec (`+ref`), which rewrites the remote ref.
+
+    The delete refspec (`:branch`, i.e. an empty source) is deliberately NOT flagged
+    (Issue #1134): like `--delete`, it removes a pointer and rewrites no history, so
+    it is allowed - consistent with the flag form. A push spec such as `src:dst`
+    (colon present but non-empty source) is a normal fast-forward and never matched
+    here; only a leading-colon empty-source spec is a delete, and that is allowed.
+    """
+    return tok.startswith("+")
 
 
 def git_subcommand(tokens: list[str]):
@@ -146,19 +167,22 @@ def git_subcommand(tokens: list[str]):
 
 
 def is_force_push(tokens: list[str]) -> bool:
-    """True iff a subcommand is a history-destructive `git push`.
+    """True iff a subcommand is a history-REWRITING `git push`.
 
     Requires `push` to be the git *subcommand* (resolved past global options), so
     `git checkout -f push` / `git branch -f push` on a ref named `push` are NOT
-    mis-flagged. Destructive = a force flag (-f / --force / --force-with-lease),
-    a delete/mirror flag (--delete / -d / --mirror), or a force/delete refspec
-    (+ref / :ref) among the arguments. shlex quoting collapses a quoted string to
-    one token, so `git commit -m "push --force"` carries no bare flag token.
+    mis-flagged. Rewriting = a force flag (-f / --force / --force-with-lease),
+    `--mirror`, or a force refspec (`+ref`) among the arguments. shlex quoting
+    collapses a quoted string to one token, so `git commit -m "push --force"`
+    carries no bare flag token.
+
+    A branch DELETE (`--delete` / `-d` / a `:branch` refspec) is intentionally not
+    matched (Issue #1134): it rewrites no history, so it is allowed.
     """
     if git_subcommand(tokens) != "push":
         return False
     for t in tokens:
-        if _is_force_flag(t) or t in _DELETE_FLAGS or _is_destructive_refspec(t):
+        if _is_force_flag(t) or t in _REWRITE_FLAGS or _is_force_refspec(t):
             return True
     return False
 

--- a/tools/ci/test_check_no_force_push.py
+++ b/tools/ci/test_check_no_force_push.py
@@ -83,22 +83,45 @@ class TestIsForcePush:
         assert h.is_force_push(["git", "-C", "/other", "push", "--force"])
         assert h.is_force_push(["git", "-c", "k=v", "push", "-f"])
 
-    # destructive-push forms beyond force flags
+    # rewrite forms beyond force flags
     def test_force_refspec(self):
         assert h.is_force_push(["git", "push", "origin", "+main"])
-
-    def test_delete_refspec(self):
-        assert h.is_force_push(["git", "push", "origin", ":old"])
 
     def test_mirror(self):
         assert h.is_force_push(["git", "push", "--mirror"])
 
-    def test_delete_flag(self):
-        assert h.is_force_push(["git", "push", "--delete", "origin", "x"])
-        assert h.is_force_push(["git", "push", "-d", "origin", "x"])
+    # --- Issue #1134: a branch DELETE is not a history rewrite -> allowed ---
+    # These previously asserted is_force_push == True (the false positive). Inverted:
+    # a delete removes a pointer, rewrites no history, and is reversible, so the
+    # guard must let it through.
+    def test_delete_refspec_allowed(self):
+        assert not h.is_force_push(["git", "push", "origin", ":old"])
+
+    def test_delete_flag_allowed(self):
+        assert not h.is_force_push(["git", "push", "--delete", "origin", "x"])
+        assert not h.is_force_push(["git", "push", "-d", "origin", "x"])
+
+    def test_delete_and_force_together_is_still_denied(self):
+        """Belt-and-suspenders: a delete does not LAUNDER a force flag in the same
+        command. `--delete` is allowed on its own, but `+ref` alongside still fires."""
+        assert h.is_force_push(["git", "push", "--delete", "origin", "+main"])
 
     def test_normal_refspec_allowed(self):
         assert not h.is_force_push(["git", "push", "origin", "main:main"])
+
+    def test_compound_delete_after_branch_D_is_allowed(self):
+        """The second #1134 false positive: a cleanup sweep does
+        `git branch -D x` then `git push origin --delete x`. Neither is a rewrite;
+        the whole command must pass (the -D and --delete must not be conflated)."""
+        assert not h.command_force_pushes(
+            "git branch -D feat/x && git push origin --delete feat/x"
+        )
+
+    def test_compound_force_after_delete_is_still_denied(self):
+        """...but a real force push in a later segment is still caught."""
+        assert h.command_force_pushes(
+            "git push origin --delete old && git push --force origin main"
+        )
 
 
 class TestGitSubcommand:


### PR DESCRIPTION
Closes [Issue #1134](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1134).

## What

`check_no_force_push` denied `git push origin --delete <branch>` (and `-d`, and the `:branch` colon refspec). A branch delete removes a **pointer**: it rewrites no history, the commits stay reachable via the reflog and any open PR, and GitHub offers one-click restore. Denying it was a false positive that fired on **every weekly branch-cleanup sweep**, and its obscure workaround (`gh api -X DELETE .../git/refs/heads/<b>`) meant the real-world outcome was stale remote branches piling up - the exact clutter the sweep exists to prevent.

## The scope is now *rewrite*, not *delete*

| Denied (rewrites/removes history) | Allowed (removes a pointer) |
|---|---|
| `-f` / `--force` / `--force-with-lease` / `--force-if-includes` | `--delete` / `-d` |
| `+ref` force refspec | `:branch` delete refspec (empty source) |
| `--mirror` (force-updates AND deletes refs) | a normal `src:dst` push spec (never matched) |

**The `:branch` decision (AC 2), stated:** *allowed*, for consistency with `--delete`. A leading-colon empty-source refspec is a delete; only a leading-`+` is a force. A normal `src:dst` was never matched.

## This edit weakens one of my own guards - flagging that explicitly

The change removes `--delete`/`-d`/`:ref` from what this PreToolUse guard denies, i.e. it widens what an agent may do without confirmation. The auto-mode classifier correctly blocked it the first time as unauthorized self-modification; it was made only after Jin-Ho explicitly authorized finishing this Issue. The guard's core purpose - stopping a history **rewrite** from clobbering a shared branch - is fully preserved.

## Test plan

- [x] All five CI pytest dirs green: **1784 passed, 46 skipped**.
- [x] The two tests that asserted `is_force_push == True` for a delete are **inverted** (that assertion encoded the bug), renamed to describe the contract they now check.
- [x] New tests: the compound cases from the Issue (`git branch -D x && git push --delete x` allowed; a force in a *later* segment still denied) and a belt-and-suspenders case (`--delete` does not launder a `+ref` in the same command).
- [x] **Drove the REAL hook via stdin** (harness-shaped JSON), not just `is_force_push` - a guard change must prove it did not go too permissive, so the probe is a **matched pair with opposite expected outcomes**:
  - still DENY: `--force` (flag first and last), `-f`, `--force-with-lease`, `+main`, `--mirror`
  - now ALLOW: `--delete`, `-d`, `:branch`, `git branch -D x && git push --delete x`, a plain `git push origin main`
  - mixed: `... --delete old && git push --force origin main` still DENIES.
- [x] Escape hatch (`CLAUDE_ALLOW_FORCE_PUSH=1`) unchanged; exec bit preserved (100755).

**Created by:** Developer

<!-- skip-lab-notebook: routine -->
