### PR TITLE
fix(registry): admit the candidate tier to the label=positive firewall (#1233)

### DIFF
--- a/research/experiments/issue_680_splice_immunogenicity_registry/labeling_constants.py
+++ b/research/experiments/issue_680_splice_immunogenicity_registry/labeling_constants.py
@@ -34,21 +34,34 @@ PEPTIDE_NULL_STATUSES = PEPTIDE_STATUSES - {PEPTIDE_STATUS_PRESENT}
 # set (LABELING_SCHEME.md section 4's consumer note).
 SCORABLE_TIER = "functional-scorable"
 
-# The tiers a `label == "positive"` row may occupy (#1178). Positivity means a
-# *measured* functional T-cell response, so it lives only on the two functional tiers:
-# `functional-scorable` (a scorable sequence in hand) and `functional-nonscorable`
-# (measured positive, but no published sequence to key on). A `presentation-prevalence`
-# row is presented-but-never-assayed and is `label == "untested"`, never `positive` - so
-# a consumer that filters on `label` alone can never pull a presentation row into the
-# positive set. validate_registry.py enforces this; see LABELING_SCHEME.md section 4.
+# The tiers a `label == "positive"` row may legally occupy (#1178, #1233). Per
+# LABELING_SCHEME.md section 4 this is THREE tiers, not two:
+#   - `functional-scorable`    - measured positive, scorable sequence in hand
+#   - `functional-nonscorable` - measured positive, but no published sequence to key on
+#   - `candidate`              - a proposed positive whose second adversarial-verify pass
+#                                did not confirm the label; it KEEPS `label=positive` and
+#                                is held out of the *scored* set by its tier, not by
+#                                overwriting its label (section 4.3).
+# The firewall's job is to catch a positive label on a tier where it is NEVER legal - a
+# `presentation-prevalence` row (presented-but-never-assayed, must be `untested`), a
+# negative tier, or a non-splice control - so a consumer that filters on `label` alone
+# can never pull one of those into the positive set. validate_registry.py enforces it.
 #
-# NB this is deliberately *not* `{SCORABLE_TIER}` alone: the 4 functional-nonscorable
-# rows are genuinely positive (a real assay), they simply lack a sequence to score, so
+# The name is `POSITIVE_LABEL_TIERS`, not `FUNCTIONAL_POSITIVE_TIERS` (#1233): `candidate`
+# is a *disputed* positive, not a functional-confirmed one, so "functional" mis-described
+# the set. Direction chosen (#1233) over demoting `candidate` to `untested`: a candidate
+# WAS assayed, so `untested` (= no functional assay performed) would assert a falsehood
+# and conflate disputed-after-assay with never-assayed. Keeping the label and the
+# dispute-status on separate axes (`label=positive` + `tier=candidate`) is the standard
+# data-curation practice and matches #1178's own thesis that the tier, not the label,
+# carries the exclusion.
+#
+# NB this is deliberately *not* `{SCORABLE_TIER}` alone: the functional-nonscorable and
+# candidate positives are genuine `label=positive` rows that simply are not *scorable*, so
 # a "reject any positive that is not functional-scorable" rule would wrongly reject them.
-# The invariant guards the dangerous case (an *unassayed* presentation row wearing a
-# positive label), not the harmless one (a positive with no scorable sequence).
+# The scored-set filter is `scorable_positive_mask` below, a strictly narrower thing.
 POSITIVE_LABEL = "positive"
-FUNCTIONAL_POSITIVE_TIERS = {"functional-scorable", "functional-nonscorable"}
+POSITIVE_LABEL_TIERS = {"functional-scorable", "functional-nonscorable", "candidate"}
 
 
 def scorable_positive_mask(df):
@@ -56,8 +69,8 @@ def scorable_positive_mask(df):
 
     The single source of truth for the LABELING_SCHEME.md section-4 rule: a scorable
     positive is `label == "positive" AND tier == "functional-scorable"`, never `label`
-    alone (which also admits the functional-nonscorable positives, which have no
-    sequence to score). Every consumer that needs the scored positive set should call
+    alone (which also admits the functional-nonscorable and candidate positives, neither
+    of which is scorable). Every consumer that needs the scored positive set should call
     this rather than re-spelling the two-column filter, so the discipline cannot drift.
     """
     return (df["label"] == POSITIVE_LABEL) & (df["tier"] == SCORABLE_TIER)

--- a/research/experiments/issue_680_splice_immunogenicity_registry/tests/test_schema_invariants.py
+++ b/research/experiments/issue_680_splice_immunogenicity_registry/tests/test_schema_invariants.py
@@ -359,6 +359,18 @@ def test_functional_nonscorable_positive_is_not_over_rejected(row, frame):
     assert violations(frame(r)) == []
 
 
+def test_candidate_positive_is_not_over_rejected(row, frame):
+    """The #1233 over-reach control, and the matched partner of
+    `test_presentation_row_labeled_positive_is_rejected`. A `candidate` is a proposed
+    positive whose second adversarial-verify pass did not confirm the label
+    (LABELING_SCHEME.md section 4.3); per the doc it KEEPS `label=positive` and is held
+    below scorable by its *tier*, not by demoting its label. So the firewall must permit
+    it - only a tier that can NEVER carry a positive (presentation / negative / control)
+    is rejected. Same `label=positive`, different tier, opposite outcome from the
+    presentation row: that pair is the falsifier for the 3-tier allowed set."""
+    assert violations(frame(dict(row, tier="candidate"))) == []
+
+
 def test_scorable_positive_mask_excludes_functional_nonscorable():
     """The canonical filter is stricter than the firewall: the *scored* set is
     functional-scorable positives only. A functional-nonscorable positive is a legal
@@ -374,14 +386,16 @@ def test_scorable_positive_mask_excludes_functional_nonscorable():
     assert scorable_positive_mask(df).tolist() == [True, False, False]
 
 
-def test_live_registry_positives_are_all_on_functional_tiers():
-    """On the real artifact: every positive row sits on a functional tier, so the
-    firewall is green in production and a future presentation-row-as-positive fold
-    fails here rather than silently entering the scored set."""
-    from labeling_constants import FUNCTIONAL_POSITIVE_TIERS
+def test_live_registry_positives_are_all_on_positive_label_tiers():
+    """On the real artifact: every positive row sits on a tier that legally carries a
+    positive label, so the firewall is green in production and a future
+    presentation-row-as-positive fold fails here rather than silently entering the scored
+    set. (0 candidate rows today, so in practice every positive is on one of the two
+    functional tiers - but the enforced invariant is the 3-tier allowed set, #1233.)"""
+    from labeling_constants import POSITIVE_LABEL_TIERS
     from validate_registry import REGISTRY
 
     df = pd.read_csv(REGISTRY, sep="\t", dtype=str).fillna("")
     pos = df[df["label"] == "positive"]
-    bad = pos[~pos["tier"].isin(FUNCTIONAL_POSITIVE_TIERS)]
-    assert bad.empty, f"positive rows on non-functional tiers: {sorted(bad['tier'].unique())}"
+    bad = pos[~pos["tier"].isin(POSITIVE_LABEL_TIERS)]
+    assert bad.empty, f"positive rows on non-positive-label tiers: {sorted(bad['tier'].unique())}"

--- a/research/experiments/issue_680_splice_immunogenicity_registry/tests/test_schema_invariants.py
+++ b/research/experiments/issue_680_splice_immunogenicity_registry/tests/test_schema_invariants.py
@@ -371,6 +371,17 @@ def test_candidate_positive_is_not_over_rejected(row, frame):
     assert violations(frame(dict(row, tier="candidate"))) == []
 
 
+def test_candidate_negative_labeled_positive_is_rejected(row, frame):
+    """Prefix-confusion guard (#1236 review). `candidate` (disputed POSITIVE, now
+    admitted) and `candidate-negative` (a soft NEGATIVE tier) share a prefix and have 0
+    rows each, so a future `.str.startswith("candidate")` refactor or a typo folding
+    `candidate-negative` into the allowed set would pass unnoticed at runtime. The
+    firewall uses exact set membership, so a positive label on `candidate-negative` must
+    still trip it - pin that here so the two tiers can never be conflated."""
+    _fails_with(frame(dict(row, tier="candidate-negative")),
+                "label 'positive' on tier 'candidate-negative'")
+
+
 def test_scorable_positive_mask_excludes_functional_nonscorable():
     """The canonical filter is stricter than the firewall: the *scored* set is
     functional-scorable positives only. A functional-nonscorable positive is a legal

--- a/research/experiments/issue_680_splice_immunogenicity_registry/validate_registry.py
+++ b/research/experiments/issue_680_splice_immunogenicity_registry/validate_registry.py
@@ -89,8 +89,8 @@ def violations(df: pd.DataFrame) -> list[str]:
         # without a scorable sequence; the *scored* set is scorable_positive_mask.)
         if r["label"] == "positive" and r["tier"] not in POSITIVE_LABEL_TIERS:
             out.append(f"{rid}: label 'positive' on tier {r['tier']!r} - a positive label "
-                       f"may sit only on {sorted(POSITIVE_LABEL_TIERS)}; a presentation "
-                       f"row is presented-but-unassayed and must be 'untested'")
+                       f"may sit only on {sorted(POSITIVE_LABEL_TIERS)}; a presentation, "
+                       f"negative, or non-splice-control tier can never carry a positive label")
         # grade -> junction_id consistency (#1086). A `coords`/`event-id` grade asserts
         # the source published a junction identifier, so the column must carry it. The
         # converse block is deliberately gone: it used to forbid a `gene-mechanism`/

--- a/research/experiments/issue_680_splice_immunogenicity_registry/validate_registry.py
+++ b/research/experiments/issue_680_splice_immunogenicity_registry/validate_registry.py
@@ -16,7 +16,7 @@ from labeling_constants import (GRADES, STRENGTHS, ASSAY_CONTEXTS, VENUE_TYPES, 
                                 DETECTION, IVS_MARKER, VENUE_BY_SOURCE_SUBSTR,
                                 ZOTERO_COLLECTION, ZOTERO_ITEMTYPE_TO_VENUE, PREPRINT_MARKERS,
                                 PEPTIDE_STATUSES, PEPTIDE_STATUS_PRESENT, PEPTIDE_NULL_STATUSES,
-                                JUNCTION_EVIDENCE_GRADES, SCORABLE_TIER, FUNCTIONAL_POSITIVE_TIERS,
+                                JUNCTION_EVIDENCE_GRADES, SCORABLE_TIER, POSITIVE_LABEL_TIERS,
                                 IN_VIVO_MODELS, IN_VIVO_NONE, IN_VIVO_MARKERS)
 from registry_dedup import duplicate_keys, row_identity
 
@@ -78,16 +78,18 @@ def violations(df: pd.DataFrame) -> list[str]:
         # positive rows must not resolve to na evidence_strength
         if r["label"] == "positive" and r["evidence_strength"] == "na":
             out.append(f"{rid}: positive row resolved to na evidence_strength (needs manual review)")
-        # tier<->label firewall (#1178): a positive label may sit ONLY on a functional
-        # tier. A `presentation-prevalence` row is presented-but-unassayed and must be
-        # `untested`; letting it wear a positive label would let a label-only consumer
-        # pull an untested peptide into the functional positive set - silent corruption
-        # of the registry's whole product. This turns the LABELING_SCHEME.md section-4
-        # rule from documented into enforced. (Not `!= SCORABLE_TIER`: the 4
-        # functional-nonscorable positives are legitimately positive without a sequence.)
-        if r["label"] == "positive" and r["tier"] not in FUNCTIONAL_POSITIVE_TIERS:
+        # tier<->label firewall (#1178, #1233): a positive label may sit ONLY on a tier
+        # that legally carries one - the two functional tiers or `candidate` (a disputed
+        # positive that keeps label=positive per LABELING_SCHEME.md section 4). A
+        # `presentation-prevalence` row is presented-but-unassayed and must be `untested`;
+        # letting it wear a positive label would let a label-only consumer pull an untested
+        # peptide into the functional positive set - silent corruption of the registry's
+        # whole product. This turns the section-4 rule from documented into enforced. (Not
+        # `!= SCORABLE_TIER`: functional-nonscorable and candidate positives are legitimate
+        # without a scorable sequence; the *scored* set is scorable_positive_mask.)
+        if r["label"] == "positive" and r["tier"] not in POSITIVE_LABEL_TIERS:
             out.append(f"{rid}: label 'positive' on tier {r['tier']!r} - a positive label "
-                       f"may sit only on {sorted(FUNCTIONAL_POSITIVE_TIERS)}; a presentation "
+                       f"may sit only on {sorted(POSITIVE_LABEL_TIERS)}; a presentation "
                        f"row is presented-but-unassayed and must be 'untested'")
         # grade -> junction_id consistency (#1086). A `coords`/`event-id` grade asserts
         # the source published a junction identifier, so the column must carry it. The

--- a/research/lab_notebook/scientist.md
+++ b/research/lab_notebook/scientist.md
@@ -8,6 +8,22 @@ Format and rules unchanged from the unified notebook — see `shared/feedback_la
 
 ## 2026-07-17
 
+### 20:13 UTC - Editor: Scientist - candidate-tier firewall reconciliation: conceded to the bot, then un-conceded against the source
+
+**Reading the actual doc reversed the fix direction, and best practice confirmed it** ([Issue #1233](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1233), [PR #1236](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/1236), follow-up [Issue #1237](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1237))
+
+Picking up the #1233 follow-up I filed an hour earlier (deferred from the #1178 review), I had recorded direction **A** - demote a \`candidate\` row to \`label=untested\` - because that was the reviewer's implied lean and I agreed with it in the moment.
+
+**The concession did not survive reading \`LABELING_SCHEME.md\` §4.** \`untested\` is defined there as \`tier=presentation-prevalence\`: *no functional assay performed*. But a \`candidate\` **was** assayed - it is a *proposed positive whose second adversarial-verify pass did not confirm the label* (§4.3). Demoting it to \`untested\` would assert a falsehood and conflate *disputed-after-assay* with *never-assayed*. So A is wrong on the merits, and the reviewer's rationale ("positivity means a measured response") is itself shaky - a candidate *has* a measured response.
+
+**Direction B is the fix: widen the firewall's allowed set to the three tiers that legally carry \`label=positive\` (\`FUNCTIONAL_POSITIVE_TIERS\` -> \`POSITIVE_LABEL_TIERS\`, adding \`candidate\`), doc unchanged.** Best-practice cross-check (data-curation / benchmark-labeling literature) was unambiguous: keep the label separate from its confidence/dispute status; represent disagreement on its own axis, don't fold it into the label. B *is* that pattern - \`label=positive\` (the proposal) + \`tier=candidate\` (the dispute) - and it matches #1178's own thesis that the tier, not the label, carries the exclusion. Rejected a dedicated \`label=disputed\` value as redundant given \`tier=candidate\` already carries the signal (one column, one fact).
+
+**Two lessons, both already in my memory, both re-earned here.**
+1. *A concession is a claim.* I yielded to the reviewer before checking the artifact; the artifact said the opposite. The rule says verify before you yield - this is the case that proves why.
+2. The matched-pair falsifier is the unit of a real firewall test: a \`candidate\` positive validates, a \`presentation\` positive is still rejected - same \`label=positive\`, different tier, opposite outcomes. The new candidate control flips only \`tier\` on the template, so it is red-before/green-after on its own.
+
+**Bot review (PR #1236): correct, well-scoped, no blocking issues.** Traced \`violations()\` fully and confirmed the test is not vacuous. Two findings taken in \`f8db0ad\`: a \`candidate\`-vs-\`candidate-negative\` prefix-confusion pin (two tiers one edit apart, 0 rows each), and broadening the firewall error string (it still named only the presentation case). Note 2 - the firewall is positive-side-only, so a \`presentation-prevalence\` row mislabeled \`negative\`/\`na\` slips both it and the \`na\`-blind subtype checks - deferred to [#1237](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1237) as a \`tier -> allowed-labels\` table (a design pass, not a narrow fix). 64/64 tests pass; live registry green (97 rows). Left at the merge gate for a human call.
+
 ### 19:24 UTC - Editor: Scientist - tier-not-label firewall review disposition; candidate-tier reconciliation deferred
 
 **The firewall PR was sound; the review found a *latent* contradiction in the tier the firewall didn't cover** ([Issue #1178](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1178), [PR #1232](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/1232), follow-up [Issue #1233](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1233))


### PR DESCRIPTION
**Created by:** Scientist

Closes #1233. Follow-up to the [#1178](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1178) firewall, from that PR's bot review (Note 1).

## The defect

The [#1178](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1178) firewall (`validate_registry.py:88`) admitted only the two functional tiers as legal carriers of `label=positive`. But `LABELING_SCHEME.md` §4 (lines 60, 63, 80) documents a **third** positive-labelled tier - `candidate`, a proposed positive whose second adversarial-verify pass did not confirm the label. Per the doc a candidate **keeps** `label=positive` and is held out of the *scored* set by its tier, not by demoting its label. So the firewall would falsely reject a candidate row. **Latent, not live:** 0 candidate rows in the registry today.

## The fix (direction B)

Widen the allowed set to the three tiers that legally carry a positive label, and rename `FUNCTIONAL_POSITIVE_TIERS` -> `POSITIVE_LABEL_TIERS` (candidate is a *disputed* positive, not functional-confirmed, so the old name mis-described the set). The doc is already correct and is unchanged.

**Why B over demoting candidate -> `untested` (the alternative):** `untested` is defined as `tier=presentation-prevalence` - *no functional assay performed* - but a candidate **was** assayed (that is why it was proposed positive). Demoting it would assert a falsehood and conflate *disputed-after-assay* with *never-assayed*. Keeping the label and the dispute-status on separate axes (`label=positive` + `tier=candidate`) is the standard data-curation practice (label separate from confidence/dispute status; represent disagreement on its own axis) and matches #1178's own thesis that the tier, not the label, carries the exclusion. A dedicated `label=disputed` value was rejected as redundant given `tier=candidate` already carries that signal.

The **scored** set is unaffected: `scorable_positive_mask` stays `tier==functional-scorable` and never admits a candidate.

## Deferred (bot Note 2)

The firewall is positive-side only: a `presentation-prevalence` row mislabeled `label=negative` / `na` is caught by neither the firewall nor the `na`-blind negative-subtype checks. The clean fix is a full `tier -> allowed-labels` table (settles the negative side too), but it needs every tier's legal label set enumerated + verified against the registry - carved to its own follow-up to keep this PR narrow.

## Test plan

- [x] `research/.venv/bin/python -m pytest research/experiments/issue_680_splice_immunogenicity_registry/tests/` - **63/63 pass** (was 62; +1 candidate test).
- [x] Matched pair (the falsifier): a `candidate`-tier positive validates (`test_candidate_positive_is_not_over_rejected`), a `presentation-prevalence` positive is still rejected (`test_presentation_row_labeled_positive_is_rejected`) - same `label=positive`, different tier, opposite outcomes.
- [x] Live registry green under the rename: `validate_registry.py` PASS (97 rows), Zotero venue cross-check ran + passed.
- [x] Rename complete: no `FUNCTIONAL_POSITIVE_TIERS` references remain in code (only the immutable lab-notebook entry + the rename-explaining comment).