### PR TITLE
fix(pm): align scan_prose_deps --check exit codes with scan_unblocked

### DIFF
--- a/research/lab_notebook/developer.md
+++ b/research/lab_notebook/developer.md
@@ -8,7 +8,13 @@ Format and rules unchanged from the unified notebook — see `shared/feedback_la
 
 ## 2026-07-16
 
-### 14:35 UTC - Editor: Developer - Recording the mechanism-class ruling: guards are controls, not guarantees ([PR #1213](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/1213) for [Issue #1150](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1150))
+### 15:55 UTC - Editor: Developer - Aligning two PM sweeps' exit codes, and the audit that was the whole job ([PR #1219](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/1219) for [Issue #1179](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1179))
+
+Burn-down item four. `scan_prose_deps --check` used `2=drift/1=error`; its sibling `scan_unblocked` used the inverse (`1=finding, 2=could-not-run`, matching argparse's exit-2-for-usage). A routine shelling both and reading the codes uniformly would misread exactly one, silently. The edit is a two-line swap; the *audit* was the actual work, and the reason this was worth doing carefully rather than fast.
+
+The AC named the audit as the risky part, correctly. I grepped scripts, `.agents/` hooks + memory, `.github/` workflows, docs, and memory files: no programmatic caller branches on either script's exit code. So "any caller relying on the old mapping" reduced to documentation - the now-stale cross-ref comment in `scan_unblocked` (which had explicitly said the two were "inverted... aligning tracked separately"), both docstrings, the `--check` help, and three test assertions - all updated in the same PR so the change isn't half-migrated. I deliberately left the historical plan/spec/lab-notebook prose untouched as point-in-time records, per the historical-doc convention.
+
+The bot review was LGTM and independently re-ran the audit rather than trusting the PR body - reaching the same "no caller depends on the codes" conclusion. Its one worthwhile observation was a within-script bonus I hadn't framed: `scan_prose_deps` has an argparse `parser.error("--only requires --apply")`, and argparse exits 2 on usage errors - so under the *old* `2=drift` mapping a usage error was indistinguishable from "drift found", and the new `2=could-not-run` mapping makes that argparse exit-2 finally consistent. A cross-script alignment that also removes a latent within-script collision. Noted it in the PR body.
 
 Landed the Developer half of the #1150 governance decision (Jin-Ho ratified 2026-07-15): a docs-only change to the AGENTS.md "GitHub Safety Wrappers" section, one edit per ratified question.
 Q1 extended the mechanism-over-memory ladder with a fourth rung above "hook" (entry-point / OS-or-server-enforced), and a paragraph naming rung 4 as the tier you actually rely on.

--- a/scripts/pm/scan_prose_deps.py
+++ b/scripts/pm/scan_prose_deps.py
@@ -7,12 +7,16 @@ the native blockedBy graph, and reports or wires the missing edges.
 Usage:
   scripts/pm/scan_prose_deps.py                 # --report (default): drift table
   scripts/pm/scan_prose_deps.py --issue N       # single-issue scope
-  scripts/pm/scan_prose_deps.py --check         # exit 2 if any drift
+  scripts/pm/scan_prose_deps.py --check         # exit 1 if any drift
   scripts/pm/scan_prose_deps.py --apply         # wire all needs-wiring records
   scripts/pm/scan_prose_deps.py --apply --only 745 594   # wire only these dependents
 
-Exits 0 clean / 2 drift-present (--check) / 1 on error or incomplete scan
-(a transient per-issue lookup failure, which takes precedence over 2).
+Exit-code convention (shared with scan_unblocked.py, aligned in Issue #1179):
+0 = ran fine, nothing to act on; 1 = ran fine, --check gate tripped (drift
+present); 2 = could-not-run (a transient per-issue lookup failure / incomplete
+scan, which takes precedence over 1). 2 == could-not-run matches argparse's own
+exit-2-for-usage-error, so a routine shelling several PM sweeps can treat the
+codes uniformly: 1 = a finding, 2 = did not execute.
 """
 import argparse
 import json
@@ -294,7 +298,7 @@ def main():
     parser.add_argument("--report", action="store_true",
                         help="print the drift table (default action; explicit form)")
     parser.add_argument("--check", action="store_true",
-                        help="exit 2 if any needs-wiring drift, 1 if any lookup failed (incomplete scan)")
+                        help="exit 1 if any needs-wiring drift, 2 if any lookup failed (incomplete scan)")
     parser.add_argument("--apply", action="store_true", help="wire the needs-wiring edges")
     parser.add_argument("--only", type=int, nargs="*", default=None,
                         help="with --apply: wire only these dependent issue numbers")
@@ -316,12 +320,15 @@ def main():
 
     print(render_report(records), end="")
     if args.check:
-        # A partially-failed scan can't be trusted to have found all drift, so an
-        # incomplete lookup signals "error" (1, this script's error code) and
-        # takes precedence over the drift code (2). Re-running clears a transient.
+        # Exit-code convention, shared with scan_unblocked.py (aligned in Issue
+        # #1179): 1 = ran fine, gate tripped (drift found); 2 = could-not-run
+        # (incomplete lookup). 2 takes precedence - a partially-failed scan can't
+        # be trusted to have found all drift - and 2 == could-not-run matches
+        # argparse's own exit-2-for-usage-error, so a routine shelling several PM
+        # sweeps can read a 2 from any of them as "this did not execute".
         if lookup_failed:
-            return 1
-        return 2 if needs else 0
+            return 2
+        return 1 if needs else 0
     return 0
 
 

--- a/scripts/pm/scan_unblocked.py
+++ b/scripts/pm/scan_unblocked.py
@@ -69,11 +69,10 @@ routine uses.
 
 **Exit codes:** `0` = ran fine (advisory, or `--check` with nothing to decide); `1` =
 ran fine, `--check` gate tripped; `2` = **could not run** (GitHub unreachable / ack
-write failed), matching argparse's own exit-2-for-usage-error convention. Note this is
-**inverted relative to `scan_prose_deps.py --check`** (which uses 2=drift, 1=infra
-error). Both are internally consistent; a routine shelling several PM sweeps must not
-assume a uniform mapping. Aligning them is tracked separately rather than silently
-changed here.
+write failed), matching argparse's own exit-2-for-usage-error convention.
+`scan_prose_deps.py --check` shares this **exact** mapping (aligned in Issue #1179,
+which adopted this one as canonical), so a routine shelling several PM `--check`
+sweeps can read the codes uniformly: `1` = a finding, `2` = did not execute.
 
 ## Scope note
 

--- a/workflow/tests/test_scan_prose_deps.py
+++ b/workflow/tests/test_scan_prose_deps.py
@@ -122,9 +122,10 @@ def test_main_report_default_exit_zero(monkeypatch, capsys):
     rc, out = _run_main(monkeypatch, capsys, [], [(745, 722)], _records())
     assert rc == 0 and "needs-wiring" in out
 
-def test_main_check_exits_2_on_drift(monkeypatch, capsys):
+def test_main_check_exits_1_on_drift(monkeypatch, capsys):
+    # Issue #1179: 1 = ran fine, gate tripped (drift), matching scan_unblocked.py.
     rc, _ = _run_main(monkeypatch, capsys, ["--check"], [(745, 722)], _records())
-    assert rc == 2
+    assert rc == 1
 
 def test_main_check_exits_0_when_clean(monkeypatch, capsys):
     clean = [{"dependent": 594, "blocker": 211, "state": "closed", "action": "closed-blocker"}]
@@ -380,23 +381,25 @@ def test_render_report_orders_lookup_failures_above_drift():
     assert order == ["edges-lookup-failed", "meta-lookup-failed", "needs-wiring"]
 
 
-def test_main_check_exits_1_on_lookup_failure(monkeypatch, capsys):
-    # A run whose only anomaly is an incomplete lookup is NOT clean: exit 1
-    # (error / re-run), distinct from 0 (clean) and 2 (real drift).
+def test_main_check_exits_2_on_lookup_failure(monkeypatch, capsys):
+    # Issue #1179: a run whose only anomaly is an incomplete lookup is could-not-run:
+    # exit 2 (matching scan_unblocked.py + argparse), distinct from 0 (clean) and
+    # 1 (real drift).
     failed = [{"dependent": 745, "blocker": 722, "state": "?", "action": "edges-lookup-failed"}]
     rc, _ = _run_main(monkeypatch, capsys, ["--check"], [(745, 722)], failed)
-    assert rc == 1
+    assert rc == 2
 
 
 def test_main_check_lookup_failure_precedes_drift(monkeypatch, capsys):
-    # Both real drift and an incomplete lookup -> exit 1 (the drift picture can't
-    # be trusted mid-failure; re-run clears the transient), not 2.
+    # Both real drift and an incomplete lookup -> exit 2 (could-not-run takes
+    # precedence: the drift picture can't be trusted mid-failure; re-run clears the
+    # transient), not 1. Issue #1179.
     mixed = [
         {"dependent": 745, "blocker": 722, "state": "open", "action": "needs-wiring"},
         {"dependent": 594, "blocker": 211, "state": "?", "action": "meta-lookup-failed"},
     ]
     rc, _ = _run_main(monkeypatch, capsys, ["--check"], [(745, 722), (594, 211)], mixed)
-    assert rc == 1
+    assert rc == 2
 
 
 def test_main_apply_only_subsets_by_dependent(monkeypatch, capsys):


### PR DESCRIPTION
## What

Aligns `scan_prose_deps.py --check` exit codes with `scan_unblocked.py` (#1179). The two PM sweeps used opposite conventions - `scan_prose_deps` was `2=drift / 1=error`, `scan_unblocked` was `1=gate-tripped / 2=could-not-run` - so any routine shelling several PM `--check` sweeps and treating the code uniformly ("2 means look at this") would misread exactly one, silently. Surfaced by the bot review on PR #1174, filed as a conscious tracked change rather than smuggled into an unrelated PR.

## How

Adopt `scan_unblocked`'s mapping as canonical (it's the cleaner one: `2 = could-not-run` matches argparse's own exit-2-for-usage, so a `2` from any tool means "did not execute"):

- **`1`** = ran fine, `--check` gate tripped (drift found)
- **`2`** = could-not-run (incomplete lookup; takes precedence on a mixed drift+failure run)
- **`0`** = ran fine, nothing to act on

The audit (the risky part) found **no programmatic caller** branches on the old codes - no CI, no hooks, no scripts. Updated in the same PR: `scan_unblocked.py`'s now-stale cross-ref comment (it said the two were "inverted... tracked separately"), both scripts' Exit-code docstrings, the `--check` help text, and the 3 test assertions. Historical plan/spec/lab-notebook prose is left as point-in-time records, not retroactively rewritten.

## Test plan

- [x] `test_scan_prose_deps.py` - 62 passed; the 3 exit-code tests flipped and renamed (`test_main_check_exits_1_on_drift`, `test_main_check_exits_2_on_lookup_failure`, `test_main_check_lookup_failure_precedes_drift`).
- [x] `test_scan_unblocked.py` - 40 passed (docstring-only change there, no behavior touched).
- [x] Grep confirms no lingering assertion of the old `2=drift` mapping anywhere in `scripts/`/`workflow/tests/`.

## Bonus: also removes a latent within-script collision

`scan_prose_deps` has an argparse `parser.error("--only requires --apply")`, and argparse exits **2** on any usage error. Under the old `2=drift` mapping that argparse exit-2 was ambiguous - a usage error read identically to "drift found". Under the new `2=could-not-run` mapping, an argparse usage error *is* a "did not execute" case, so the collision is gone. (Surfaced by the PR #1219 bot review.)

Closes #1179.

**Created by:** Developer
