### PR TITLE
test(ci): path-filtered canary asserting the calibration README mirrors its notebook

### DIFF
--- a/.github/workflows/calibration-readme-canary.yml
+++ b/.github/workflows/calibration-readme-canary.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.13"
 

--- a/.github/workflows/calibration-readme-canary.yml
+++ b/.github/workflows/calibration-readme-canary.yml
@@ -1,0 +1,43 @@
+name: Calibration README canary
+
+# CI canary for Issue #1184: the calibration experiment's README LOCO table
+# (AUPRC / lift / AUPRG per cohort) is a hand-copied mirror of numbers computed in
+# notebook.ipynb, so it drifts silently whenever the notebook is refreshed and the
+# README is not - exactly the Issue #1065 drift (pre-#805 numbers surviving in the
+# README for weeks). This asserts the README still reproduces the notebook's
+# committed output cell and fails loudly on any disagreement.
+#
+# Path-filtered: runs only on PRs that touch the README, the notebook, or the
+# check's own moving parts. A separate workflow (not a job in tests.yml) so the
+# path filter gates THIS check without throttling the unconditional pytest job -
+# which already runs the check's unit tests (test_check_calibration_readme_mirror).
+
+on:
+  push:
+    branches: [main]
+    paths: &paths
+      - research/experiments/issue_547_immunogenicity_calibration/README.md
+      - research/experiments/issue_547_immunogenicity_calibration/notebook.ipynb
+      - tools/ci/check_calibration_readme_mirror.py
+      - tools/ci/test_check_calibration_readme_mirror.py
+      - .github/workflows/calibration-readme-canary.yml
+  pull_request:
+    branches: [main]
+    paths: *paths
+
+jobs:
+  calibration-readme-canary:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Assert README LOCO table mirrors the notebook (notebook is source of truth)
+        # Pure stdlib - no dependencies to install. Exits non-zero and names every
+        # drifted cell on disagreement.
+        run: python tools/ci/check_calibration_readme_mirror.py

--- a/research/lab_notebook/developer.md
+++ b/research/lab_notebook/developer.md
@@ -8,7 +8,13 @@ Format and rules unchanged from the unified notebook — see `shared/feedback_la
 
 ## 2026-07-16
 
-### 14:35 UTC - Editor: Developer - Recording the mechanism-class ruling: guards are controls, not guarantees ([PR #1213](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/1213) for [Issue #1150](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1150))
+### 15:35 UTC - Editor: Developer - A docs-mirror canary, and the coverage floor the review asked for ([PR #1217](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/1217) for [Issue #1184](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1184))
+
+Burn-down item two. The calibration README quotes a LOCO table (AUPRC/lift/AUPRG) hand-copied from `notebook.ipynb`, so it drifts silently on every notebook refresh - the #1065 drift. PR #1183 fixed the instance and ran the mirror check by hand; this promotes it to a path-filtered canary.
+
+Two things worth recording. First, the parser bug that only a real run surfaces: my first header detector matched by substring, so the cell's *prose title* ("Per-cohort discrimination - AUPRC/prevalence lift vs AUPRG") looked like the header (it contains all four column words) and the parser read zero rows and reported the whole table as drift. Token-exact header matching fixed it, and I added a regression test for exactly that trap. It is the same lesson as always - drive the real artifact; a synthetic table fixture would have been built to parse and never caught it.
+
+Second, the review's one worthwhile finding was a *vacuous-pass* hole I had left: `compare({}, {})` returns clean, and the notebook parser returns `{}` (rather than raising) when the header resolves but every data row drops - so a doubly-malformed parse would be green on a broken mirror. That is precisely the "agreement AND coverage" property the sibling annotate-flag-canary already documents, and I had built the agreement half without the coverage half. Added a coverage floor in `main()` (refuse a zero-cohort parse) plus a test that drives it. The exact-equality-on-AUPRC/AUPRG choice drew an FYI about display-precision coupling, which is the intended tradeoff - it is what catches IMPROVE's 0.032 vs 0.0322 - so I left it and noted why.
 
 Landed the Developer half of the #1150 governance decision (Jin-Ho ratified 2026-07-15): a docs-only change to the AGENTS.md "GitHub Safety Wrappers" section, one edit per ratified question.
 Q1 extended the mechanism-over-memory ladder with a fourth rung above "hook" (entry-point / OS-or-server-enforced), and a paragraph naming rung 4 as the tier you actually rely on.

--- a/tools/ci/check_calibration_readme_mirror.py
+++ b/tools/ci/check_calibration_readme_mirror.py
@@ -232,6 +232,22 @@ def main(argv: Optional[list[str]] = None) -> int:
 
     notebook = parse_notebook_loco(args.notebook)
     readme = parse_readme_loco(args.readme)
+
+    # Coverage floor (mirrors the annotate-flag-canary's "agreement AND coverage"
+    # convention): compare() returns [] on two empty dicts, so a run where BOTH
+    # sides parse to zero cohorts - a header that resolves but every data row is
+    # dropped (a leading pandas index column, a cohort label with a space) on both
+    # notebook and README at once - would pass vacuously. Refuse a zero-cohort
+    # parse outright so the canary can only be green on a real, populated match.
+    if not notebook or not readme:
+        empty = "notebook" if not notebook else "README"
+        print(
+            f"Coverage floor: parsed 0 cohorts from the {empty} - the mirror cannot "
+            "be verified. A zero-cohort parse must never pass vacuously (a table "
+            "header resolved but no data rows parsed)."
+        )
+        return 1
+
     problems = compare(notebook, readme)
     if problems:
         print("Calibration README LOCO table drifted from the notebook (source of truth):")

--- a/tools/ci/check_calibration_readme_mirror.py
+++ b/tools/ci/check_calibration_readme_mirror.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python3
+"""Canary: the calibration README's LOCO table must mirror its notebook (Issue #1184).
+
+`research/experiments/issue_547_immunogenicity_calibration/README.md` quotes a
+per-cohort LOCO discrimination table (AUPRC / lift / AUPRG). Those numbers are
+computed in `notebook.ipynb` and the README is a hand-copied mirror of them, so
+it drifts silently whenever the notebook is refreshed and the README is not -
+exactly what happened in Issue #1065 (the README kept quoting pre-#805 values for
+weeks). PR #1183 fixed the instance and named the notebook as the source of
+truth; this promotes the check PR #1183 ran by hand into a mechanism.
+
+The notebook's committed output cell wins. This module parses the source-of-truth
+table out of that output cell and the mirror table out of the README, and asserts
+they agree: AUPRC and AUPRG exactly, lift within rounding (the README rounds
+146.7 to ~147). A mismatch exits non-zero and names every disagreeing cell.
+
+Pure stdlib; the pure functions are unit-tested in
+`test_check_calibration_readme_mirror.py`, and a path-filtered CI job
+(`.github/workflows/calibration-readme-canary.yml`) runs this end-to-end.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+EXPERIMENT_DIR = REPO_ROOT / "research" / "experiments" / "issue_547_immunogenicity_calibration"
+DEFAULT_NOTEBOOK = EXPERIMENT_DIR / "notebook.ipynb"
+DEFAULT_README = EXPERIMENT_DIR / "README.md"
+
+# Lift is rounded for display (146.7 -> ~147), so it is compared within this
+# absolute tolerance; AUPRC and AUPRG are asserted to the README's full precision.
+LIFT_TOL = 0.5
+
+
+@dataclass(frozen=True)
+class LocoRow:
+    auprc: float
+    lift: float
+    auprg: float
+
+
+# --- notebook (source of truth) ----------------------------------------------
+
+
+def _code_cell_output_text(cell: dict) -> str:
+    """Concatenate the human-visible text of a code cell's outputs."""
+    text = ""
+    for out in cell.get("outputs", []):
+        if out.get("output_type") == "stream":
+            text += "".join(out.get("text", []))
+        elif "data" in out:
+            plain = out["data"].get("text/plain")
+            if plain:
+                text += "".join(plain)
+    return text
+
+
+def _is_header_row(line: str) -> bool:
+    """True for the table's column-header row: cohort + AUPRC + lift + AUPRG as
+    exact whitespace tokens.
+
+    Token-exact, not substring: the cell's *title* line ("Per-cohort discrimination
+    - AUPRC/prevalence lift vs AUPRG ...") contains all four words as substrings
+    but none as standalone columns, so a substring test would mistake it for the
+    header and parse zero rows.
+    """
+    toks = {t.lower() for t in line.split()}
+    return {"cohort", "auprc", "lift", "auprg"} <= toks
+
+
+def _is_loco_source_table(text: str) -> bool:
+    """A discrimination table whose header carries cohort + AUPRC + lift + AUPRG.
+
+    This distinguishes the source table (the `Per-cohort discrimination` cell) from
+    the neighbouring `LOCO results` cell, which has auprc/auprg but no `lift`
+    column - so a header row with all four is the unambiguous discriminator.
+    """
+    return any(_is_header_row(line) for line in text.splitlines())
+
+
+def parse_notebook_loco(notebook_path: Path) -> dict[str, LocoRow]:
+    """Parse the per-cohort AUPRC/lift/AUPRG table from the notebook's output cell.
+
+    Locates the single code cell whose output holds the discrimination table
+    (identified by content, not index, so a re-ordered notebook still resolves)
+    and parses its whitespace-delimited rows by header-column name. Raises if zero
+    or more than one such table is found - a notebook restructure should fail this
+    loudly, never silently pick the wrong cell.
+    """
+    nb = json.loads(notebook_path.read_text(encoding="utf-8"))
+    matches = [
+        _code_cell_output_text(c)
+        for c in nb.get("cells", [])
+        if c.get("cell_type") == "code" and _is_loco_source_table(_code_cell_output_text(c))
+    ]
+    if len(matches) != 1:
+        raise ValueError(
+            f"expected exactly one LOCO discrimination table in {notebook_path.name}, "
+            f"found {len(matches)} (notebook restructured? update the canary)"
+        )
+    return _parse_whitespace_table(matches[0])
+
+
+def _parse_whitespace_table(text: str) -> dict[str, LocoRow]:
+    """Parse a pandas-`to_string` table into {cohort -> LocoRow} by column name."""
+    lines = text.splitlines()
+    header_idx = next(i for i, ln in enumerate(lines) if _is_header_row(ln))
+    header = lines[header_idx].split()
+    col = {name.lower(): j for j, name in enumerate(header)}
+    out: dict[str, LocoRow] = {}
+    for ln in lines[header_idx + 1 :]:
+        toks = ln.split()
+        if len(toks) != len(header):
+            continue  # blank line or trailing prose after the table body
+        try:
+            out[toks[col["cohort"]]] = LocoRow(
+                auprc=float(toks[col["auprc"]]),
+                lift=float(toks[col["lift"]]),
+                auprg=float(toks[col["auprg"]]),
+            )
+        except (KeyError, ValueError):
+            continue
+    return out
+
+
+# --- README (mirror) ---------------------------------------------------------
+
+_NUM_RE = re.compile(r"[-+]?\d*\.?\d+")
+
+
+def _first_float(cell: str) -> Optional[float]:
+    m = _NUM_RE.search(cell)
+    return float(m.group()) if m else None
+
+
+def parse_readme_loco(readme_path: Path) -> dict[str, LocoRow]:
+    """Parse the LOCO mirror table out of the README markdown.
+
+    Finds the pipe table whose header row names AUPRC, lift and AUPRG, then reads
+    each data row, extracting the leading float from each cell (so `~147×` and
+    `~1.2× (near baseline)` both parse). Raises if the table is not found.
+    """
+    lines = readme_path.read_text(encoding="utf-8").splitlines()
+    header_idx = None
+    cols: dict[str, int] = {}
+    for i, ln in enumerate(lines):
+        if not ln.lstrip().startswith("|"):
+            continue
+        low = ln.lower()
+        if "auprc" in low and "auprg" in low and "lift" in low and "cohort" in low:
+            cells = [c.strip().lower() for c in ln.strip().strip("|").split("|")]
+            for j, name in enumerate(cells):
+                if "cohort" in name:
+                    cols["cohort"] = j
+                elif name == "auprc":
+                    cols["auprc"] = j
+                elif "lift" in name:
+                    cols["lift"] = j
+                elif name == "auprg":
+                    cols["auprg"] = j
+            header_idx = i
+            break
+    if header_idx is None or not {"cohort", "auprc", "lift", "auprg"} <= set(cols):
+        raise ValueError(f"LOCO mirror table not found in {readme_path.name}")
+
+    out: dict[str, LocoRow] = {}
+    # skip the header separator row (|---|---|), then read until the table ends
+    for ln in lines[header_idx + 2 :]:
+        if not ln.lstrip().startswith("|"):
+            break
+        cells = [c.strip() for c in ln.strip().strip("|").split("|")]
+        if len(cells) <= max(cols.values()):
+            continue
+        cohort = cells[cols["cohort"]].strip()
+        auprc = _first_float(cells[cols["auprc"]])
+        lift = _first_float(cells[cols["lift"]])
+        auprg = _first_float(cells[cols["auprg"]])
+        if cohort and None not in (auprc, lift, auprg):
+            out[cohort] = LocoRow(auprc=auprc, lift=lift, auprg=auprg)
+    return out
+
+
+# --- comparison --------------------------------------------------------------
+
+
+def compare(notebook: dict[str, LocoRow], readme: dict[str, LocoRow]) -> list[str]:
+    """Return a list of human-readable mismatches; empty means the mirror is clean.
+
+    AUPRC and AUPRG must match the notebook's value exactly (the README quotes them
+    to full precision, e.g. `0.0322`, so a lower-precision `0.032` is genuine drift,
+    not a faithful rounding - this is the exact class PR #1183 fixed on IMPROVE).
+    Lift alone is compared within `LIFT_TOL`, because the README deliberately rounds
+    it for display (146.7 -> ~147).
+    """
+    problems: list[str] = []
+    nb_cohorts, rm_cohorts = set(notebook), set(readme)
+    if nb_cohorts != rm_cohorts:
+        missing = nb_cohorts - rm_cohorts
+        extra = rm_cohorts - nb_cohorts
+        if missing:
+            problems.append(f"cohorts in notebook but not README: {sorted(missing)}")
+        if extra:
+            problems.append(f"cohorts in README but not notebook: {sorted(extra)}")
+
+    for cohort in sorted(nb_cohorts & rm_cohorts):
+        nb, rm = notebook[cohort], readme[cohort]
+        for field in ("auprc", "auprg"):
+            nb_v, rm_v = getattr(nb, field), getattr(rm, field)
+            if nb_v != rm_v:
+                problems.append(
+                    f"{cohort} {field.upper()}: README {rm_v} != notebook {nb_v}"
+                )
+        if abs(nb.lift - rm.lift) > LIFT_TOL:
+            problems.append(
+                f"{cohort} lift: README {rm.lift} vs notebook {nb.lift} "
+                f"(exceeds rounding tolerance {LIFT_TOL})"
+            )
+    return problems
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--notebook", type=Path, default=DEFAULT_NOTEBOOK)
+    ap.add_argument("--readme", type=Path, default=DEFAULT_README)
+    args = ap.parse_args(argv)
+
+    notebook = parse_notebook_loco(args.notebook)
+    readme = parse_readme_loco(args.readme)
+    problems = compare(notebook, readme)
+    if problems:
+        print("Calibration README LOCO table drifted from the notebook (source of truth):")
+        for p in problems:
+            print(f"  - {p}")
+        print("\nFix: refresh the README table from notebook.ipynb (the notebook wins).")
+        return 1
+    print(f"Calibration README mirrors the notebook: {len(readme)} cohorts agree.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/ci/test_check_calibration_readme_mirror.py
+++ b/tools/ci/test_check_calibration_readme_mirror.py
@@ -120,6 +120,43 @@ def test_title_line_is_not_mistaken_for_the_header():
         nb_path.unlink()
 
 
+def test_coverage_floor_rejects_a_vacuous_zero_cohort_parse(tmp_path):
+    """A header that resolves but yields zero data rows must FAIL, not pass green.
+
+    Without the coverage floor, `compare({}, {})` returns [] and the canary is
+    green on a broken mirror - the vacuous pass the sibling annotate-flag-canary
+    guards against. Here the notebook header is intact but every row carries a
+    leading index column (7 tokens vs a 6-token header), so all rows drop to {}.
+    """
+    import json
+
+    zero_row_nb = {
+        "cells": [
+            {
+                "cell_type": "code",
+                "outputs": [
+                    {
+                        "output_type": "stream",
+                        "text": [
+                            "Per-cohort discrimination:\n",
+                            " cohort  true_pos  prevalence  AUPRC  lift  AUPRG\n",
+                            "  0    NCI    103    0.000245 0.0359 146.7 0.9999\n",
+                        ],
+                    }
+                ],
+            }
+        ]
+    }
+    nb_path = tmp_path / "zero.ipynb"
+    nb_path.write_text(json.dumps(zero_row_nb), encoding="utf-8")
+
+    # the parse is genuinely empty (rows dropped), and compare would pass vacuously
+    assert m.parse_notebook_loco(nb_path) == {}
+    assert m.compare({}, {}) == []
+    # but main() refuses it via the coverage floor
+    assert m.main(["--notebook", str(nb_path)]) == 1
+
+
 def test_missing_table_raises():
     import json
     import tempfile

--- a/tools/ci/test_check_calibration_readme_mirror.py
+++ b/tools/ci/test_check_calibration_readme_mirror.py
@@ -1,0 +1,134 @@
+"""Unit tests for the calibration README<->notebook mirror canary (Issue #1184).
+
+The load-bearing test is `test_stale_pre_1183_readme_is_red`: a check that cannot
+fail on the actual historical drift (Issue #1065, the pre-#805 numbers surviving
+in the README) is not a check. It reconstructs that stale table and asserts the
+canary flags every drifted cell.
+"""
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import check_calibration_readme_mirror as m  # noqa: E402
+
+# The pre-#1183 (pre-#805) values that silently survived in the README while the
+# notebook already carried the refreshed ones - straight from the PR #1183 body.
+_STALE_README = """# Calibration
+
+| cohort left out | prevalence | AUPRC | LOCO lift | AUPRG |
+|---|---|---|---|---|
+| NCI | 0.000245 | 0.027 | ~111x | 0.998 |
+| TESLA | 0.046 | 0.201 | ~4.4x | 0.859 |
+| HiTIDE | 0.026 | 0.071 | ~2.7x | 0.815 |
+| IMPROVE | 0.027 | 0.032 | ~1.2x | 0.268 |
+"""
+
+# A synthetic notebook whose ONLY discrimination-table cell leads with the exact
+# prose title that broke the first parser (its substrings look like a header).
+_TITLE_TRAP_NOTEBOOK = {
+    "cells": [
+        {
+            "cell_type": "code",
+            "outputs": [
+                {
+                    "output_type": "stream",
+                    "text": [
+                        "Per-cohort discrimination - AUPRC/prevalence lift vs AUPRG (comparable):\n",
+                        " cohort  true_pos  prevalence  AUPRC  lift  AUPRG\n",
+                        "    NCI       103    0.000245 0.0359 146.7 0.9999\n",
+                        "  TESLA        34    0.046196 0.2482   5.4 0.8779\n",
+                    ],
+                }
+            ],
+        }
+    ],
+}
+
+
+def test_parse_notebook_loco_matches_source_of_truth():
+    nb = m.parse_notebook_loco(m.DEFAULT_NOTEBOOK)
+    assert set(nb) == {"NCI", "TESLA", "HiTIDE", "IMPROVE"}
+    assert nb["NCI"] == m.LocoRow(auprc=0.0359, lift=146.7, auprg=0.9999)
+    assert nb["IMPROVE"] == m.LocoRow(auprc=0.0322, lift=1.2, auprg=0.2678)
+
+
+def test_parse_readme_loco_reads_the_mirror_table():
+    rm = m.parse_readme_loco(m.DEFAULT_README)
+    assert set(rm) == {"NCI", "TESLA", "HiTIDE", "IMPROVE"}
+    # `~147x` and `~1.2x (near baseline)` both parse to their leading float
+    assert rm["NCI"].lift == 147.0
+    assert rm["IMPROVE"].auprg == 0.2678
+
+
+def test_current_readme_mirrors_the_notebook_green():
+    nb = m.parse_notebook_loco(m.DEFAULT_NOTEBOOK)
+    rm = m.parse_readme_loco(m.DEFAULT_README)
+    assert m.compare(nb, rm) == []
+
+
+def test_stale_pre_1183_readme_is_red(tmp_path):
+    """The canary MUST flag the real historical drift - the AC2 falsifier."""
+    stale = tmp_path / "README.md"
+    stale.write_text(_STALE_README, encoding="utf-8")
+    nb = m.parse_notebook_loco(m.DEFAULT_NOTEBOOK)
+    rm = m.parse_readme_loco(stale)
+    problems = m.compare(nb, rm)
+    assert problems, "the canary did not flag the pre-#1183 drift - it is a hollow check"
+    # every cohort's AUPRC and AUPRG drifted, so each is named
+    joined = "\n".join(problems)
+    for cohort in ("NCI", "TESLA", "HiTIDE", "IMPROVE"):
+        assert f"{cohort} AUPRC" in joined, f"missed the {cohort} AUPRC drift"
+
+
+def test_main_exit_codes(tmp_path, capsys):
+    # green on the real pair
+    assert m.main([]) == 0
+    # red on a stale README
+    stale = tmp_path / "README.md"
+    stale.write_text(_STALE_README, encoding="utf-8")
+    assert m.main(["--readme", str(stale)]) == 1
+
+
+def test_lift_compared_within_rounding_but_auprc_exact():
+    nb = {"X": m.LocoRow(auprc=0.0359, lift=146.7, auprg=0.9999)}
+    # README rounds 146.7 -> 147: within tolerance, AUPRC/AUPRG exact -> clean
+    assert m.compare(nb, {"X": m.LocoRow(auprc=0.0359, lift=147.0, auprg=0.9999)}) == []
+    # a lift off by more than the rounding tolerance is caught
+    assert m.compare(nb, {"X": m.LocoRow(auprc=0.0359, lift=150.0, auprg=0.9999)})
+    # an AUPRC that differs in the last printed digit is caught (no lift excuse)
+    assert m.compare(nb, {"X": m.LocoRow(auprc=0.0360, lift=146.7, auprg=0.9999)})
+
+
+def test_title_line_is_not_mistaken_for_the_header():
+    """Regression: the cell's prose title has cohort/AUPRC/lift/AUPRG as substrings;
+    token-exact header matching must skip it and parse the real rows."""
+    import json
+
+    nb_path = None
+    import tempfile
+
+    with tempfile.NamedTemporaryFile("w", suffix=".ipynb", delete=False) as f:
+        json.dump(_TITLE_TRAP_NOTEBOOK, f)
+        nb_path = Path(f.name)
+    try:
+        rows = m.parse_notebook_loco(nb_path)
+        assert rows["NCI"] == m.LocoRow(auprc=0.0359, lift=146.7, auprg=0.9999)
+        assert rows["TESLA"].auprg == 0.8779
+    finally:
+        nb_path.unlink()
+
+
+def test_missing_table_raises():
+    import json
+    import tempfile
+
+    with tempfile.NamedTemporaryFile("w", suffix=".ipynb", delete=False) as f:
+        json.dump({"cells": []}, f)
+        p = Path(f.name)
+    try:
+        with pytest.raises(ValueError):
+            m.parse_notebook_loco(p)
+    finally:
+        p.unlink()


### PR DESCRIPTION
## What

Promotes the README<->notebook mirror check that PR #1183 ran by hand into a path-filtered CI mechanism (#1184). The calibration experiment's README quotes a per-cohort LOCO table (AUPRC / lift / AUPRG) hand-copied from `notebook.ipynb`, so it drifts silently on every notebook refresh - exactly the #1065 drift, where pre-#805 numbers survived in the README for weeks. The prose said "the notebook wins"; a prose convention is a memory rule, and this rule already slipped once.

## How

- `tools/ci/check_calibration_readme_mirror.py` (pure stdlib): parses the notebook's committed `Per-cohort discrimination` output cell - located by **content, not index**, so a re-ordered notebook still resolves, and raising if zero/multiple match - and the README mirror table, then asserts **AUPRC/AUPRG exactly, lift within rounding** (the README rounds 146.7 to ~147). This is PR #1183's stated semantic. Exact (not round-to-README-precision) equality on AUPRC/AUPRG is deliberate: it catches IMPROVE's `0.032` vs notebook `0.0322`, a genuine drift a rounding tolerance would hide.
- `.github/workflows/calibration-readme-canary.yml`: runs the check end-to-end, path-filtered to the README, notebook, check script, its test, and the workflow itself (mirrors the `annotate-flag-canary` pattern) so it costs nothing on unrelated PRs.
- `tools/ci/test_check_calibration_readme_mirror.py`: pins the red/green falsifier and a regression for the title-line-mistaken-for-header bug I hit while building it.

## Test plan

- [x] `python tools/ci/check_calibration_readme_mirror.py` green on the real pair (4 cohorts agree); runs under plain `python3` (stdlib only, as CI invokes it).
- [x] **Red on the actual defect:** `test_stale_pre_1183_readme_is_red` reconstructs the pre-#805 values and asserts every drifted cell is flagged; `test_main_exit_codes` confirms exit 1 on a stale README, exit 0 on the real one.
- [x] Token-exact header match verified to skip the cell's prose title (regression test) - the first parser mistook it for the header and read zero rows.
- [x] Full `tools/ci/` dir green: 928 passed (+3). YAML validated; the `&paths` anchor resolves identically on push + pull_request.

Closes #1184.

**Created by:** Developer
