### PR TITLE
refactor(alignment): extract STAR read-arg construction into a helper

### DIFF
--- a/research/lab_notebook/developer.md
+++ b/research/lab_notebook/developer.md
@@ -8,7 +8,13 @@ Format and rules unchanged from the unified notebook — see `shared/feedback_la
 
 ## 2026-07-16
 
-### 14:35 UTC - Editor: Developer - Recording the mechanism-class ruling: guards are controls, not guarantees ([PR #1213](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/1213) for [Issue #1150](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1150))
+### 15:45 UTC - Editor: Developer - STAR read-arg helper: the parallel-sibling refactor ([PR #1218](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/1218) for [Issue #1081](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1081))
+
+Burn-down item three. PR #1077 extracted HISAT2's SE/PE read-input construction into a pure helper but left STAR on the old inline `FASTQ_FILES` if-block; this is the STAR sibling, a pure consistency refactor with no behavior change (the STAR branch was correct as-is).
+
+`star_command.build_read_files_in` mirrors `hisat2_command.build_read_args` exactly, the one shape difference being that STAR's `--readFilesIn` takes a bare space-separated file list, not `-U`/`-1 -2` flags. The behavior-preservation claim is the load-bearing one for a "correct as-is" refactor, so I verified it three ways: 8 helper unit cases, a dry-run snapshot asserting `--readFilesIn` renders the same file list the old shell produced, and confirmation the default HISAT2 path is untouched (star-branch-only edit).
+
+The bot review was LGTM. Its worthwhile nit was a real coverage gap I had mirrored from the HISAT2 sibling: the rule-layer wiring test only exercised the paired-end render, leaving the SE render (r1, no r2) proven only at the unit layer. I added a single-end dry-run fixture + assertion to close it end-to-end - exceeding the sibling's coverage rather than inheriting its limitation. I declined the other nit (factor out the near-identical `_get_star_read_args`/`_get_hisat2_read_args`): they live in mutually-exclusive `if`/`elif` branches, sharing would force hoisting + a builder param that reads worse, and per ADR-0003 the HISAT2 side is slated for retirement, so the duplication is transient - the bot agreed on all three points.
 
 Landed the Developer half of the #1150 governance decision (Jin-Ho ratified 2026-07-15): a docs-only change to the AGENTS.md "GitHub Safety Wrappers" section, one edit per ratified question.
 Q1 extended the mechanism-over-memory ladder with a fourth rung above "hook" (entry-point / OS-or-server-enforced), and a paragraph naming rung 4 as the tier you actually rely on.

--- a/workflow/rules/alignment.smk
+++ b/workflow/rules/alignment.smk
@@ -306,9 +306,23 @@ if config.get("alignment", {}).get("aligner") == "hisat2":
 
 elif config.get("alignment", {}).get("aligner") == "star":
 
+    from star_command import build_read_files_in
+
     _STAR_INDEX_DIR = config.get("alignment", {}).get(
         "star_index_dir", "indices/star"
     )
+
+    def _get_star_read_args(wildcards, input):
+        """Resolve STAR's --readFilesIn value (single-end vs paired-end) for one sample.
+
+        Mirrors `_get_hisat2_read_args`: delegates the single-end / paired-end
+        selection to the pure `build_read_files_in` helper (unit-tested in
+        test_star_command.py). Reads the already-resolved input paths so the
+        emitted command uses exactly the staged files. `input.fastq2` is a
+        (possibly empty) list from `_get_fastq2`.
+        """
+        fastq2 = input.fastq2[0] if input.fastq2 else ""
+        return build_read_files_in(input.fastq1, fastq2)
 
     rule star_index:
         """Build STAR genome index (one-time; reused for all samples).
@@ -374,6 +388,7 @@ elif config.get("alignment", {}).get("aligner") == "star":
             # by the same config knob as the HISAT2 NH prefilter (`_UNIQ_ENABLED`,
             # from `uniqueness_filter.is_enabled`). Empty string = count all reads.
             uniqueness_flag="--unique-only" if _UNIQ_ENABLED else "",
+            read_files_in=_get_star_read_args,
         threads: config.get("alignment", {}).get("threads", 8)
         resources:
             mem_mb=32000,
@@ -387,16 +402,11 @@ elif config.get("alignment", {}).get("aligner") == "star":
                 READCMD="--readFilesCommand zcat"
             fi
 
-            FASTQ_FILES="{input.fastq1}"
-            if [[ -n "{input.fastq2}" ]]; then
-                FASTQ_FILES="{input.fastq1} {input.fastq2}"
-            fi
-
             STAR \\
                 --runMode alignReads \\
                 --runThreadN {threads} \\
                 --genomeDir {input.index_dir} \\
-                --readFilesIn $FASTQ_FILES \\
+                --readFilesIn {params.read_files_in} \\
                 $READCMD \\
                 --outFileNamePrefix {params.output_prefix} \\
                 --outSAMtype None \\

--- a/workflow/scripts/star_command.py
+++ b/workflow/scripts/star_command.py
@@ -1,0 +1,28 @@
+"""Build STAR's --readFilesIn argument (single-end vs paired-end).
+
+Used by `alignment.smk` to translate a sample's fastq paths into STAR's
+`--readFilesIn` value: `<r1>` for single-end, `<r1> <r2>` for paired-end.
+Extracted from the `star_align` rule's inline shell so the single-end /
+paired-end selection is unit-testable (see `test_star_command.py`), mirroring
+`hisat2_command.build_read_args`. The one shape difference from the HISAT2 helper
+is that STAR takes a bare space-separated file list, not `-U` / `-1 / -2` flags.
+Consistency follow-up to Issue #962 (which extracted the HISAT2 side); the STAR
+branch is behavior-correct today, this only removes the HISAT2/STAR asymmetry.
+"""
+
+
+def build_read_files_in(fastq1, fastq2):
+    """Return STAR's --readFilesIn argument for a sample.
+
+    Paired-end (`<r1> <r2>`) when a non-empty `fastq2` is given, else single-end
+    (`<r1>`). `fastq2` may be `None`, an empty/whitespace-only string, or a path;
+    whitespace-only is treated as single-end, matching `build_read_args` and the
+    samples.tsv convention in `strandness.get_strandness_from_row`.
+    """
+    r1 = str(fastq1 or "").strip()
+    r2 = str(fastq2 or "").strip()
+    if not r1:
+        raise ValueError("fastq1 is required for STAR alignment (got empty).")
+    if r2:
+        return f"{r1} {r2}"
+    return r1

--- a/workflow/tests/test_alignment_star_command.py
+++ b/workflow/tests/test_alignment_star_command.py
@@ -13,6 +13,7 @@ This is the first shell-level rule snapshot test in the codebase. Existing
 tests cover pure Python helpers (test_strandness.py, test_bed12_to_junctions.py,
 test_star_sj_to_junctions.py, etc.); this complements them at the rule layer.
 """
+import re
 import shutil
 import subprocess
 import textwrap
@@ -108,3 +109,24 @@ def test_star_align_does_not_throttle_min_unique_count(star_dry_run_output):
 def test_star_align_does_not_throttle_min_total_count(star_dry_run_output):
     """--outSJfilterCountTotalMin throttles output below paper baseline."""
     assert "--outSJfilterCountTotalMin" not in star_dry_run_output
+
+
+def test_star_align_readfilesin_renders_helper_output(star_dry_run_output):
+    """The rule renders `--readFilesIn` from `build_read_files_in` (Issue #1081).
+
+    The stub sample is paired-end, so the helper emits the space-separated
+    `<r1> <r2>` file list - proving the SE/PE construction now flows through the
+    extracted helper rather than the removed inline shell.
+    """
+    assert re.search(
+        r"--readFilesIn \S*test_R1\.fq\.gz \S*test_R2\.fq\.gz", star_dry_run_output
+    ), "expected --readFilesIn to render the paired-end file list from the helper"
+
+
+def test_star_align_inline_fastq_files_block_is_gone(star_dry_run_output):
+    """The old inline `FASTQ_FILES=...` shell assembly is fully replaced.
+
+    Its absence is the behaviour-preserving signature of the extraction: if it
+    reappeared the rule would be building the read list two ways.
+    """
+    assert "FASTQ_FILES=" not in star_dry_run_output

--- a/workflow/tests/test_alignment_star_command.py
+++ b/workflow/tests/test_alignment_star_command.py
@@ -86,6 +86,59 @@ def star_dry_run_output(tmp_path_factory):
     return result.stdout
 
 
+@pytest.fixture(scope="module")
+def star_dry_run_output_single_end(tmp_path_factory):
+    """Render the star_align command for a SINGLE-END sample (empty fastq2).
+
+    The main fixture is paired-end; this one closes the SE gap the #1081 review
+    flagged, so `--readFilesIn` is asserted to render the helper's SE form (r1
+    only) at the rule layer, not just in the pure-helper unit test.
+    """
+    if shutil.which("snakemake") is None:
+        pytest.skip("snakemake not on PATH - activate the snakemake conda env")
+
+    tmp_path = tmp_path_factory.mktemp("star_stub_se")
+    fq1 = tmp_path / "test_R1.fq.gz"
+    fq1.touch()  # no R2: single-end
+
+    star_index_dir = tmp_path / "star_index"
+    star_index_dir.mkdir()
+    (star_index_dir / "index.done").touch()
+
+    samples = tmp_path / "samples.tsv"
+    samples.write_text(
+        "patient_id\tsample_id\tsample_type\tfastq1\tfastq2\n"
+        f"testpatient\ttestsample\tPrimary Tumor\t{fq1}\t\n"  # empty fastq2 = SE
+    )
+
+    override = tmp_path / "override.yaml"
+    override.write_text(textwrap.dedent(f"""\
+        samples_tsv: "{samples}"
+        alignment:
+          aligner: "star"
+          star_index_dir: "{star_index_dir}"
+    """))
+
+    target = "results/testpatient/alignment/testsample/raw_junctions.tsv"
+    result = subprocess.run(
+        [
+            "snakemake", "-n", "--printshellcmds",
+            "--configfile", "config/config.yaml", str(override),
+            "--", target,
+        ],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        pytest.fail(
+            f"snakemake SE dry-run failed (exit {result.returncode}):\n"
+            f"STDOUT:\n{result.stdout}\n\nSTDERR:\n{result.stderr}"
+        )
+    return result.stdout
+
+
 def test_star_align_uses_twopass_mode(star_dry_run_output):
     """2-pass mode is the flag that gives STAR its novel-junction edge over HISAT2."""
     assert "--twopassMode Basic" in star_dry_run_output
@@ -130,3 +183,17 @@ def test_star_align_inline_fastq_files_block_is_gone(star_dry_run_output):
     reappeared the rule would be building the read list two ways.
     """
     assert "FASTQ_FILES=" not in star_dry_run_output
+
+
+def test_star_align_readfilesin_renders_single_end(star_dry_run_output_single_end):
+    """SE render: `--readFilesIn` carries only r1, no second file (Issue #1081 review).
+
+    Complements the paired-end wiring test - together they prove both helper
+    branches flow through the rule end-to-end, not just at the unit layer.
+    """
+    assert re.search(
+        r"--readFilesIn \S*test_R1\.fq\.gz", star_dry_run_output_single_end
+    ), "expected --readFilesIn to render the single-end r1 file from the helper"
+    assert "test_R2" not in star_dry_run_output_single_end, (
+        "single-end render must not include a second read file"
+    )

--- a/workflow/tests/test_star_command.py
+++ b/workflow/tests/test_star_command.py
@@ -1,0 +1,41 @@
+"""Unit tests for the STAR --readFilesIn arg helper used by star_align.
+
+Guards the single-end vs paired-end file-list selection. That branch was
+previously inline shell in `alignment.smk` (unreachable by a test); this is the
+STAR sibling of `test_hisat2_command.py`, extracted as the Issue #1081 symmetry
+follow-up to #962. STAR takes a bare space-separated file list, not `-U`/`-1/-2`.
+"""
+import pytest
+
+from star_command import build_read_files_in
+
+
+class TestBuildReadFilesIn:
+    def test_single_end_is_r1_only(self):
+        assert build_read_files_in("r1.fq.gz", "") == "r1.fq.gz"
+
+    def test_single_end_none_fastq2(self):
+        assert build_read_files_in("r1.fq.gz", None) == "r1.fq.gz"
+
+    def test_whitespace_fastq2_is_single_end(self):
+        # Mirrors build_read_args: whitespace-only fastq2 is single-end.
+        assert build_read_files_in("r1.fq.gz", "   ") == "r1.fq.gz"
+
+    def test_paired_end_is_space_separated(self):
+        assert build_read_files_in("r1.fq.gz", "r2.fq.gz") == "r1.fq.gz r2.fq.gz"
+
+    def test_paired_end_with_directory_paths(self):
+        r1 = "data/patient_002/BG003082_T0_R1.fastq.gz"
+        r2 = "data/patient_002/BG003082_T0_R2.fastq.gz"
+        assert build_read_files_in(r1, r2) == f"{r1} {r2}"
+
+    def test_strips_surrounding_whitespace(self):
+        assert build_read_files_in("  r1.fq.gz  ", "  r2.fq.gz  ") == "r1.fq.gz r2.fq.gz"
+
+    def test_empty_fastq1_raises(self):
+        with pytest.raises(ValueError):
+            build_read_files_in("", "r2.fq.gz")
+
+    def test_none_fastq1_raises(self):
+        with pytest.raises(ValueError):
+            build_read_files_in(None, "")


### PR DESCRIPTION
## What

Closes the HISAT2/STAR asymmetry flagged by the PR #1077 (#962) bot review. That PR extracted HISAT2's SE/PE read-input construction into a pure, unit-tested helper (`hisat2_command.build_read_args`) but left STAR on the old inline `FASTQ_FILES=...` if-block. This is the STAR sibling - a consistency/maintainability refactor, no behavior change (the STAR branch was correct as-is).

## How

- `workflow/scripts/star_command.py::build_read_files_in` mirrors `build_read_args`; the one shape difference is that STAR's `--readFilesIn` takes a bare space-separated file list (`<r1>` SE / `<r1> <r2>` PE), not `-U`/`-1 -2` flags. Same empty-`fastq2` -> SE, whitespace-strip, and empty-`fastq1` fail-fast contract.
- `alignment.smk`'s `star_align` rule now renders `--readFilesIn {params.read_files_in}` via a `_get_star_read_args` delegate (mirroring `_get_hisat2_read_args`); the inline shell block is removed.

## Test plan

- [x] `test_star_command.py` - 8 helper cases mirroring `test_hisat2_command.py` (SE/PE, None/whitespace fastq2, whitespace strip, empty/None-fastq1 raises).
- [x] `test_alignment_star_command.py` - 2 new dry-run wiring snapshots: `--readFilesIn` renders the helper's paired-end file list, and the inline `FASTQ_FILES=` block is gone. All 7 in the file pass.
- [x] **Behavior unchanged:** the dry-run renders `--readFilesIn test_R1.fq.gz test_R2.fq.gz` - identical to the old `$FASTQ_FILES` expansion. DAG topology identical (inputs/outputs/rules unchanged; intra-rule extraction only), so no DAG render needed.
- [x] Default HISAT2 path unaffected: `test_alignment_hisat2_command.py` + `test_hisat2_command.py` green (13), and the default-config dry-run parses (my edit is star-branch-only).

Closes #1081.

**Created by:** Developer
