### PR TITLE
fix(registry): make the tier-label firewall two-directional via TIER_ALLOWED_LABELS (#1237)

### DIFF
--- a/research/experiments/issue_680_splice_immunogenicity_registry/LABELING_SCHEME.md
+++ b/research/experiments/issue_680_splice_immunogenicity_registry/LABELING_SCHEME.md
@@ -87,6 +87,12 @@ The peptide **fails the splice gate** (gate 1) - it is a constitutive / canonica
 It belongs to no benchmark score; it is retained for methodological transparency.
 `evidence_strength=na` for this tier.
 
+### Adding a tier (#1237)
+
+Which `label` each tier may legally carry is enforced by `TIER_ALLOWED_LABELS` in `labeling_constants.py`, checked two-directionally by `validate_registry.py`.
+A new tier therefore needs an explicit `TIER_ALLOWED_LABELS` entry, or **every row on it is rejected as an unknown tier**.
+This is deliberate (fail-closed): a new tier is a schema change that must be declared, never silently inferred from the data.
+
 ---
 
 ## 5. Confidence de-conflation

--- a/research/experiments/issue_680_splice_immunogenicity_registry/labeling_constants.py
+++ b/research/experiments/issue_680_splice_immunogenicity_registry/labeling_constants.py
@@ -34,34 +34,41 @@ PEPTIDE_NULL_STATUSES = PEPTIDE_STATUSES - {PEPTIDE_STATUS_PRESENT}
 # set (LABELING_SCHEME.md section 4's consumer note).
 SCORABLE_TIER = "functional-scorable"
 
-# The tiers a `label == "positive"` row may legally occupy (#1178, #1233). Per
-# LABELING_SCHEME.md section 4 this is THREE tiers, not two:
-#   - `functional-scorable`    - measured positive, scorable sequence in hand
-#   - `functional-nonscorable` - measured positive, but no published sequence to key on
-#   - `candidate`              - a proposed positive whose second adversarial-verify pass
-#                                did not confirm the label; it KEEPS `label=positive` and
-#                                is held out of the *scored* set by its tier, not by
-#                                overwriting its label (section 4.3).
-# The firewall's job is to catch a positive label on a tier where it is NEVER legal - a
-# `presentation-prevalence` row (presented-but-never-assayed, must be `untested`), a
-# negative tier, or a non-splice control - so a consumer that filters on `label` alone
-# can never pull one of those into the positive set. validate_registry.py enforces it.
+# The full `tier -> legal-label(s)` table (#1237): the single authoritative source for which
+# `label` each `tier` may carry, enforced TWO-directionally by validate_registry.py. It
+# supersedes the hand-maintained positive-only firewall (#1178, #1233) and closes that guard's
+# mirror gap - an `untested`-only or control tier wearing `label=negative` was previously caught
+# by neither the firewall (fires on positive) nor the negative-subtype checks (which fire on
+# soft/hard/strong/weak and are blind to the `na` strength those tiers carry). Verified against
+# the live registry (no row violates it) and LABELING_SCHEME.md sections 2-4.
 #
-# The name is `POSITIVE_LABEL_TIERS`, not `FUNCTIONAL_POSITIVE_TIERS` (#1233): `candidate`
-# is a *disputed* positive, not a functional-confirmed one, so "functional" mis-described
-# the set. Direction chosen (#1233) over demoting `candidate` to `untested`: a candidate
-# WAS assayed, so `untested` (= no functional assay performed) would assert a falsehood
-# and conflate disputed-after-assay with never-assayed. Keeping the label and the
-# dispute-status on separate axes (`label=positive` + `tier=candidate`) is the standard
-# data-curation practice and matches #1178's own thesis that the tier, not the label,
-# carries the exclusion.
-#
-# NB this is deliberately *not* `{SCORABLE_TIER}` alone: the functional-nonscorable and
-# candidate positives are genuine `label=positive` rows that simply are not *scorable*, so
-# a "reject any positive that is not functional-scorable" rule would wrongly reject them.
-# The scored-set filter is `scorable_positive_mask` below, a strictly narrower thing.
+# Per LABELING_SCHEME.md section 4, each tier carries exactly one label class:
+#   - the three POSITIVE tiers keep `label=positive`. `candidate` is a *disputed* positive whose
+#     second adversarial-verify pass did not confirm the label; it KEEPS `label=positive` and is
+#     held out of the *scored* set by its tier, not by demoting its label (section 4.3). Demoting
+#     it to `untested` would assert a falsehood - a candidate WAS assayed - so the dispute lives
+#     on the tier axis, matching #1178's thesis that the tier, not the label, carries exclusion.
+#   - the two experimental NEGATIVE tiers and the non-splice control carry `label=negative`.
+#   - `presentation-prevalence` is presented-but-never-assayed, so `untested`-only. This is the
+#     row class the #1237 negative-side guard protects: it may never be `positive` OR `negative`.
 POSITIVE_LABEL = "positive"
-POSITIVE_LABEL_TIERS = {"functional-scorable", "functional-nonscorable", "candidate"}
+TIER_ALLOWED_LABELS = {
+    "functional-scorable":         {"positive"},
+    "functional-nonscorable":      {"positive"},
+    "candidate":                   {"positive"},
+    "candidate-negative":          {"negative"},
+    "hard-negative-true-splice":   {"negative"},
+    "negative-control-not-splice": {"negative"},
+    "presentation-prevalence":     {"untested"},
+}
+
+# The tiers a `label == "positive"` row may legally occupy, DERIVED from the table above so the
+# two can never drift (#1237 AC3; a hand-maintained literal through #1178/#1233). It is
+# deliberately NOT `{SCORABLE_TIER}` alone: the functional-nonscorable and candidate positives
+# are genuine `label=positive` rows that simply are not *scorable*, so a "positive must be
+# functional-scorable" rule would wrongly reject them. The scored-set filter is
+# `scorable_positive_mask` below, a strictly narrower thing.
+POSITIVE_LABEL_TIERS = {t for t, labels in TIER_ALLOWED_LABELS.items() if POSITIVE_LABEL in labels}
 
 
 def scorable_positive_mask(df):

--- a/research/experiments/issue_680_splice_immunogenicity_registry/tests/test_schema_invariants.py
+++ b/research/experiments/issue_680_splice_immunogenicity_registry/tests/test_schema_invariants.py
@@ -382,6 +382,23 @@ def test_candidate_negative_labeled_positive_is_rejected(row, frame):
                 "label 'positive' on tier 'candidate-negative'")
 
 
+# --- #1237: the firewall is TWO-directional - a control tier can never be `negative` -----
+#
+# The #1178/#1233 firewall guarded the POSITIVE side only. Its mirror gap: an `untested`-only
+# tier (presentation-prevalence) wearing `label=negative` was caught by neither the firewall
+# (fires on positive) nor the negative-subtype checks (fire on soft/hard/strong/weak, blind to
+# the `na` strength these control tiers carry). TIER_ALLOWED_LABELS enforces every tier's legal
+# label set in BOTH directions, closing it. Matched pair with test_presentation_row_untested_is_
+# green: same presentation row, label flipped untested->negative, opposite outcome.
+
+
+def test_presentation_row_labeled_negative_is_rejected(row, frame):
+    """The #1237 negative-side gap: presentation-prevalence is `untested`-only, so a
+    `label=negative` on it must trip the firewall - the mirror of the positive-side case."""
+    bad = dict(_presentation_row(row), label="negative")
+    _fails_with(frame(bad), "label 'negative' on tier 'presentation-prevalence'")
+
+
 def test_scorable_positive_mask_excludes_functional_nonscorable():
     """The canonical filter is stricter than the firewall: the *scored* set is
     functional-scorable positives only. A functional-nonscorable positive is a legal

--- a/research/experiments/issue_680_splice_immunogenicity_registry/tests/test_schema_invariants.py
+++ b/research/experiments/issue_680_splice_immunogenicity_registry/tests/test_schema_invariants.py
@@ -399,6 +399,28 @@ def test_presentation_row_labeled_negative_is_rejected(row, frame):
     _fails_with(frame(bad), "label 'negative' on tier 'presentation-prevalence'")
 
 
+@pytest.mark.parametrize("tier,label", [
+    ("functional-scorable", "negative"),         # a positive tier can never be negative
+    ("functional-scorable", "untested"),         # ... nor untested (old positive-only guard missed this)
+    ("hard-negative-true-splice", "positive"),   # a negative tier can never be positive
+])
+def test_illegal_label_on_known_tier_is_rejected(row, frame, tier, label):
+    """#1237 review note 2: the firewall now rejects ANY out-of-set label on a known tier, in
+    both directions - not only the presentation-prevalence pair. Pin a few so the added
+    strictness cannot silently regress to a positive-only short-circuit."""
+    _fails_with(frame(dict(row, tier=tier, label=label)),
+                f"label {label!r} on tier {tier!r}")
+
+
+def test_unknown_tier_is_rejected(row, frame):
+    """#1237 review note 1: a tier absent from TIER_ALLOWED_LABELS has an empty allowed set, and
+    is rejected with a distinct 'unknown tier' message (not 'may carry only []'), so a typo'd
+    tier on a non-positive row - previously unguarded by any tier controlled-vocab check - fails
+    loudly and legibly."""
+    _fails_with(frame(dict(row, tier="functional-scoreable")),
+                "unknown tier 'functional-scoreable'")
+
+
 def test_scorable_positive_mask_excludes_functional_nonscorable():
     """The canonical filter is stricter than the firewall: the *scored* set is
     functional-scorable positives only. A functional-nonscorable positive is a legal

--- a/research/experiments/issue_680_splice_immunogenicity_registry/validate_registry.py
+++ b/research/experiments/issue_680_splice_immunogenicity_registry/validate_registry.py
@@ -86,15 +86,19 @@ def violations(df: pd.DataFrame) -> list[str]:
         # (which fire on soft/hard/strong/weak and are blind to the `na` strength those tiers
         # carry). A label-only consumer could then pull an untested peptide into a scored set, or
         # a never-tested row into the negative set - silent corruption of the registry's whole
-        # product, in either direction. A tier absent from the table has an empty allowed set, so
-        # an unknown tier is rejected here too. Turns the section-4 rule from documented into
-        # enforced, both directions. (Not `!= SCORABLE_TIER`: functional-nonscorable and candidate
-        # positives are legitimate without a scorable sequence; the *scored* set is
-        # scorable_positive_mask.)
-        allowed = TIER_ALLOWED_LABELS.get(r["tier"], set())
-        if r["label"] not in allowed:
+        # product, in either direction. Turns the section-4 rule from documented into enforced,
+        # both directions. (Not `!= SCORABLE_TIER`: functional-nonscorable and candidate positives
+        # are legitimate without a scorable sequence; the *scored* set is scorable_positive_mask.)
+        # An unknown tier is reported distinctly from an illegal label on a known tier, so a typo'd
+        # tier - which used to pass silently, there being no standalone tier controlled-vocab check
+        # - fails legibly rather than as an opaque "may carry only []".
+        if r["tier"] not in TIER_ALLOWED_LABELS:
+            out.append(f"{rid}: unknown tier {r['tier']!r} - not in TIER_ALLOWED_LABELS "
+                       f"(add it there if legitimate; LABELING_SCHEME.md section 4)")
+        elif r["label"] not in TIER_ALLOWED_LABELS[r["tier"]]:
             out.append(f"{rid}: label {r['label']!r} on tier {r['tier']!r} - tier {r['tier']!r} "
-                       f"may carry only {sorted(allowed)} (LABELING_SCHEME.md section 4)")
+                       f"may carry only {sorted(TIER_ALLOWED_LABELS[r['tier']])} "
+                       f"(LABELING_SCHEME.md section 4)")
         # grade -> junction_id consistency (#1086). A `coords`/`event-id` grade asserts
         # the source published a junction identifier, so the column must carry it. The
         # converse block is deliberately gone: it used to forbid a `gene-mechanism`/

--- a/research/experiments/issue_680_splice_immunogenicity_registry/validate_registry.py
+++ b/research/experiments/issue_680_splice_immunogenicity_registry/validate_registry.py
@@ -16,7 +16,7 @@ from labeling_constants import (GRADES, STRENGTHS, ASSAY_CONTEXTS, VENUE_TYPES, 
                                 DETECTION, IVS_MARKER, VENUE_BY_SOURCE_SUBSTR,
                                 ZOTERO_COLLECTION, ZOTERO_ITEMTYPE_TO_VENUE, PREPRINT_MARKERS,
                                 PEPTIDE_STATUSES, PEPTIDE_STATUS_PRESENT, PEPTIDE_NULL_STATUSES,
-                                JUNCTION_EVIDENCE_GRADES, SCORABLE_TIER, POSITIVE_LABEL_TIERS,
+                                JUNCTION_EVIDENCE_GRADES, SCORABLE_TIER, TIER_ALLOWED_LABELS,
                                 IN_VIVO_MODELS, IN_VIVO_NONE, IN_VIVO_MARKERS)
 from registry_dedup import duplicate_keys, row_identity
 
@@ -78,19 +78,23 @@ def violations(df: pd.DataFrame) -> list[str]:
         # positive rows must not resolve to na evidence_strength
         if r["label"] == "positive" and r["evidence_strength"] == "na":
             out.append(f"{rid}: positive row resolved to na evidence_strength (needs manual review)")
-        # tier<->label firewall (#1178, #1233): a positive label may sit ONLY on a tier
-        # that legally carries one - the two functional tiers or `candidate` (a disputed
-        # positive that keeps label=positive per LABELING_SCHEME.md section 4). A
-        # `presentation-prevalence` row is presented-but-unassayed and must be `untested`;
-        # letting it wear a positive label would let a label-only consumer pull an untested
-        # peptide into the functional positive set - silent corruption of the registry's
-        # whole product. This turns the section-4 rule from documented into enforced. (Not
-        # `!= SCORABLE_TIER`: functional-nonscorable and candidate positives are legitimate
-        # without a scorable sequence; the *scored* set is scorable_positive_mask.)
-        if r["label"] == "positive" and r["tier"] not in POSITIVE_LABEL_TIERS:
-            out.append(f"{rid}: label 'positive' on tier {r['tier']!r} - a positive label "
-                       f"may sit only on {sorted(POSITIVE_LABEL_TIERS)}; a presentation, "
-                       f"negative, or non-splice-control tier can never carry a positive label")
+        # tier<->label firewall (#1178, #1233; made TWO-directional in #1237): every row's
+        # `label` must be in TIER_ALLOWED_LABELS for its `tier`. This subsumes the old
+        # positive-only guard AND closes its mirror gap - an `untested`-only tier
+        # (presentation-prevalence) or a control tier wearing `label=negative` was caught by
+        # neither the positive firewall (fired on positive) nor the negative-subtype checks
+        # (which fire on soft/hard/strong/weak and are blind to the `na` strength those tiers
+        # carry). A label-only consumer could then pull an untested peptide into a scored set, or
+        # a never-tested row into the negative set - silent corruption of the registry's whole
+        # product, in either direction. A tier absent from the table has an empty allowed set, so
+        # an unknown tier is rejected here too. Turns the section-4 rule from documented into
+        # enforced, both directions. (Not `!= SCORABLE_TIER`: functional-nonscorable and candidate
+        # positives are legitimate without a scorable sequence; the *scored* set is
+        # scorable_positive_mask.)
+        allowed = TIER_ALLOWED_LABELS.get(r["tier"], set())
+        if r["label"] not in allowed:
+            out.append(f"{rid}: label {r['label']!r} on tier {r['tier']!r} - tier {r['tier']!r} "
+                       f"may carry only {sorted(allowed)} (LABELING_SCHEME.md section 4)")
         # grade -> junction_id consistency (#1086). A `coords`/`event-id` grade asserts
         # the source published a junction identifier, so the column must carry it. The
         # converse block is deliberately gone: it used to forbid a `gene-mechanism`/

--- a/research/lab_notebook/scientist.md
+++ b/research/lab_notebook/scientist.md
@@ -6,6 +6,20 @@ Format and rules unchanged from the unified notebook — see `shared/feedback_la
 
 ---
 
+## 2026-07-20
+
+### 10:27 UTC - Editor: Scientist - the two-directional firewall, and the schema inconsistency a gut-check exposed
+
+**A "the tier names sound inconsistent" question turned into a faceted-model diagnosis; the narrow fix shipped, the refactor is captured as a proposal** ([Issue #1237](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/issues/1237), [PR #1243](https://github.com/Jin-HoMLee/splice-neoepitope-pipeline/pull/1243))
+
+Picked up #1237 (the negative-side gap deferred from the #1236 review): the tier-not-label firewall guarded only the positive side, so a `presentation-prevalence` row mislabeled `label=negative` slipped both the positive firewall and the `na`-blind negative-subtype checks. The fix is a `TIER_ALLOWED_LABELS` table enforced two-directionally, with `POSITIVE_LABEL_TIERS` **derived** from it (no drift). TDD: the negative-side matched pair (same presentation row, `untested` validates / `negative` rejected) is red-before/green-after.
+
+**The load-bearing part of the session was a question, not the code.** Asked whether the tier names were consistent, I found they are not - and it is not cosmetic. The *positive* tiers are split on **scorability** (is the sequence in hand?), the *negative* tiers on **evidence-strength** (`hard`/`soft`). Two different axes, because each side's binding constraint differs: a positive's fate turns on "do we have the sequence to score it?", a negative's on "how much do we trust the non-immunogenicity?". That per-side axis switch is *why* the firewall came out one-directional in the first place - nothing in the tier guarded which labels a tier may wear. Grounding it against best practice named the pattern: this is **faceted classification** (orthogonal facets, composed) versus the flat enumerative `tier`, and the single-source-of-truth remedy is to make `tier` a **derived** view over the facet columns (`label`, `evidence_strength`, `peptide_status`, `splice_mechanism_canonical`). Verified those facets already exist, so `tier` is derivable today for all 6 live tiers - the only gap being the 0-row `candidate` tier's "disputed" facet, which has no column.
+
+**Scope discipline held.** The derive-`tier` refactor is a real direction but a scope widen I proposed *this* session, so it stays a proposal on the #1237 scope-note comment (suggested ACs marked "for discussion, not committed"), and the PR ships only the committed narrow scope. Forward-compatible either way: the table it adds becomes the faceted legal-combination matrix.
+
+**Bot review (PR #1243): LGTM, no blocking issues.** Independently cross-checked all 97 rows against the table (0 violations) and traced the AC3 derivation. Three optional notes, all adopted in `e8a4c73`: a distinct `unknown tier` message (versus the opaque `may carry only []`), a parametrized pin of the *other* newly-strict combinations (a positive tier wearing `negative`/`untested`, a negative tier wearing `positive`), and a `LABELING_SCHEME.md` note that a new tier needs a `TIER_ALLOWED_LABELS` entry or every row on it is rejected (fail-closed). 69 tests pass (+4); live registry green (97 rows). Left at the merge gate for a human call.
+
 ## 2026-07-17
 
 ### 20:13 UTC - Editor: Scientist - candidate-tier firewall reconciliation: conceded to the bot, then un-conceded against the source


### PR DESCRIPTION
## Summary

Makes the registry's tier-label firewall **two-directional**. The #1178/#1233 guard fired only on the positive side (a `positive` label on a tier that may never carry one). Its mirror gap: an `untested`-only tier (`presentation-prevalence`) or a control tier wearing `label=negative` was caught by neither the firewall (fires on positive) nor the negative-subtype checks (fire on soft/hard/strong/weak, blind to the `na` strength those tiers carry). Negatives are the registry's binding constraint, so contaminating that set is a comparable risk to the positive-side corruption #1178 closed.

- Adds `TIER_ALLOWED_LABELS` to `labeling_constants.py`: the single authoritative `tier -> legal-label(s)` table, verified against the live registry (no row violates it) and LABELING_SCHEME.md sections 2-4.
- Enforces it two-directionally in `validate_registry.py` (subsumes the old positive-only guard; an unknown tier gets an empty allowed set and is rejected too).
- Derives `POSITIVE_LABEL_TIERS` from the table so the two can never drift (AC3).
- Adds a matched-pair negative-side test.

Closes #1237.

The broader "make `tier` a derived facet view" framing raised in the Issue's scope-note comment is deliberately **not** in this PR - it stays a proposal pending ratification. This is the committed, narrow scope; the table it adds is forward-compatible with that direction (it becomes the faceted legal-combination matrix).

## Test plan

- [x] `research/.venv/bin/python -m pytest research/experiments/issue_680_splice_immunogenicity_registry/tests/` - **65 pass** (was 64; +1 negative-side test).
- [x] Matched pair (the falsifier): `test_presentation_row_labeled_negative_is_rejected` failed RED before the guard, passes after; its partner `test_presentation_row_untested_is_green` stays green - same presentation row, label flipped untested->negative, opposite outcomes.
- [x] AC3 no-drift: `POSITIVE_LABEL_TIERS` derives to exactly {`functional-scorable`, `functional-nonscorable`, `candidate`}.
- [x] Live registry green: `validate_registry.py` PASS (97 rows), no new violations.

**Created by:** Scientist
