### PR TITLE
fix(pm): cross-check the unplanned label against the observed commitment act

### DIFF
--- a/research/lab_notebook/pm.md
+++ b/research/lab_notebook/pm.md
@@ -6,6 +6,22 @@ Format and rules unchanged from the unified notebook — see `shared/feedback_la
 
 ---
 
+## 2026-07-16
+
+### 14:16 UTC - Editor: PM
+
+**The `unplanned` label got its cross-check, and the number confirmed the alarm exactly.** [Issue #1188](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1188) -> [PR #1212](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/1212), third and final child of [#1144](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1144) (after [#1180](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1180)'s unclassifiable fix and [#1138](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1138)'s commitment-act read). The new `marker_slip()` reports the observed unplanned share (never crossed `Backlog -> Ready`) beside the label-derived share and surfaces their per-item disagreement. Live: **13 of 26 delivered (50%) observably slipped, while the label reports 0** - it has never been applied to anything repo-wide.
+
+**The decision the Issue built toward was gate-or-no-gate, and the measurement is what flipped my instinct on it.** A 50% miss reads like "add a gate so authors stop forgetting the label." But that is the wrong mechanism, and the number is precisely what shows why: this is not forgetfulness of a *good* marker, it is a marker that is **structurally redundant** with a signal GitHub records for free and no one can forget. A gate propping up a hand-maintained duplicate of the commitment act would be mechanizing the wrong half. So: **no gate** - make the reliable signal primary (this PR), per deterministic-before-semantic. The evidence points one step further, to *retiring* the label outright, but that is a governance call I refused to pre-decide; it is filed as [#1211](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1211) (`needs-design`) so the deferral has an open carrier and is not dropped.
+
+**The test I am most glad I wrote is the one that proves two-shares-side-by-side is not enough.** `test_aggregate_share_agreement_does_not_mean_per_item_fidelity`: a window where observed 50% and labelled 50% match perfectly, yet two of four items are classified *wrongly* by the label (one slip, one mislabelled, cancelling in aggregate). AC1 asked for the two shares; that test is why the deliverable is the per-item *counts*, not the shares. A share comparison would have called that clean.
+
+**Two prior entries in this arc recorded that I re-commit the exact bug the moment after I fix it - so the thing worth recording this time is that it did not happen.** The "unknown != zero" discipline ([#1180](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1180)/[#1185](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1185)) had to be re-applied to a brand-new axis - a failed commitment fetch must make the *slip* unknown, never zero, never the whole population - and it held: `available=False` with None buckets, gated on the same `commitments_available` flag the console and HTML both key off, so they cannot disagree. The review was LGTM with only optional nits. I do not read that as immunity earned; the prior two were also written carefully. I read it as: porting an already-paid-for invariant to a new axis is a *different, easier* act than discovering it, and the danger was always in the discovery.
+
+**The one nit worth applying was a real drift-guard, not a style note.** The review flagged that `observed_unplanned` re-inlined `never_committed_issues`' filter - two definitions of "delivered without a commitment act" with nothing enforcing they stay equal. Reusing the function single-sources it so `n_observed_unplanned` and the SDR's `n_never_committed` can never drift apart. That is exactly the class of latent bug this whole arc is about (a second copy of a fact that silently diverges), so leaving it as an inline would have been tone-deaf to the PR's own thesis.
+
+**At the merge gate now - Jin-Ho's call.** Closing this closes the last open child of [#1144](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1144), whose AC3 is the same decision recorded here, so the parent should roll up too. And [#1211](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1211) is the retire-the-label decision waiting on him.
+
 ## 2026-07-15
 
 ### 15:39 UTC - Editor: PM

--- a/scripts/pm/milestone_report.py
+++ b/scripts/pm/milestone_report.py
@@ -289,6 +289,83 @@ def never_committed_issues(issues: list[dict]) -> list[dict]:
     return [i for i in delivered_issues(issues) if not i.get("committed_at")]
 
 
+def marker_slip(issues: list[dict]) -> dict[str, Any]:
+    """Cross-check the hand-applied ``unplanned`` label against the OBSERVED arrival
+    signal, and surface their disagreement as the slip rate. Issue #1188.
+
+    Two independent measures of the same fact - "did this delivered item arrive unplanned?":
+
+    - **observed**: it has no ``committed_at`` - it never crossed into `Ready`. Recorded by
+      GitHub as a ``ProjectV2ItemStatusChangedEvent``, for free, and cannot be forgotten
+      (see ``never_committed_issues`` / ``first_ready_at``).
+    - **labelled**: someone applied the ``unplanned`` label at close (see ``is_unplanned``).
+      Hand-maintained, and a forgotten label is indistinguishable from committed work - so
+      the label can only ever bias the unplanned share DOWNWARD.
+
+    The disagreement is the whole point (that is why this is not just two shares side by
+    side):
+
+    - ``n_slip``:        observed-unplanned AND unlabelled - the under-report #1144 predicted
+                         would dominate. Each of these is an item the label silently counted
+                         as committed work.
+    - ``n_mislabelled``: labelled AND observably committed - the opposite error (a label on an
+                         item that DID cross the commitment act).
+    - ``n_agree``:       observed-unplanned AND labelled.
+
+    Both shares are reported over *delivered* (``observed_pct`` / ``labelled_pct``) so they
+    are directly comparable, per AC1 - but note that the two aggregate shares agreeing does
+    NOT mean the label is right per item (they can match while ``n_slip`` and
+    ``n_mislabelled`` are both nonzero), which is exactly why the per-item counts exist.
+
+    **The unknown case is load-bearing.** When the commitment history could not be read
+    (``commitments_available`` is False), the observed axis is unknown for every item, so
+    the slip is unknown too. It is reported as ``available=False`` with None buckets - never
+    zero, never the whole population. Folding an unreadable fetch into "everything slipped"
+    (or into "nothing slipped") is the one-output-for-three-worlds fabrication this module
+    exists to kill (#1180), one axis over. ``n_delivered`` stays known regardless: we know
+    WHAT shipped even when we cannot see HOW it arrived.
+
+    Note there is no ``marker_in_use`` guard here, deliberately: ``is_unplanned`` reads the
+    per-issue labels directly, so when the marker has never been applied repo-wide every
+    observed-unplanned item simply falls into ``n_slip`` and ``n_labelled_unplanned`` is 0.
+    That is not a degenerate case to suppress - it is precisely the live 2026-07 finding
+    (the label reports zero while half of delivered work observably never committed), and it
+    must render as total slip, not as "unclassifiable".
+    """
+    delivered = delivered_issues(issues)
+    n_delivered = len(delivered)
+
+    if not commitments_available(issues):
+        return {
+            "available": False,
+            "n_delivered": n_delivered,
+            "n_observed_unplanned": None,
+            "n_labelled_unplanned": None,
+            "observed_pct": None,
+            "labelled_pct": None,
+            "n_slip": None,
+            "n_mislabelled": None,
+            "n_agree": None,
+        }
+
+    observed_unplanned = [i for i in delivered if not i.get("committed_at")]
+    n_observed = len(observed_unplanned)
+    n_labelled = len(unplanned_issues(delivered))
+    n_slip = sum(1 for i in observed_unplanned if not is_unplanned(i))
+    n_mislabelled = sum(1 for i in delivered if is_unplanned(i) and i.get("committed_at"))
+    return {
+        "available": True,
+        "n_delivered": n_delivered,
+        "n_observed_unplanned": n_observed,
+        "n_labelled_unplanned": n_labelled,
+        "observed_pct": (100.0 * n_observed / n_delivered) if n_delivered else None,
+        "labelled_pct": (100.0 * n_labelled / n_delivered) if n_delivered else None,
+        "n_slip": n_slip,
+        "n_mislabelled": n_mislabelled,
+        "n_agree": n_observed - n_slip,
+    }
+
+
 def lead_times(issues: list[dict]) -> list[float]:
     return [t for t in (lead_time_days(i) for i in issues) if t is not None]
 
@@ -501,6 +578,7 @@ def compute_window_metrics(
         "commitments_available": commitments_available(week_issues),
         "per_role_counts": per_role_counts(week_issues),
         **throughput_breakdown(week_issues, marker_in_use=marker_in_use),
+        "marker_slip": marker_slip(week_issues),
         "weekly_series": weekly_series(all_issues, until, n_weeks,
                                        marker_in_use=marker_in_use),
     }
@@ -535,6 +613,7 @@ def compute_metrics(issues: list[dict], milestone: dict,
         "commitments_available": commitments_available(issues),
         "per_role_counts": per_role_counts(issues),
         **throughput_breakdown(issues, marker_in_use=marker_in_use),
+        "marker_slip": marker_slip(issues),
     }
 
 
@@ -982,6 +1061,22 @@ def print_metrics(milestone: dict, metrics: dict) -> None:
     elif metrics.get("n_never_committed"):
         print(f"  never crossed Backlog->Ready     : {metrics['n_never_committed']} delivered "
               f"(no commitment act -> cycle time UNDEFINED for these, not zero)")
+    # The `unplanned` LABEL cross-checked against the OBSERVED arrival axis (Issue #1188).
+    # Both shares are printed side by side so neither silently stands in for the other, and
+    # their per-item DISAGREEMENT is surfaced as the slip. A share comparison alone is not
+    # enough: the two shares can agree in aggregate while the label is wrong per item.
+    slip = metrics.get("marker_slip")
+    if slip and not slip["available"]:
+        print("  unplanned marker slip            : UNKNOWN - commitment history could not "
+              "be read, so the observed arrival axis cannot be cross-checked against the "
+              "label (NOT the same as 'no slip')")
+    elif slip:
+        print(f"  unplanned marker slip            : observed {slip['n_observed_unplanned']} "
+              f"({_fmt(slip['observed_pct'], '%')}) vs labelled {slip['n_labelled_unplanned']} "
+              f"({_fmt(slip['labelled_pct'], '%')}) of {slip['n_delivered']} delivered")
+        print(f"                                     -> {slip['n_slip']} slipped "
+              f"(observably unplanned, unlabelled), {slip['n_mislabelled']} mislabelled "
+              f"(labelled, observably committed), {slip['n_agree']} agree")
     print(f"  per-role (delivered)             : {metrics['per_role_counts']}")
     series = metrics.get("weekly_series")
     if series:

--- a/scripts/pm/milestone_report.py
+++ b/scripts/pm/milestone_report.py
@@ -348,7 +348,11 @@ def marker_slip(issues: list[dict]) -> dict[str, Any]:
             "n_agree": None,
         }
 
-    observed_unplanned = [i for i in delivered if not i.get("committed_at")]
+    # Single-source the observed-unplanned definition with `never_committed_issues`
+    # (both mean "delivered without a commitment act") so `n_observed_unplanned` and the
+    # SDR's `n_never_committed` can never drift. In this branch commitments are available,
+    # so it returns exactly the delivered-without-`committed_at` set. Review finding on PR #1212.
+    observed_unplanned = never_committed_issues(issues)
     n_observed = len(observed_unplanned)
     n_labelled = len(unplanned_issues(delivered))
     n_slip = sum(1 for i in observed_unplanned if not is_unplanned(i))
@@ -1017,6 +1021,16 @@ def _fmt(v: Optional[float], unit: str = "") -> str:
     return "n/a" if v is None else f"{v:.1f}{unit}"
 
 
+def _pct(v: Optional[float]) -> str:
+    """A percentage as a whole number with a trailing % (n/a if None).
+
+    Matches the HTML report's ``%.0f%%`` so the same share reads identically on both
+    surfaces - the console had used ``_fmt(..., '%')`` (one decimal), a precision mismatch
+    caught in the PR #1212 review.
+    """
+    return "n/a" if v is None else f"{v:.0f}%"
+
+
 def print_metrics(milestone: dict, metrics: dict) -> None:
     state = milestone.get("state")
     if state and state != "n/a":  # milestone mode
@@ -1072,8 +1086,8 @@ def print_metrics(milestone: dict, metrics: dict) -> None:
               "label (NOT the same as 'no slip')")
     elif slip:
         print(f"  unplanned marker slip            : observed {slip['n_observed_unplanned']} "
-              f"({_fmt(slip['observed_pct'], '%')}) vs labelled {slip['n_labelled_unplanned']} "
-              f"({_fmt(slip['labelled_pct'], '%')}) of {slip['n_delivered']} delivered")
+              f"({_pct(slip['observed_pct'])}) vs labelled {slip['n_labelled_unplanned']} "
+              f"({_pct(slip['labelled_pct'])}) of {slip['n_delivered']} delivered")
         print(f"                                     -> {slip['n_slip']} slipped "
               f"(observably unplanned, unlabelled), {slip['n_mislabelled']} mislabelled "
               f"(labelled, observably committed), {slip['n_agree']} agree")

--- a/scripts/pm/templates/milestone_report.html.j2
+++ b/scripts/pm/templates/milestone_report.html.j2
@@ -100,6 +100,30 @@
     <span class="sub">{{ metrics.n_never_committed }} delivered never crossed <code>Backlog -&gt; Ready</code> - cycle time is <strong>undefined</strong> for those (not zero), so they are excluded from the cycle-time figures and counted here instead</span>
     {% endif %}
   </div>
+
+  <!-- Unplanned marker slip cross-check (Issue #1188): the hand-applied `unplanned` LABEL
+       vs the OBSERVED arrival axis (never crossed Backlog -> Ready, recorded by GitHub for
+       free and impossible to forget). A forgotten label reads as committed, biasing the
+       unplanned share downward, so the DISAGREEMENT is the deliverable - not the two shares
+       side by side. The two shares can even MATCH in aggregate while the label is wrong on
+       every item, which is why the per-item slip/mislabelled counts, not the shares, are the
+       fidelity signal. When the commitment history is unreadable the slip is UNKNOWN, never
+       zero (the #1180 one-output-for-three-worlds fabrication, one axis over). -->
+  {% if metrics.marker_slip is defined and metrics.marker_slip %}
+  {% set slip = metrics.marker_slip %}
+  <div class="rolebar">
+    {% if not slip.available %}
+    <span class="pill">marker slip · <strong>unknown</strong></span>
+    <span class="sub">commitment history could not be read, so the observed arrival axis cannot be cross-checked against the label - this is NOT the same as "no slip"</span>
+    {% else %}
+    <span class="pill">observed unplanned · <strong>{{ slip.n_observed_unplanned }}</strong>{% if slip.observed_pct is not none %} ({{ "%.0f%%"|format(slip.observed_pct) }}){% endif %}</span>
+    <span class="pill">labelled unplanned · <strong>{{ slip.n_labelled_unplanned }}</strong>{% if slip.labelled_pct is not none %} ({{ "%.0f%%"|format(slip.labelled_pct) }}){% endif %}</span>
+    <span class="pill">slip · <strong>{{ slip.n_slip }}</strong></span>
+    {% if slip.n_mislabelled %}<span class="pill">mislabelled · <strong>{{ slip.n_mislabelled }}</strong></span>{% endif %}
+    <span class="sub">of {{ slip.n_delivered }} delivered: <strong>{{ slip.n_slip }}</strong> observably unplanned but unlabelled (the label undercounts), {{ slip.n_mislabelled }} labelled yet observably committed, {{ slip.n_agree }} agree. Aggregate shares can match while the label is wrong per item, so the counts are the fidelity signal.</span>
+    {% endif %}
+  </div>
+  {% endif %}
   <div class="rolebar">
     {% for role, count in metrics.per_role_counts.items() %}
       <span class="pill">{{ role }} · <strong>{{ count }}</strong></span>

--- a/tools/ci/test_milestone_report.py
+++ b/tools/ci/test_milestone_report.py
@@ -690,6 +690,138 @@ class TestCommitmentFetchFailureIsUnknownNotZero:
         assert mr.commitments_available(mixed) is False
 
 
+class TestMarkerSlip:
+    """The hand-applied `unplanned` LABEL cross-checked against the OBSERVED arrival
+    signal (never crossed Backlog -> Ready). Issue #1188.
+
+    Two independent measures of the same fact - "did this delivered item arrive
+    unplanned?":
+      - observed:  it has no ``committed_at`` (never entered `Ready`) - recorded by
+                   GitHub for free, cannot be forgotten.
+      - labelled:  someone applied the ``unplanned`` label at close - hand-maintained.
+
+    A forgotten label is indistinguishable from committed work, so the label biases the
+    unplanned share DOWNWARD. Their DISAGREEMENT is the deliverable:
+      - ``n_slip``:        observed-unplanned AND unlabelled (the under-report #1144 predicted).
+      - ``n_mislabelled``: labelled AND observably committed (the opposite error).
+      - ``n_agree``:       observed-unplanned AND labelled.
+    """
+
+    def _d(self, n, committed=None, unplanned=False, available=True):
+        labels = ["unplanned"] if unplanned else []
+        i = _issue(n, "CLOSED", "2026-06-01T00:00:00Z", "2026-06-05T00:00:00Z",
+                   ["role:pm"], "COMPLETED", labels)
+        if committed:
+            i["committed_at"] = committed
+        i["commitments_available"] = available
+        return i
+
+    def test_matched_pair_agree_vs_slip(self):
+        """THE control: two observably-unplanned items, ONLY the label flipped.
+
+        Both never crossed `Ready`, so both are observably unplanned. One carries the
+        label (agree), one does not (the slip). If the cross-check ignored the label,
+        both would land the same and this fails.
+        """
+        agree = self._d(1, committed=None, unplanned=True)
+        slip = self._d(2, committed=None, unplanned=False)
+        m = mr.marker_slip([agree, slip])
+        assert m["available"] is True
+        assert m["n_observed_unplanned"] == 2   # both never committed
+        assert m["n_labelled_unplanned"] == 1   # only #1 carries the label
+        assert m["n_slip"] == 1                  # #2: observed-unplanned but unlabelled
+        assert m["n_agree"] == 1                 # #1: observed-unplanned and labelled
+        assert m["n_mislabelled"] == 0
+
+    def test_mislabelled_is_labelled_but_observably_committed(self):
+        """The symmetric error: the label is applied, but the item DID cross the commitment act."""
+        mislabelled = self._d(1, committed="2026-06-02T00:00:00Z", unplanned=True)
+        clean = self._d(2, committed="2026-06-02T00:00:00Z", unplanned=False)
+        m = mr.marker_slip([mislabelled, clean])
+        assert m["n_observed_unplanned"] == 0   # both committed
+        assert m["n_mislabelled"] == 1          # #1: labelled yet committed
+        assert m["n_slip"] == 0
+        assert m["n_agree"] == 0
+
+    def test_aggregate_share_agreement_does_not_mean_per_item_fidelity(self):
+        """Why the cross-check earns its keep: the two shares can MATCH while the label
+        is wrong on every item.
+
+        4 delivered: #1 observed-unplanned+labelled (agree), #2 observed-unplanned+unlabelled
+        (slip), #3 committed+labelled (mislabelled), #4 committed+unlabelled (clean). Observed
+        share = 2/4 = labelled share = 2/4 - identical in aggregate, yet two of the four items
+        are classified WRONGLY by the label. A share comparison alone would call this clean.
+        """
+        issues = [
+            self._d(1, committed=None, unplanned=True),
+            self._d(2, committed=None, unplanned=False),
+            self._d(3, committed="2026-06-02T00:00:00Z", unplanned=True),
+            self._d(4, committed="2026-06-02T00:00:00Z", unplanned=False),
+        ]
+        m = mr.marker_slip(issues)
+        assert m["n_delivered"] == 4
+        assert m["observed_pct"] == pytest.approx(50.0)
+        assert m["labelled_pct"] == pytest.approx(50.0)
+        assert m["n_slip"] == 1        # #2
+        assert m["n_mislabelled"] == 1 # #3
+        assert m["n_agree"] == 1       # #1
+
+    def test_marker_never_applied_is_total_slip(self):
+        """The live 2026-07 finding, as a fixture: observed-unplanned items exist, but NOT
+        ONE carries the label -> every one is a slip and the label reports zero."""
+        issues = [self._d(1, committed=None, unplanned=False),
+                  self._d(2, committed=None, unplanned=False),
+                  self._d(3, committed="2026-06-02T00:00:00Z", unplanned=False)]
+        m = mr.marker_slip(issues)
+        assert m["n_observed_unplanned"] == 2
+        assert m["n_labelled_unplanned"] == 0   # the label reports zero...
+        assert m["n_slip"] == 2                  # ...while two observably slipped
+        assert m["n_agree"] == 0
+
+    def test_unavailable_commitments_is_unknown_never_folded(self):
+        """Matched pair to ``test_matched_pair_agree_vs_slip``: same issues, but the
+        commitment fetch failed. The observed axis is then unknown, so slip is unknown -
+        NOT zero, NOT the whole population (the #1180 / #1185 fabrication class)."""
+        died = [self._d(1, committed=None, unplanned=True, available=False),
+                self._d(2, committed=None, unplanned=False, available=False)]
+        m = mr.marker_slip(died)
+        assert m["available"] is False
+        assert m["n_observed_unplanned"] is None
+        assert m["n_labelled_unplanned"] is None
+        assert m["n_slip"] is None
+        assert m["n_mislabelled"] is None
+        assert m["n_agree"] is None
+        assert m["observed_pct"] is None
+        assert m["labelled_pct"] is None
+        # delivered is still known - we know WHAT shipped, not how it arrived.
+        assert m["n_delivered"] == 2
+
+    def test_descoped_never_counted(self):
+        """Keys off DELIVERED: a descoped close is not shipped work, however it arrived."""
+        descoped = _issue(9, "CLOSED", "2026-06-01T00:00:00Z", "2026-06-05T00:00:00Z",
+                          ["role:pm"], "NOT_PLANNED", ["unplanned"])
+        descoped["commitments_available"] = True
+        m = mr.marker_slip([descoped])
+        assert m["n_delivered"] == 0
+        assert m["n_observed_unplanned"] == 0
+        assert m["n_slip"] == 0
+
+    def test_metrics_carry_the_cross_check(self):
+        agree = self._d(1, committed=None, unplanned=True)
+        slip = self._d(2, committed=None, unplanned=False)
+        m = mr.compute_metrics([agree, slip], {"closed_at": None, "created_at": None},
+                               marker_in_use=True)
+        assert m["marker_slip"]["n_slip"] == 1
+        assert m["marker_slip"]["n_agree"] == 1
+
+    def test_window_metrics_carry_the_cross_check(self):
+        agree = self._d(1, committed=None, unplanned=True)
+        slip = self._d(2, committed=None, unplanned=False)
+        week = [agree, slip]
+        m = mr.compute_window_metrics(week, week, UNTIL, 1, marker_in_use=True)
+        assert m["marker_slip"]["n_slip"] == 1
+
+
 class TestNegativeCycleTimeIsDropped:
     def test_committed_after_closed_is_not_a_fast_delivery(self):
         """A close -> reopen -> re-commit can put committed_at AFTER closed_at.


### PR DESCRIPTION
Closes #1188.

## What

The `unplanned` marker is applied by hand at close, and a forgotten label is indistinguishable from committed work - so the label can only bias the unplanned share **downward**, never up. [Issue #1138](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1138) landed the independent source this needs: an item that closed without ever crossing `Backlog -> Ready` is observably unplanned, recorded by GitHub for free and impossible to forget.

Adds `marker_slip()`, a pure metric that reports the **observed** unplanned share alongside the **label-derived** share and surfaces their per-item **disagreement**:

- `n_slip` - observably unplanned but **unlabelled** (the under-report [Issue #1144](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1144) predicted).
- `n_mislabelled` - **labelled** but observably committed (the opposite error).
- `n_agree` - observably unplanned and labelled.

The two aggregate shares can *match* while the label is wrong on every item, so the per-item counts, not the shares, are the fidelity signal. A failed commitment fetch reads as **unknown** (`available=False`, None buckets), never as zero or the whole population - the [Issue #1180](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1180) fabrication class, one axis over. Wired into both metric modes, the console, and the HTML report.

## The measured finding (AC4 evidence)

Live SDR over the week ending 2026-07-13: **13 of 26 delivered (50%) observably never crossed `Backlog -> Ready`, while the `unplanned` label reports 0** (the marker has never been applied repo-wide). **AC4 decision: no closure-time gate/hook is warranted** - the marker is structurally redundant with the free commitment-act signal, so the fix is to make the reliable signal primary (this PR), not to gate the redundant one. Full decision on [Issue #1188](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1188#issuecomment-4992832808); the label-*retirement* follow-up is tracked (not pre-decided) in [Issue #1211](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1211).

## Test plan

- [x] `marker_slip` unit tests: matched pair (agree / slip), mislabelled, unknown-on-failed-fetch, aggregate-shares-match-but-per-item-wrong, marker-never-applied total slip, descoped-excluded, both metric modes carry it.
- [x] Full `test_milestone_report.py` suite green (82 passed), incl. the no-em/en-dash guard on template + emitted strings.
- [x] Live integration smoke: real SDR run against board 9 (`--weekly --since 2026-06-15 --until 2026-07-13`) - console + HTML render both show the cross-check (observed 13 / 50%, labelled 0 / 0%, slip 13); rendered HTML carries no em/en dash.

**Created by:** PM