### PR TITLE
fix(registry): enforce the tier-not-label firewall on the positive set (#1178)

### DIFF
--- a/research/experiments/issue_680_splice_immunogenicity_registry/figures/_regenerate_figures.py
+++ b/research/experiments/issue_680_splice_immunogenicity_registry/figures/_regenerate_figures.py
@@ -20,6 +20,12 @@ import pandas as pd
 HERE = Path(__file__).resolve().parent
 REGISTRY = HERE.parent / "registry.tsv"
 
+# Single-source the scorable-positive filter from the registry's labeling module
+# (#1178) rather than re-spelling the two-column rule here, so this deck figure and
+# the validator can never disagree on what "scorable positive" means.
+sys.path.insert(0, str(HERE.parent))
+from labeling_constants import scorable_positive_mask  # noqa: E402  (path-dependent)
+
 INK = "#1b1b1b"
 MUTED = "#9aa0a6"
 ACCENT = "#c1443b"
@@ -100,7 +106,7 @@ def fig_allele_skew(df: pd.DataFrame) -> None:
 
 def fig_evidence_balance(df: pd.DataFrame) -> None:
     """Positives are abundant; experimental negatives are the binding constraint."""
-    scorable_pos = int(((df.label == "positive") & (df.tier == "functional-scorable")).sum())
+    scorable_pos = int(scorable_positive_mask(df).sum())
     hard_neg = int((df.tier == "hard-negative-true-splice").sum())
     soft_neg = int((df.tier == "candidate-negative").sum())
 

--- a/research/experiments/issue_680_splice_immunogenicity_registry/labeling_constants.py
+++ b/research/experiments/issue_680_splice_immunogenicity_registry/labeling_constants.py
@@ -34,6 +34,34 @@ PEPTIDE_NULL_STATUSES = PEPTIDE_STATUSES - {PEPTIDE_STATUS_PRESENT}
 # set (LABELING_SCHEME.md section 4's consumer note).
 SCORABLE_TIER = "functional-scorable"
 
+# The tiers a `label == "positive"` row may occupy (#1178). Positivity means a
+# *measured* functional T-cell response, so it lives only on the two functional tiers:
+# `functional-scorable` (a scorable sequence in hand) and `functional-nonscorable`
+# (measured positive, but no published sequence to key on). A `presentation-prevalence`
+# row is presented-but-never-assayed and is `label == "untested"`, never `positive` - so
+# a consumer that filters on `label` alone can never pull a presentation row into the
+# positive set. validate_registry.py enforces this; see LABELING_SCHEME.md section 4.
+#
+# NB this is deliberately *not* `{SCORABLE_TIER}` alone: the 4 functional-nonscorable
+# rows are genuinely positive (a real assay), they simply lack a sequence to score, so
+# a "reject any positive that is not functional-scorable" rule would wrongly reject them.
+# The invariant guards the dangerous case (an *unassayed* presentation row wearing a
+# positive label), not the harmless one (a positive with no scorable sequence).
+POSITIVE_LABEL = "positive"
+FUNCTIONAL_POSITIVE_TIERS = {"functional-scorable", "functional-nonscorable"}
+
+
+def scorable_positive_mask(df):
+    """Canonical boolean mask for the scorable positive set (#1178).
+
+    The single source of truth for the LABELING_SCHEME.md section-4 rule: a scorable
+    positive is `label == "positive" AND tier == "functional-scorable"`, never `label`
+    alone (which also admits the functional-nonscorable positives, which have no
+    sequence to score). Every consumer that needs the scored positive set should call
+    this rather than re-spelling the two-column filter, so the discipline cannot drift.
+    """
+    return (df["label"] == POSITIVE_LABEL) & (df["tier"] == SCORABLE_TIER)
+
 # Controlled vocabulary for the #823 assay_context column. Captures *which
 # immunological system* produced the functional readout, so a scoring run can
 # weight rows by assay realism (patient ex-vivo detection > healthy-donor IVS

--- a/research/experiments/issue_680_splice_immunogenicity_registry/tests/test_schema_invariants.py
+++ b/research/experiments/issue_680_splice_immunogenicity_registry/tests/test_schema_invariants.py
@@ -317,3 +317,71 @@ def test_live_registry_has_one_source_string_per_study():
         "distinct `source` strings != 12 studies; a fold either added a study "
         "(update this number deliberately) or re-split an existing one (fix the spelling)"
     )
+
+
+# --- #1178: the tier<->label firewall (a presentation row can never be positive) ---
+#
+# Best-bet 3 now produces `tier=presentation-prevalence` / `label=untested` rows, so the
+# LABELING_SCHEME.md section-4 rule (scorable = label==positive AND tier==functional-
+# scorable) stops being documentation and becomes load-bearing: a presentation row that
+# wore a positive label would enter the functional positive set through any label-only
+# filter, silently corrupting the registry's whole product. The guard enforces it.
+#
+# Matched pair on the actual risk (same presentation row, one field flipped, opposite
+# outcomes), plus an over-reach control proving the guard does NOT reject the 4 real
+# functional-nonscorable positives (measured positive, just no scorable sequence).
+
+
+def _presentation_row(row):
+    """A valid presentation-prevalence row: MS-presented, never functionally assayed."""
+    return dict(row, tier="presentation-prevalence", label="untested",
+                assay_context="prevalence_only", evidence_strength="na", readout="MS")
+
+
+def test_presentation_row_untested_is_green(row, frame):
+    """The control: `untested` is a presentation row's only legal label; it must validate."""
+    assert violations(frame(_presentation_row(row))) == []
+
+
+def test_presentation_row_labeled_positive_is_rejected(row, frame):
+    """The defect the guard exists for: a presentation row wearing a positive label."""
+    bad = dict(_presentation_row(row), label="positive")
+    _fails_with(frame(bad), "label 'positive' on tier 'presentation-prevalence'")
+
+
+def test_functional_nonscorable_positive_is_not_over_rejected(row, frame):
+    """The over-reach control. The 4 real functional-nonscorable positives are a measured
+    response with no scorable sequence - legitimately `label=positive`. A narrower
+    "positive must be functional-scorable" rule would wrongly reject them, so pin that
+    this row stays green and the firewall never fires on it."""
+    r = dict(row, tier="functional-nonscorable", peptide="", length="",
+             peptide_status="published-pending")
+    assert violations(frame(r)) == []
+
+
+def test_scorable_positive_mask_excludes_functional_nonscorable():
+    """The canonical filter is stricter than the firewall: the *scored* set is
+    functional-scorable positives only. A functional-nonscorable positive is a legal
+    row but not scorable (no sequence), so the mask must exclude it - the exact
+    label-vs-tier conflation the single-source helper exists to prevent."""
+    from labeling_constants import scorable_positive_mask
+
+    df = pd.DataFrame([
+        {"label": "positive", "tier": "functional-scorable"},
+        {"label": "positive", "tier": "functional-nonscorable"},
+        {"label": "untested", "tier": "presentation-prevalence"},
+    ], dtype=str)
+    assert scorable_positive_mask(df).tolist() == [True, False, False]
+
+
+def test_live_registry_positives_are_all_on_functional_tiers():
+    """On the real artifact: every positive row sits on a functional tier, so the
+    firewall is green in production and a future presentation-row-as-positive fold
+    fails here rather than silently entering the scored set."""
+    from labeling_constants import FUNCTIONAL_POSITIVE_TIERS
+    from validate_registry import REGISTRY
+
+    df = pd.read_csv(REGISTRY, sep="\t", dtype=str).fillna("")
+    pos = df[df["label"] == "positive"]
+    bad = pos[~pos["tier"].isin(FUNCTIONAL_POSITIVE_TIERS)]
+    assert bad.empty, f"positive rows on non-functional tiers: {sorted(bad['tier'].unique())}"

--- a/research/experiments/issue_680_splice_immunogenicity_registry/validate_registry.py
+++ b/research/experiments/issue_680_splice_immunogenicity_registry/validate_registry.py
@@ -16,7 +16,7 @@ from labeling_constants import (GRADES, STRENGTHS, ASSAY_CONTEXTS, VENUE_TYPES, 
                                 DETECTION, IVS_MARKER, VENUE_BY_SOURCE_SUBSTR,
                                 ZOTERO_COLLECTION, ZOTERO_ITEMTYPE_TO_VENUE, PREPRINT_MARKERS,
                                 PEPTIDE_STATUSES, PEPTIDE_STATUS_PRESENT, PEPTIDE_NULL_STATUSES,
-                                JUNCTION_EVIDENCE_GRADES, SCORABLE_TIER,
+                                JUNCTION_EVIDENCE_GRADES, SCORABLE_TIER, FUNCTIONAL_POSITIVE_TIERS,
                                 IN_VIVO_MODELS, IN_VIVO_NONE, IN_VIVO_MARKERS)
 from registry_dedup import duplicate_keys, row_identity
 
@@ -78,6 +78,17 @@ def violations(df: pd.DataFrame) -> list[str]:
         # positive rows must not resolve to na evidence_strength
         if r["label"] == "positive" and r["evidence_strength"] == "na":
             out.append(f"{rid}: positive row resolved to na evidence_strength (needs manual review)")
+        # tier<->label firewall (#1178): a positive label may sit ONLY on a functional
+        # tier. A `presentation-prevalence` row is presented-but-unassayed and must be
+        # `untested`; letting it wear a positive label would let a label-only consumer
+        # pull an untested peptide into the functional positive set - silent corruption
+        # of the registry's whole product. This turns the LABELING_SCHEME.md section-4
+        # rule from documented into enforced. (Not `!= SCORABLE_TIER`: the 4
+        # functional-nonscorable positives are legitimately positive without a sequence.)
+        if r["label"] == "positive" and r["tier"] not in FUNCTIONAL_POSITIVE_TIERS:
+            out.append(f"{rid}: label 'positive' on tier {r['tier']!r} - a positive label "
+                       f"may sit only on {sorted(FUNCTIONAL_POSITIVE_TIERS)}; a presentation "
+                       f"row is presented-but-unassayed and must be 'untested'")
         # grade -> junction_id consistency (#1086). A `coords`/`event-id` grade asserts
         # the source published a junction identifier, so the column must carry it. The
         # converse block is deliberately gone: it used to forbid a `gene-mechanism`/

--- a/research/lab_notebook/scientist.md
+++ b/research/lab_notebook/scientist.md
@@ -8,6 +8,20 @@ Format and rules unchanged from the unified notebook — see `shared/feedback_la
 
 ## 2026-07-17
 
+### 19:24 UTC - Editor: Scientist - tier-not-label firewall review disposition; candidate-tier reconciliation deferred
+
+**The firewall PR was sound; the review found a *latent* contradiction in the tier the firewall didn't cover** ([Issue #1178](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1178), [PR #1232](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/1232), follow-up [Issue #1233](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1233))
+
+#1178 enforces the tier-not-label firewall on the scorable positive set: `label=="positive"` may sit only on a functional tier (`functional-scorable` / `functional-nonscorable`), so a `presentation-prevalence` row can never wear a positive label. CI green (6/6), tests rigorous (matched pair + over-reach control). The bot review approved overall and raised one substantive finding.
+
+**Note 1 (the real one): the firewall's allowed set omits a third positive-labelled tier the doc documents.** `FUNCTIONAL_POSITIVE_TIERS` admits two tiers, but `LABELING_SCHEME.md` §4 names a `candidate` tier (a disputed positive that failed a second verify pass) that per the doc *keeps* `label=positive`, held out of the scored set by tier not label. The firewall would falsely reject exactly that row. Latent, not live: **0** `candidate`-tier rows in the registry today, so nothing fails now.
+
+**Decision (direction A, deferred).** Resolve by demoting a `candidate` row to `label=untested` rather than admitting it to the positive set - aligns with the firewall's own thesis that a positive label means a *confirmed, measured* functional response, and matches the reviewer's implied lean (so this resolves *with* the review, not against it). Rejected the alternative (add `candidate` to the allowed set) - it keeps the doc but weakens the firewall and mis-names the constant. Because it is a labeling-scheme change with zero live pressure, carved to [#1233](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1233) rather than widening #1232's scope. Notes 2 (one-directional invariant; an `na`-labelled presentation row mislabeled `negative` slips both the firewall and the negative-subtype checks) and 3 (docstring omits `candidate`) folded into #1233; Note 4 (no controlled-vocab check on `tier`) acknowledged as fail-safe + pre-existing, no action.
+
+Posted the full per-finding disposition on the PR ([comment](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/1232#issuecomment-5006749778)). #1232 left mergeable at the gate for a human merge; nothing here blocks it.
+
+Process note: opened the session believing #1178 had already merged (its fix commit was the tip of the checked-out branch, not on `main`) - verified state before touching the board and caught it. The "ahead of origin looks merged" trap, exactly as the memory rule warns.
+
 ### 13:06 UTC - Editor: Scientist
 
 **The #737 sparsity recompute landed exactly as predicted - but the note about *why* was half-wrong, and my sweep had a blind spot** ([Issue #1069](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1069), [PR #1226](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/1226))


### PR DESCRIPTION
**Created by:** Scientist

Closes #1178.

## What

Enforces the **tier-not-label firewall** on the registry's scorable positive set. The `LABELING_SCHEME.md` section-4 rule - a scorable positive is `label=="positive" AND tier=="functional-scorable"`, never `label` alone - was documented but not enforced. As best-bet 3 begins producing `tier=presentation-prevalence` rows ([#1175](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1175): 29 landed, more from [#1176](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1176)), that gap became a live silent-corruption risk: a presentation row wearing a positive label would flow into the functional positive set through any label-only filter.

## The invariant (and an AC-wording correction)

The guard: **`label=="positive"` may sit only on a functional tier** (`functional-scorable` or `functional-nonscorable`); a `presentation-prevalence` row can never be positive - it must be `untested`.

This is *narrower* than AC2's literal wording ("reject any positive with a non-functional tier"), and deliberately so: the live registry has `label=="positive"` legitimately in **two** tiers - `functional-scorable` (82) and `functional-nonscorable` (4 real functional positives that simply lack a scorable sequence). A check written to AC2's letter would reject those 4 valid rows. The invariant here enforces AC2's *intent* (keep an unassayed presentation row out of the positive set) while admitting the legitimate functional-nonscorable positives. Flagged and reasoned on the issue ([comment](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1178#issuecomment-5004200205)); web-checked as the right call (enforce intent, not letter; narrow core invariants over broad ones).

## Changes

- `labeling_constants.py`: `FUNCTIONAL_POSITIVE_TIERS` + a canonical `scorable_positive_mask()` helper - the single source for the scored-set filter, so consumers stop re-spelling the two-column rule.
- `validate_registry.py`: the firewall check, failing loudly.
- `figures/_regenerate_figures.py`: routed the one inline duplicate of the filter through the helper.
- `tests/test_schema_invariants.py`: matched-pair + controls (below).

## Scope split (per PR best practice)

- **AC1 + AC2** ship here (behavior change + tests).
- **AC4 + AC5** (relocate the decoy seed - a pure move, no behavior change) carved to [#1231](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1231), split so the firewall's review isn't muddied by a file move.
- **AC3** (score presentation separately) carried to [#736](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/736) - nothing to enforce until the scoring harness exists.

## Test plan

- [x] `research/.venv/bin/python -m pytest research/experiments/issue_680_splice_immunogenicity_registry/tests/` - **62/62 pass**.
- [x] Matched pair: a `presentation-prevalence` row is green when `untested`, rejected when `positive` (the exact corruption). Falsifier-checked: the reject message is emitted only by the new guard.
- [x] Over-reach control: a `functional-nonscorable` positive (the 4 real rows) stays green - the narrow invariant does not reject it.
- [x] Helper semantics pinned: `scorable_positive_mask` excludes functional-nonscorable positives (scored set = functional-scorable only).
- [x] Live-registry pin + no regression: `validate_registry.py` green (97 rows), and the refactored figure regenerator runs clean (exit 0, figure content unchanged - PNGs not re-committed).
