### PR TITLE
feat(ci): hook-liveness contract tests - drive every hook's real trigger, assert the artifact (#1140)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -131,6 +131,14 @@ jobs:
         # CI-invisible until #901 added it here, the same regression class #713
         # fixed for tools/project_map.
         #
+        # tools/ci also carries the hook-liveness contract suite
+        # (test_hook_liveness_contract.py, Issue #1140): it drives every hook
+        # registered in .agents/settings.json through its real subprocess entry
+        # path and asserts the observable artifact, so an inert hook (one that
+        # never fires on its real trigger) reds this job. This runs on every PR,
+        # which covers "any change under .agents/hooks/ or .agents/settings.json"
+        # and then some (a hook regressed by an unrelated change is caught too).
+        #
         # `-m "not live"` deselects the live-API smoke (Issue #711): a transient
         # GitHub-API blip must not red this per-PR job (or poison the hermetic
         # unit signal sharing it). The live recheck smoke now runs nightly +

--- a/docs/superpowers/specs/2026-07-15-hook-liveness-contract-tests-design.md
+++ b/docs/superpowers/specs/2026-07-15-hook-liveness-contract-tests-design.md
@@ -1,0 +1,79 @@
+# Hook-liveness contract tests - design
+
+Issue [#1140](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1140) (Sub D of epic [#1135](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1135)).
+Date: 2026-07-15.
+Author: Developer.
+
+## The class this closes
+
+Four governance mechanisms shipped **completely inert** this month; each passed its unit tests, none was ever invoked through its real path.
+The common shape: the test exercised everything downstream of the trigger and nothing at it, so it could only ever come back green.
+`post_gh_pr_create`'s `matches_pr_create()` returned `False` for a heredoc-then-`gh pr create` (the way every PR with a real body is opened) and was dead for months while every unit test passed.
+
+Mutation testing (the sibling, Issue #1141) structurally cannot see this class: a hook that is never invoked has no surviving mutant, because no test calls it through its real path.
+This mechanism is the half that catches an inert hook.
+
+## What we build
+
+A **hook-liveness contract suite**: for every hook registered in `.agents/settings.json`, a test that
+
+1. constructs the hook's **real trigger** as the harness would deliver it (the real command *string*, including the heredoc-then-command shape),
+2. drives it through the hook's **real entry path** - the hook script as a subprocess reading the harness JSON envelope on stdin, exactly as the harness invokes it, not by calling an inner function or `main()` with a hand-built payload,
+3. asserts the **observable artifact** appears (a `permissionDecision: deny` on stdout, or an appended `.agents/hook_fires.jsonl` line),
+4. and, as a matched-pair control, asserts a should-not-fire counterexample produces **no** artifact.
+
+**Absence of the artifact is the failure signal.** The suite must be able to come back red when a hook is inert.
+
+## Why "real entry path" = subprocess-with-real-command, not the harness `if:` gate
+
+The harness applies the `if:` matcher (e.g. `Bash(gh *)`) before invoking the hook command.
+That gate is vendor-documented **best-effort** and, per project convention, every hook self-matches internally and fails open - so the gate is a performance optimization, not a correctness boundary.
+We therefore do **not** re-implement the harness gate (it is harness code we cannot see and would only be guessing at).
+We drive the hook script directly, piping the true command string in the real envelope - which is exactly what the harness does once the gate passes, and it is the layer where every one of the four dead hooks actually failed (their own internal matcher, `matches_pr_create` et al.).
+
+This is the concrete engineering form of the standing AC: **drive the real trigger, never pipe a synthetic payload into `main()`.**
+
+## Architecture
+
+Two files, one CI job.
+
+### `tools/ci/hook_contract.py` - the shared harness (single-authored)
+
+- `registered_hooks()` - parse `.agents/settings.json`, return one record per `(event, matcher, if, command)` registration. This is the enumeration AC and the drift guard: the suite is parametrized off *this*, so a newly registered hook with no contract entry fails the completeness test rather than being silently uncovered.
+- Envelope builders per event: `pretooluse_bash(command)`, `pretooluse_edit(tool, file_path, old, new, content)`, `posttooluse_bash(command, tool_response)`, `stop_envelope(...)` - each returns the JSON dict the harness pipes on stdin for that event/matcher.
+- `drive(hook_path, envelope, *, gh_stub=None, env=None)` - run the hook as a subprocess (`sys.executable hook_path`), stdin = `json.dumps(envelope)`, capture stdout/stderr/exit. When `gh_stub` is set, prepend a temp dir holding a stub `gh` to `PATH` (the `test_set_status.py` pattern) so board hooks reach their handler without a network call.
+- Observable detectors: `deny_decision(result)` reads stdout JSON for `permissionDecision == "deny"`; `fired(before, after)` diffs `.agents/hook_fires.jsonl` line count around a `drive()` call. A `fire_log_guard()` context manager snapshots the real (gitignored) log so the suite leaves it untouched.
+
+### `tools/ci/test_hook_liveness_contract.py` - the suite
+
+- A per-hook **registry**: `{hook_basename: HookContract(...)}` where each `HookContract` carries the real fire command, the real no-fire counterexample, the observable kind (`DENY` | `FIRE_LOG`), and whether a `gh` stub is needed. Populated per hook (the fan-out output below).
+- `test_every_registered_hook_has_a_contract()` - the completeness AC: `set(registered_hooks basenames) == set(registry)`; an unregistered-but-present hook and a registered-but-uncovered hook both fail here.
+- Parametrized `test_hook_fires_on_real_trigger(contract)` and `test_hook_silent_on_counterexample(contract)` - the matched pair, per hook.
+- `test_heredoc_gh_pr_create_shape()` - explicit coverage of the exact string that killed two hooks.
+- `test_breaking_a_matcher_turns_the_contract_red()` - the red-on-break **demonstration**, not assertion: copy one hook to a temp file, break its matcher, drive the real trigger through the copy, assert the contract detector now reports no fire. Demonstrated, not claimed.
+
+### CI
+
+Extend the existing hook-test CI job (or add a path-filtered one) to run the suite on any change under `.agents/hooks/` or `.agents/settings.json`.
+
+## Per-hook fan-out
+
+Ten distinct hook scripts, each with a different trigger shape, observable, and counterexample.
+Determining each hook's *real* fire trigger and a genuine no-fire counterexample requires reading that hook's own matcher - independent per-hook source analysis, which is the natural unit of parallel work.
+Each hook is analyzed by one agent (produce the `HookContract` spec) and adversarially verified by a second (confirm the fire command truly fires and the counterexample truly does not, by reasoning about the hook's real matcher - the check against a wrong trigger, the `matches_pr_create` failure mode).
+The main session assembles the verified specs into the single registry and runs the suite.
+
+## The live-`gh` wrinkle
+
+`post_gh_pr_create`, `post_gh_pr_review_request`, and `recheck_dispatch` write their fire-log line only *after* a live `gh` mutation.
+Their contract drives the real trigger with a stub `gh` on `PATH` (returning canned board/PR JSON), so the matcher-plus-handler path runs end-to-end and the fire-log append is the observable - proving liveness without a network call.
+`write_session_watermark` (Stop event) writes a watermark file, not a deny/fire-log line; its observable is that file appearing, driven with a temp `CLAUDE_PROJECT_DIR`.
+
+## Out of scope (surfaced, per AC 1)
+
+The `@claude` mention guard (`check_at_claude.py`) is registered at **user** level (`~/.claude/settings.json`), not in `.agents/settings.json`, so it is outside this suite's registry-driven scope.
+That it is unreachable from the project registry is itself worth noting (AC 1: "a hook absent from the registry is a liveness bug worth surfacing"); we record it as a known gap rather than silently omitting it.
+
+## Testing
+
+The suite *is* the test. Its own credibility rests on `test_breaking_a_matcher_turns_the_contract_red` - if that demonstration cannot make the suite red, the suite is itself a hollow check and the whole exercise has failed.

--- a/docs/superpowers/specs/2026-07-15-hook-liveness-contract-tests-design.md
+++ b/docs/superpowers/specs/2026-07-15-hook-liveness-contract-tests-design.md
@@ -40,7 +40,7 @@ Two files, one CI job.
 ### `tools/ci/hook_contract.py` - the shared harness (single-authored)
 
 - `registered_hooks()` - parse `.agents/settings.json`, return one record per `(event, matcher, if, command)` registration. This is the enumeration AC and the drift guard: the suite is parametrized off *this*, so a newly registered hook with no contract entry fails the completeness test rather than being silently uncovered.
-- Envelope builders per event: `pretooluse_bash(command)`, `pretooluse_edit(tool, file_path, old, new, content)`, `posttooluse_bash(command, tool_response)`, `stop_envelope(...)` - each returns the JSON dict the harness pipes on stdin for that event/matcher.
+- Envelope builders per event: `pretooluse_bash(command, cwd=None)`, `pretooluse_edit(file_path, old_string, new_string)`, `pretooluse_write(file_path, content)`, `posttooluse_bash(command, tool_response)`, `stop_envelope(cwd=None)` - each returns the JSON dict the harness pipes on stdin for that event/matcher. (`pretooluse_bash` takes an optional top-level `cwd` for `check_memory_path_cwd_drift`, which keys on the session cwd.)
 - `drive(hook_path, envelope, *, gh_stub=None, env=None)` - run the hook as a subprocess (`sys.executable hook_path`), stdin = `json.dumps(envelope)`, capture stdout/stderr/exit. When `gh_stub` is set, prepend a temp dir holding a stub `gh` to `PATH` (the `test_set_status.py` pattern) so board hooks reach their handler without a network call.
 - Observable detectors: `deny_decision(result)` reads stdout JSON for `permissionDecision == "deny"`; `fired(before, after)` diffs `.agents/hook_fires.jsonl` line count around a `drive()` call. A `fire_log_guard()` context manager snapshots the real (gitignored) log so the suite leaves it untouched.
 

--- a/research/experiments/issue_1140_hook_liveness_contracts/README.md
+++ b/research/experiments/issue_1140_hook_liveness_contracts/README.md
@@ -1,0 +1,24 @@
+# Issue #1140 - hook-liveness contract specs (workflow provenance)
+
+Provenance record for the per-hook contract specs that back `tools/ci/test_hook_liveness_contract.py`.
+Related: [Issue #1140](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1140), epic [#1135](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1135), [PR #1195](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/1195), design [`docs/superpowers/specs/2026-07-15-hook-liveness-contract-tests-design.md`](../../../docs/superpowers/specs/2026-07-15-hook-liveness-contract-tests-design.md).
+
+## How these were produced
+
+A 22-agent workflow (one **analyze** + one adversarial **verify** agent per hook, over the 11 hooks registered in `.agents/settings.json`). Each analyze agent read its hook's real internal matcher and *drove* the hook through `hook_contract.drive()` to produce an empirically-validated `HookContract` spec (real fire trigger, real close counterexample, observable kind, `gh`-stub need). Each verify agent independently re-drove all three directions and ran a per-hook red-on-break check. The main session assembled the verified specs into the single `CONTRACTS` registry in the suite.
+
+The assembled, in-use form of this data lives in the committed suite; these files are the raw record, kept because the workflow scratchpad is ephemeral.
+
+## Files
+
+- `workflow_agent_results.json` - the full per-hook `{spec, verify}` records (analyze spec + adversarial-verify verdict, incl. each agent's evidence and rationale). 11 hooks.
+- `verified_specs.json` - the merged effective spec per hook (verify corrections applied over the analyze spec), the intermediate that fed registry assembly.
+
+## What the adversarial pass caught (the value of the verify stage)
+
+Two real harness gaps that the analyze specs alone would have shipped:
+
+1. **`check_memory_path_cwd_drift`** keys on the session `cwd` in the PreToolUse envelope, which the harness's `pretooluse_bash` did not carry - so the contract could never fire through the harness as first built. Fixed by adding an optional `cwd` to `pretooluse_bash`.
+2. **`write_session_watermark`** has no discriminating matcher (it writes unconditionally on Stop), and the first observable helper always forced a writable `CLAUDE_PROJECT_DIR`, so the hook could never be made silent - the counterexample was structurally impossible. Fixed by making the matched pair writable-root (writes) vs unwritable-root (fails open, silent).
+
+One hook (`write_session_watermark`) came back `confirmed=false` from verify for exactly reason 2 above, and one (`check_memory_path_cwd_drift`) carried corrections; both were reconciled before the suite's first run. All 11 red-on-break checks passed.

--- a/research/experiments/issue_1140_hook_liveness_contracts/verified_specs.json
+++ b/research/experiments/issue_1140_hook_liveness_contracts/verified_specs.json
@@ -1,0 +1,212 @@
+{
+  "check_gh_issue_develop_parent.py": {
+    "observable": "deny",
+    "envelope_builder": "pretooluse_bash",
+    "fire_input": {
+      "command": "gh issue develop 538 --name feat/x --checkout"
+    },
+    "nofire_input": {
+      "command": "gh issue view 538"
+    },
+    "needs_gh_stub": true,
+    "gh_stub_source": "#!/bin/sh\ncase \"$*\" in\n  *\"repo view\"*) echo \"Jin-HoMLee/splice-neoepitope-pipeline\" ;;\n  *\"api graphql\"*) echo '{\"data\":{\"repository\":{\"issue\":{\"subIssuesSummary\":{\"total\":5}}}}}' ;;\nesac\nexit 0\n",
+    "extra_args": [],
+    "heredoc_fire_input": {
+      "command": "cat > /tmp/plan.md <<'EOF'\nbranching notes for the epic\nEOF\ngh issue develop 538 --name feat/x --checkout"
+    },
+    "basename": "check_gh_issue_develop_parent.py",
+    "confirmed": true
+  },
+  "check_board_query_pagination.py": {
+    "observable": "deny",
+    "envelope_builder": "pretooluse_bash",
+    "fire_input": {
+      "command": "gh api graphql -f query='query { user(login:\"Jin-HoMLee\"){ projectV2(number:9){ items(first:100){ nodes { id } } } } }'"
+    },
+    "nofire_input": {
+      "command": "gh api graphql -f query='query { user(login:\"Jin-HoMLee\"){ projectV2(number:9){ items(first:100){ pageInfo{ hasNextPage endCursor } nodes { id } } } } }'"
+    },
+    "needs_gh_stub": false,
+    "gh_stub_source": null,
+    "extra_args": [],
+    "heredoc_fire_input": null,
+    "basename": "check_board_query_pagination.py",
+    "confirmed": true
+  },
+  "check_no_force_push.py": {
+    "observable": "deny",
+    "envelope_builder": "pretooluse_bash",
+    "fire_input": {
+      "command": "git push --force origin main"
+    },
+    "nofire_input": {
+      "command": "git push origin main"
+    },
+    "needs_gh_stub": false,
+    "gh_stub_source": null,
+    "extra_args": [],
+    "heredoc_fire_input": null,
+    "basename": "check_no_force_push.py",
+    "confirmed": true
+  },
+  "check_commit_push_separation.py": {
+    "observable": "deny",
+    "envelope_builder": "pretooluse_bash",
+    "fire_input": {
+      "command": "git commit -m 'x' && git push"
+    },
+    "nofire_input": {
+      "command": "git push origin main"
+    },
+    "needs_gh_stub": false,
+    "gh_stub_source": null,
+    "extra_args": [],
+    "heredoc_fire_input": null,
+    "basename": "check_commit_push_separation.py",
+    "confirmed": true
+  },
+  "check_no_cd_outside_cwd.py": {
+    "observable": "deny",
+    "envelope_builder": "pretooluse_bash",
+    "fire_input": {
+      "command": "cd /etc/secret"
+    },
+    "nofire_input": {
+      "command": "cd workflow"
+    },
+    "needs_gh_stub": false,
+    "gh_stub_source": null,
+    "extra_args": [],
+    "heredoc_fire_input": null,
+    "basename": "check_no_cd_outside_cwd.py",
+    "confirmed": true
+  },
+  "check_memory_path_cwd_drift.py": {
+    "observable": "deny (primary, verified) AND fire_log (also fires on every deny). Spec's 'deny' is correct as the primary observable; a fire_log line is appended coincidentally.",
+    "envelope_builder": "REQUIRES a cwd-carrying builder (e.g. a new pretooluse_bash_cwd(command, cwd) or extend pretooluse_bash to accept/pass cwd). As named ('pretooluse_bash'), the contract CANNOT run through hc.observe(): HookContract.envelope() calls _BUILDERS['pretooluse_bash'](**spec_input) and pretooluse_bash rejects the 'cwd' kwarg with TypeError. The hook keys on data.get('cwd') and pretooluse_bash never emits cwd, so through the unmodified harness the hook reads cwd=None -> cwd_outside_clone False -> can never fire.",
+    "fire_input": {
+      "command": "grep foo .agents/memory/shared/MEMORY.md",
+      "cwd": "/private/tmp/claude-scratch",
+      "_note": "correct trigger, but the cwd key must be carried by a cwd-aware envelope builder, not passed to pretooluse_bash"
+    },
+    "nofire_input": {
+      "command": "grep foo .agents/memory/shared/MEMORY.md",
+      "cwd": "/Users/jin-holee/dev/GitHub/Jin-HoMLee/splice-neoepitope-pipeline",
+      "_note": "correct matched-pair control; confirmed silent"
+    },
+    "needs_gh_stub": false,
+    "gh_stub_source": null,
+    "extra_args": [],
+    "heredoc_fire_input": null,
+    "basename": "check_memory_path_cwd_drift.py",
+    "confirmed": true
+  },
+  "check_no_emdash.py": {
+    "observable": "deny",
+    "envelope_builder": "pretooluse_edit",
+    "fire_input": {
+      "file_path": "research/notes.md",
+      "old_string": "hello - world",
+      "new_string": "hello \u2014 world"
+    },
+    "nofire_input": {
+      "file_path": "research/notes.md",
+      "old_string": "hello - world",
+      "new_string": "hello -- world"
+    },
+    "needs_gh_stub": false,
+    "gh_stub_source": null,
+    "extra_args": [],
+    "heredoc_fire_input": null,
+    "basename": "check_no_emdash.py",
+    "confirmed": true
+  },
+  "post_gh_pr_create.py": {
+    "observable": "fire_log",
+    "envelope_builder": "posttooluse_bash",
+    "fire_input": {
+      "command": "gh pr create --title \"t\" --body \"closes #1140\" --base main",
+      "tool_response": {
+        "stdout": "https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/1140\n"
+      }
+    },
+    "nofire_input": {
+      "command": "gh pr view 1140",
+      "tool_response": {
+        "stdout": "https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/1140\n"
+      }
+    },
+    "needs_gh_stub": true,
+    "gh_stub_source": "#!/bin/sh\ncase \"$*\" in\n  *\"pr view\"*) echo '{\"isDraft\": true, \"body\": \"draft body\"}' ;;\n  *\"project item-add\"*) echo '{\"id\": \"ITEM_1\"}' ;;\n  *) echo '{}' ;;\nesac\nexit 0",
+    "extra_args": [],
+    "heredoc_fire_input": {
+      "command": "cat > /tmp/pr_1140.md <<'EOF'\nPR body with (parens) and prose.\nEOF\ngh pr create --title \"t\" --body-file /tmp/pr_1140.md --base main",
+      "tool_response": {
+        "stdout": "https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/1140\n"
+      }
+    },
+    "basename": "post_gh_pr_create.py",
+    "confirmed": true
+  },
+  "post_gh_pr_review_request.py": {
+    "observable": "fire_log",
+    "envelope_builder": "posttooluse_bash",
+    "fire_input": {
+      "command": "gh pr comment 996 --body \"@claude review\"",
+      "tool_response": {
+        "stdout": ""
+      }
+    },
+    "nofire_input": {
+      "command": "gh pr comment 996 --body \"@-claude review\"",
+      "tool_response": {
+        "stdout": ""
+      }
+    },
+    "needs_gh_stub": true,
+    "gh_stub_source": "#!/bin/bash\nif [ \"$1\" = \"pr\" ] && [ \"$2\" = \"view\" ]; then\n  echo '{\"url\":\"https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/996\",\"closingIssuesReferences\":[{\"number\":123}]}'\n  exit 0\nfi\nif [ \"$1\" = \"api\" ] && [ \"$2\" = \"graphql\" ]; then\n  for a in \"$@\"; do\n    case \"$a\" in\n      *updateProjectV2ItemFieldValue*) echo '{\"data\":{\"updateProjectV2ItemFieldValue\":{\"projectV2Item\":{\"id\":\"x\"}}}}'; exit 0;;\n    esac\n  done\n  echo '{\"data\":{\"repository\":{\"pullRequest\":{\"projectItems\":{\"nodes\":[{\"id\":\"ITEM1\",\"project\":{\"number\":9},\"fieldValues\":{\"nodes\":[{\"name\":\"Ready for review\",\"field\":{\"name\":\"Status\"}}]}}]}},\"issue\":{\"projectItems\":{\"nodes\":[{\"id\":\"ITEM2\",\"project\":{\"number\":9},\"fieldValues\":{\"nodes\":[{\"name\":\"Ready for review\",\"field\":{\"name\":\"Status\"}}]}}]}}}}}'\n  exit 0\nfi\nexit 0",
+    "extra_args": [],
+    "heredoc_fire_input": null,
+    "basename": "post_gh_pr_review_request.py",
+    "confirmed": true
+  },
+  "recheck_dispatch.py": {
+    "observable": "fire_log",
+    "envelope_builder": "posttooluse_bash",
+    "fire_input": {
+      "command": "gh issue edit 42 --milestone \"i5 - S3 - Data Preparation\"",
+      "tool_response": {
+        "stdout": ""
+      }
+    },
+    "nofire_input": {
+      "command": "gh issue edit 42 --add-label \"role:developer\"",
+      "tool_response": {
+        "stdout": ""
+      }
+    },
+    "needs_gh_stub": true,
+    "gh_stub_source": "#!/bin/sh\nargs=\"$*\"\ncase \"$args\" in\n  *\"repos/Jin-HoMLee/splice-neoepitope-pipeline/issues/\"*)\n    # get_issue_milestone (--jq already applied \u2192 emit the transformed shape)\n    printf '%s' '{\"title\":\"i5 - S3 - Data Preparation\",\"due_on\":\"2026-08-01T00:00:00Z\"}'\n    ;;\n  *updateProjectV2ItemFieldValue*)\n    # _mutate_target_date \u2192 force failure so apply_target_sync fails open to the\n    # manual-param warning, which _is_fire() classifies as a real fire\n    printf '%s' '{\"errors\":[{\"message\":\"stub forced failure\"}]}'\n    ;;\n  *projectItems*)\n    # get_issue_target_date \u2192 on-board item, Target date differs from due_on\n    printf '%s' '{\"data\":{\"repository\":{\"issue\":{\"projectItems\":{\"nodes\":[{\"id\":\"PVTI_stubitem123\",\"project\":{\"number\":9},\"fieldValues\":{\"nodes\":[{\"date\":\"2026-07-01\",\"field\":{\"name\":\"Target date\"}}]}}]}}}}}'\n    ;;\n  *)\n    printf '%s' '{}'\n    ;;\nesac\nexit 0",
+    "extra_args": [
+      "--scope",
+      "shared"
+    ],
+    "heredoc_fire_input": null,
+    "basename": "recheck_dispatch.py",
+    "confirmed": true
+  },
+  "write_session_watermark.py": {
+    "observable": "watermark",
+    "envelope_builder": "stop_envelope",
+    "fire_input": {
+      "cwd": "<writable-project-root>"
+    },
+    "nofire_input": null,
+    "needs_gh_stub": false,
+    "gh_stub_source": null,
+    "extra_args": [],
+    "heredoc_fire_input": null,
+    "basename": "write_session_watermark.py",
+    "confirmed": false
+  }
+}

--- a/research/experiments/issue_1140_hook_liveness_contracts/workflow_agent_results.json
+++ b/research/experiments/issue_1140_hook_liveness_contracts/workflow_agent_results.json
@@ -1,0 +1,408 @@
+[
+  {
+    "spec": {
+      "basename": "check_gh_issue_develop_parent.py",
+      "event": "PreToolUse",
+      "observable": "deny",
+      "envelope_builder": "pretooluse_bash",
+      "fire_input": {
+        "command": "gh issue develop 538 --name feat/x --checkout"
+      },
+      "nofire_input": {
+        "command": "gh issue view 538"
+      },
+      "needs_gh_stub": true,
+      "gh_stub_source": "#!/bin/sh\ncase \"$*\" in\n  *\"repo view\"*) echo \"Jin-HoMLee/splice-neoepitope-pipeline\" ;;\n  *\"api graphql\"*) echo '{\"data\":{\"repository\":{\"issue\":{\"subIssuesSummary\":{\"total\":5}}}}}' ;;\nesac\nexit 0\n",
+      "extra_args": [],
+      "heredoc_relevant": true,
+      "heredoc_fire_input": {
+        "command": "cat > /tmp/plan.md <<'EOF'\nbranching notes for the epic\nEOF\ngh issue develop 538 --name feat/x --checkout"
+      },
+      "drove_successfully": true,
+      "evidence": "Drove the hook via hc.drive() with the gh stub (subprocess, stdin=envelope). FIRE (`gh issue develop 538 --name feat/x --checkout`): exit=0, deny=True, fire_log=True, stdout is a hookSpecificOutput permissionDecision:deny naming Issue #538 with 5 sub-issue(s). NOFIRE (`gh issue view 538`): exit=0, deny=False, fire_log=False, empty stdout - develop_args() returns None so the hook no-ops before any gh call. HEREDOC FIRE (cat heredoc then `gh issue develop 538 ...` on the 4th line): exit=0, deny=True, fire_log=True - normalize_command strips the heredoc body and turns the unquoted newline into a separator so the develop invocation lands at a command start. All three matched expectations (all pass: True).",
+      "rationale": "The internal matcher is develop_args(): it tokenizes the normalized command and only matches a `gh issue develop` at a command start, then issue_number()/resolve_repo()/sub_issue_total() drive live gh, and main() denies + logs only when subIssuesSummary.total > 0. So the real trigger must (a) be a genuine `gh issue develop` at a command start and (b) resolve to a parent - the gh stub supplies repo view + a graphql total of 5 to reach the deny. The nofire `gh issue view 538` is a genuine close counterexample: same `gh issue <N>` shape, one subcommand different (view vs develop), which develop_args must reject - and it does, no gh call, no deny. Heredoc is the killer shape for gh-matching hooks (Issue #1142/#1130): a multi-line heredoc-then-develop previously sat after an ordinary word, read as not-at-command-start, and silently allowed branching off an epic; normalize_command fixes it, verified here that the same parent denies both at command start and after the heredoc. Observable is the stdout permissionDecision:deny (fire_log co-fires on every deny)."
+    },
+    "verify": {
+      "basename": "check_gh_issue_develop_parent.py",
+      "confirmed": true,
+      "fire_observed": true,
+      "nofire_silent": true,
+      "red_on_break_works": true,
+      "corrections": null,
+      "notes": "Independently re-drove all three directions with the repo test venv against the REAL hook (re-read the source first, did not trust the spec's reading). FIRE (`gh issue develop 538 --name feat/x --checkout`, gh stub supplying repo view + graphql total=5): deny=True, fire_log=True, exit=0, stdout is a hookSpecificOutput permissionDecision:deny naming Issue #538 with 5 sub-issue(s). NOFIRE (`gh issue view 538`): deny=False, fire_log=False, exit=0, empty stdout - develop_args() returns None (view != develop) so the hook no-ops before any gh call; a genuine one-subcommand-off matched-pair control. HEREDOC fire also verified (deny+fire_log): normalize_command strips the heredoc body and splits the unquoted newline so the develop invocation lands at a command start (#1142 killer shape handled).\n\nRED-ON-BREAK caveat worth recording: my first attempt broke the matcher in a temp copy of ONLY the hook file and it exited 1 - a HOLLOW red, because the hook does `import _shell_parse` from its own directory and the lone temp copy could not import that sibling, so the observable vanished from an import crash, not the matcher. Fixed by copying `_shell_parse.py` alongside: the unbroken temp copy then FIRES (deny=True, exit=0), proving the copy runs identically; injecting `return None` into develop_args's matcher loop makes deny=False with exit_code still 0 (script runs fine, just no match). So the contract genuinely goes red on a real internal-matcher break, not on a crash. (Incidental: the temp copy writes its fire-log to a tmp-relative LOG_PATH, so fire_log reads False on the copy - irrelevant, deny is the primary observable.) Spec correct in every field: observable=deny, builder=pretooluse_bash, gh stub required and sufficient, nofire a true close counterexample, heredoc fires. No corrections."
+    }
+  },
+  {
+    "spec": {
+      "basename": "check_board_query_pagination.py",
+      "event": "PreToolUse",
+      "observable": "deny",
+      "envelope_builder": "pretooluse_bash",
+      "fire_input": {
+        "command": "gh api graphql -f query='query { user(login:\"Jin-HoMLee\"){ projectV2(number:9){ items(first:100){ nodes { id } } } } }'"
+      },
+      "nofire_input": {
+        "command": "gh api graphql -f query='query { user(login:\"Jin-HoMLee\"){ projectV2(number:9){ items(first:100){ pageInfo{ hasNextPage endCursor } nodes { id } } } } }'"
+      },
+      "needs_gh_stub": false,
+      "gh_stub_source": null,
+      "extra_args": [],
+      "heredoc_relevant": false,
+      "heredoc_fire_input": null,
+      "drove_successfully": true,
+      "evidence": "Drove the real hook via hc.drive() with hc.pretooluse_bash envelopes. FIRE: exit 0, deny_decision=True, fire_log appended True, stdout begins {\"hookSpecificOutput\": {\"hookEventName\": \"PreToolUse\", \"permissionDecision\": \"deny\", \"permissionDecisionReason\": \"Refusing an unpaginated ProjectV2 board query: ...\". NOFIRE (same query but with pageInfo{ hasNextPage endCursor }): exit 0, deny_decision=False, fire_log=False, empty stdout. Observable present on fire, absent on nofire, both directions confirmed.",
+      "rationale": "The hook's internal matcher is api_args() (command-start `gh api` tokenization via normalize_command + shlex punctuation split) followed by is_unpaginated_board_query(), which requires the joined args to contain \"projectV2\" AND an items(first:...) connection AND NO pagination token (hasNextPage/endCursor/after:). The fire_input is a real command-start `gh api graphql` board query with projectV2 + items(first:100) and no cursor, exactly the truncating shape the guard exists to refuse - it lands through the real matcher (deny on stdout + fire_log line). The nofire_input is the genuinely-close counterexample: byte-identical command except it adds `pageInfo{ hasNextPage endCursor }` inside items, so _PAGINATION_RE matches and the matcher correctly reads it as a real cursor loop and allows. This isolates the exact predicate under test (presence/absence of a pagination token) rather than something incidental. No gh/network I/O in this hook (pure string inspection), so no gh stub is needed; the registered if-clause is Bash(gh api *) and extra_args is empty. Heredoc shape is not the killer case here (this hook matches `gh api`, not `gh pr create`), though normalize_command still guards the multi-line variant."
+    },
+    "verify": {
+      "basename": "check_board_query_pagination.py",
+      "confirmed": true,
+      "fire_observed": true,
+      "nofire_silent": true,
+      "red_on_break_works": true,
+      "corrections": null,
+      "notes": "Independently re-read the hook and re-drove all three tests via hc.drive() with pretooluse_bash envelopes. (1) FIRE: the unpaginated projectV2 items(first:100) query with no cursor -> deny_decision=True AND fire_log line appended; stdout begins with the \"Refusing an unpaginated ProjectV2 board query\" deny payload. (2) NOFIRE: byte-identical query plus pageInfo{ hasNextPage endCursor } -> deny_decision=False, fire_log=False, empty stdout. It is a true matched-pair control: differs only in the presence of a pagination token, which is exactly the predicate is_unpaginated_board_query tests via _PAGINATION_RE. (3) RED-ON-BREAK: copied the hook to a temp dir (plus its _shell_parse.py sibling dependency, required for the import at line 49), injected `return False` into is_unpaginated_board_query (the internal matcher, not the envelope path or the log), drove the fire_input through the copy -> deny disappeared (deny=False, no stdout). This proves the observable is causally tied to the matcher, not incidental, so the contract can return red. Spec fields all verified correct: observable=deny (the primary; a fire_log line is also emitted on the same deny, but deny is the right observable to assert), envelope_builder=pretooluse_bash, needs_gh_stub=false (the hook does pure string inspection, no gh/network I/O per its docstring and confirmed by driving with no stub), heredoc_relevant=false (this hook matches gh api, not gh pr create; normalize_command still guards the multi-line variant but the killer heredoc-then-command shape is not the case under test here). No corrections required."
+    }
+  },
+  {
+    "spec": {
+      "basename": "check_no_force_push.py",
+      "event": "PreToolUse",
+      "observable": "deny",
+      "envelope_builder": "pretooluse_bash",
+      "fire_input": {
+        "command": "git push --force origin main"
+      },
+      "nofire_input": {
+        "command": "git push origin main"
+      },
+      "needs_gh_stub": false,
+      "gh_stub_source": null,
+      "extra_args": [],
+      "heredoc_relevant": false,
+      "heredoc_fire_input": null,
+      "drove_successfully": true,
+      "evidence": "Ran drive() via workflow/tests/.venv/bin/python from repo root. FIRE (\"git push --force origin main\"): deny_decision=True, exit 0, stdout begins {\"hookSpecificOutput\": {\"hookEventName\": \"PreToolUse\", \"permissionDecision\": \"deny\", \"permissionDecisionReason\": \"Refusi...; fire_log guard also reported fired=True. NOFIRE (\"git push origin main\"): deny_decision=False, exit 0, stdout='' (empty), fire_log fired=False.",
+      "rationale": "The hook's internal matcher is command_force_pushes -> is_force_push, which resolves the real git subcommand (past global options) and requires it to be 'push' plus a destructive flag/refspec (-f/--force/--force-with-lease, --delete/-d/--mirror, or +ref/:ref). \"git push --force origin main\" is exactly a history-destructive push in a real argument position, so it lands in the matcher and produces the stdout permissionDecision:deny observable. \"git push origin main\" is the closest genuine counterexample: same subcommand, same args, but no force/delete token, so is_force_push returns False and the hook must let it pass silently (empty stdout, no deny) - which it does. The registration matcher is Bash with if Bash(git *), and the fire command is a plain git push, so it also passes the real gate. No heredoc shape applies (this hook matches git, not gh pr create). No live gh call, so no stub needed."
+    },
+    "verify": {
+      "basename": "check_no_force_push.py",
+      "confirmed": true,
+      "fire_observed": true,
+      "nofire_silent": true,
+      "red_on_break_works": true,
+      "corrections": null,
+      "notes": "Independently re-read the hook; internal matcher is command_force_pushes -> split_subcommands -> is_force_push (subcommand must resolve to 'push' past global opts, plus a force flag/-d/--mirror/--delete or +ref/:ref token). Re-drove via workflow/tests/.venv/bin/python from repo root. FIRE 'git push --force origin main': deny_decision=True, fire_log appended, exit 0, stdout begins {\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"deny\"...}. NOFIRE 'git push origin main': deny_decision=False, stdout='' (empty), no fire_log - genuine matched-pair control (same subcommand/args, only the force token differs). RED-ON-BREAK: copied hook + _shell_parse.py dep to a temp dir, replaced the is_force_push body with 'return False', re-drove the fire command through the COPY -> deny observable disappeared (empty stdout, no fire_log), proving the contract goes red when the matcher breaks. Spec accurate on all fields; observable is 'deny' (fire_log also fires as a secondary artifact but deny is the primary and what the spec claims). No gh stub needed, heredoc not relevant (matches git, not gh pr create)."
+    }
+  },
+  {
+    "spec": {
+      "basename": "check_commit_push_separation.py",
+      "event": "PreToolUse",
+      "observable": "deny",
+      "envelope_builder": "pretooluse_bash",
+      "fire_input": {
+        "command": "git commit -m 'x' && git push"
+      },
+      "nofire_input": {
+        "command": "git push origin main"
+      },
+      "needs_gh_stub": false,
+      "gh_stub_source": null,
+      "extra_args": [],
+      "heredoc_relevant": false,
+      "heredoc_fire_input": null,
+      "drove_successfully": true,
+      "evidence": "Drove via hc.drive() with pretooluse_bash. FIRE \"git commit -m 'x' && git push\": exit 0, deny=True, stdout begins {\"hookSpecificOutput\": {\"hookEventName\": \"PreToolUse\", \"permissionDecision\": \"deny\", \"permissionDecisionReason\": \"Refusing to chain `git commit` and `git push` in one command...\". NOFIRE \"git push origin main\": exit 0, deny=False, stdout empty (''). Multi-line killer shape \"git commit -m 'x'\\ngit push\" (Issue #1142): exit 0, deny=True, confirming normalize_command handles the newline-separator case.",
+      "rationale": "The internal matcher is chained_violation(cmd), which tokenizes via split_subcommands (with _shell_parse.normalize_command applied first for the #1142 newline shape) and denies when a git commit subcommand precedes a git push (commit->push) or a git push precedes a gh pr merge (push->merge). The real trigger is a single Bash command chaining two of these steps across separate subcommands. fire_input is a genuine commit->push chain that collapses the review gate the hook protects. nofire_input is a standalone git push - the single most important close counterexample, since a naive static deny on \"git push\" would block it; the hook must let a lone push pass because only the chain is dangerous. Observable is the stdout permissionDecision:deny (it also appends a fire_log line, but deny is the primary PreToolUse artifact). Not a gh pr create hook, so heredoc shape is not the killer case here (though the multi-line #1142 case was verified separately and also fires)."
+    },
+    "verify": {
+      "basename": "check_commit_push_separation.py",
+      "confirmed": true,
+      "fire_observed": true,
+      "nofire_silent": true,
+      "red_on_break_works": true,
+      "corrections": null,
+      "notes": "Re-read the hook independently. Internal matcher is chained_violation(cmd), which tokenizes via split_subcommands (normalize_command applied first for #1142 newline shape) and denies commit->push or push->merge across separate subcommands. All three checks held via hook_contract.drive(): (1) FIRE 'git commit -m \\\\'x\\\\' && git push' -> deny=True, exit 0, stdout begins {\\\"hookSpecificOutput\\\":{...\\\"permissionDecision\\\":\\\"deny\\\"...}. (2) NOFIRE 'git push origin main' -> deny=False, stdout='' - a standalone push is the correct matched-pair control; the hook must let a lone push pass since only the chain is dangerous. (3) RED-ON-BREAK: copied the hook plus its _shell_parse.py sibling (the hook imports it from its own dir) to a temp dir, patched chained_violation to return None early, drove fire_input through the copy -> deny=False, stdout='' - observable disappeared, so the contract can come back red. Spec fields (observable=deny, envelope_builder=pretooluse_bash, needs_gh_stub=false, extra_args=[]) all verified correct. No corrections."
+    }
+  },
+  {
+    "spec": {
+      "basename": "check_no_cd_outside_cwd.py",
+      "event": "PreToolUse",
+      "observable": "deny",
+      "envelope_builder": "pretooluse_bash",
+      "fire_input": {
+        "command": "cd /etc/secret"
+      },
+      "nofire_input": {
+        "command": "cd workflow"
+      },
+      "needs_gh_stub": false,
+      "gh_stub_source": null,
+      "extra_args": [],
+      "heredoc_relevant": false,
+      "heredoc_fire_input": null,
+      "drove_successfully": true,
+      "evidence": "Ran drive_cd.py with workflow/tests/.venv/bin/python from repo root. FIRE (cd /etc/secret): deny_decision=True, exit 0, stdout emits permissionDecision:deny with reason \"Refusing a `cd` out of the project worktree (`cd /etc/secret`)...\". NOFIRE (cd workflow): deny_decision=False, stdout='' (empty), exit 0 - the subdir cd is correctly allowed. Also confirmed the Issue #1142 multi-line merge case: \"cd /tmp\\ncd /etc/secret\" -> deny_decision=True (the benign first line does not mask the escaping second line).",
+      "rationale": "The hook's internal matcher is first_escaping_cd(), which walks chained/normalized subcommands against a running virtual cwd and returns the target of the first `cd` resolving outside the worktree root plus temp roots (/tmp, /private/tmp, /var/tmp, /var/folders, $TMPDIR). fire_input \"cd /etc/secret\" is an absolute path outside both the worktree and every temp root, so is_inside_safe returns False and the hook prints a deny - the real trigger through the registered Bash matcher (if: \"Bash(cd*)\"). nofire_input \"cd workflow\" is a genuine close counterexample: same `cd` builtin, but it resolves to PROJECT_ROOT/workflow (a subdirectory of the worktree), which is_inside_safe accepts, so the matcher must let it pass - distinguishing \"cd out of tree\" from \"cd into a subdir\" is precisely the semantic a static Bash(cd *) deny could not express and the whole reason this is a hook. Observable is the stdout permissionDecision:deny (the hook also appends a fire_log line on the same deny path, but deny is the primary/first observable). No gh call is reached, so no stub is needed; not a gh-matching hook, so heredoc-then-command shape is not the killer case (though multi-line normalization was still verified)."
+    },
+    "verify": {
+      "basename": "check_no_cd_outside_cwd.py",
+      "confirmed": true,
+      "fire_observed": true,
+      "nofire_silent": true,
+      "red_on_break_works": true,
+      "corrections": null,
+      "notes": "Independently re-read the hook and re-drove all three via hook_contract.drive() from repo root with workflow/tests/.venv/bin/python. (1) FIRE cd /etc/secret -> deny_decision=True, exit 0, stdout emits permissionDecision:deny; fire_log also appended (same deny path). (2) NOFIRE cd workflow -> deny_decision=False, stdout empty, no fire_log - a true matched-pair control: same cd builtin, resolves to PROJECT_ROOT/workflow (subdir), correctly allowed by is_inside_safe. (3) RED-ON-BREAK: copied the hook + its _shell_parse dependency to a temp dir, inserted `return None` at the top of first_escaping_cd (the internal matcher), drove the fire_input through the copy -> deny_decision=False, exit 0, empty stderr (clean run, matcher just never matched). The deny disappeared, proving the observable is causally tied to the matcher and the contract can return red. All spec fields hold: observable=deny (fire_log is a co-observable on the same path but deny is primary), triggers correct, needs_gh_stub=false (no gh call reached), heredoc_relevant=false (not a gh-matching hook; multi-line normalization exists but is not the killer case). No corrections needed."
+    }
+  },
+  {
+    "spec": {
+      "basename": "check_memory_path_cwd_drift.py",
+      "event": "PreToolUse",
+      "observable": "deny",
+      "envelope_builder": "pretooluse_bash",
+      "fire_input": {
+        "command": "grep foo .agents/memory/shared/MEMORY.md",
+        "cwd": "/private/tmp/claude-scratch"
+      },
+      "nofire_input": {
+        "command": "grep foo .agents/memory/shared/MEMORY.md",
+        "cwd": "/Users/jin-holee/dev/GitHub/Jin-HoMLee/splice-neoepitope-pipeline"
+      },
+      "needs_gh_stub": false,
+      "gh_stub_source": null,
+      "extra_args": [],
+      "heredoc_relevant": false,
+      "heredoc_fire_input": null,
+      "drove_successfully": true,
+      "evidence": "Drove the hook via hc.drive() with workflow/tests/.venv/bin/python. FIRE (command='grep foo .agents/memory/shared/MEMORY.md', cwd='/private/tmp/claude-scratch'): exit 0, deny_decision=True, fire_log fired=True. stdout began: {\"hookSpecificOutput\": {\"hookEventName\": \"PreToolUse\", \"permissionDecision\": \"deny\", \"permissionDecisionReason\": \"Refusing a relative memory path (`.agents/memory/shared/MEMORY.md`) while the shell cwd has drifted OUT of the clone root...\"}. Fire-log line appended: {\"hook\":\"check_memory_path_cwd_drift\",\"action\":\"refused-memory-path-cwd-drift\",\"ref\":\".agents/memory/shared/MEMORY.md\",\"cwd\":\"/private/tmp/claude-scratch\",...}. NOFIRE (same command, cwd=clone root): exit 0, deny_decision=False, fire_log fired=False, stdout=''. Second NOFIRE (drifted cwd but ABSOLUTE memory path): deny_decision=False, fire_log fired=False, stdout=''.",
+      "rationale": "The hook's internal matcher is the AND of two conditions in main(): cwd_outside_clone(cwd, PROJECT_ROOT) must be True AND offending_ref() must return a relative path under .agents/memory or .claude/memory. The observable is a stdout permissionDecision:deny (deny_payload), plus a coincident hook_fires.jsonl append. The real trigger is a Bash command carrying a clone-root-relative memory path while the session cwd (from the PreToolUse JSON `cwd` field) has drifted outside the clone subtree - exactly the silent-wrong-file incident from Issue #1053. The nofire is the tightest matched pair: the IDENTICAL command, changing only cwd to the clone root (inside the subtree), which cwd_outside_clone correctly reports as not-outside, so the hook allows. This isolates the cwd-drift condition, which is the hook's entire reason to exist. A second genuine counterexample (drifted cwd but an absolute memory path) also correctly passes, since is_relative_memory_token rejects absolute/home-anchored tokens as cwd-independent. IMPORTANT HARNESS NOTE: this hook keys on the PreToolUse `cwd` field, but hc.pretooluse_bash(command) does not emit a `cwd` key - so both fire_input and nofire_input carry a `cwd` that must be merged into the envelope (I injected it into the dict returned by pretooluse_bash before calling hc.drive()). Without cwd in the envelope the hook reads cwd=None, cwd_outside_clone returns False, and it can never fire; validating this hook through the shared harness requires extending the bash envelope builder to pass cwd through. No gh stub, no extra_args, and the heredoc-then-gh shape is irrelevant (this hook matches Bash/Edit/Write generically, not gh pr create)."
+    },
+    "verify": {
+      "basename": "check_memory_path_cwd_drift.py",
+      "confirmed": true,
+      "fire_observed": true,
+      "nofire_silent": true,
+      "red_on_break_works": true,
+      "corrections": {
+        "envelope_builder": "REQUIRES a cwd-carrying builder (e.g. a new pretooluse_bash_cwd(command, cwd) or extend pretooluse_bash to accept/pass cwd). As named ('pretooluse_bash'), the contract CANNOT run through hc.observe(): HookContract.envelope() calls _BUILDERS['pretooluse_bash'](**spec_input) and pretooluse_bash rejects the 'cwd' kwarg with TypeError. The hook keys on data.get('cwd') and pretooluse_bash never emits cwd, so through the unmodified harness the hook reads cwd=None -> cwd_outside_clone False -> can never fire.",
+        "observable": "deny (primary, verified) AND fire_log (also fires on every deny). Spec's 'deny' is correct as the primary observable; a fire_log line is appended coincidentally.",
+        "fire_input": {
+          "command": "grep foo .agents/memory/shared/MEMORY.md",
+          "cwd": "/private/tmp/claude-scratch",
+          "_note": "correct trigger, but the cwd key must be carried by a cwd-aware envelope builder, not passed to pretooluse_bash"
+        },
+        "nofire_input": {
+          "command": "grep foo .agents/memory/shared/MEMORY.md",
+          "cwd": "/Users/jin-holee/dev/GitHub/Jin-HoMLee/splice-neoepitope-pipeline",
+          "_note": "correct matched-pair control; confirmed silent"
+        }
+      },
+      "notes": "All THREE behavioral checks held when I manually injected cwd into the envelope (reproducing the spec author's approach): FIRE -> deny + fire_log; NOFIRE (identical command, cwd=clone root) -> silent; NOFIRE-2 (drifted cwd, absolute memory path) -> silent; RED-ON-BREAK (cwd_outside_clone forced to return False, copy placed IN the real hooks dir so PROJECT_ROOT resolves identically) -> deny and fire_log both vanish. The hook itself is ALIVE and discriminates correctly. The observable, trigger, and nofire are all correct; no gh stub needed (verified needs_gh_stub=false is right).\n\nCRITICAL SPEC DEFECT (put in corrections): the machine-readable fields are not executable through the shared harness. envelope_builder='pretooluse_bash' + a 'cwd' key inside fire_input causes hc.observe() to raise TypeError('pretooluse_bash() got an unexpected keyword argument cwd'), NOT a green/red result. I verified this directly: observe(contract, fire_input) RAISED. The hook's SOLE trigger condition is the PreToolUse `cwd`, which pretooluse_bash structurally drops, so without a cwd-aware builder the hook reads cwd=None and can NEVER fire through the harness. This is exactly the #1140 failure class (a contract that looks specified but is inert through its real entry path). The spec author was transparent about this in their evidence/rationale, but the fix must land in the harness (a cwd-carrying builder or a pretooluse_bash extended to pass cwd) before this contract can actually gate anything. confirmed=true reflects that the hook's behavior is genuinely alive and all three directions held under correct driving; the corrections flag the required harness/builder change so the contract entry is runnable as-registered."
+    }
+  },
+  {
+    "spec": {
+      "basename": "check_no_emdash.py",
+      "event": "PreToolUse",
+      "observable": "deny",
+      "envelope_builder": "pretooluse_edit",
+      "fire_input": {
+        "file_path": "research/notes.md",
+        "old_string": "hello - world",
+        "new_string": "hello \u2014 world"
+      },
+      "nofire_input": {
+        "file_path": "research/notes.md",
+        "old_string": "hello - world",
+        "new_string": "hello -- world"
+      },
+      "needs_gh_stub": false,
+      "gh_stub_source": null,
+      "extra_args": [],
+      "heredoc_relevant": false,
+      "heredoc_fire_input": null,
+      "drove_successfully": true,
+      "evidence": "Drove the real hook via hc.drive() with workflow/tests/.venv/bin/python. FIRE (Edit net-adding U+2014 to research/notes.md): exit=0, deny=True, fire_log=True; stdout begins {\"hookSpecificOutput\": {\"hookEventName\": \"PreToolUse\", \"permissionDecision\": \"deny\", \"permissionDecisionReason\": \"This edit adds em-dash (U+2014) in research/no... NOFIRE (same edit shape but new_string uses plain hyphens \"hello -- world\", no net dash add): exit=0, deny=False, fire_log=False, stdout=''. CONTRACT_OK: True. Independent live confirmation: my own Write of the driver script containing a literal em-dash was itself denied by this guard until I rebuilt the char via chr(0x2014).",
+      "rationale": "The hook's internal matcher is tool_name in GUARDED_TOOLS=(Edit,MultiEdit,Write) followed by added_violations(old,new), which flags a char whose count is strictly higher in new than old. The registration matcher Edit|MultiEdit|Write routes the tool; the real firing decision is the net-add delta scan. fire_input is a genuine Edit whose new_string adds one em-dash (U+2014) over its old_string, to a non-allowlisted path (research/notes.md avoids the check_no_emdash / hook_fires.jsonl allowlist substrings), so the guard denies. nofire_input is a close counterexample: the identical edit context but new_string contains only plain ASCII hyphens, so added_violations returns empty and the guard correctly lets it pass - proving the matcher keys on the em/en dash net-add, not merely on the presence of a dash or on the tool being Edit."
+    },
+    "verify": {
+      "basename": "check_no_emdash.py",
+      "confirmed": true,
+      "fire_observed": true,
+      "nofire_silent": true,
+      "red_on_break_works": true,
+      "corrections": null,
+      "notes": "Independently re-read the hook (.agents/hooks/check_no_emdash.py) and re-drove via hc.drive() with workflow/tests/.venv/bin/python. All three checks held.\n\n1) FIRE (real hook): Edit net-adding one U+2014 to research/notes.md (non-allowlisted path) -> deny=True, fire_log=True, exit=0, stdout begins {\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"deny\",...}. Observable \"deny\" appears. (fire_log also fires, but spec's chosen observable \"deny\" is valid.)\n\n2) NOFIRE (matched-pair control): identical edit context, new_string \"hello -- world\" (plain ASCII hyphens, zero net dash add) -> deny=False, fire_log=False, exit=0, stdout=''. Silent. The counterexample is a genuine control: same tool, same path, same old_string; the ONLY variable is em-dash-added vs not. So it isolates the em/en-dash net-add matcher rather than tool routing or dash presence.\n\n3) RED ON BREAK: copied the hook to a temp file and broke its INTERNAL matcher by replacing added_violations()'s body with `return []` (confirmed the source edit landed: BROKEN_SRC_HAS_RETURN_EMPTY=True). Drove the SAME fire_input through the copy -> broken deny=False, broken fire_log=False, stdout=''. The observable DISAPPEARED, proving the contract can go red. The break is in the load-bearing matcher (the net-add delta scan), not a superficial layer.\n\nSpec fields verified correct as written: observable=deny (fire_log co-fires but deny is a valid pick), envelope_builder=pretooluse_edit, needs_gh_stub=false (no gh call in this hook), heredoc_relevant=false (Edit tool, no shell tokenization). Allowlist note: fire/nofire path research/notes.md correctly avoids the _ALLOWLIST_SUBSTRINGS (\"check_no_emdash\", \".agents/hook_fires.jsonl\") and the CLAUDE_ALLOW_EMDASH escape hatch is not set in the drive env. No corrections needed."
+    }
+  },
+  {
+    "spec": {
+      "basename": "post_gh_pr_create.py",
+      "event": "PostToolUse",
+      "observable": "fire_log",
+      "envelope_builder": "posttooluse_bash",
+      "fire_input": {
+        "command": "gh pr create --title \"t\" --body \"closes #1140\" --base main",
+        "tool_response": {
+          "stdout": "https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/1140\n"
+        }
+      },
+      "nofire_input": {
+        "command": "gh pr view 1140",
+        "tool_response": {
+          "stdout": "https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/1140\n"
+        }
+      },
+      "needs_gh_stub": true,
+      "gh_stub_source": "#!/bin/sh\ncase \"$*\" in\n  *\"pr view\"*) echo '{\"isDraft\": true, \"body\": \"draft body\"}' ;;\n  *\"project item-add\"*) echo '{\"id\": \"ITEM_1\"}' ;;\n  *) echo '{}' ;;\nesac\nexit 0",
+      "extra_args": [],
+      "heredoc_relevant": true,
+      "heredoc_fire_input": {
+        "command": "cat > /tmp/pr_1140.md <<'EOF'\nPR body with (parens) and prose.\nEOF\ngh pr create --title \"t\" --body-file /tmp/pr_1140.md --base main",
+        "tool_response": {
+          "stdout": "https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/1140\n"
+        }
+      },
+      "drove_successfully": true,
+      "evidence": "Drove via hc.drive() with the gh stub (draft path avoids the bot-review sub-branch, reaching _log_fire). FIRE (`gh pr create ...`): exit 0, w.fired()=True, appended line {\"hook\":\"post_gh_pr_create\",\"pr\":1140,\"repo\":\"Jin-HoMLee/splice-neoepitope-pipeline\",\"action\":\"board-add+status:In progress\"}; stdout carried the additionalContext confirmation. HEREDOC (`cat > pr.md <<'EOF' ... EOF` then `gh pr create --body-file ...`, the shape that killed matches_pr_create pre-#1130): exit 0, fired=True, identical fire-log line. NOFIRE (`gh pr view 1140`, same PR URL in output): exit 0, fired=False, empty stdout. SUMMARY fire=True heredoc=True nofire=False.",
+      "rationale": "The hook's internal matcher is matches_pr_create(cmd) (main() returns 0 immediately unless it returns True). The observable is the .agents/hook_fires.jsonl line appended by _log_fire, which is only reached after the live gh calls (_pr_view, _add_to_board, _set_status) succeed - hence the gh stub. The stub returns isDraft:true so should_request_review is False, routing to the plain _set_status/else branch and reaching _log_fire without the bot-review delegation. fire_input is a genuine `gh pr create` invocation; the URL in tool_response is what parse_pr_url consumes. nofire_input is `gh pr view 1140` - a real, close sibling command (same PR, same URL in output) that the matcher must let pass: it isolates the matcher, since only the create-vs-view distinction differs, not the URL parse. heredoc_fire_input is load-bearing because this exact heredoc-then-gh-pr-create shape returned False from matches_pr_create for months (Issue #1130), leaving the hook silently dead on the dominant real PR-open path; it now fires (verified)."
+    },
+    "verify": {
+      "basename": "post_gh_pr_create.py",
+      "confirmed": true,
+      "fire_observed": true,
+      "nofire_silent": true,
+      "red_on_break_works": true,
+      "corrections": null,
+      "notes": "Independently re-read the hook and re-drove all three via hc.drive() with the spec's gh stub (workflow/tests/.venv/bin/python). FIRE (`gh pr create ... --body \"closes #1140\"`, PR URL in tool_response.stdout): exit 0, fired=True, appended {\"hook\":\"post_gh_pr_create\",\"pr\":1140,\"repo\":\"Jin-HoMLee/splice-neoepitope-pipeline\",\"action\":\"board-add+status:In progress\"} (draft path via stub isDraft:true, reaching _log_fire through the else/_set_status branch). HEREDOC shape (the #1130-killer path) also fired=True, identical line. NOFIRE (`gh pr view 1140`, same PR URL in output): exit 0, fired=False - a real matched-pair control isolating the create-vs-view matcher distinction, not the URL parse. RED-ON-BREAK: copied the hook to a temp dir with its _shell_parse.py dep, forced matches_pr_create to `return False`, drove FIRE through the copy -> exit 0, fired=False; the observable disappears, so the contract can return red. Spec is correct as written: observable=fire_log, envelope_builder=posttooluse_bash, needs_gh_stub=true (stub is load-bearing - _log_fire is only reached after _pr_view/_add_to_board/_set_status succeed), fire/nofire/heredoc inputs all verified. No corrections."
+    }
+  },
+  {
+    "spec": {
+      "basename": "post_gh_pr_review_request.py",
+      "event": "PostToolUse",
+      "observable": "fire_log",
+      "envelope_builder": "posttooluse_bash",
+      "fire_input": {
+        "command": "gh pr comment 996 --body \"@claude review\"",
+        "tool_response": {
+          "stdout": ""
+        }
+      },
+      "nofire_input": {
+        "command": "gh pr comment 996 --body \"@-claude review\"",
+        "tool_response": {
+          "stdout": ""
+        }
+      },
+      "needs_gh_stub": true,
+      "gh_stub_source": "#!/bin/bash\nif [ \"$1\" = \"pr\" ] && [ \"$2\" = \"view\" ]; then\n  echo '{\"url\":\"https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/996\",\"closingIssuesReferences\":[{\"number\":123}]}'\n  exit 0\nfi\nif [ \"$1\" = \"api\" ] && [ \"$2\" = \"graphql\" ]; then\n  for a in \"$@\"; do\n    case \"$a\" in\n      *updateProjectV2ItemFieldValue*) echo '{\"data\":{\"updateProjectV2ItemFieldValue\":{\"projectV2Item\":{\"id\":\"x\"}}}}'; exit 0;;\n    esac\n  done\n  echo '{\"data\":{\"repository\":{\"pullRequest\":{\"projectItems\":{\"nodes\":[{\"id\":\"ITEM1\",\"project\":{\"number\":9},\"fieldValues\":{\"nodes\":[{\"name\":\"Ready for review\",\"field\":{\"name\":\"Status\"}}]}}]}},\"issue\":{\"projectItems\":{\"nodes\":[{\"id\":\"ITEM2\",\"project\":{\"number\":9},\"fieldValues\":{\"nodes\":[{\"name\":\"Ready for review\",\"field\":{\"name\":\"Status\"}}]}}]}}}}}'\n  exit 0\nfi\nexit 0",
+      "extra_args": [],
+      "heredoc_relevant": false,
+      "heredoc_fire_input": null,
+      "drove_successfully": true,
+      "evidence": "Drove hook_contract.drive() with a canned gh stub. FIRE `gh pr comment 996 --body \"@claude review\"`: exit 0, fire_log appended one line {\"hook\":\"post_gh_pr_review_request\",\"pr\":996,\"issues\":[123],\"repo\":\"Jin-HoMLee/splice-neoepitope-pipeline\",\"action\":\"status:In review\"}, stdout emitted hookSpecificOutput additionalContext \"PR #996 + linked Issue(s) ... Status -> In review.\" Second FIRE `gh pr review 996 --approve` also fired=True with an appended line. NOFIRE `gh pr comment 996 --body \"@-claude review\"`: exit 0, fired=False, empty stdout. RESULT fire_fired=True fire2_fired=True nofire_fired=False.",
+      "rationale": "The internal matcher is matches_review_request(cmd), which shlex-tokenizes (after _shell_parse.normalize_command) and matches two command-start shapes: `gh pr review <ref>` (any direct review) and `gh pr comment <ref>` whose body contains the literal REVIEW_TRIGGER \"@claude review\" (case-insensitive). The observable is the appended .agents/hook_fires.jsonl line, which _log_fire writes only AFTER apply_review_request resolves the PR via a live `gh pr view` and flips at least one board card via `gh api graphql` mutations - hence the gh stub returning a tracked-repo PR URL, a linked issue, and projectItems on project #9 with a flippable \"Ready for review\" status. The nofire uses the hyphenated `@-claude review` reference form, which deliberately does NOT contain the substring \"@claude review\", so _has_trigger returns False and the comment is correctly let pass - the exact close counterexample the matcher must not fire on. Heredoc is not the killer shape here: this hook matches gh pr comment/review with an inline --body, and per the hook's own docstring a trigger living only inside a heredoc/--body-file body is stripped by normalize_command and intentionally not detected, so the canonical inline form is the real trigger."
+    },
+    "verify": {
+      "basename": "post_gh_pr_review_request.py",
+      "confirmed": true,
+      "fire_observed": true,
+      "nofire_silent": true,
+      "red_on_break_works": true,
+      "corrections": null,
+      "notes": "Independently re-read the hook and re-drove all three directions with the spec's gh stub. FIRE `gh pr comment 996 --body \"@claude review\"`: exit 0, fired=True, fire-log line appended {\"hook\":\"post_gh_pr_review_request\",\"pr\":996,\"issues\":[123],\"repo\":\"Jin-HoMLee/splice-neoepitope-pipeline\",\"action\":\"status:In review\"}, and stdout emitted the additionalContext \"PR #996 + linked Issue(s) #123 Status -> In review\". The second fire shape `gh pr review 996 --approve` also fired=True. NOFIRE `gh pr comment 996 --body \"@-claude review\"`: exit 0, fired=False, empty stdout - genuine matched-pair control (hyphenated reference form lacks the literal \"@claude review\" substring). RED-ON-BREAK: copied the hook + _shell_parse.py to a temp dir, injected `return None` immediately after _tokenize in matches_review_request so it never matches, drove the FIRE input through the copy - fired=False, observable gone, proving main() returns before apply_review_request and the contract can go red. Observable=fire_log, envelope_builder=posttooluse_bash, needs_gh_stub=true all correct; the gh stub must return a tracked-repo PR URL, a linked issue, and flippable \"Ready for review\" projectItems on project #9. Spec is accurate as written; no corrections."
+    }
+  },
+  {
+    "spec": {
+      "basename": "recheck_dispatch.py",
+      "event": "PostToolUse",
+      "observable": "fire_log",
+      "envelope_builder": "posttooluse_bash",
+      "fire_input": {
+        "command": "gh issue edit 42 --milestone \"i5 - S3 - Data Preparation\"",
+        "tool_response": {
+          "stdout": ""
+        }
+      },
+      "nofire_input": {
+        "command": "gh issue edit 42 --add-label \"role:developer\"",
+        "tool_response": {
+          "stdout": ""
+        }
+      },
+      "needs_gh_stub": true,
+      "gh_stub_source": "#!/bin/sh\nargs=\"$*\"\ncase \"$args\" in\n  *\"repos/Jin-HoMLee/splice-neoepitope-pipeline/issues/\"*)\n    # get_issue_milestone (--jq already applied \u2192 emit the transformed shape)\n    printf '%s' '{\"title\":\"i5 - S3 - Data Preparation\",\"due_on\":\"2026-08-01T00:00:00Z\"}'\n    ;;\n  *updateProjectV2ItemFieldValue*)\n    # _mutate_target_date \u2192 force failure so apply_target_sync fails open to the\n    # manual-param warning, which _is_fire() classifies as a real fire\n    printf '%s' '{\"errors\":[{\"message\":\"stub forced failure\"}]}'\n    ;;\n  *projectItems*)\n    # get_issue_target_date \u2192 on-board item, Target date differs from due_on\n    printf '%s' '{\"data\":{\"repository\":{\"issue\":{\"projectItems\":{\"nodes\":[{\"id\":\"PVTI_stubitem123\",\"project\":{\"number\":9},\"fieldValues\":{\"nodes\":[{\"date\":\"2026-07-01\",\"field\":{\"name\":\"Target date\"}}]}}]}}}}}'\n    ;;\n  *)\n    printf '%s' '{}'\n    ;;\nesac\nexit 0",
+      "extra_args": [
+        "--scope",
+        "shared"
+      ],
+      "heredoc_relevant": false,
+      "heredoc_fire_input": null,
+      "drove_successfully": true,
+      "evidence": "Drove hc.drive() with workflow/tests/.venv/bin/python, extra_args=[\"--scope\",\"shared\"], gh stub on PATH. FIRE (`gh issue edit 42 --milestone \"...\"`): exit 0, fire_log_guard.fired()=True, new_lines=[{\"ts\":\"2026-07-15T08:58:54Z\",\"hook\":\"target_sync_check\",\"issue\":42}]; stdout carried additionalContext \"[target re-sync needed \u2014 move on #42, new milestone \\\"i5 - S3 - Data Preparation\\\"] ... Re-sync via GraphQL updateProjectV2ItemFieldValue ... date: 2026-08-01\". NOFIRE (`gh issue edit 42 --add-label \"role:developer\"`): exit 0, stdout '' (empty), fired()=False.",
+      "rationale": "recheck_dispatch is a PostToolUse hook with no deny/watermark, so its only observable is an appended .agents/hook_fires.jsonl line via _wrap_warning\u2192_log_fire. Under the registered extra_args [\"--scope\",\"shared\"], _in_scope() suppresses the \"pm\"-scoped recheck_milestone/recheck_parent_status checks; only target_sync_check (\"shared\") can fire. Its real internal matcher is PATTERN_MOVE = `\\bgh\\s+issue\\s+edit\\s+(\\d+)\\b[^|;&]*--milestone\\b`, evaluated in dispatch()'s finditer loop over apply_target_sync(). To reach a logged fire, _is_fire(\"target_sync_check\", out) must be truthy, i.e. the output must NOT start with \"[target auto-synced\" \u2014 the fail-open manual-param path. The gh stub gives a milestone with due_on 2026-08-01 and an on-board item whose Target date is 2026-07-01 (drift present), then forces the updateProjectV2ItemFieldValue mutation to fail (errors payload) so apply_target_sync falls back to target_sync_check()'s \"[target re-sync needed \u2026]\" warning \u2014 a real fire. The nofire is a genuine close counterexample: the identical `gh issue edit 42` prefix but with `--add-label` instead of `--milestone`, so PATTERN_MOVE (which requires the `--milestone` token) correctly does not match and no gh call / no fire occurs. This is the exact blind spot of the old tests, which monkeypatched apply_target_sync to a no-op (test_recheck_dispatch.py line 96) and thus never drove the real gh-touching fire path. heredoc_relevant is false: this hook matches gh issue edit anywhere via re.search on the whole string, not a gh pr create command-start walk, so the heredoc shape is not its killer case."
+    },
+    "verify": {
+      "basename": "recheck_dispatch.py",
+      "confirmed": true,
+      "fire_observed": true,
+      "nofire_silent": true,
+      "red_on_break_works": true,
+      "corrections": null,
+      "notes": "Independently re-read the hook and re-drove all three directions via hook_contract.drive() (workflow/tests/.venv/bin/python, extra_args=[--scope,shared], gh stub on PATH). The spec is correct on every field; no corrections.\n\n1. FIRE (`gh issue edit 42 --milestone \"i5 - S3 - Data Preparation\"`): exit 0, fire_log_guard.fired()=True, new line {\"hook\":\"target_sync_check\",\"issue\":42} appended. stdout carried additionalContext \"[target re-sync needed \u2014 move on #42 ...] ... Re-sync via GraphQL updateProjectV2ItemFieldValue ... date: 2026-08-01\". Trace confirms: recheck_milestone/recheck_parent_status are scope \"pm\" and suppressed under --scope shared, so only target_sync_check (scope shared) can fire; PATTERN_MOVE matches, apply_target_sync sees milestone due_on 2026-08-01 vs on-board Target 2026-07-01 (drift), the stub forces the updateProjectV2ItemFieldValue mutation to return an errors payload so _mutate_target_date returns False, apply_target_sync falls open to target_sync_check()'s manual-param warning, and _is_fire() classifies it as a real fire (non-empty, not \"[target auto-synced\").\n\n2. NOFIRE (`gh issue edit 42 --add-label \"role:developer\"`): exit 0, fired()=False, stdout empty. Genuine matched-pair control - identical `gh issue edit 42` prefix, only --milestone swapped for --add-label, so PATTERN_MOVE (requires the --milestone token) correctly does not match. No gh call, no fire.\n\n3. RED-ON-BREAK: copied the hook to a temp file, replaced the internal matcher PATTERN_MOVE with a never-matching regex, drove the identical fire_input through the copy: exit 0, fired()=False, stdout empty. The observable DISAPPEARS when the matcher is broken, so the contract can come back red - not hollow.\n\nMethod note: the gh stub is required (the hook reaches three live gh calls: get_issue_milestone via REST, get_issue_target_date via GraphQL projectItems, and the forced-failing updateProjectV2ItemFieldValue mutation). The stub's case-order is sound - the mutation matches updateProjectV2ItemFieldValue before the projectItems arm, and the GraphQL queries do not contain the literal \"repos/.../issues/\" path so they never hit the REST arm. This is exactly the blind spot of the old test (test_recheck_dispatch.py monkeypatched apply_target_sync to a no-op, never driving the real gh-touching fire path)."
+    }
+  },
+  {
+    "spec": {
+      "basename": "write_session_watermark.py",
+      "event": "Stop",
+      "observable": "watermark",
+      "envelope_builder": "stop_envelope",
+      "fire_input": {
+        "cwd": "<writable-project-root>"
+      },
+      "nofire_input": {
+        "cwd": "/dev/null/sub"
+      },
+      "needs_gh_stub": false,
+      "gh_stub_source": null,
+      "extra_args": [],
+      "heredoc_relevant": false,
+      "heredoc_fire_input": null,
+      "drove_successfully": true,
+      "evidence": "Drove the real hook subprocess via hc.drive() with stop_envelope, env stripped of CLAUDE_PROJECT_DIR so payload cwd governs root resolution (_project_root: CLAUDE_PROJECT_DIR > payload cwd > process cwd). FIRE (cwd=writable tempdir): exit=0, stdout='' (no stop decision), marker WRITTEN -> .agents/last_session_marker.json body {\"last_session_end_utc\": \"2026-07-15T08:58:57Z\", \"schema\": 1}. NOFIRE (cwd under a non-directory so .agents mkdir raises NotADirectoryError): verified twice - (a) cwd=/var/.../afile/sub exit=0 stdout='' marker NOT written; (b) cwd=/dev/null/sub exit=0 stdout='' marker_exists=False. The hook fails open on the unwritable root (its core \"must never block session stop\" contract) and writes nothing, so no watermark observable appears.",
+      "rationale": "This is a Stop hook with NO discriminating internal matcher - it unconditionally writes the session watermark on every turn-end (write_watermark called directly from main after resolving root). So the observable is the written marker file (WATERMARK), never a deny or fire_log, and there is no gh call. The real trigger is simply a Stop envelope with a resolvable, writable project root: root resolves via CLAUDE_PROJECT_DIR env > payload cwd > process cwd, and write_watermark mkdirs .agents/ and atomically writes last_session_marker.json. The genuine close counterexample is an UNWRITABLE root: since the hook has no trigger to reject, the only way to correctly produce no observable is the failure path the hook is explicitly designed to swallow - _project_root points at a location where mkdir raises, write_watermark raises, main() catches and fails open (exit 0, no marker). That exercises the hook's defining behavior (a watermark failure must never break/block the session) and is a real, reachable state (a stale/lost clone root, a root under a non-directory), not a synthetic payload-into-main call. extra_args=[] because the Stop registration carries no args (the --marker routine path is the separate CLI recap-beat invocation, not the Stop hook)."
+    },
+    "verify": {
+      "basename": "write_session_watermark.py",
+      "confirmed": false,
+      "fire_observed": true,
+      "nofire_silent": false,
+      "red_on_break_works": true,
+      "corrections": {
+        "basename": "write_session_watermark.py",
+        "event": "Stop",
+        "observable": "watermark",
+        "envelope_builder": "stop_envelope",
+        "fire_input": {
+          "cwd": "<writable-project-root>"
+        },
+        "nofire_input": null,
+        "nofire_input_defect": "The spec's nofire_input {\"cwd\": \"/dev/null/sub\"} is NOT a valid matched-pair control through the suite's real detector. test_hook_silent_on_counterexample calls hc.observe(c, c.nofire_input), which for WATERMARK routes to _observe_watermark (hook_contract.py:348-365). That detector force-sets CLAUDE_PROJECT_DIR to a fresh writable tempdir, and _project_root (write_session_watermark.py:58-66) ranks CLAUDE_PROJECT_DIR ABOVE the payload cwd. So the nofire's cwd is entirely ignored, the resolved root is always writable, and this matcher-less hook ALWAYS writes the marker. Measured: observe(contract, {\"cwd\": \"/dev/null/sub\"}) returns True, so the assert ... is False FAILS. There is NO spec-field value for nofire_input that produces silence under the current _observe_watermark, because the detector always creates a writable root and the hook has no discriminating matcher. A real counterexample requires a HARNESS change: _observe_watermark must let a nofire_input drive the RESOLVED root (CLAUDE_PROJECT_DIR) to an unwritable path (e.g. accept a 'project_dir' override or NOT force CLAUDE_PROJECT_DIR when the spec supplies an unwritable cwd and env is stripped). The spec author's evidence only achieved silence by manually stripping CLAUDE_PROJECT_DIR in a bespoke drive() call - a driving mode the suite does not use (the exact 'validated on a non-real path' failure #1140 targets).",
+        "needs_gh_stub": false,
+        "gh_stub_source": null,
+        "extra_args": [],
+        "heredoc_relevant": false,
+        "heredoc_fire_input": null,
+        "drove_successfully": true,
+        "evidence": "Re-drove independently via hc.observe (the suite's real path). FIRE: observe(fire_input) -> True, marker written to <root>/.agents/last_session_marker.json body {\"last_session_end_utc\": \"...Z\", \"schema\": 1}. NOFIRE: observe(nofire_input {cwd:/dev/null/sub}) -> True (marker STILL written; CLAUDE_PROJECT_DIR override defeats the payload cwd) -> test_hook_silent would FAIL. RED-ON-BREAK: copied hook into HOOKS_DIR with write_watermark neutralized (return None before the write), observe(fire_input) -> False (observable disappeared) -> fire half is falsifiable. Also cross-checked the spec's own driving (drive() with env stripped of CLAUDE_PROJECT_DIR): fire writes, nofire silent - but that is not the suite's detector.",
+        "rationale": "Fire trigger, observable (watermark), event (Stop), builder (stop_envelope), needs_gh_stub (false), extra_args ([]), and heredoc_relevant (false) are all correct. The ONLY defect is nofire_input: it is unreachable-as-silent through the canonical _observe_watermark detector, making the matched-pair control hollow. Because the hook has no internal matcher (it unconditionally writes on a writable root), the fire test is non-vacuous (red-on-break proves an inert hook fails it) but the nofire control cannot be realized as a spec field under the current harness."
+      },
+      "notes": "Adversarial verdict: NOT confirmed. Fire and red-on-break hold; the nofire counterexample is broken as-specified and cannot be fixed with a spec field alone.\n\nTHREE RESULTS via the real suite path (hc.observe, what test_hook_fires_on_real_trigger and test_hook_silent_on_counterexample actually call):\n1. FIRE: observe(fire_input) = True. Marker last_session_marker.json written. PASSES.\n2. NOFIRE: observe({\"cwd\":\"/dev/null/sub\"}) = True (marker STILL written). test_hook_silent_on_counterexample would FAIL. Not a real matched-pair control.\n3. RED-ON-BREAK: broken copy (write_watermark neutralized) -> observe(fire_input) = False. Fire half is genuinely falsifiable.\n\nWHY nofire fires: _observe_watermark (hook_contract.py:348-365) does env = dict(os.environ, CLAUDE_PROJECT_DIR=d) with d a fresh WRITABLE tempdir, then setdefault's cwd. _project_root (hook lines 58-66) resolves CLAUDE_PROJECT_DIR > payload cwd > process cwd, so CLAUDE_PROJECT_DIR=d always wins and the nofire's cwd=/dev/null/sub is dead. The hook has NO discriminating matcher (it writes unconditionally on any writable root), so the only \"no observable\" state is an UNWRITABLE resolved root - which _observe_watermark structurally cannot produce because it always builds a writable one. Therefore no nofire_input value can make test_hook_silent pass under the current harness.\n\nThe spec's evidence obtained nofire silence only by manually stripping CLAUDE_PROJECT_DIR in a hand-rolled drive() call - a driving mode the suite does NOT use. That is the same \"verified on a non-real path\" failure mode Issue #1140 exists to catch (cf. my role memory: \"Drive the real trigger, not a synthetic payload\").\n\nREQUIRED FIX (harness, not spec field): _observe_watermark needs a way for a nofire_input to force the RESOLVED root unwritable - e.g. honor a \"project_dir\" override in spec_input pointed at an unwritable path (/dev/null/sub) and pass it AS CLAUDE_PROJECT_DIR (or omit the forced CLAUDE_PROJECT_DIR and let payload cwd govern when a nofire flag is set). Until then this hook has a live fire test and a hollow nofire test; recommend the analyze registry either (a) get the harness fix, or (b) mark this hook's nofire as N/A with a documented reason so the suite does not carry a green-but-vacuous silence assertion.\n\nCAVEAT on red_on_break_works=true: \"break the internal matcher\" is only loosely applicable - this hook has no matcher, so I broke its firing logic (the write). Breaking it does turn the FIRE test red, which is the meaningful liveness guarantee here (an inert watermark hook fails). But note this does NOT rescue the nofire: even with the write intact, the nofire control cannot go red-to-green because it fires regardless."
+    }
+  }
+]

--- a/research/lab_notebook/developer.md
+++ b/research/lab_notebook/developer.md
@@ -6,7 +6,9 @@ Format and rules unchanged from the unified notebook — see `shared/feedback_la
 
 ---
 
-## 2026-07-15 - A test that drives the hook the way the harness does, so an inert one reds ([PR #1195](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/1195) closes [Issue #1140](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1140))
+## 2026-07-15
+
+### 11:29 UTC - Editor: Developer - A test that drives the hook the way the harness does, so an inert one reds ([PR #1195](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/1195) closes [Issue #1140](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1140))
 
 **Headline:** Shipped the hook-liveness contract suite (Sub D of epic [#1135](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1135)) - for every hook registered in `.agents/settings.json`, a test that drives its real trigger through its real subprocess entry path (stdin envelope, not `main()`) and asserts the observable artifact. This is the half that catches the class mutation testing (Sub B, [#1141](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1141)) structurally cannot: a hook that is never invoked has no surviving mutant. Four governance hooks shipped completely inert this month while green on unit tests; `post_gh_pr_create` was dead for months on the heredoc shape.
 

--- a/research/lab_notebook/developer.md
+++ b/research/lab_notebook/developer.md
@@ -6,6 +6,30 @@ Format and rules unchanged from the unified notebook — see `shared/feedback_la
 
 ---
 
+## 2026-07-15 - A test that drives the hook the way the harness does, so an inert one reds ([PR #1195](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/1195) closes [Issue #1140](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1140))
+
+**Headline:** Shipped the hook-liveness contract suite (Sub D of epic [#1135](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1135)) - for every hook registered in `.agents/settings.json`, a test that drives its real trigger through its real subprocess entry path (stdin envelope, not `main()`) and asserts the observable artifact. This is the half that catches the class mutation testing (Sub B, [#1141](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1141)) structurally cannot: a hook that is never invoked has no surviving mutant. Four governance hooks shipped completely inert this month while green on unit tests; `post_gh_pr_create` was dead for months on the heredoc shape.
+
+**Work shipped:**
+
+- `tools/ci/hook_contract.py` - shared harness: enumerate the 12 registrations / 11 distinct hooks from `.agents/settings.json`, build the real stdin envelope per event, `drive()` each hook as a subprocess, detect the three observable kinds (deny-on-stdout, fire-log append restored after each test, watermark file), with a stub `gh` on PATH for board hooks that reach a live `gh` call.
+- `tools/ci/test_hook_liveness_contract.py` - 27 tests: completeness/drift (registry must equal the settings.json registry), a matched-pair fire/no-fire per hook, an explicit heredoc-shape case for the gh-matching hooks, and a red-on-break demonstration.
+- Collected by the existing `pytest tools/ci/` CI run (every PR) - a superset of AC 6's "any change under `.agents/hooks/`".
+
+**How I built it (the interesting part):** a 22-agent workflow (analyze + adversarial-verify per hook) derived and *empirically drove* each contract rather than reasoning about it. The adversarial pass earned its cost - it caught two harness gaps I'd otherwise have shipped: the drift hook needed a cwd-carrying envelope, and the matcher-less watermark hook needed a writable-vs-unwritable-root matched pair (my first version could never make it go silent). Both fixed before the first suite run.
+
+**The property that matters:** the suite can come back *red*, proven twice - breaking `check_no_force_push`'s matcher silences its deny (in-suite demo), and breaking `post_gh_pr_create`'s `matches_pr_create` (the hook that shipped dead) silences its fire-log observable. A red-on-break that itself relocates the hook had a trap the fan-out surfaced: a lone copy fails to import `_shell_parse` and vanishes from a *crash*, a hollow red - fixed by copying the sibling alongside plus an unbroken relocated control that must still fire.
+
+**Bot review:** strong LGTM, ready-to-merge, 4 minor + 1 follow-up. Addressed all 4 in `7c92a41` (byte-based fire detection immune to a non-terminated tail; airtight `tmp_path` red-on-break out of the tracked dir; serial-execution note against xdist; doc signature drift). The `check_at_claude` user-level guard is outside this registry-driven suite by design (surfaced per AC 1) - tracked as follow-up [#1196](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1196).
+
+**Issues created today:**
+
+- [Issue #1196](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1196) - liveness contract for the user-level `check_at_claude` guard (registry-external; the highest-harm guard to have go silently inert).
+
+**Verification:** 27/27 suite, 856/856 across `tools/ci` (no regressions), `.agents/` clean after runs (fire-log snapshot/restore).
+
+---
+
 ## 2026-07-14 - The queue was lying, and it had been for months ([Issue #1153](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1153))
 
 ### 15:40 UTC - Editor: Developer - The filter production was already running, that nobody chose ([Issue #1118](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1118), [PR #1168](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/1168))

--- a/tools/ci/hook_contract.py
+++ b/tools/ci/hook_contract.py
@@ -1,0 +1,385 @@
+#!/usr/bin/env python3
+"""Shared harness for the hook-liveness contract suite (Issue #1140).
+
+The contract suite proves each hook registered in `.agents/settings.json` still
+*fires* when given its real trigger through its real entry path - the hook script
+run as a subprocess reading the harness JSON envelope on stdin, exactly as the
+harness invokes it. It exists because four governance hooks shipped completely
+inert this month (each green on its unit tests, none ever invoked through its real
+path); `post_gh_pr_create` was dead for months because `matches_pr_create()`
+returned False for the heredoc-then-`gh pr create` shape that opens every real PR.
+
+This module is the single-authored interface the per-hook contracts target:
+
+- `registered_hooks()` enumerates the registry (the enumeration + drift AC).
+- envelope builders produce the exact stdin payload per event/matcher.
+- `drive()` runs a hook subprocess the way the harness does (stdin = envelope
+  JSON), optionally with a stub `gh` first on PATH for hooks that reach a live
+  `gh` call before their observable (the `test_set_status.py` pattern).
+- observable detectors read the two artifact kinds a hook can produce: a
+  `permissionDecision: deny` on stdout, or an appended `.agents/hook_fires.jsonl`
+  line.
+
+We deliberately do NOT re-implement the harness `if:` gate. That gate is
+vendor-documented best-effort and every hook self-matches internally and fails
+open, so it is a performance optimization, not a correctness boundary - and it is
+the internal matcher, not the gate, where all four dead hooks actually failed. The
+real entry path is the subprocess with the true command string.
+"""
+from __future__ import annotations
+
+import json
+import os
+import stat
+import subprocess
+import sys
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Iterator, Optional
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+SETTINGS_PATH = REPO_ROOT / ".agents" / "settings.json"
+HOOKS_DIR = REPO_ROOT / ".agents" / "hooks"
+FIRE_LOG_PATH = REPO_ROOT / ".agents" / "hook_fires.jsonl"
+
+
+# --- registry enumeration ----------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Registration:
+    """One `(event, matcher, if, command)` hook registration in settings.json."""
+
+    event: str  # PreToolUse | PostToolUse | Stop
+    matcher: str  # e.g. "Bash", "Edit|MultiEdit|Write", ""
+    if_clause: str  # e.g. "Bash(gh *)", ""
+    command: str  # the raw command string as registered
+    basename: str  # the hook script filename, e.g. "check_no_force_push.py"
+
+    @property
+    def path(self) -> Path:
+        return HOOKS_DIR / self.basename
+
+
+def registered_hooks(settings_path: Path = SETTINGS_PATH) -> list[Registration]:
+    """Parse settings.json and return one Registration per hook command.
+
+    The suite is parametrized off this, so a newly registered hook with no
+    contract entry fails the completeness test rather than being silently
+    uncovered (the enumeration + drift AC of #1140).
+    """
+    data = json.loads(settings_path.read_text(encoding="utf-8"))
+    out: list[Registration] = []
+    for event, entries in (data.get("hooks") or {}).items():
+        for entry in entries or []:
+            matcher = entry.get("matcher", "") or ""
+            for hk in entry.get("hooks") or []:
+                cmd = hk.get("command", "") or ""
+                out.append(
+                    Registration(
+                        event=event,
+                        matcher=matcher,
+                        if_clause=hk.get("if", "") or "",
+                        command=cmd,
+                        basename=_basename_of(cmd),
+                    )
+                )
+    return out
+
+
+def _basename_of(command: str) -> str:
+    """The hook script filename from a registered command string.
+
+    Registered commands look like `${CLAUDE_PROJECT_DIR}/.agents/hooks/foo.py`
+    possibly with trailing args (`recheck_dispatch.py --scope shared`). We take
+    the first token that ends in `.py`.
+    """
+    for tok in command.split():
+        if tok.endswith(".py"):
+            return Path(tok).name
+    # Fall back to the last path-like token's name.
+    return Path(command.split()[0]).name if command.split() else ""
+
+
+def distinct_hook_basenames(settings_path: Path = SETTINGS_PATH) -> set[str]:
+    """The set of distinct hook script filenames registered in settings.json.
+
+    A single script may be registered under more than one matcher
+    (`check_memory_path_cwd_drift.py` is on both Bash and Edit/Write); the
+    contract is per-script, so we dedupe.
+    """
+    return {r.basename for r in registered_hooks(settings_path)}
+
+
+# --- envelope builders -------------------------------------------------------
+# Each returns the JSON dict the harness pipes on the hook's stdin. Keys match
+# what the hooks actually read (`tool_name`, `tool_input.command`, etc.).
+
+
+def pretooluse_bash(command: str, cwd: Optional[str] = None) -> dict:
+    """PreToolUse Bash envelope. `cwd` populates the top-level session-cwd field
+    the harness delivers, which `check_memory_path_cwd_drift.py` keys on to detect
+    a drifted shell; omit it for hooks that only read `tool_input.command`."""
+    env: dict = {
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Bash",
+        "tool_input": {"command": command},
+    }
+    if cwd is not None:
+        env["cwd"] = cwd
+    return env
+
+
+def pretooluse_edit(file_path: str, old_string: str, new_string: str) -> dict:
+    return {
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Edit",
+        "tool_input": {
+            "file_path": file_path,
+            "old_string": old_string,
+            "new_string": new_string,
+        },
+    }
+
+
+def pretooluse_write(file_path: str, content: str) -> dict:
+    return {
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Write",
+        "tool_input": {"file_path": file_path, "content": content},
+    }
+
+
+def posttooluse_bash(command: str, tool_response: object) -> dict:
+    return {
+        "hook_event_name": "PostToolUse",
+        "tool_name": "Bash",
+        "tool_input": {"command": command},
+        "tool_response": tool_response,
+    }
+
+
+def stop_envelope(cwd: Optional[str] = None) -> dict:
+    env: dict = {"hook_event_name": "Stop"}
+    if cwd is not None:
+        env["cwd"] = cwd
+    return env
+
+
+# --- driving a hook the way the harness does ---------------------------------
+
+
+@dataclass
+class DriveResult:
+    exit_code: int
+    stdout: str
+    stderr: str
+
+
+def drive(
+    hook_path: Path,
+    envelope: dict,
+    *,
+    gh_stub: Optional[str] = None,
+    env: Optional[dict] = None,
+    extra_args: Optional[list[str]] = None,
+    timeout: float = 30.0,
+) -> DriveResult:
+    """Run a hook script as a subprocess with `envelope` JSON on stdin.
+
+    This is the real entry path: the harness invokes the registered command with
+    the hook JSON on stdin. `gh_stub`, when given, is shell source written to a
+    `gh` executable placed first on PATH, so hooks that reach a live `gh` call
+    before their observable run end-to-end offline (the `test_set_status.py`
+    pattern). `extra_args` mirrors a registration that carries args
+    (`recheck_dispatch.py --scope shared`).
+    """
+    run_env = dict(os.environ if env is None else env)
+    with _optional_gh_stub(gh_stub) as stub_dir:
+        if stub_dir is not None:
+            run_env["PATH"] = f"{stub_dir}{os.pathsep}{run_env.get('PATH', '')}"
+        proc = subprocess.run(
+            [sys.executable, str(hook_path), *(extra_args or [])],
+            input=json.dumps(envelope),
+            capture_output=True,
+            text=True,
+            env=run_env,
+            timeout=timeout,
+        )
+    return DriveResult(proc.returncode, proc.stdout, proc.stderr)
+
+
+@contextmanager
+def _optional_gh_stub(source: Optional[str]) -> Iterator[Optional[Path]]:
+    if source is None:
+        yield None
+        return
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as d:
+        gh = Path(d) / "gh"
+        gh.write_text(source, encoding="utf-8")
+        gh.chmod(gh.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+        yield Path(d)
+
+
+# --- observable detectors ----------------------------------------------------
+
+
+def deny_decision(result: DriveResult) -> bool:
+    """True iff the hook emitted a PreToolUse `permissionDecision: deny`."""
+    if not result.stdout.strip():
+        return False
+    try:
+        payload = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return False
+    decision = payload.get("hookSpecificOutput") or payload
+    return decision.get("permissionDecision") == "deny"
+
+
+@contextmanager
+def fire_log_guard(log_path: Path = FIRE_LOG_PATH) -> Iterator["FireLogWatcher"]:
+    """Snapshot the real (gitignored) fire-log so the suite leaves it untouched.
+
+    Yields a watcher whose `.fired()` reports whether new lines were appended
+    across a `drive()` call. On exit the log is restored to its pre-test bytes
+    (or removed if it did not exist), so contract tests never pollute the real
+    `.agents/hook_fires.jsonl`.
+    """
+    existed = log_path.exists()
+    original = log_path.read_bytes() if existed else b""
+    watcher = FireLogWatcher(log_path, len(original.splitlines()))
+    try:
+        yield watcher
+    finally:
+        if existed:
+            log_path.write_bytes(original)
+        elif log_path.exists():
+            log_path.unlink()
+
+
+@dataclass
+class FireLogWatcher:
+    log_path: Path
+    _baseline_lines: int
+
+    def fired(self) -> bool:
+        """True iff the fire-log has grown since the guard opened."""
+        if not self.log_path.exists():
+            return False
+        current = len(self.log_path.read_bytes().splitlines())
+        return current > self._baseline_lines
+
+    def new_lines(self) -> list[dict]:
+        if not self.log_path.exists():
+            return []
+        lines = self.log_path.read_text(encoding="utf-8").splitlines()[self._baseline_lines :]
+        out = []
+        for ln in lines:
+            try:
+                out.append(json.loads(ln))
+            except json.JSONDecodeError:
+                pass
+        return out
+
+
+# --- per-hook contract shape (populated by the suite's registry) -------------
+
+DENY = "deny"
+FIRE_LOG = "fire_log"
+WATERMARK = "watermark"
+
+_BUILDERS: dict[str, Callable[..., dict]] = {
+    "pretooluse_bash": pretooluse_bash,
+    "pretooluse_edit": pretooluse_edit,
+    "pretooluse_write": pretooluse_write,
+    "posttooluse_bash": posttooluse_bash,
+    "stop_envelope": stop_envelope,
+}
+
+
+@dataclass(frozen=True)
+class HookContract:
+    """The liveness contract for one hook script.
+
+    `fire_input` is the real trigger that MUST produce `observable`; `nofire_input`
+    is the matched-pair counterexample that must produce nothing. Both are the
+    kwargs dicts passed to the named `envelope_builder`. `heredoc_fire_input`, when
+    set, is an additional fire trigger using the heredoc-then-command shape (the
+    exact string class that killed `matches_pr_create`). `gh_stub_source` /
+    `extra_args` cover the live-`gh` and arg-carrying registrations.
+    """
+
+    basename: str
+    observable: str  # DENY | FIRE_LOG | WATERMARK
+    envelope_builder: str  # a key of _BUILDERS
+    fire_input: dict
+    nofire_input: dict
+    heredoc_fire_input: Optional[dict] = None
+    gh_stub_source: Optional[str] = None
+    extra_args: Optional[list[str]] = None
+    notes: str = ""
+
+    def envelope(self, spec_input: dict) -> dict:
+        return _BUILDERS[self.envelope_builder](**spec_input)
+
+    @property
+    def hook_path(self) -> Path:
+        return HOOKS_DIR / self.basename
+
+
+def observe(contract: HookContract, spec_input: dict) -> bool:
+    """Drive `contract`'s hook with `spec_input` and report whether its observable
+    artifact appeared - the single place the three artifact kinds are detected.
+
+    Runs inside a `fire_log_guard` so the real (gitignored) fire-log is restored
+    afterward regardless of the observable kind.
+    """
+    if contract.observable == WATERMARK:
+        return _observe_watermark(contract, spec_input)
+    with fire_log_guard() as watcher:
+        result = drive(
+            contract.hook_path,
+            contract.envelope(spec_input),
+            gh_stub=contract.gh_stub_source,
+            extra_args=contract.extra_args,
+        )
+        if contract.observable == DENY:
+            return deny_decision(result)
+        return watcher.fired()
+
+
+WRITABLE_ROOT = "<TMP>"  # sentinel: resolve to a fresh writable tempdir at drive time
+
+
+def _observe_watermark(contract: HookContract, spec_input: dict) -> bool:
+    """Stop-hook watermark observable.
+
+    `write_session_watermark` has no discriminating matcher - it writes the marker
+    on every turn-end - so its only "no observable" state is a resolved root that
+    cannot be written (it fails open on OSError). The matched pair is therefore a
+    writable root (writes) vs an unwritable root (silent). The root is taken from
+    `spec_input["root"]`: the `WRITABLE_ROOT` sentinel becomes a fresh writable
+    tempdir, any other value (e.g. `/dev/null/sub`) is used literally so mkdir
+    fails and no marker appears. The root is passed as `CLAUDE_PROJECT_DIR`, which
+    the hook ranks first when resolving where to write.
+    """
+    import tempfile
+
+    root_spec = spec_input.get("root", WRITABLE_ROOT)
+    if root_spec == WRITABLE_ROOT:
+        with tempfile.TemporaryDirectory() as d:
+            return _drive_watermark(contract, d)
+    return _drive_watermark(contract, root_spec)
+
+
+def _drive_watermark(contract: HookContract, root: str) -> bool:
+    env = dict(os.environ, CLAUDE_PROJECT_DIR=root)
+    root_path = Path(root)
+    before = set(root_path.rglob("*")) if root_path.exists() else set()
+    drive(contract.hook_path, stop_envelope(), env=env, extra_args=contract.extra_args)
+    if not root_path.exists():
+        return False  # unwritable root: hook failed open, nothing written
+    return bool(set(root_path.rglob("*")) - before)

--- a/tools/ci/hook_contract.py
+++ b/tools/ci/hook_contract.py
@@ -243,14 +243,21 @@ def deny_decision(result: DriveResult) -> bool:
 def fire_log_guard(log_path: Path = FIRE_LOG_PATH) -> Iterator["FireLogWatcher"]:
     """Snapshot the real (gitignored) fire-log so the suite leaves it untouched.
 
-    Yields a watcher whose `.fired()` reports whether new lines were appended
-    across a `drive()` call. On exit the log is restored to its pre-test bytes
-    (or removed if it did not exist), so contract tests never pollute the real
+    Yields a watcher whose `.fired()` reports whether the log grew across a
+    `drive()` call. On exit the log is restored to its pre-test bytes (or removed
+    if it did not exist), so contract tests never pollute the real
     `.agents/hook_fires.jsonl`.
+
+    NOTE - serial execution assumed. The guard snapshots and restores the single
+    shared fire-log, so `observe()` calls must not run concurrently against it.
+    The CI job runs this suite serially (`pytest tools/ci/ -m "not live"`, no
+    `-n`); if that job ever adopts `pytest-xdist`, concurrent `observe()` calls
+    would race on snapshot/restore. Keep this suite off xdist, or give each worker
+    an isolated log, before parallelizing.
     """
     existed = log_path.exists()
     original = log_path.read_bytes() if existed else b""
-    watcher = FireLogWatcher(log_path, len(original.splitlines()))
+    watcher = FireLogWatcher(log_path, len(original))
     try:
         yield watcher
     finally:
@@ -263,21 +270,28 @@ def fire_log_guard(log_path: Path = FIRE_LOG_PATH) -> Iterator["FireLogWatcher"]
 @dataclass
 class FireLogWatcher:
     log_path: Path
-    _baseline_lines: int
+    _baseline_bytes: int
 
     def fired(self) -> bool:
-        """True iff the fire-log has grown since the guard opened."""
+        """True iff the fire-log grew since the guard opened.
+
+        Byte-length growth, not line count, so a fire is detected even if a prior
+        last line was not newline-terminated (a line-count delta would under-count
+        an append concatenated onto an unterminated tail).
+        """
         if not self.log_path.exists():
             return False
-        current = len(self.log_path.read_bytes().splitlines())
-        return current > self._baseline_lines
+        return len(self.log_path.read_bytes()) > self._baseline_bytes
 
     def new_lines(self) -> list[dict]:
+        """The JSON records appended past the baseline byte offset."""
         if not self.log_path.exists():
             return []
-        lines = self.log_path.read_text(encoding="utf-8").splitlines()[self._baseline_lines :]
+        tail = self.log_path.read_bytes()[self._baseline_bytes :]
         out = []
-        for ln in lines:
+        for ln in tail.decode("utf-8", "replace").splitlines():
+            if not ln.strip():
+                continue
             try:
                 out.append(json.loads(ln))
             except json.JSONDecodeError:

--- a/tools/ci/test_hook_liveness_contract.py
+++ b/tools/ci/test_hook_liveness_contract.py
@@ -1,0 +1,360 @@
+"""Hook-liveness contract suite (Issue #1140, Sub D of #1135).
+
+Every hook registered in `.agents/settings.json` gets a contract that drives its
+REAL trigger through its REAL entry path (the hook script as a subprocess reading
+the harness JSON envelope on stdin) and asserts its observable artifact appears -
+a `permissionDecision: deny` on stdout, an appended `.agents/hook_fires.jsonl`
+line, or a written watermark file. A matched-pair counterexample asserts the hook
+stays silent when it should.
+
+This exists because four governance hooks shipped completely inert this month,
+each green on its unit tests, none ever invoked through its real path. The
+unit tests called inner functions (`matches_pr_create`) or piped a synthetic
+payload into `main()`; both bypass the layer where the hooks actually failed.
+Mutation testing (Issue #1141) is structurally blind to this class - a hook that
+is never invoked has no surviving mutant. This suite is the half that catches it.
+
+The registry below is populated per hook by the analyze+verify fan-out of
+Issue #1140; `test_every_registered_hook_has_a_contract` fails if the registry
+and `.agents/settings.json` ever disagree, so a newly registered hook cannot be
+silently uncovered.
+"""
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import hook_contract as hc  # noqa: E402
+
+# --- gh stubs for hooks that reach a live `gh` call before their observable ---
+# Each returns just enough canned JSON for the hook to run its matcher-plus-handler
+# path to the point of appending its fire-log line, with no network. Mirrors the
+# `test_set_status.py` PATH-stub pattern; validated per hook by the #1140 fan-out.
+
+_STUB_GH_ISSUE_DEVELOP_PARENT = """#!/bin/sh
+case "$*" in
+  *"repo view"*) echo "Jin-HoMLee/splice-neoepitope-pipeline" ;;
+  *"api graphql"*) echo '{"data":{"repository":{"issue":{"subIssuesSummary":{"total":5}}}}}' ;;
+esac
+exit 0
+"""
+
+_STUB_PR_CREATE = """#!/bin/sh
+case "$*" in
+  *"pr view"*) echo '{"isDraft": true, "body": "draft body"}' ;;
+  *"project item-add"*) echo '{"id": "ITEM_1"}' ;;
+  *) echo '{}' ;;
+esac
+exit 0
+"""
+
+_STUB_PR_REVIEW_REQUEST = """#!/bin/bash
+if [ "$1" = "pr" ] && [ "$2" = "view" ]; then
+  echo '{"url":"https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/996","closingIssuesReferences":[{"number":123}]}'
+  exit 0
+fi
+if [ "$1" = "api" ] && [ "$2" = "graphql" ]; then
+  for a in "$@"; do
+    case "$a" in
+      *updateProjectV2ItemFieldValue*) echo '{"data":{"updateProjectV2ItemFieldValue":{"projectV2Item":{"id":"x"}}}}'; exit 0;;
+    esac
+  done
+  echo '{"data":{"repository":{"pullRequest":{"projectItems":{"nodes":[{"id":"ITEM1","project":{"number":9},"fieldValues":{"nodes":[{"name":"Ready for review","field":{"name":"Status"}}]}}]}},"issue":{"projectItems":{"nodes":[{"id":"ITEM2","project":{"number":9},"fieldValues":{"nodes":[{"name":"Ready for review","field":{"name":"Status"}}]}}]}}}}}'
+  exit 0
+fi
+exit 0
+"""
+
+_STUB_RECHECK_DISPATCH = """#!/bin/sh
+args="$*"
+case "$args" in
+  *"repos/Jin-HoMLee/splice-neoepitope-pipeline/issues/"*)
+    printf '%s' '{"title":"i5 - S3 - Data Preparation","due_on":"2026-08-01T00:00:00Z"}'
+    ;;
+  *updateProjectV2ItemFieldValue*)
+    printf '%s' '{"errors":[{"message":"stub forced failure"}]}'
+    ;;
+  *projectItems*)
+    printf '%s' '{"data":{"repository":{"issue":{"projectItems":{"nodes":[{"id":"PVTI_stubitem123","project":{"number":9},"fieldValues":{"nodes":[{"date":"2026-07-01","field":{"name":"Target date"}}]}}]}}}}}'
+    ;;
+  *)
+    printf '%s' '{}'
+    ;;
+esac
+exit 0
+"""
+
+_PR_URL = "https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/1140\n"
+# cwd values for the drift hook, computed at runtime so the contract is portable:
+# a cwd above the clone fires, the clone root itself stays silent.
+_OUTSIDE_CLONE = str(Path(hc.REPO_ROOT).parent)
+_INSIDE_CLONE = str(hc.REPO_ROOT)
+
+# --- the registry ------------------------------------------------------------
+# basename -> HookContract. `fire_input`/`nofire_input` are kwargs for the named
+# envelope builder; `heredoc_fire_input` (when set) is the heredoc-then-command
+# shape that killed matches_pr_create; `gh_stub_source` is set for board hooks
+# that reach a live `gh` call before their fire-log observable.
+#
+# POPULATED FROM THE #1140 ANALYZE+VERIFY FAN-OUT. Until every registered hook is
+# present, `test_every_registered_hook_has_a_contract` is red by design.
+
+# The em-dash the check_no_emdash fixture must carry at runtime, built with
+# chr() so this source file stays pure ASCII (and does not itself trip the guard).
+_EMDASH = chr(0x2014)
+
+CONTRACTS: dict[str, hc.HookContract] = {
+    "check_gh_issue_develop_parent.py": hc.HookContract(
+        basename="check_gh_issue_develop_parent.py",
+        observable=hc.DENY,
+        envelope_builder="pretooluse_bash",
+        fire_input={"command": "gh issue develop 538 --name feat/x --checkout"},
+        nofire_input={"command": "gh issue view 538"},
+        heredoc_fire_input={
+            "command": "cat > /tmp/plan.md <<'EOF'\nbranching notes for the epic\nEOF\ngh issue develop 538 --name feat/x --checkout"
+        },
+        gh_stub_source=_STUB_GH_ISSUE_DEVELOP_PARENT,
+        notes="denies branching off a parent/epic (subIssuesSummary.total > 0)",
+    ),
+    "check_board_query_pagination.py": hc.HookContract(
+        basename="check_board_query_pagination.py",
+        observable=hc.DENY,
+        envelope_builder="pretooluse_bash",
+        fire_input={
+            "command": "gh api graphql -f query='query { user(login:\"Jin-HoMLee\"){ projectV2(number:9){ items(first:100){ nodes { id } } } } }'"
+        },
+        nofire_input={
+            "command": "gh api graphql -f query='query { user(login:\"Jin-HoMLee\"){ projectV2(number:9){ items(first:100){ pageInfo{ hasNextPage endCursor } nodes { id } } } } }'"
+        },
+        notes="denies an unpaginated projectV2 items(first:) board query (pure string inspection, no gh call)",
+    ),
+    "check_no_force_push.py": hc.HookContract(
+        basename="check_no_force_push.py",
+        observable=hc.DENY,
+        envelope_builder="pretooluse_bash",
+        fire_input={"command": "git push --force origin main"},
+        nofire_input={"command": "git push origin main"},
+        notes="denies a force push; a plain push passes",
+    ),
+    "check_commit_push_separation.py": hc.HookContract(
+        basename="check_commit_push_separation.py",
+        observable=hc.DENY,
+        envelope_builder="pretooluse_bash",
+        fire_input={"command": "git commit -m 'x' && git push"},
+        nofire_input={"command": "git push origin main"},
+        notes="denies a chained commit&&push; a lone push passes",
+    ),
+    "check_no_cd_outside_cwd.py": hc.HookContract(
+        basename="check_no_cd_outside_cwd.py",
+        observable=hc.DENY,
+        envelope_builder="pretooluse_bash",
+        fire_input={"command": "cd /etc/secret"},
+        nofire_input={"command": "cd workflow"},
+        notes="denies a cd outside the cwd subtree; a cd into a subdir passes",
+    ),
+    "check_memory_path_cwd_drift.py": hc.HookContract(
+        basename="check_memory_path_cwd_drift.py",
+        observable=hc.DENY,
+        envelope_builder="pretooluse_bash",
+        fire_input={
+            "command": "grep foo .agents/memory/shared/MEMORY.md",
+            "cwd": _OUTSIDE_CLONE,
+        },
+        nofire_input={
+            "command": "grep foo .agents/memory/shared/MEMORY.md",
+            "cwd": _INSIDE_CLONE,
+        },
+        notes="denies a relative memory-path op when the session cwd has drifted outside the clone",
+    ),
+    "check_no_emdash.py": hc.HookContract(
+        basename="check_no_emdash.py",
+        observable=hc.DENY,
+        envelope_builder="pretooluse_edit",
+        fire_input={
+            "file_path": "research/notes.md",
+            "old_string": "hello - world",
+            "new_string": "hello " + _EMDASH + " world",
+        },
+        nofire_input={
+            "file_path": "research/notes.md",
+            "old_string": "hello - world",
+            "new_string": "hello -- world",
+        },
+        notes="denies an edit that net-adds an em/en-dash; a plain-hyphen edit passes",
+    ),
+    "post_gh_pr_create.py": hc.HookContract(
+        basename="post_gh_pr_create.py",
+        observable=hc.FIRE_LOG,
+        envelope_builder="posttooluse_bash",
+        fire_input={
+            "command": 'gh pr create --title "t" --body "closes #1140" --base main',
+            "tool_response": {"stdout": _PR_URL},
+        },
+        nofire_input={
+            "command": "gh pr view 1140",
+            "tool_response": {"stdout": _PR_URL},
+        },
+        heredoc_fire_input={
+            "command": "cat > /tmp/pr_1140.md <<'EOF'\nPR body with (parens) and prose.\nEOF\ngh pr create --title \"t\" --body-file /tmp/pr_1140.md --base main",
+            "tool_response": {"stdout": _PR_URL},
+        },
+        gh_stub_source=_STUB_PR_CREATE,
+        notes="board-adds a freshly created PR (the hook that sat dead for months on the heredoc shape)",
+    ),
+    "post_gh_pr_review_request.py": hc.HookContract(
+        basename="post_gh_pr_review_request.py",
+        observable=hc.FIRE_LOG,
+        envelope_builder="posttooluse_bash",
+        fire_input={
+            "command": 'gh pr comment 996 --body "@claude review"',
+            "tool_response": {"stdout": ""},
+        },
+        nofire_input={
+            "command": 'gh pr comment 996 --body "@-claude review"',
+            "tool_response": {"stdout": ""},
+        },
+        gh_stub_source=_STUB_PR_REVIEW_REQUEST,
+        notes="advances a PR + its linked Issues to In review on the real review trigger; the hyphenated reference form must not fire",
+    ),
+    "recheck_dispatch.py": hc.HookContract(
+        basename="recheck_dispatch.py",
+        observable=hc.FIRE_LOG,
+        envelope_builder="posttooluse_bash",
+        fire_input={
+            "command": 'gh issue edit 42 --milestone "i5 - S3 - Data Preparation"',
+            "tool_response": {"stdout": ""},
+        },
+        nofire_input={
+            "command": 'gh issue edit 42 --add-label "role:developer"',
+            "tool_response": {"stdout": ""},
+        },
+        gh_stub_source=_STUB_RECHECK_DISPATCH,
+        extra_args=["--scope", "shared"],
+        notes="runs the milestone->Target-date sync on a milestone edit; a label edit does not trigger it",
+    ),
+    "write_session_watermark.py": hc.HookContract(
+        basename="write_session_watermark.py",
+        observable=hc.WATERMARK,
+        envelope_builder="stop_envelope",
+        # No discriminating matcher: writes on any writable root. The matched pair
+        # is a writable root (writes) vs an unwritable root (fails open, silent).
+        fire_input={"root": hc.WRITABLE_ROOT},
+        nofire_input={"root": "/dev/null/sub"},
+        notes="writes the session watermark on Stop; an unwritable root fails open with no marker",
+    ),
+}
+
+
+# --- completeness / drift ----------------------------------------------------
+
+
+def test_every_registered_hook_has_a_contract():
+    """The registry and the settings.json registry must agree exactly.
+
+    A registered-but-uncovered hook (drift toward an inert hook shipping unseen)
+    and a contract for a hook no longer registered both fail here.
+    """
+    registered = hc.distinct_hook_basenames()
+    covered = set(CONTRACTS)
+    missing = registered - covered
+    stale = covered - registered
+    assert not missing, f"registered hooks with no liveness contract: {sorted(missing)}"
+    assert not stale, f"contracts for unregistered hooks: {sorted(stale)}"
+
+
+def test_every_contract_hook_script_exists():
+    for name, c in CONTRACTS.items():
+        assert c.hook_path.exists(), f"{name}: hook script missing at {c.hook_path}"
+
+
+# --- the matched pair, per hook ----------------------------------------------
+
+
+@pytest.mark.parametrize("name", sorted(CONTRACTS), ids=lambda n: n.replace(".py", ""))
+def test_hook_fires_on_real_trigger(name):
+    """The real trigger, driven through the real entry path, produces the artifact."""
+    c = CONTRACTS[name]
+    assert hc.observe(c, c.fire_input) is True, (
+        f"{name}: real trigger produced no {c.observable} artifact - the hook is inert "
+        f"on its own trigger (fire_input={c.fire_input})"
+    )
+
+
+@pytest.mark.parametrize("name", sorted(CONTRACTS), ids=lambda n: n.replace(".py", ""))
+def test_hook_silent_on_counterexample(name):
+    """A real, close counterexample produces no artifact (the matched-pair control)."""
+    c = CONTRACTS[name]
+    assert hc.observe(c, c.nofire_input) is False, (
+        f"{name}: counterexample wrongly produced a {c.observable} artifact - the "
+        f"contract cannot distinguish fire from no-fire (nofire_input={c.nofire_input})"
+    )
+
+
+# --- the shape that killed two hooks -----------------------------------------
+
+
+@pytest.mark.parametrize(
+    "name",
+    sorted(n for n, c in CONTRACTS.items() if c.heredoc_fire_input is not None),
+    ids=lambda n: n.replace(".py", ""),
+)
+def test_heredoc_shape_still_fires(name):
+    """A heredoc-then-command trigger fires - the exact string that left
+    `matches_pr_create` dead for months while every unit test passed."""
+    c = CONTRACTS[name]
+    assert hc.observe(c, c.heredoc_fire_input) is True, (
+        f"{name}: the heredoc-then-command shape produced no {c.observable} artifact - "
+        f"this is the shape that shipped two hooks inert (input={c.heredoc_fire_input})"
+    )
+
+
+# --- red-on-break: demonstrate the suite can fail ----------------------------
+
+
+def _temp_broken_copy(basename: str, transform) -> Path:
+    """Write a sibling copy of a hook into HOOKS_DIR with `transform` applied to
+    its source, so the copy's relative `_shell_parse` import still resolves.
+    Returns the temp path (caller deletes)."""
+    src = (hc.HOOKS_DIR / basename).read_text(encoding="utf-8")
+    broken = transform(src)
+    assert broken != src, "red-on-break transform did not change the source"
+    dst = hc.HOOKS_DIR / f"_redonbreak_tmp_{basename}"
+    dst.write_text(broken, encoding="utf-8")
+    return dst
+
+
+def test_breaking_a_matcher_turns_the_contract_red():
+    """DEMONSTRATION (not assertion): neutralize `check_no_force_push`'s matcher in
+    a temp copy, drive its real force-push trigger through the copy, and confirm the
+    deny observable DISAPPEARS. If breaking the matcher could not silence the hook,
+    the whole suite would be a hollow check about hollow checks."""
+    fire = {"command": "git push --force origin main"}
+
+    # sanity: the real hook fires on this trigger
+    real = hc.HookContract(
+        "check_no_force_push.py", hc.DENY, "pretooluse_bash", fire, {"command": "git status"}
+    )
+    assert hc.observe(real, fire) is True, "precondition: real hook must deny a force push"
+
+    # break the matcher: command_force_pushes always returns False
+    def neutralize(src: str) -> str:
+        marker = "def command_force_pushes"
+        assert marker in src, "matcher function name changed; update the red-on-break demo"
+        return src.replace(
+            marker + "(cmd: str) -> bool:",
+            marker + "(cmd: str) -> bool:\n    return False  # red-on-break: matcher neutralized",
+            1,
+        )
+
+    tmp = _temp_broken_copy("check_no_force_push.py", neutralize)
+    try:
+        broken = hc.HookContract(
+            tmp.name, hc.DENY, "pretooluse_bash", fire, {"command": "git status"}
+        )
+        assert hc.observe(broken, fire) is False, (
+            "breaking the matcher did NOT silence the hook - the contract cannot come "
+            "back red, so it is a hollow check"
+        )
+    finally:
+        tmp.unlink(missing_ok=True)

--- a/tools/ci/test_hook_liveness_contract.py
+++ b/tools/ci/test_hook_liveness_contract.py
@@ -19,6 +19,7 @@ Issue #1140; `test_every_registered_hook_has_a_contract` fails if the registry
 and `.agents/settings.json` ever disagree, so a newly registered hook cannot be
 silently uncovered.
 """
+import shutil
 import sys
 from pathlib import Path
 
@@ -312,49 +313,47 @@ def test_heredoc_shape_still_fires(name):
 # --- red-on-break: demonstrate the suite can fail ----------------------------
 
 
-def _temp_broken_copy(basename: str, transform) -> Path:
-    """Write a sibling copy of a hook into HOOKS_DIR with `transform` applied to
-    its source, so the copy's relative `_shell_parse` import still resolves.
-    Returns the temp path (caller deletes)."""
-    src = (hc.HOOKS_DIR / basename).read_text(encoding="utf-8")
-    broken = transform(src)
-    assert broken != src, "red-on-break transform did not change the source"
-    dst = hc.HOOKS_DIR / f"_redonbreak_tmp_{basename}"
-    dst.write_text(broken, encoding="utf-8")
-    return dst
-
-
-def test_breaking_a_matcher_turns_the_contract_red():
+def test_breaking_a_matcher_turns_the_contract_red(tmp_path):
     """DEMONSTRATION (not assertion): neutralize `check_no_force_push`'s matcher in
-    a temp copy, drive its real force-push trigger through the copy, and confirm the
-    deny observable DISAPPEARS. If breaking the matcher could not silence the hook,
-    the whole suite would be a hollow check about hollow checks."""
-    fire = {"command": "git push --force origin main"}
+    an isolated copy, drive its real force-push trigger through the copy, and confirm
+    the deny observable DISAPPEARS. If breaking the matcher could not silence the
+    hook, the whole suite would be a hollow check about hollow checks.
 
-    # sanity: the real hook fires on this trigger
-    real = hc.HookContract(
-        "check_no_force_push.py", hc.DENY, "pretooluse_bash", fire, {"command": "git status"}
+    The copy lives in a pytest tmp_path (never the tracked hooks dir), with
+    `_shell_parse.py` copied alongside so the hook's relative import resolves - a
+    lone copy would fail to import and vanish from an import CRASH, not the matcher,
+    which is a *hollow* red (this exact trap surfaced during the #1140 fan-out)."""
+    fire_env = hc.pretooluse_bash("git push --force origin main")
+
+    # precondition: the real hook denies this force push
+    real = hc.drive(hc.HOOKS_DIR / "check_no_force_push.py", fire_env)
+    assert hc.deny_decision(real) is True, "precondition: real hook must deny a force push"
+
+    # build an isolated broken copy: matcher neutralized to always return False
+    src = (hc.HOOKS_DIR / "check_no_force_push.py").read_text(encoding="utf-8")
+    marker = "def command_force_pushes(cmd: str) -> bool:"
+    assert marker in src, "matcher signature changed; update the red-on-break demo"
+    broken = src.replace(
+        marker, marker + "\n    return False  # red-on-break: matcher neutralized", 1
     )
-    assert hc.observe(real, fire) is True, "precondition: real hook must deny a force push"
+    assert broken != src
 
-    # break the matcher: command_force_pushes always returns False
-    def neutralize(src: str) -> str:
-        marker = "def command_force_pushes"
-        assert marker in src, "matcher function name changed; update the red-on-break demo"
-        return src.replace(
-            marker + "(cmd: str) -> bool:",
-            marker + "(cmd: str) -> bool:\n    return False  # red-on-break: matcher neutralized",
-            1,
-        )
+    broken_hook = tmp_path / "check_no_force_push.py"
+    broken_hook.write_text(broken, encoding="utf-8")
+    shutil.copy2(hc.HOOKS_DIR / "_shell_parse.py", tmp_path / "_shell_parse.py")
 
-    tmp = _temp_broken_copy("check_no_force_push.py", neutralize)
-    try:
-        broken = hc.HookContract(
-            tmp.name, hc.DENY, "pretooluse_bash", fire, {"command": "git status"}
-        )
-        assert hc.observe(broken, fire) is False, (
-            "breaking the matcher did NOT silence the hook - the contract cannot come "
-            "back red, so it is a hollow check"
-        )
-    finally:
-        tmp.unlink(missing_ok=True)
+    # unbroken control: the same isolated copy (before breaking) must still fire,
+    # so a silenced deny is attributable to the matcher break, not the relocation.
+    control_hook = tmp_path / "control.py"
+    control_hook.write_text(src, encoding="utf-8")
+    control = hc.drive(control_hook, fire_env)
+    assert hc.deny_decision(control) is True, (
+        "the relocated but UNbroken copy must still deny - otherwise a silenced deny "
+        "would be an artifact of the move (e.g. a failed import), a hollow red"
+    )
+
+    broken_result = hc.drive(broken_hook, fire_env)
+    assert hc.deny_decision(broken_result) is False, (
+        "breaking the matcher did NOT silence the hook - the contract cannot come "
+        "back red, so it is a hollow check"
+    )


### PR DESCRIPTION
Closes #1140 (Sub D of epic #1135).

## What this does

A **hook-liveness contract suite**: for every hook registered in `.agents/settings.json`, a test that drives its **real trigger** through its **real entry path** (the hook script as a subprocess reading the harness JSON envelope on stdin - not an inner function, not `main()` with a hand-built payload) and asserts the **observable artifact** appears. A matched-pair counterexample asserts the hook stays silent when it should.

This closes the class where four governance hooks shipped **completely inert** this month, each green on its unit tests, none ever invoked through its real path. `post_gh_pr_create` was dead for months because `matches_pr_create()` returned `False` for the heredoc-then-`gh pr create` shape that opens every real PR. Mutation testing (Issue #1141) is structurally blind to this class - a hook never invoked has no surviving mutant. This is the half that catches it.

## How

- `tools/ci/hook_contract.py` - shared harness: enumerates the 12 registrations / 11 distinct hook scripts from `.agents/settings.json`, builds the real stdin envelope per event, drives each hook as a subprocess, and detects the three observable kinds (a `permissionDecision: deny` on stdout, an appended `.agents/hook_fires.jsonl` line restored after each test, or a written watermark file). Board hooks that reach a live `gh` call run against a stub `gh` on `PATH` (the `test_set_status.py` pattern).
- `tools/ci/test_hook_liveness_contract.py` - the suite: a per-hook registry, a completeness/drift test (registry must equal the settings.json registry, so a newly registered hook cannot be silently uncovered), the matched-pair fire/no-fire tests, an explicit heredoc-shape test for the gh-matching hooks, and a **red-on-break demonstration** (neutralize a matcher, watch the contract go red).

The per-hook contract specs were derived and empirically validated by a fan-out of 22 agents (analyze + adversarial verify per hook); the adversarial pass caught two real harness gaps (a cwd-carrying envelope for the drift hook, and the writable-vs-unwritable-root matched pair for the matcher-less watermark hook), both fixed here.

## Design

[docs/superpowers/specs/2026-07-15-hook-liveness-contract-tests-design.md](docs/superpowers/specs/2026-07-15-hook-liveness-contract-tests-design.md)

## Out of scope (surfaced per AC 1)

`check_at_claude.py` is registered at **user** level (`~/.claude/settings.json`), not in `.agents/settings.json`, so it is outside this registry-driven suite. Recorded as a known gap rather than silently omitted.

## Test plan

- [x] Full suite green: `pytest tools/ci/test_hook_liveness_contract.py` - 27 passed (completeness + script-exists + 11 fire + 11 no-fire + 2 heredoc + red-on-break).
- [x] No regressions: `pytest tools/ci/ -m "not live"` - 856 passed.
- [x] Red-on-break is real, not vacuous: breaking `check_no_force_push`'s matcher makes its deny vanish (in-suite demonstration); independently, breaking `post_gh_pr_create`'s `matches_pr_create` makes its fire-log observable vanish (the exact hook that shipped dead).
- [x] Harness manually validated across all three observable kinds (deny-on-bash, deny-on-edit, watermark) before the fan-out.
- [x] Fire-log left untouched: `git status .agents/` clean after runs (the guard snapshots and restores the gitignored `hook_fires.jsonl`).
- [x] Portable: the drift hook's cwd values are computed from the clone root at runtime, not hardcoded to this machine.


**Created by:** Developer
