### PR TITLE
fix(pm): scope the milestone-report seed to the milestone's own issues + lead role

### DIFF
--- a/research/lab_notebook/pm.md
+++ b/research/lab_notebook/pm.md
@@ -8,6 +8,18 @@ Format and rules unchanged from the unified notebook — see `shared/feedback_la
 
 ## 2026-07-16
 
+### 16:07 UTC - Editor: PM
+
+**The seed-scoping fix passed every unit test and was still wrong, and only the real data said so.** [Issue #1005](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1005) -> [PR #1220](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/1220). The milestone-report seed dumped every lab-notebook entry in the milestone's date *window* across every role, flooding a 5-issue Modeling report with ~68 lines of unrelated Dev/STAR/GCS work. The obvious fix: scope entries to the milestone's own delivered issues by matching `#N` refs. I wrote it, wrote the matched-pair tests, went green, and then - because [Issue #1005](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1005)'s establishing case was a *real* milestone - regenerated the i5-S5 seed to look. It pulled **9 entries for 5 issues, 7 of them primarily about non-milestone work.**
+
+**The unit tests could not have caught it, because the thing that was wrong lived in data my fixtures did not model.** My fixtures were short, single-issue entries. Real scientist entries are long and cross-reference a dozen issues in passing, so a whole-body `#N` match hit a milestone issue mentioned three paragraphs down in an entry that was *about* something else. The fix was to anchor on the entry's **headline** (the line that names what it is about, by convention) instead of the whole body - and to add the control the fixtures had been missing: an entry whose headline names a non-milestone issue but whose body cross-references a milestone one, asserted **out**. After that, i5-S5 dropped to 2 on-milestone bullets.
+
+**This is the live-integration-smoke shape again, one layer in: unit tests validate my MODEL of the input, not the input.** The fixtures encoded my belief about what a lab-notebook entry looks like; the belief was too tidy, and green tests certified the tidy version. The only check that could fail was running against the real establishing case - which the Issue handed me for exactly this reason, and which I nearly skipped because the tests were already green. The falsifier was the messy real data, not another fixture.
+
+**The bot review was LGTM with only cosmetics** (a stale "in the milestone window" placeholder that no longer described the behavior, and a doubled `delivered_issues` call) - both applied. The interesting note it raised and I agree with: dropping the date window entirely is a genuine *semantics* change, not a refactor (an out-of-window "revisited #566" retrospective would now seed) - and it is more correct, because an issue number is a precise anchor and a date is a proxy for one.
+
+**At the merge gate now - Jin-Ho's call.**
+
 ### 14:16 UTC - Editor: PM
 
 **The `unplanned` label got its cross-check, and the number confirmed the alarm exactly.** [Issue #1188](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1188) -> [PR #1212](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/1212), third and final child of [#1144](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1144) (after [#1180](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1180)'s unclassifiable fix and [#1138](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1138)'s commitment-act read). The new `marker_slip()` reports the observed unplanned share (never crossed `Backlog -> Ready`) beside the label-derived share and surfaces their per-item disagreement. Live: **13 of 26 delivered (50%) observably slipped, while the label reports 0** - it has never been applied to anything repo-wide.

--- a/scripts/pm/milestone_report.py
+++ b/scripts/pm/milestone_report.py
@@ -883,17 +883,30 @@ def fetch_window_issues(since: str, until: str) -> list[dict]:
 # --- aggregation layer (narrative auto-seed) --------------------------------
 
 _SEED_HEADLINE_MAX = 180
-# Byline/timestamp sub-headers to skip when digesting an entry — e.g. the PM
-# notebook's "### HH:MM UTC — Editor: PM" line, which is metadata, not content.
+# Byline/timestamp sub-headers to skip when digesting an entry - e.g. the PM
+# notebook's "### HH:MM UTC - Editor: PM" line, which is metadata, not content.
 _BYLINE_RE = re.compile(r"^\d{1,2}:\d{2}\b|\b(editor|author|role)\s*:", re.IGNORECASE)
+# A leading bold label like "**Headline:**" / "**Result:**" - dropped so the entry's
+# actual content seeds, not the mangled "Headline:** ..." the char-lstrip below used to
+# strand (Issue #1005). Requires the ``:`` immediately before the closing ``**``, so a
+# bold *sentence* ("**We shipped it.**", no colon there) is left untouched.
+_BOLD_LABEL_RE = re.compile(r"^\*\*[^*\n]{1,40}:\*\*\s*")
+# Issue/PR cross-references inside a lab-notebook entry ("#500", "[Issue #500](...)").
+_ISSUE_REF_RE = re.compile(r"#(\d+)\b")
+# One "## <YYYY-MM-DD> ...entry body..." block, up to the next date header.
+_ENTRY_RE = re.compile(r"^## (\d{4}-\d{2}-\d{2})\b(.*?)(?=^## \d{4}-\d{2}-\d{2}\b|\Z)",
+                       flags=re.DOTALL | re.MULTILINE)
 
 
 def _first_prose_line(body: str) -> str:
-    """The first human-prose line of an entry body — skips blank lines, markdown
-    bullet/heading markers, HTML comments, and byline/timestamp sub-headers
-    (so the digest picks the descriptive title, not "Editor: PM"). One line."""
+    """The first human-prose line of an entry body - skips blank lines, markdown
+    bullet/heading markers, HTML comments, byline/timestamp sub-headers (so the digest
+    picks the descriptive title, not "Editor: PM"), and a leading ``**Label:**`` bold
+    prefix (so a ``**Headline:**`` entry seeds its content, not "Headline:**"). One line."""
     for line in body.strip().splitlines():
-        stripped = line.strip().lstrip("#*->–— ").strip()
+        # Drop a leading **Label:** BEFORE the char-lstrip: the lstrip eats the leading
+        # ``*`` but would strand ``Headline:**`` otherwise (the Issue #1005 defect).
+        stripped = _BOLD_LABEL_RE.sub("", line.strip()).lstrip("#*->–— ").strip()
         if not stripped or stripped.startswith("<!--"):
             continue
         if _BYLINE_RE.search(stripped):
@@ -902,36 +915,80 @@ def _first_prose_line(body: str) -> str:
     return ""
 
 
-def _lab_notebook_seed(roles: set[str], window: tuple[Optional[datetime], Optional[datetime]]) -> str:
-    """Best-effort: digest lab-notebook entries dated within the milestone window
-    for the involved roles into one pointer bullet each (date + headline), NOT
-    verbatim bodies — the sidecar is meant for a human to expand. '' if none."""
-    start, end = window
+def _lead_roles(per_role_counts: dict[str, int]) -> set[str]:
+    """The milestone's lead role(s): the role(s) with the most *delivered* issues.
+
+    Scopes the seed to who actually led the milestone (Issue #1005 defect 2), rather than
+    every role that touched any issue (open/descoped included). Ties keep all co-leads.
+    Empty ``per_role_counts`` -> empty set, so the caller can fall back."""
+    if not per_role_counts:
+        return set()
+    top = max(per_role_counts.values())
+    return {role for role, count in per_role_counts.items() if count == top}
+
+
+def _entry_refs_milestone(text: str, issue_numbers: set[int]) -> bool:
+    """True if ``text`` cites at least one of the milestone's delivered issue numbers.
+
+    Applied to an entry's *headline* (see ``_digest_notebook_text``) to scope the seed to
+    the milestone's own work (Issue #1005 defect 1). A `#N` ref catches the Issue or its
+    PR text; we intersect against delivered *issue* numbers (the data the report has). An
+    entry whose headline names only a PR and never its Issue would be missed - acceptable,
+    because this repo's notebook convention names the Issue in the entry headline."""
+    if not issue_numbers:
+        return False
+    cited = {int(n) for n in _ISSUE_REF_RE.findall(text)}
+    return bool(cited & issue_numbers)
+
+
+def _digest_notebook_text(text: str, short: str, issue_numbers: set[int]) -> list[str]:
+    """One pointer bullet (date + headline) per entry in ``text`` that references the
+    milestone's issues. Pure over the raw notebook text so it is unit-testable without
+    the filesystem (Issue #1005)."""
     bullets: list[str] = []
-    for role in sorted(roles):
+    for m in _ENTRY_RE.finditer(text):
+        headline = _first_prose_line(m.group(2))
+        # Belongs to the milestone if its HEADLINE names one of the milestone's issues -
+        # NOT merely a passing body cross-reference. A lab-notebook entry's first prose
+        # line names the issue it is *about* (convention); its body cross-references many
+        # others. Matching the whole body over-collects badly: on i5-S5 it pulled 9 entries
+        # for a 5-issue milestone, 7 of them primarily about non-milestone work (Issue #1005).
+        if not _entry_refs_milestone(headline, issue_numbers):
+            continue
+        if len(headline) > _SEED_HEADLINE_MAX:
+            headline = headline[: _SEED_HEADLINE_MAX - 1].rstrip() + "…"
+        bullets.append(f"- **{m.group(1)}** ({short}): {headline}")
+    return bullets
+
+
+def _lab_notebook_seed(lead_roles: set[str], issue_numbers: set[int]) -> str:
+    """Best-effort: digest the lead role(s)' lab-notebook entries that reference the
+    milestone's issues into one pointer bullet each (date + headline), NOT verbatim
+    bodies - the sidecar is meant for a human to expand. '' if none.
+
+    Scopes to the milestone's *own* issues (not a raw date window) and to its *lead*
+    role(s) (not every involved role), the two over-collection defects of Issue #1005."""
+    bullets: list[str] = []
+    for role in sorted(lead_roles):
         short = role.split(":", 1)[-1]
         nb = REPO_ROOT / "research" / "lab_notebook" / f"{short}.md"
         if not nb.exists():
             continue
         text = nb.read_text(encoding="utf-8", errors="replace")
-        # Entries are "## <YYYY-MM-DD>" headed; digest those inside the window.
-        for m in re.finditer(r"^## (\d{4}-\d{2}-\d{2})\b(.*?)(?=^## \d{4}-\d{2}-\d{2}\b|\Z)",
-                             text, flags=re.DOTALL | re.MULTILINE):
-            day = parse_iso(m.group(1) + "T00:00:00Z")
-            if (start and day and day < start) or (end and day and day > end):
-                continue
-            headline = _first_prose_line(m.group(2))
-            if len(headline) > _SEED_HEADLINE_MAX:
-                headline = headline[: _SEED_HEADLINE_MAX - 1].rstrip() + "…"
-            bullets.append(f"- **{m.group(1)}** ({short}): {headline}")
+        bullets.extend(_digest_notebook_text(text, short, issue_numbers))
     return "\n".join(bullets)
 
 
 def seed_narrative(milestone: dict, issues: list[dict], metrics: dict) -> str:
     """First-draft narrative markdown for the author-owned sidecar."""
-    roles = {r for i in issues for r in i.get("roles", [])}
-    window = (parse_iso(milestone.get("created_at")), parse_iso(milestone.get("closed_at")))
-    seed = _lab_notebook_seed(roles, window)
+    # Scope the seed to the milestone's lead role(s) and its own delivered issues, not
+    # every role over a raw date window (Issue #1005). Fall back to all involved roles
+    # only when no delivered issue carries a role label (nothing for per_role_counts to
+    # identify a lead from).
+    lead_roles = _lead_roles(metrics.get("per_role_counts") or {}) \
+        or {r for i in issues for r in i.get("roles", [])}
+    delivered_numbers = {i["number"] for i in delivered_issues(issues)}
+    seed = _lab_notebook_seed(lead_roles, delivered_numbers)
     delivered = delivered_issues(issues)
     descoped = descoped_issues(issues)
     carried = [i for i in issues if i.get("state") != "CLOSED"]

--- a/scripts/pm/milestone_report.py
+++ b/scripts/pm/milestone_report.py
@@ -987,9 +987,9 @@ def seed_narrative(milestone: dict, issues: list[dict], metrics: dict) -> str:
     # identify a lead from).
     lead_roles = _lead_roles(metrics.get("per_role_counts") or {}) \
         or {r for i in issues for r in i.get("roles", [])}
-    delivered_numbers = {i["number"] for i in delivered_issues(issues)}
-    seed = _lab_notebook_seed(lead_roles, delivered_numbers)
     delivered = delivered_issues(issues)
+    delivered_numbers = {i["number"] for i in delivered}
+    seed = _lab_notebook_seed(lead_roles, delivered_numbers)
     descoped = descoped_issues(issues)
     carried = [i for i in issues if i.get("state") != "CLOSED"]
 
@@ -1004,7 +1004,7 @@ def seed_narrative(milestone: dict, issues: list[dict], metrics: dict) -> str:
         f"     The {len(delivered)} delivered issues are listed in the Inventory appendix",
         "     below - narrate the highlights here, don't re-list them. -->",
         "",
-        "_Seeded from the lead role's lab-notebook entries in the milestone window - "
+        "_Seeded from the lead role's lab-notebook entries naming the milestone's issues - "
         "replace with the deliverables narrative._",
         "",
     ]

--- a/tools/ci/test_milestone_report.py
+++ b/tools/ci/test_milestone_report.py
@@ -377,6 +377,90 @@ class TestSeedNarrative:
         assert "Inventory appendix" in deliverables  # points there instead
 
 
+class TestSeedScoping:
+    """The seed is scoped to the milestone's own issues + lead role, and parses a
+    ``**Headline:**`` entry cleanly (Issue #1005).
+
+    Before this, the seed dumped every lab-notebook entry in the milestone's date
+    *window* across *all* roles, so a 5-issue Modeling milestone was flooded with
+    unrelated Dev board-governance / STAR / GCS entries, and ``**Headline:**``-prefixed
+    entries rendered as the mangled ``Headline:** ...`` fragment.
+    """
+
+    # --- defect 3: the **Headline:** parse -----------------------------------
+
+    def test_first_prose_line_strips_headline_label(self):
+        # THE establishing case: `**Headline:** [PR #564] ...` used to seed as the
+        # mangled `Headline:** [PR #564] ...` (the char-lstrip ate the `**` but left
+        # `Headline:**`). The content after the label is what we want.
+        body = "\n**Headline:** [PR #564](x) vehicle-only baseline shipped\n\nmore"
+        assert mr._first_prose_line(body) == "[PR #564](x) vehicle-only baseline shipped"
+
+    def test_first_prose_line_strips_any_bold_label(self):
+        assert mr._first_prose_line("**Result:** it worked") == "it worked"
+
+    def test_first_prose_line_keeps_plain_bold_sentence(self):
+        # Matched control: a bold LEAD *sentence* (no `:` before the closing `**`) is
+        # NOT a label - its content must survive, unchanged from prior behavior.
+        out = mr._first_prose_line("**Half our work never crossed the point.** rest")
+        assert "Half our work never crossed the point." in out
+
+    def test_first_prose_line_headline_after_byline(self):
+        # The byline is still skipped, and the Headline label below it is stripped.
+        body = "### 15:39 UTC - Editor: PM\n\n**Headline:** the real title"
+        assert mr._first_prose_line(body) == "the real title"
+
+    # --- defect 2: scope to the lead role(s) ---------------------------------
+
+    def test_lead_roles_picks_the_max_count(self):
+        assert mr._lead_roles(
+            {"role:developer": 5, "role:scientist": 2, "role:pm": 1}) == {"role:developer"}
+
+    def test_lead_roles_keeps_ties(self):
+        assert mr._lead_roles(
+            {"role:scientist": 3, "role:developer": 3}) == {"role:scientist", "role:developer"}
+
+    def test_lead_roles_empty_dict_is_empty(self):
+        assert mr._lead_roles({}) == set()
+
+    # --- defect 1: scope entries to the milestone's issues -------------------
+
+    def test_entry_refs_milestone_true_when_a_milestone_issue_is_cited(self):
+        entry = "Shipped it. [Issue #500](x) -> [PR #501](y)."
+        assert mr._entry_refs_milestone(entry, {500, 999}) is True
+
+    def test_entry_refs_milestone_false_when_unrelated(self):
+        # References #123, which is not one of the milestone's issues -> excluded.
+        assert mr._entry_refs_milestone("Board work on [Issue #123](x).", {500, 999}) is False
+
+    def test_entry_refs_milestone_false_when_no_milestone_issues(self):
+        assert mr._entry_refs_milestone("mentions #500", set()) is False
+
+    def test_digest_scopes_to_milestone_issues(self):
+        # THE control for defect 1: two entries, one about a milestone issue (#500),
+        # one about unrelated #123. Only the linked one is seeded, regardless of date.
+        text = (
+            "## 2026-07-01\n\n**Headline:** delivered [Issue #500](x)\n\n"
+            "## 2026-06-01\n\nUnrelated board work, see [Issue #123](y)\n"
+        )
+        bullets = mr._digest_notebook_text(text, "developer", {500})
+        assert len(bullets) == 1
+        assert "2026-07-01" in bullets[0]
+        assert "delivered [Issue #500](x)" in bullets[0]   # Headline label stripped too
+        assert "#123" not in "\n".join(bullets)
+
+    def test_digest_excludes_body_only_cross_reference(self):
+        # The over-collection the establishing case exposed: an entry primarily about a
+        # NON-milestone issue (#999 in its headline) that merely cross-references a
+        # milestone issue (#500) deep in its body must NOT be seeded. Matching the whole
+        # body pulled 7 such noise entries into the i5-S5 seed; the headline decides.
+        text = (
+            "## 2026-07-01\n\n**Headline:** shipped [Issue #999](x)\n\n"
+            "Along the way we also touched [Issue #500](y) in passing.\n"
+        )
+        assert mr._digest_notebook_text(text, "scientist", {500}) == []
+
+
 # --- arrival axis: committed vs unplanned (Issue #811) -----------------------
 
 # The matched pair the AC asks for: same window, same delivered status, one


### PR DESCRIPTION
Closes #1005.

## What

`seed_narrative` (the author-owned Deliverables sidecar seed) over-collected: it dumped every lab-notebook entry in the milestone's date *window* across *every* involved role, so the i5-S5 Modeling report (5 issues) was flooded with ~68 lines of unrelated Dev board-governance / STAR / GCS entries, and `**Headline:**`-prefixed entries rendered as the mangled `Headline:** ...` fragment.

Three fixes (the Issue's three defects):

1. **Scope to the milestone's own issues** - an entry is seeded only when its **headline** names one of the milestone's delivered issues. A whole-body `#N` match over-collects: scientist entries cross-reference many issues in passing, so it pulled **9** entries (7 primarily about non-milestone work) for i5-S5's 5 issues. The headline names the issue the entry is *about*, so it's the right anchor.
2. **Scope to the lead role(s)** - `_lead_roles` picks the role(s) with the most delivered issues (`per_role_counts`), not every role that touched any issue.
3. **Fix the `**Headline:**` parse** - `_first_prose_line` strips a leading `**Label:**` bold prefix so the entry's content seeds, not `Headline:**`.

New pure helpers (`_lead_roles` / `_entry_refs_milestone` / `_digest_notebook_text`) keep the scoping unit-testable without the filesystem.

## Test plan

- [x] 12 new unit tests (`TestSeedScoping`): the `**Headline:**` / `**Label:**` strip + the plain-bold-sentence control; `_lead_roles` max-count + ties + empty; `_entry_refs_milestone`; and the two digest controls - a linked entry is seeded, a body-only cross-reference is **not**.
- [x] Full `test_milestone_report.py` suite green (94 passed), incl. the no-em/en-dash guard on emitted strings.
- [x] Live verification on the establishing case (`i5 - S5 - Modeling`, regenerated into a scratch dir): the Deliverables seed drops from ~68 flooded lines to **2 on-milestone bullets** (#566, #708 - both genuine delivered issues, scientist-only). The committed sidecar is untouched (the script never overwrites an existing one).

## Out of scope

The 2026-07-05 comment's two extra cosmetic ideas (footer "as of" stamp, pre-close "state open") are explicitly distinct from these seed-scoping ACs and are not addressed here.

**Created by:** PM